### PR TITLE
stop off-graph plotting of collapsed family members

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1000,3 +1000,9 @@ or 'False')
 + Restore job submit failure hook activation, broken in 4.5.1.
 
 + Runahead limit is now displayed in the gcontrol status bar.
+
++ gcontrol graph-view: members of collapsed families are no longer
+plotted off to the side as rectangular nodes (no longer necessary as we
+now have family state coloring and member state info in hover-over
+tool-tips).
+

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -71,6 +71,7 @@ Dependency graph suite control interface.
     def on_url_clicked( self, widget, url, event ):
         if event.button != 3:
             return False
+
         if url == 'KEY':
             # graph key node
             return


### PR DESCRIPTION
It is no longer necessary to plot members of collapsed families as
rectangular nodes off to the side, because we now have family state
colouring and member state information in hover-over tool-tips.
Closes #143.
