### PR TITLE
Moved some gtk imports down to avoid display errors.

### DIFF
--- a/bin/cylc-dbviewer
+++ b/bin/cylc-dbviewer
@@ -21,9 +21,7 @@ from cylc.remote import remrun
 if remrun().execute():
     sys.exit(0)
 
-import os, gtk
-import warnings
-warnings.filterwarnings('ignore', 'use the new', Warning)
+import os
 from cylc.CylcOptionParsers import cop
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
@@ -31,7 +29,6 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../')
 
 from cylc.global_config import globalcfg
 from cylc.suite_logging import suite_log
-from cylc.gui.db_viewer import MainApp
 
 parser = cop( """cylc [db] dbviewer [OPTIONS]
 
@@ -46,6 +43,14 @@ parser.add_option( "--pyro-timeout", metavar='SEC',
         action="store", default=None, dest="pyro_timeout" )
 
 ( options, args ) = parser.parse_args()
+
+# import modules that require gtk now, so that a display is not needed
+# just to get command help (e.g. when running make on a post-commit hook
+# on a remote repository).
+import gtk
+import warnings
+warnings.filterwarnings('ignore', 'use the new', Warning)
+from cylc.gui.db_viewer import MainApp
 
 # Make current working directory be $HOME. Otherwise (1) if the user
 # attempts to start the dbviewer from a CWD that has been removed, Pyro

--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -21,8 +21,6 @@ from cylc.remote import remrun
 if remrun().execute():
     sys.exit(0)
 
-import gtk, gobject
-from xdot import DotWindow
 from cylc.CylcOptionParsers import cop
 from cylc.cycle_time import ct, CycleTimeError
 from cylc.command_prep import prep_file
@@ -31,12 +29,6 @@ from cylc.command_prep import prep_file
 # right-click menu have been rather hastily stuck on to the original
 # viewer, via changes to this file and to lib/cylc/cylc_xdot.py - all
 # of which could stand some refactoring to streamline the code a bit.
-
-try:
-    from cylc.cylc_xdot import MyDotWindow, MyDotWindow2
-except Exception, x:
-    print >> sys.stderr, str(x)
-    raise SystemExit( "Cylc graphing disabled" )
 
 def on_url_clicked( widget, url, event, window ):
     if event.button != 3:
@@ -153,6 +145,17 @@ parser.add_option( "--output",
     metavar="FILE", action="store", default=None, dest="outputfile" )
 
 ( options, args ) = parser.parse_args()
+
+# import modules that require gtk now, so that a display is not needed
+# just to get command help (e.g. when running make on a post-commit hook
+# on a remote repository).
+import gtk, gobject
+from xdot import DotWindow
+try:
+    from cylc.cylc_xdot import MyDotWindow, MyDotWindow2
+except Exception, x:
+    print >> sys.stderr, str(x)
+    raise SystemExit( "Cylc graphing disabled" )
 
 if options.filename:
     if len(args) != 0:

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -23,17 +23,13 @@ if '--use-ssh' in sys.argv[1:]:
     if remrun().execute():
         sys.exit(0)
 
-import os,re,gtk
-import warnings
-warnings.filterwarnings('ignore', 'use the new', Warning)
+import os
 from cylc.CylcOptionParsers import cop
 from copy import copy
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../')
 
-from cylc.gui.SuiteControl import ControlApp
-from cylc.gui.gcylc_config import config
 from cylc.global_config import globalcfg
 from cylc.suite_host import is_remote_host
 from cylc.suite_logging import suite_log
@@ -75,6 +71,15 @@ parser.add_option( "-l", "--list-themes",
 parser.remove_option("-f" ) # don't need force (To Do: a read-only GUI)
 
 ( options, args ) = parser.parse_args()
+
+# import modules that require gtk now, so that a display is not needed
+# just to get command help (e.g. when running make on a post-commit hook
+# on a remote repository).
+import gtk
+import warnings
+warnings.filterwarnings('ignore', 'use the new', Warning)
+from cylc.gui.SuiteControl import ControlApp
+from cylc.gui.gcylc_config import config
 
 globals = globalcfg()
 cylc_tmpdir = globals.cfg['temporary directory']

--- a/bin/gcapture
+++ b/bin/gcapture
@@ -16,16 +16,12 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import gtk
-import gobject
 import os, sys
 from optparse import OptionParser
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
 
 from cylc.global_config import globalcfg
-from cylc.gui.warning_dialog import warning_dialog
-from cylc.gui.gcapture import gcapture, gcapture_tmpfile
 
 # This is a unit test for $CYLC_DIR/lib/cylc/gui/gcapture.py
 # but it may be more generally useful.
@@ -56,6 +52,12 @@ parser.add_option( "--other",
     action="store_true", default=False, dest="other" )
 
 (options, args) = parser.parse_args()
+
+# import modules that require gtk now, so that a display is not needed
+# just to get command help (e.g. when running make on a post-commit hook
+# on a remote repository).
+import gtk
+import gobject
 
 if options.other and not options.filep:
     parser.error( '--other requires --prefix' )


### PR DESCRIPTION
Running 'make' on a remote post-commit hook failed with "can't open
display" errors from a few commands (when generating command help transcripts) - which this fixes.
