### PR TITLE
Create task job log dir in the submit command.

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -39,6 +39,7 @@ from cylc.port_scan import SuiteIdentificationError
 from cylc.regpath import RegPath
 from cylc.command_prep import prep_file
 from cylc.suite_logging import suite_log
+from cylc.global_config import gcfg
 
 usage = """cylc [task] submit|single [OPTIONS] ARGS
 
@@ -109,6 +110,8 @@ except Exception,x:
         raise
     raise SystemExit(x)
 
+# create task log directory
+gcfg.get_task_log_dir( suite, create=True )
 
 use_lockserver = False
 if config['cylc']['lockserver']['enable']:


### PR DESCRIPTION
Since moving task log dir config to the site/user file, the "cylc
submit" command (and "cylc jobscript", which wraps it) failed if
the task job log dir did not already exist.

Closes #274
