### PR TITLE
Backslash escape quotes and strings in values of environment variables

### DIFF
--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -197,7 +197,10 @@ cd $CYLC_TASK_WORK_PATH""" % data )
         if len( self.task_env.keys()) > 0:
             self.FILE.write( "\n\n# ENVIRONMENT:" )
             for var in self.task_env:
-                self.FILE.write( "\n" + var + "=\"" + str( self.task_env[var] ) + "\"" )
+                value = str( self.task_env[var] )
+                for old, new in [('"', '\\"'), ("'", "\\'"), (" ", "\\ ")]:
+                    value = value.replace(old, new)
+                self.FILE.write( "\n%s=%s" % ( var, value ) )
             # export them all (see note below)
             self.FILE.write( "\nexport" )
             for var in self.task_env:


### PR DESCRIPTION
in job files to allow shell tilde expansion to work.
