### PR TITLE
fix simulation mode job submission parsing.

### DIFF
--- a/examples/large/suite.rc
+++ b/examples/large/suite.rc
@@ -161,15 +161,11 @@ description = "EcoConnect Operation, circa August 2011"
         [[[environment]]]
             SYS = "${USER##*_}"
             ARCHIVE = /$SYS/archive/ecoconnect
-        #[[[event hooks]]]
-        #    started = nagios.sh
-        #    failed = nagios.sh
-        #    warning = nagios.sh
-        #    succeeded = nagios.sh
-        #    submission failed = nagios.sh
-        #    timeout = nagios.sh
-        #    submission timeout = 2
-        #    execution timeout = 30
+        [[[event hooks]]]
+            script = nagios.sh
+            events = started,failed,succeeded,submission_failed,timeout
+            submission timeout = 2
+            execution timeout = 30
 
     [[UKMO]]
         description = "UK Met Office data retrieval"

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1129,7 +1129,7 @@ class config( CylcConfigObj ):
         taskd.owner = taskconfig['remote']['owner']
 
         if self.simulation_mode:
-            taskd.job_submit_method = self['cylc']['simulation mode']['job submission method']
+            taskd.job_submit_method = self['cylc']['simulation mode']['job submission']['method']
             taskd.commands = self['cylc']['simulation mode']['command scripting']
         else:
             taskd.job_submit_method = taskconfig['job submission']['method']


### PR DESCRIPTION
A minor fix to config.py: suite.rc simulation mode job submission method syntax has changed. Discovered in an attempt to run the _large_ example.
