### PR TITLE
Syntax highlighting for gedit

### DIFF
--- a/conf/cylc.lang
+++ b/conf/cylc.lang
@@ -8,6 +8,10 @@
  To use it, place or symlink this file in
  ~/.local/share/gtksourceview-2.0/language-specs/ - or, if possible,
  /usr/share/gtksourceview-2.0/language-specs/
+ 
+ If your installation uses GNOME 3, the '2.0' in the paths will need
+ to be '3.0', and the version="2.0" string below will need changing
+ as well.
 
  If using gedit, gedit will need to be totally closed down and reloaded.
 


### PR DESCRIPTION
This adds some syntax highlighting for the suite definition file under <code>gedit</code>, in a similar fashion to the <code>gvim</code> one.
