### PR TITLE
cylc/cylc#154: fix remote gcontrol fail for fresh suites

### DIFF
--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -148,7 +148,7 @@ class tupdater(threading.Thread):
                                                             self.cfg.suite,
                                                             self.cfg.owner,
                                                             self.cfg.host)
-                if any(self.stop_summary):
+                if self.stop_summary is not None and any(self.stop_summary):
                     self.info_bar.set_stop_summary(self.stop_summary)
             return False
         else:
@@ -555,7 +555,7 @@ class lupdater(threading.Thread):
                                                             self.cfg.suite,
                                                             self.cfg.owner,
                                                             self.cfg.host)
-                if any(self.stop_summary):
+                if self.stop_summary is not None and any(self.stop_summary):
                     self.info_bar.set_stop_summary(self.stop_summary)
             return False
         else:

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -122,7 +122,7 @@ class xupdater(threading.Thread):
                                                             self.cfg.suite,
                                                             self.cfg.owner,
                                                             self.cfg.host)
-                if any(self.stop_summary):
+                if self.stop_summary is not None and any(self.stop_summary):
                     self.info_bar.set_stop_summary(self.stop_summary)
             return False
         else:


### PR DESCRIPTION
This addresses cylc/cylc#154. A `cylc cat-state` that fails (due to the state file not having been created) will cause `cylc gcontrol` to fail - this fixes it.
