### PR TITLE
Fixed get-config for retrieval entire runtime section.

### DIFF
--- a/bin/cylc-get-config
+++ b/bin/cylc-get-config
@@ -204,7 +204,7 @@ else:
     for d in data:
         if isinstance( d, dict ):
             if options.pnative:
-                print prefix + d
+                print d
             else:
                 print_cfg( d, level=len(args[1:]), prefix=prefix)
         else:

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -504,23 +504,30 @@ class config( CylcConfigObj ):
         return res
 
     def get_config( self, args, sparse=False ):
-        target = self
-        keys = args
-        so_far = []
         if args[0] == 'runtime' and not sparse:
             # load and override runtime defaults
-            rtcfg = {}
-            replicate( rtcfg, self.runtime_defaults )
-            override( rtcfg, self['runtime'][args[1]] )
-            target = rtcfg
-            keys = args[2:]
-            so_far = args[:2]
-
+            if len(args) > 1:
+                # a single namespace
+                rtcfg = {}
+                replicate( rtcfg, self.runtime_defaults )
+                override( rtcfg, self['runtime'][args[1]] )
+                target = rtcfg
+                keys = args[2:]
+            else:
+                # all namespaces requested
+                target = {}
+                keys = []
+                for ns in self['runtime'].keys():
+                    rtcfg = {}
+                    replicate( rtcfg, self.runtime_defaults )
+                    override( rtcfg, self['runtime'][ns] )
+                    target[ns] = rtcfg
+        else:
+            target = self
+            keys = args
         res = target
         for key in keys:
-            so_far.append(key)
             res = res[key]
-
         return res
 
 


### PR DESCRIPTION
This fixes a bug just reported by Matt Shin: "cylc get-config -i [runtime] SUITE" (i.e. attempting to retrieve the complete runtime section) resulted in a traceback. The fix allows this, although doing so would not be advisable for any sizeable suite (because of the amount of information returned).
