### PR TITLE
Cylc ping needs to contact suite if port file exists.

### DIFF
--- a/bin/cylc-ping
+++ b/bin/cylc-ping
@@ -60,6 +60,7 @@ try:
     proxy = cylc_pyro_client.client( suite, pphrase, options.owner,
             options.host, options.pyro_timeout, options.port,
             options.verbose).get_proxy( 'remote' )
+    proxy.ping()
 except Exception, x:
     if options.debug:
         raise

--- a/lib/cylc/remote_switch.py
+++ b/lib/cylc/remote_switch.py
@@ -88,6 +88,9 @@ class remote_switch( Pyro.core.ObjBase ):
         self.process_tasks = True
         return result( True )
 
+    def ping( self ):
+        return result( True )
+
     def ping_task( self, task_id ):
         # is this task running at the moment
         found = False


### PR DESCRIPTION
Since the recent replacement of port-scanning with port files on disk, "cylc ping" is not returning error status when the target suite is not running _if_ the suite port file still exists. Normally the port file is deleted on suite shutdown, in which case ping reports an error because it can't find the port file - which is how I missed this problem.
