### PR TITLE
cylc/cylc#148: landscape option for cylc graph, cylc gcontrol

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -139,7 +139,7 @@ parser.add_option( "-n", "--namespaces",
 parser.add_option( "-l", "--landscape",
     help="Plot in landscape mode instead of portrait (the default)."
     "Cannot be used in conjunction with -f, --file",
-    action="store_true", default=False, dest="landscape")
+    action="store_true", default=False, dest="landscape" )
 
 parser.add_option( "-f", "--file", 
     help="View a specific dot-language graphfile.",
@@ -180,12 +180,17 @@ prep = prep_file( args[0], options )
 suite, suiterc = prep.execute()
 watchers = prep.get_rcfiles()
 
+if options.landscape:
+    orientation = "LR"
+else:
+    orientation = "TB"
+
 # parse and plot the suite.rc dependency graph
 if len(args) < 1 or len(args) > 3:
     parser.error( "Argument list should be: SUITE [START [STOP]]" )
 
 if options.namespaces:
-    window = MyDotWindow2( suite, suiterc, watchers, options.outputfile, options.landscape )
+    window = MyDotWindow2( suite, suiterc, watchers, options.outputfile, orientation )
 else:
     # SUITE DEPENDENCY GRAPH
 
@@ -216,7 +221,7 @@ else:
         raw = True
 
     window = MyDotWindow( suite, suiterc, watchers, start_ctime, stop_ctime, raw, options.outputfile,
-                          options.landscape )
+                          orientation )
 
 window.widget.connect( 'clicked', on_url_clicked, window )
 

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -44,13 +44,13 @@ class MyDotWindow2( xdot.DotWindow ):
         </toolbar>
     </ui>
     '''
-    def __init__(self, suite, suiterc, watch, outfile=None, landscape_mode=False ):
+    def __init__(self, suite, suiterc, watch, outfile=None, orientation="TB" ):
         self.outfile = outfile
         self.disable_output_image = False
         self.suite = suite
         self.file = suiterc
         self.watch = []
-        self.landscape_mode = landscape_mode
+        self.orientation = orientation
 
         gtk.Window.__init__(self)
 
@@ -106,7 +106,7 @@ class MyDotWindow2( xdot.DotWindow ):
         uimanager.add_ui_from_string(self.ui)
 
         landscape_toolitem = uimanager.get_widget('/ToolBar/Landscape')
-        landscape_toolitem.set_active(self.landscape_mode)
+        landscape_toolitem.set_active(self.orientation == "LR")
 
         # Create a Toolbar
 
@@ -163,8 +163,7 @@ class MyDotWindow2( xdot.DotWindow ):
     def get_graph( self ):
         title = self.suite + ' runtime namespace inheritance graph'
         graph = CGraphPlain( title )
-        if self.landscape_mode:
-            graph.graph_attr['rankdir'] = 'LR'
+        graph.graph_attr['rankdir'] = self.orientation
         for ns in self.inherit:
             if self.inherit[ns]:
                 attr = {}
@@ -186,13 +185,17 @@ class MyDotWindow2( xdot.DotWindow ):
                 print >> sys.stderr, x
                 self.disable_output_image = True
 
-    def on_landscape(self, toolitem):
-        self.set_landscape(toolitem.get_active())
+    def on_landscape( self, toolitem ):
+        if toolitem.get_active():
+            self.set_orientation( "LR" )  # Left to right ordering of nodes
+        else:
+            self.set_orientation( "TB" )  # Top to bottom (default) ordering
 
-    def set_landscape(self, landscape_mode):
-        if landscape_mode == self.landscape_mode:
+    def set_orientation( self, orientation="TB" ):
+        """Set the orientation of the graph node ordering."""
+        if orientation == self.orientation:
             return False
-        self.landscape_mode = landscape_mode
+        self.orientation = orientation
         self.get_graph()
 
     def update(self):
@@ -241,7 +244,7 @@ class MyDotWindow( xdot.DotWindow ):
     </ui>
     '''
     def __init__(self, suite, suiterc, watch, ctime, stop_after, raw, outfile=None,
-                 landscape_mode=False ):
+                 orientation="TB" ):
         self.outfile = outfile
         self.disable_output_image = False
         self.suite = suite
@@ -250,7 +253,7 @@ class MyDotWindow( xdot.DotWindow ):
         self.raw = raw
         self.stop_after = stop_after
         self.watch = []
-        self.landscape_mode = landscape_mode
+        self.orientation = orientation
 
         gtk.Window.__init__(self)
 
@@ -305,6 +308,9 @@ class MyDotWindow( xdot.DotWindow ):
 
         # Add a UI descrption
         uimanager.add_ui_from_string(self.ui)
+
+        landscape_toolitem = uimanager.get_widget('/ToolBar/Landscape')
+        landscape_toolitem.set_active(self.orientation == "LR")
 
         # Create a Toolbar
 
@@ -382,8 +388,7 @@ class MyDotWindow( xdot.DotWindow ):
                 ungroup_recursive=ungroup_recursive, 
                 group_all=group_all, ungroup_all=ungroup_all )
 
-        if self.landscape_mode:
-            graph.graph_attr['rankdir'] = 'LR'
+        graph.graph_attr['rankdir'] = self.orientation
 
         for node in graph.nodes():
             name, tag = node.get_name().split('%')
@@ -401,13 +406,17 @@ class MyDotWindow( xdot.DotWindow ):
                 print >> sys.stderr, x
                 self.disable_output_image = True
 
-    def on_landscape(self, toolitem):
-        self.set_landscape(toolitem.get_active())
+    def on_landscape( self, toolitem ):
+        if toolitem.get_active():
+            self.set_orientation( "LR" )  # Left to right ordering of nodes
+        else:
+            self.set_orientation( "TB" )  # Top to bottom (default) ordering
 
-    def set_landscape(self, landscape_mode):
-        if landscape_mode == self.landscape_mode:
+    def set_orientation( self, orientation="TB" ):
+        """Set the orientation of the graph node ordering."""
+        if orientation == self.orientation:
             return False
-        self.landscape_mode = landscape_mode
+        self.orientation = orientation
         self.get_graph()
 
     def update(self):

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -262,7 +262,7 @@ Dependency graph suite control interface.
         
         self.menu_landscape_item = gtk.CheckMenuItem( 'Toggle _Landscape Mode' )
         items.append( self.menu_landscape_item )
-        self.menu_landscape_item.set_active( self.x.landscape_mode )
+        self.menu_landscape_item.set_active( self.x.orientation == "LR" )
         self.menu_landscape_item.connect( 'activate', self.toggle_landscape_mode )
         return items
 
@@ -337,7 +337,11 @@ Dependency graph suite control interface.
         self.x.action_required = True
 
     def toggle_landscape_mode( self, w ):
-        self.x.landscape_mode = not self.x.landscape_mode
+        """Change the orientation of the graph - 'portrait' or 'landscape'."""
+        if self.x.orientation == "TB":  # Top -> bottom ordering
+            self.x.orientation = "LR"  # Left -> right ordering
+        elif self.x.orientation == "LR":
+            self.x.orientation = "TB"
         self.x.action_required = True
 
     def toggle_key( self, w ):

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -74,7 +74,7 @@ class xupdater(threading.Thread):
         self.action_required = True
         self.oldest_ctime = None
         self.newest_ctime = None
-        self.landscape_mode = False
+        self.orientation = "TB"  # Top to Bottom ordering of nodes, by default.
         self.show_key = False # graph key visibility default
         self.best_fit = False
         self.crop = False
@@ -563,10 +563,7 @@ class xupdater(threading.Thread):
         if self.show_key:
             self.add_graph_key()
 
-        if self.landscape_mode:
-            self.graphw.graph_attr['rankdir'] = 'LR'
-        else:
-            self.graphw.graph_attr['rankdir'] = 'TB'
+        self.graphw.graph_attr['rankdir'] = self.orientation
 
         # process extra nodes (important nodes outside of focus range,
         # and family members that aren't plotted in the main graph).


### PR DESCRIPTION
This addresses cylc/cylc#148 - it adds an option to switch a cylc dependency or namespace graph to a left-to-right orientation ('landscape'). There's now a command line option and toolbar item to allow this in `cylc graph`, and a menu option in `cylc gcontrol`.
