### PR TITLE
Job status file: don't start with an append.

### DIFF
--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -204,7 +204,7 @@ done""")
 {
     echo "CYLC_JOB_PID=$$"
     date -u +'CYLC_JOB_INIT_TIME=%FT%H:%M:%SZ'
-} >>$CYLC_TASK_LOG_ROOT.status
+} >$CYLC_TASK_LOG_ROOT.status
 cylc task started""" )
 
     def write_work_directory_create( self ):


### PR DESCRIPTION
See closing comment in #282. This change will allow the job file to create a new status file each time a job is submitted.
