### PR TITLE
help: sort commands in alphabetically order.

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -104,7 +104,7 @@ def match_command( abbrev ):
     else:
         return matches[0]
 
-def pretty_print( incom, choose_dict, indent=True, numbered=False ):
+def pretty_print( incom, choose_dict, indent=True, numbered=False, sort=False ):
     # pretty print commands or topics from a dict:
     # (com[item] = description)
     
@@ -128,6 +128,8 @@ def pretty_print( incom, choose_dict, indent=True, numbered=False ):
     if len(choose) > 9:
         pad = True
 
+    if sort:
+        choose.sort()
     for item in choose:
         if item not in incom:
             raise SystemExit( "ERROR: summary for '" + item + "' not found" )
@@ -403,7 +405,7 @@ def category_help(category):
     print '  The category ' + alts + ' may be omitted.'
     print
     print 'COMMANDS:'
-    pretty_print( comsum, coms )
+    pretty_print( comsum, coms, sort=True )
 
 # no arguments: print help and exit
 if len(sys.argv) == 1:


### PR DESCRIPTION
I wonder if this is a change you can pull in. I find it quite useful to sort the commands alphabetically in help, but it may not be the correct functional order to display?
