### PR TITLE
Use a custom exception for include-file not found errors.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -39,7 +39,7 @@ from regpath import RegPath
 from trigger import triggerx
 from Jinja2Support import Jinja2Process, TemplateError, TemplateSyntaxError
 from continuation_lines import join
-from include_files import inline
+from include_files import inline, IncludeFileError
 from dictcopy import replicate, override
 
 try:
@@ -115,7 +115,10 @@ class config( CylcConfigObj ):
         f.close()
 
         # handle cylc include-files
-        flines = inline( flines, self.dir )
+        try:
+            flines = inline( flines, self.dir )
+        except IncludeFileError, x:
+            raise SuiteConfigError( str(x) )
 
         # handle Jinja2 expressions
         try:

--- a/lib/cylc/include_files.py
+++ b/lib/cylc/include_files.py
@@ -17,12 +17,21 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re, os, sys
-from cylcconfigobj import ConfigObjError
 import datetime
 from shutil import copy
 
 # To Do: the four file inclusion functions below are very similar and
 # should be combined into one.
+
+class IncludeFileError( Exception ):
+    """
+    Attributes:
+        message - what the problem is. 
+    """
+    def __init__( self, msg ):
+        self.msg = msg
+    def __str__( self ):
+        return repr(self.msg)
 
 done = []
 included = []
@@ -50,7 +59,7 @@ def inline( lines, dir ):
                 # recursive inclusion
                 outf.extend( inline( inc, dir ))
             else:
-                raise ConfigObjError, "ERROR, Include-file not found: " + inc
+                raise IncludeFileError( "ERROR, include-file not found: " + inc )
         else:
             # no match
             outf.append( line )


### PR DESCRIPTION
This has no no effect except to raise an IncludeFileError instead of a
ConfigObjError, which was misleading (include-files are a cylc feature,
not from configobj).
