### PR TITLE
cylc gui: reduce poll of a stopped suite.

### DIFF
--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -16,24 +16,19 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from cylc.config import config
+from cylc import cylc_pyro_client, dump
 from cylc.task_state import task_state
-from DotMaker import DotMaker
-import cylc.dump
-import inspect
-import sys, re, string
-import gobject
-import time
-import threading
-from cylc import cylc_pyro_client
+from cylc.gui.DotMaker import DotMaker
 from cylc.state_summary import get_id_summary
 from cylc.strftime import strftime
+import gobject
 import gtk
-import pygtk
-from string import zfill
-from copy import copy
+import re
+import string
+import sys
+import threading
+from time import sleep, time
 
-####pygtk.require('2.0')
 
 try:
     any
@@ -45,7 +40,61 @@ except NameError:
                 return True
         return False
 
+
+class PollSchd(object):
+    """Keep information on whether an updater should poll or not."""
+
+    DELAYS = {(None, 5): 1, (5, 60): 5, (60, 300): 60, (300, None): 300}
+
+    def __init__(self, start=False):
+        """Return a new instance.
+
+        If start is False, the updater can always poll.
+
+        If start is True, the updater should only poll if the ready method
+        returns True.
+
+        """
+
+        self.t_init = None
+        self.t_prev = None
+        if start:
+            self.start()
+
+    def ready(self):
+        """Return True if a poll is ready."""
+        if self.t_init is None:
+            return True
+        if self.t_prev is None:
+            self.t_prev = time()
+            return True
+        dt_init = time() - self.t_init
+        dt_prev = time() - self.t_prev
+        for k, v in self.DELAYS.items():
+            lower, upper = k
+            if ((lower is None or dt_init >= lower) and
+                (upper is None or dt_init < upper)):
+                if dt_prev > v:
+                    self.t_prev = time()
+                    return True
+                else:
+                    return False
+        return True
+
+    def start(self):
+        """Start keeping track of latest poll, if not already started."""
+        if self.t_init is None:
+            self.t_init = time()
+            self.t_prev = None
+
+    def stop(self):
+        """Stop keeping track of latest poll."""
+        self.t_init = None
+        self.t_prev = None
+
+
 def compare_dict_of_dict( one, two ):
+    """Return True if one == two, else return False."""
     for key in one:
         if key not in two:
             return False
@@ -66,9 +115,9 @@ def compare_dict_of_dict( one, two ):
 
     return True
 
-def markup( col, string ):
-    return string
-    #return '<span foreground="' + col + '">' + string + '</span>'
+
+def markup( col, s ):
+    return s
 
 
 def get_col_priority( priority ):
@@ -83,6 +132,7 @@ def get_col_priority( priority ):
     else:
         # not needed
         return '#f0f'
+
 
 class tupdater(threading.Thread):
 
@@ -105,6 +155,8 @@ class tupdater(threading.Thread):
         self.god = None
         self.mode = "waiting..."
         self.dt = "waiting..."
+        self.status = None
+        self.poll_schd = PollSchd()
 
         self.autoexpand_states = [ 'submitted', 'running', 'failed', 'held' ]
         self._last_autoexpand_me = []
@@ -135,10 +187,10 @@ class tupdater(threading.Thread):
             self.remote = client.get_proxy( 'remote' )
         except Exception, x:
             if self.stop_summary is None:
-                self.stop_summary = cylc.dump.get_stop_state_summary(
-                                                            self.cfg.suite,
-                                                            self.cfg.owner,
-                                                            self.cfg.host)
+                self.stop_summary = dump.get_stop_state_summary(
+                                                       self.cfg.suite,
+                                                       self.cfg.owner,
+                                                       self.cfg.host)
                 if self.stop_summary is not None and any(self.stop_summary):
                     self.info_bar.set_stop_summary(self.stop_summary)
             return False
@@ -146,6 +198,7 @@ class tupdater(threading.Thread):
             #print 'GOT A CLIENT PROXY'
             self.stop_summary = None
             self.status = "connected"
+            self.poll_schd.stop()
             self.info_bar.set_status( self.status )
             self.families = self.remote.get_families()
             self.family_hierarchy = self.remote.get_family_hierarchy()
@@ -164,6 +217,7 @@ class tupdater(threading.Thread):
         self.fam_state_summary = {}
 
         self.status = "stopped"
+        self.poll_schd.start()
         self.info_bar.set_state( [] )
         self.info_bar.set_status( self.status )
         if self.stop_summary is not None and any(self.stop_summary):
@@ -461,11 +515,11 @@ class tupdater(threading.Thread):
         glbl = None
         states = {}
         while not self.quit:
-            if self.update():
+            if self.poll_schd.ready() and self.update():
                 gobject.idle_add( self.update_gui )
                 # TO DO: only update globals if they change, as for tasks
                 gobject.idle_add( self.update_globals )
-            time.sleep(1)
+            sleep(1)
         else:
             pass
             ####print "Disconnecting task state info thread"
@@ -493,6 +547,8 @@ class lupdater(threading.Thread):
         self.god = None
         self.mode = "waiting..."
         self.dt = "waiting..."
+        self.status = None
+        self.poll_schd = PollSchd()
         self.filter = ""
 
         self.led_treeview = treeview
@@ -528,10 +584,10 @@ class lupdater(threading.Thread):
             self.remote = client.get_proxy( 'remote' )
         except:
             if self.stop_summary is None:
-                self.stop_summary = cylc.dump.get_stop_state_summary(
-                                                            self.cfg.suite,
-                                                            self.cfg.owner,
-                                                            self.cfg.host)
+                self.stop_summary = dump.get_stop_state_summary(
+                                                       self.cfg.suite,
+                                                       self.cfg.owner,
+                                                       self.cfg.host)
                 if self.stop_summary is not None and any(self.stop_summary):
                     self.info_bar.set_stop_summary(self.stop_summary)
             return False
@@ -541,6 +597,7 @@ class lupdater(threading.Thread):
             self.allowed_families = self.remote.get_vis_families()
             self.stop_summary = None
             self.status = "connected"
+            self.poll_schd.stop()
             self.info_bar.set_status( self.status )
             return True
 
@@ -557,6 +614,7 @@ class lupdater(threading.Thread):
         self.led_liststore.clear()
 
         self.status = "stopped"
+        self.poll_schd.start()
         if not self.quit:
             self.info_bar.set_state( [] )
             self.info_bar.set_status( self.status )
@@ -819,11 +877,11 @@ class lupdater(threading.Thread):
         glbl = None
         states = {}
         while not self.quit:
-            if self.update():
+            if self.poll_schd.ready() and self.update():
                 gobject.idle_add( self.update_gui )
                 # TO DO: only update globals if they change, as for tasks
                 gobject.idle_add( self.update_globals )
-            time.sleep(1)
+            sleep(1)
         else:
             pass
             ####print "Disconnecting task state info thread"

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -16,20 +16,19 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys, os, re
-import gobject
-import time
-import threading
-from cylc import cylc_pyro_client, dump
-from cylc import graphing
-from cylc.strftime import strftime
-import gtk
-import pygtk
+from cylc import cylc_pyro_client, dump, graphing
 from cylc.cycle_time import ct
-import cylc.dump
+from cylc.gui.stateview import compare_dict_of_dict, PollSchd
 from cylc.mkdir_p import mkdir_p
 from cylc.state_summary import get_id_summary
-####pygtk.require('2.0')
+from cylc.strftime import strftime
+import gobject
+import os
+import re
+import sys
+import threading
+from time import sleep
+
 
 try:
     any
@@ -41,25 +40,6 @@ except NameError:
                 return True
         return False
 
-def compare_dict_of_dict( one, two ):
-    # return True if one == two, else return False.
-    for key in one:
-        if key not in two:
-            return False
-        for subkey in one[ key ]:
-            if subkey not in two[ key ]:
-                return False
-            if one[key][subkey] != two[key][subkey]:
-                return False
-    for key in two:
-        if key not in one:
-            return False
-        for subkey in two[ key ]:
-            if subkey not in one[ key ]:
-                return False
-            if two[key][subkey] != one[key][subkey]:
-                return False
-    return True
 
 class xupdater(threading.Thread):
     def __init__(self, cfg, theme, info_bar, xdot ):
@@ -92,6 +72,8 @@ class xupdater(threading.Thread):
         self.god = None
         self.mode = "waiting..."
         self.dt = "waiting..."
+        self.status = None
+        self.poll_schd = PollSchd()
 
         self.reconnect()
         # TO DO: handle failure to get a remote proxy in reconnect()
@@ -142,11 +124,13 @@ class xupdater(threading.Thread):
                     raise SuiteConfigError, 'ERROR, illegal dir? ' + self.live_graph_dir 
             self.first_update = True
             self.status = "connected"
+            self.poll_schd.stop()
             self.info_bar.set_status( self.status )
             return True
 
     def connection_lost( self ):
         self.status = "stopped"
+        self.poll_schd.start()
         self.prev_graph_id = ()
         self.normal_fit = True
         # Get an *empty* graph object
@@ -250,7 +234,7 @@ class xupdater(threading.Thread):
     def run(self):
         glbl = None
         while not self.quit:
-            if self.update():
+            if self.poll_schd.ready() and self.update():
                 needed_no_redraw = self.update_graph()
                 # DO NOT USE gobject.idle_add() HERE - IT DRASTICALLY
                 # AFFECTS PERFORMANCE FOR LARGE SUITES? appears to
@@ -258,7 +242,7 @@ class xupdater(threading.Thread):
                 ################ gobject.idle_add( self.update_xdot )
                 self.update_xdot( no_zoom=needed_no_redraw )
                 gobject.idle_add( self.update_globals )
-            time.sleep(1)
+            sleep(1)
         else:
             pass
             ####print "Disconnecting task state info thread"


### PR DESCRIPTION
Gradual increase of poll delay of a stopped suite.

Note: Because each view is updated by its own thread, destroying a view
will reset the poll delay.

Ultimately, I guess we'll need #75 to resolve all the issues.
