### PR TITLE
Work directory

### DIFF
--- a/conf/suiterc.spec
+++ b/conf/suiterc.spec
@@ -90,6 +90,7 @@ description = string( default="No description supplied" )
             command template = string( default=None )
             job script shell = option( /bin/bash, /usr/bin/bash, /bin/ksh, /usr/bin/ksh, default=/bin/bash )
             log directory = string( default='$HOME/cylc-run/$CYLC_SUITE_REG_NAME/log/job' )
+            share directory = string( default='$CYLC_SUITE_DEF_PATH/share' )
             work directory = string( default='$CYLC_SUITE_DEF_PATH/work/$TASK_ID' )
         [[[remote]]]
             host = string( default=None )

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1140,6 +1140,7 @@ class config( CylcConfigObj ):
         taskd.job_submit_command_template = taskconfig['job submission']['command template']
 
         taskd.job_submit_log_directory = taskconfig['job submission']['log directory']
+        taskd.job_submit_share_directory = taskconfig['job submission']['share directory']
         taskd.job_submit_work_directory = taskconfig['job submission']['work directory']
 
         # Remotely hosted tasks

--- a/lib/cylc/job_submission/job_submit.py
+++ b/lib/cylc/job_submission/job_submit.py
@@ -55,7 +55,7 @@ class job_submit(object):
 
     def __init__( self, task_id, pre_command, task_command,
             post_command, task_env, directives, 
-            manual_messaging, logfiles, log_dir, work_dir, task_owner,
+            manual_messaging, logfiles, log_dir, share_dir, work_dir, task_owner,
             remote_host, remote_cylc_dir, remote_suite_dir,
             remote_shell_template, remote_log_dir, 
             job_submit_command_template, job_submission_shell ): 
@@ -71,6 +71,7 @@ class job_submit(object):
         self.directives  = directives
         self.logfiles = logfiles
  
+        self.share_dir = share_dir
         self.work_dir = work_dir
         self.job_submit_command_template = job_submit_command_template
         self.job_submission_shell = job_submission_shell
@@ -175,6 +176,7 @@ class job_submit(object):
                 self.task_command, self.post_command,
                 self.remote_cylc_dir, self.remote_suite_dir, 
                 self.job_submission_shell, 
+                self.share_dir,
                 self.work_dir,
                 self.__class__.simulation_mode,
                 self.__class__.__name__ )

--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -27,7 +27,7 @@ class jobfile(object):
             directives, final_directive, manual_messaging,
             precommand_scripting, command_scripting,
             postcommand_scripting, remote_cylc_dir, remote_suite_dir,
-            shell, work_dir, simulation_mode, job_submission_method ):
+            shell, share_dir, work_dir, simulation_mode, job_submission_method ):
 
         self.task_id = task_id
         self.cylc_env = cylc_env
@@ -39,6 +39,7 @@ class jobfile(object):
         self.command_scripting = command_scripting
         self.postcommand_scripting = postcommand_scripting
         self.shell = shell
+        self.share_dir = share_dir
         self.work_dir = work_dir
         self.simulation_mode = simulation_mode
         self.job_submission_method = job_submission_method
@@ -143,10 +144,11 @@ class jobfile(object):
 cylc task started || exit 1""" )
 
     def write_work_directory_create( self ):
+        data = { "share_dir": self.share_dir,  "work_dir": self.work_dir }
         self.FILE.write( """
 
 # SHARE DIRECTORY CREATE
-CYLC_SUITE_SHARE_PATH=$CYLC_SUITE_DEF_PATH/share
+CYLC_SUITE_SHARE_PATH=%(share_dir)s
 export CYLC_SUITE_SHARE_PATH
 mkdir -p $CYLC_SUITE_DEF_PATH/share || true
 
@@ -155,7 +157,7 @@ CYLC_TASK_WORK_PATH=%(work_dir)s
 export CYLC_TASK_WORK_PATH
 mkdir -p $(dirname $CYLC_TASK_WORK_PATH) || true
 mkdir -p $CYLC_TASK_WORK_PATH
-cd $CYLC_TASK_WORK_PATH""" % { "work_dir": self.work_dir } )
+cd $CYLC_TASK_WORK_PATH""" % data )
 
     def write_environment_2( self ):
         if len( self.task_env.keys()) > 0:

--- a/lib/cylc/job_submission/ll_ecox.py
+++ b/lib/cylc/job_submission/ll_ecox.py
@@ -22,7 +22,7 @@ from _ecox import ecox
 class ll_ecox( ecox, loadleveler ):
     def __init__( self, task_id, pre_command, task_command,
             post_command, task_env, directives, manual_messaging,
-            logfiles, log_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
+            logfiles, log_dir, share_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
             remote_suite_dir, remote_shell_template, remote_log_dir,
             job_submit_command_template, job_submission_shell ): 
 
@@ -30,6 +30,6 @@ class ll_ecox( ecox, loadleveler ):
 
         loadleveler.__init__( self, task_id, pre_command, task_command,
             post_command, task_env, directives, manual_messaging,
-            logfiles, log_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
+            logfiles, log_dir, share_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
             remote_suite_dir, remote_shell_template, remote_log_dir,
             job_submit_command_template, job_submission_shell )

--- a/lib/cylc/job_submission/ll_raw_ecox.py
+++ b/lib/cylc/job_submission/ll_raw_ecox.py
@@ -22,7 +22,7 @@ from _ecox import ecox
 class ll_raw_ecox( ecox, ll_raw ):
     def __init__( self, task_id, pre_command, task_command,
             post_command, task_env, directives, manual_messaging,
-            logfiles, log_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
+            logfiles, log_dir, share_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
             remote_suite_dir, remote_shell_template, remote_log_dir,
             job_submit_command_template, job_submission_shell ): 
 
@@ -30,6 +30,6 @@ class ll_raw_ecox( ecox, ll_raw ):
 
         loadleveler.__init__( self, task_id, pre_command, task_command,
             post_command, task_env, directives, manual_messaging,
-            logfiles, log_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
+            logfiles, log_dir, share_dir, work_dir, task_owner, remote_host, remote_cylc_dir,
             remote_suite_dir, remote_shell_template, remote_log_dir,
             job_submit_command_template, job_submission_shell )

--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -329,6 +329,7 @@ class task( Pyro.core.ObjBase ):
                         self.directives, self.manual_messaging,
                         self.logfiles, 
                         self.__class__.job_submit_log_directory,
+                        self.__class__.job_submit_share_directory,
                         self.__class__.job_submit_work_directory,
                         self.__class__.owner,
                         self.__class__.remote_host,

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -62,6 +62,7 @@ class taskdef(object):
         self.job_submission_shell = None
         self.job_submit_command_template = None
         self.job_submit_log_directory = None
+        self.job_submit_share_directory = None
         self.job_submit_work_directory = None
         self.manual_messaging = False
         self.modifiers = []
@@ -258,6 +259,7 @@ class taskdef(object):
         tclass.job_submission_shell = self.job_submission_shell
         tclass.job_submit_command_template = self.job_submit_command_template
         tclass.job_submit_log_directory = self.job_submit_log_directory
+        tclass.job_submit_share_directory = self.job_submit_share_directory
         tclass.job_submit_work_directory = self.job_submit_work_directory
         tclass.manual_messaging = self.manual_messaging
 


### PR DESCRIPTION
The job file will now export 2 environment variables `CYLC_SUITE_SHARE_PATH` and `CYLC_TASK_WORK_PATH`, and `cd $CYLC_TASK_WORK_PATH` before running _environment 2_.

(I have also rearranged the functions in `lib/cylc/job_submission/jobfile.py` so that they are in the right order.)
