### PR TITLE
doc/make-index.sh: use "cylc --version" ...

### DIFF
--- a/doc/make-index.sh
+++ b/doc/make-index.sh
@@ -23,7 +23,7 @@
 # generated (PDF and/or HTML single page and/or HTML multi-page).
 # It can however be executed manually from within the doc directory.
 
-CYLC_VERSION=$( git describe )
+CYLC_VERSION=$($(dirname $0)/../bin/cylc --version)
 INDEX=index.html
 
 cat > $INDEX <<END


### PR DESCRIPTION
... to generate the version string.

This allows the script to be used in any arbitrary tar ball of cylc.
