### PR TITLE
Updated .gitignore for doc directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,25 @@
+
+# python bytecode
 *.pyc
-doc/command-usage/*
+
+# generated documentation
+doc/command-usage/
 doc/commands.tex
-doc/cylc-user-guide.aux
-doc/cylc-user-guide.lof
-doc/cylc-user-guide.log
-doc/cylc-user-guide.out
-doc/cylc-user-guide.pdf
-doc/cylc-user-guide.toc
-doc/suiterc.spec.tex
+doc/index.html
+doc/cug.html
+doc/cug1.html
+doc/cug.pdf
+doc/cylc-version.txt
+doc/cug-html*.html
+doc/cug-html.css
+doc/cug-pdf.aux
+doc/cug-pdf.lof
+doc/cug-pdf.log
+doc/cug-pdf.out
+doc/cug-pdf.toc
+
+# vim backup files
 *.swp
-*.dot
-CDB
+
+# emacs backup files
+*~


### PR DESCRIPTION
To prevent generated documentation from cluttering up `git status` output.
