### PR TITLE
Minor change to a Jinja2 example suite.

### DIFF
--- a/examples/jinja2/defaults/suite.rc
+++ b/examples/jinja2/defaults/suite.rc
@@ -3,23 +3,18 @@
 title = "Jinja2 example: use of defaults and external input"
 
 description = """
-The template variable FIRST_TASK must be given on the cylc command line
-using --set or --set-file=FILE; two other variables, LAST_TASK and
-N_MEMBERS can be set similarly, but if not they have default values.""" 
+The template variable N_MEMBERS can be set on the command line with
+--set or --set-file=FILE; but if not a default values is supplied.""" 
 
-{% set LAST_TASK = LAST_TASK | default( 'baz' ) %}
 {% set N_MEMBERS = N_MEMBERS | default( 3 ) | int %}
-
-{# input of FIRST_TASK is required - no default #}
 
 [scheduling]
     initial cycle time = 2010080800
     final cycle time   = 2010081600
     [[dependencies]]
         [[[0]]]
-            graph = """{{ FIRST_TASK }} => ens
-                 ens:succeed-all => {{ LAST_TASK }}"""
-
+            graph = """foo => ens
+                 ens:succeed-all => bar"""
 [runtime]
     [[ens]]
 {% for I in range( 0, N_MEMBERS ) %}


### PR DESCRIPTION
The examples/jinja2/defaults suite had (deliberately) a template
variable with no default set, requiring use of the new --set command
line options. However, this broke automated validation of the example
suites.
