### PR TITLE
Repeating asynchronous tasks need instance-specific environment vars.

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -35,6 +35,7 @@ from collections import deque
 from cylc import task_state
 from cylc.strftime import strftime
 from cylc.RunEventHandler import RunHandler
+from OrderedDict import OrderedDict
 import logging
 import Pyro.core
 
@@ -384,6 +385,11 @@ class task( Pyro.core.ObjBase ):
         rtconfig = deepcopy( self.__class__.rtconfig )
         self.override( rtconfig, overrides )
         self.set_from_rtconfig( rtconfig )
+
+        if len(self.env_vars) > 0:
+            # Add in any instance-specific environment variables
+            # (currently only used by async_repeating tasks)
+            rtconfig['environment'].update( self.env_vars )
 
         self.log( 'DEBUG', 'submitting task job script' )
         # construct the job launcher here so that a new one is used if

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -186,6 +186,10 @@ class taskdef(object):
         tclass.title = self.rtconfig['title']
         tclass.description = self.rtconfig['description']
 
+        # For any instance-specific environment variables (note that
+        # [runtime][TASK][enviroment] is now held in a class variable).
+        tclass.env_vars = OrderedDict()
+
         tclass.name = self.name        # TO DO: NOT NEEDED, USED class.__name__
         tclass.instance_count = 0
         tclass.upward_instance_count = 0


### PR DESCRIPTION
Recent changes moved [runtime] environment to a class variable, updated
by broadcast (if necessary) at the last minute. So, now also update the
enviroment dict with instance-specific environment variables, if any, at
the last minute. To test run the examples/satellite/ suite.
