### PR TITLE
Alter family right click menu

### DIFF
--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -931,7 +931,7 @@ The Cylc Suite Engine.
 
         return False
 
-    def get_right_click_menu( self, task_id, hide_task=False ):
+    def get_right_click_menu( self, task_id, hide_task=False, task_is_family=False ):
         """Return the default menu for a task."""
         menu = gtk.Menu()
         if not hide_task:
@@ -941,9 +941,8 @@ The Cylc Suite Engine.
             title_item = gtk.MenuItem( 'Task: ' + task_id.replace( "_", "__" ) )
             title_item.set_sensitive(False)
             menu.append( title_item )
-            menu.append( gtk.SeparatorMenuItem() )
 
-        menu_items = self._get_right_click_menu_items( task_id )
+        menu_items = self._get_right_click_menu_items( task_id, task_is_family )
         for item in menu_items:
             menu.append( item )
 
@@ -951,7 +950,7 @@ The Cylc Suite Engine.
         return menu
 
 
-    def _get_right_click_menu_items( self, task_id ):
+    def _get_right_click_menu_items( self, task_id, task_is_family=False ):
         # Return the default menu items for a task
         name, ctime = task_id.split('%')
 
@@ -963,6 +962,12 @@ The Cylc Suite Engine.
         ## cug_pdf_item.set_label( '_PDF User Guide' )
         ## help_menu.append( cug_pdf_item )
         ## cug_pdf_item.connect( 'activate', self.browse, '--pdf' )
+
+        if task_is_family:
+            # At the moment, there are no relevant menu items.
+            return []
+
+        items.append( gtk.SeparatorMenuItem() )
 
         info_item = gtk.ImageMenuItem( 'View State' )
         img = gtk.image_new_from_stock(  gtk.STOCK_DIALOG_INFO, gtk.ICON_SIZE_MENU )

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -26,6 +26,7 @@ from cylc.cycle_time import ct
 from cylc.cylc_xdot import xdot_widgets
 from gcapture import gcapture_tmpfile
 
+
 class ControlGraph(object):
     """
 Dependency graph suite control interface.
@@ -163,7 +164,7 @@ Dependency graph suite control interface.
         ungroup_rec_item.set_sensitive( not self.x.ungroup_recursive )
         ungroup_rec_item.connect( 'activate', self.grouping, name, False, True )
 
-        title_item = gtk.MenuItem( 'Task: ' + task_id )
+        title_item = gtk.MenuItem( 'Task: ' + task_id.replace("_", "__") )
         title_item.set_sensitive(False)
         menu.append( title_item )
 
@@ -181,7 +182,9 @@ Dependency graph suite control interface.
         if type == 'live task':
             menu.append( gtk.SeparatorMenuItem() )
             
-            default_menu = self.get_right_click_menu( task_id, hide_task=True )
+            is_fam = (name in self.x.families)
+            default_menu = self.get_right_click_menu( task_id, hide_task=True,
+                                                      task_is_family=is_fam )
             for item in default_menu.get_children():
                 default_menu.remove( item )
                 menu.append( item )

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -87,7 +87,9 @@ LED suite control interface.
 
         task_id = name + '%' + ctime
 
-        menu = self.get_right_click_menu( task_id )
+        is_fam = (name in self.t.families)
+
+        menu = self.get_right_click_menu( task_id, task_is_family=is_fam )
 
         sep = gtk.SeparatorMenuItem()
         sep.show()

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -247,9 +247,13 @@ Text Treeview suite control interface.
 
         task_id = name + '%' + ctime
 
-        menu = self.get_right_click_menu( task_id )
+        is_fam = (name in self.t.families)
 
-        menu.append( gtk.SeparatorMenuItem() )
+        menu = self.get_right_click_menu( task_id, task_is_family=is_fam )
+
+        sep = gtk.SeparatorMenuItem()
+        sep.show()
+        menu.append( sep )
 
         group_item = gtk.CheckMenuItem( 'Toggle Family Grouping' )
         group_item.set_active( self.t.should_group_families )

--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -114,6 +114,7 @@ class tupdater(threading.Thread):
         self.global_summary = {}
         self.fam_state_summary = {}
         self.stop_summary = None
+        self.families = []
         self.god = None
         self.mode = "waiting..."
         self.dt = "waiting..."
@@ -154,6 +155,7 @@ class tupdater(threading.Thread):
             self.stop_summary = None
             self.status = "connected"
             self.info_bar.set_status( self.status )
+            self.families = self.remote.get_families()
             self.family_hierarchy = self.remote.get_family_hierarchy()
             self.allowed_families = self.remote.get_vis_families()
             return True
@@ -502,6 +504,7 @@ class lupdater(threading.Thread):
         self.state_summary = {}
         self.global_summary = {}
         self.stop_summary = None
+        self.families = []
         self.god = None
         self.mode = "waiting..."
         self.dt = "waiting..."

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -78,6 +78,7 @@ class xupdater(threading.Thread):
         self.filter_include = None
         self.filter_exclude = None
         self.state_filter = None
+        self.families = []
 
         self.cfg = cfg
         self.info_bar = info_bar


### PR DESCRIPTION
This change strips the right click menu when it applies to families. I couldn't find any applicable menu items for families (although I could be wrong) so there aren't any default menu items for these.

This refers to issue https://github.com/cylc/cylc/issues/133
