### PR TITLE
This completes the changes required for #221.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -508,7 +508,8 @@ class scheduler(object):
         for itask in self.pool.get_tasks():
             if itask.id == task_id:
                 found = True
-                if itask.state.is_currently('waiting') or itask.state.is_currently('queued'):
+                if itask.state.is_currently('waiting') or itask.state.is_currently('queued') or \
+                        itask.state.is_currently('retrying'):
                     was_waiting = True
                     itask.state.set_status( 'held' )
                 break
@@ -753,7 +754,8 @@ class scheduler(object):
                 itask.reconfigure_me = False
                 if itask.name in self.orphans:
                     # orphaned task
-                    if itask.state.is_currently('waiting') or itask.state.is_currently('queued'):
+                    if itask.state.is_currently('waiting') or itask.state.is_currently('queued') or \
+                            itask.state.is_currently('retrying'):
                         # if not started running yet, remove it.
                         self.pool.remove( itask, '(task orphaned by suite reload)' )
                     else:
@@ -1350,7 +1352,8 @@ class scheduler(object):
             self.hold_suite_now = True
             self.log.warning( "Holding all waiting or queued tasks now")
             for itask in self.pool.get_tasks():
-                if itask.state.is_currently('queued') or itask.state.is_currently('waiting'):
+                if itask.state.is_currently('queued') or itask.state.is_currently('waiting') or \
+                        itask.state.is_currently('retrying'):
                     # (not runahead: we don't want these converted to
                     # held or they'll be released immediately on restart)
                     itask.state.set_status('held')

--- a/lib/cylc/task_types/catchup_clocktriggered.py
+++ b/lib/cylc/task_types/catchup_clocktriggered.py
@@ -65,7 +65,8 @@ class catchup_clocktriggered( clocktriggered ):
         # delayed start time is up.
         ready = False
         if self.state.is_currently('queued') or \
-                self.state.is_currently('waiting') and self.prerequisites.all_satisfied():
+                self.state.is_currently('waiting') and self.prerequisites.all_satisfied() or \
+                 self.state.is_currently('retrying') and self.prerequisites.all_satisfied():
 
             if not self.catchup_status_determined:
                 try:

--- a/lib/cylc/task_types/clocktriggered.py
+++ b/lib/cylc/task_types/clocktriggered.py
@@ -52,18 +52,17 @@ class clocktriggered(object):
         # not ready unless delayed start time is up too.
         ready = False
         if self.state.is_currently('queued') or \
-                self.state.is_currently('waiting') and self.prerequisites.all_satisfied():
+                self.state.is_currently('waiting') and self.prerequisites.all_satisfied() or \
+                 self.state.is_currently('retrying') and self.prerequisites.all_satisfied():
             if self.start_time_reached():
                 # We've reached the clock-trigger time
                 if self.retry_delay_timer_start:
-                    # A retry delay has been set ...
                     diff = clocktriggered.clock.get_datetime() - self.retry_delay_timer_start
                     foo = datetime.timedelta( 0,0,0,0,self.retry_delay,0,0 )
                     if diff >= foo:
                         # ... we've reached the retry delay time
                         ready = True
                 else:
-                    # no retry delay has been set
                     ready = True
             else:
                 self.log( 'DEBUG', 'prerequisites satisfied but waiting on delayed start time' )


### PR DESCRIPTION
Adjusts for the fact that the old task.is_waiting() test used to return
True for retrying tasks as well as ones in the 'waiting' state. Now we
do direct tests on the state value, so must check for 'retrying' too
where appropriate.
