### PR TITLE
simulation mode and ecox demo: fix syntax.

### DIFF
--- a/examples/demo/ecox/suite.rc
+++ b/examples/demo/ecox/suite.rc
@@ -165,7 +165,7 @@ description = "EcoConnect Operation, circa August 2011"
             # note that timeout values are redefined in some tasks
             # ALSO: event hooks are ignored by default in simulation mode.
             script = nagios.sh
-            events = started,failed,succeeded,submission_failed,timeout
+            events = started,failed,succeeded,submission_failed,submission_timeout,execution_timeout
             submission timeout = 2
             execution timeout = 30
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -372,6 +372,8 @@ class config( CylcConfigObj ):
 
         if self.verbose:
             print "CHECKING suite event hooks"
+        script = None
+        events = []
         if not self.simulation_mode or self['cylc']['simulation mode']['event hooks']['enable']:
             # configure suite event hooks
             script = self['cylc']['event hooks']['script']


### PR DESCRIPTION
Simulation mode and the ecox demo appear to be broken. This should fix the problem.
