### PR TITLE
Bug fix doc/Makefile for missing latex commands.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -18,11 +18,14 @@
 
 CYLC=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))../bin/cylc
 
-.PHONY: all clean html html-multi html-single pdf
+.PHONY: all index clean html html-multi html-single pdf
 
 DEPS := $(shell ./scripts/get-deps.sh)
 
-all: $(DEPS) index.html
+all: index
+
+index: $(DEPS)
+	./scripts/make-index.sh
 
 html: html-multi html-single
 
@@ -32,8 +35,6 @@ html-single: html/single/cug-html.html
 
 pdf: pdf/cug-pdf.pdf
 
-index.html: html/multi/cug-html.html html/single/cug-html.html pdf/cug-pdf.pdf
-	./scripts/make-index.sh
 
 cylc.txt: ../bin/cylc
 	$< --help > $@

--- a/doc/changes.html
+++ b/doc/changes.html
@@ -33,8 +33,8 @@ guide, command help, or post a question to the cylc mailing list. <p>
 		<h2>5.0.2</h2>
 
 <ul>
-		<li> <b>Bug fix for doc "make clean"</b> - it was not cleaning out
-		all generated files.</li>
+		<li> <b>Bug fixes for doc/Makefile:</b> - "make clean" was not
+		working, and a fatal error occured if htlatex was not installed.</li>
 
 </ul>
 


### PR DESCRIPTION
The generated dependencies ('html', 'pdf') were not being used properly,
resulting in a fatal error if htlatex was not installed.
