### PR TITLE
cylc/cylc#153: fix family filtering in tree view

### DIFF
--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -104,7 +104,6 @@ Text Treeview suite control interface.
             # sub_nm seems to contain the family name repeated?
             if self.tfilt:
                 sub_nm = self.ttree_paths.get( path, {} ).get( 'names', [] )
-                #print path, self.ttree_paths
                 nres = nres or any([self.tfilt in n for n in sub_nm])
 
         return sres and nres

--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -351,7 +351,7 @@ class tupdater(threading.Thread):
                         f_iter = self.ttreestore.append(
                                       f_iter, [ ctime, fam ] + f_data )
                         family_iters[fam] = f_iter
-                    self._update_path_info( f_iter, state, fam )
+                    self._update_path_info( f_iter, state, name )
                 # Add task to tree
                 self.ttreestore.append( f_iter, [ ctime, name ] + new_data[ctime][name])
         if self.autoexpand:


### PR DESCRIPTION
This fixes cylc/cylc#153 - nodes in the Tree View were filtered by their parent name, not any of their descendant names.
