### PR TITLE
Led vert labels

### DIFF
--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -133,12 +133,24 @@ Text treeview base GUI suite control interface.
 
     def reset_led_headings( self ):
         tvcs = self.led_treeview.get_columns()
+        labels = []
         for n in range( 1,1+len( self.task_list) ):
-            heading = self.led_headings[n]
-            # double on underscores or they get turned into underlines
-            # (may be related to keyboard mnemonics for button labels?)
-            heading = re.sub( '_', '__', heading )
-            tvcs[n].set_title( heading )
+            labels.append(gtk.Label(self.led_headings[n]))
+            labels[-1].set_use_underline(False)
+            labels[-1].set_angle(90)
+            labels[-1].show()
+            label_box = gtk.VBox()
+            label_box.pack_start(labels[-1], expand=False, fill=False)
+            label_box.show()
+            tvcs[n].set_widget( label_box )
+        max_pixel_length = -1
+        for label in labels:
+            x, y = label.get_layout().get_size()
+            if x > max_pixel_length:
+                max_pixel_length = x
+        for label in labels:
+            while label.get_layout().get_size()[0] < max_pixel_length:
+                label.set_text(label.get_text() + ' ')
 
     def ledview_widgets( self ):
         types = tuple( [gtk.gdk.Pixbuf]* (10 + len( self.task_list)))


### PR DESCRIPTION
Hi Hilary,

Here's the vertical labels code that Matt discussed in his email (point 1, I think). For the first bit of code to send to you, it's pretty horrible, but I don't think there's a way around the way the TreeView headers handle vertical spacing - they're not proper containers really. It justifies the labels reasonably well, given that it won't always be fixed-width fonts.

I have to say, the 'dot' view or light panel is my favourite of all the views, especially for large suites like your nzlam example.

Cheers,

Ben
