### PR TITLE
Closes #324 - visualization settings being ignored.

### DIFF
--- a/bin/cylc-depend
+++ b/bin/cylc-depend
@@ -52,7 +52,7 @@ suite, pphrase = prep_pyro( args[0], options ).execute()
 task_id = args[1]
 dep = args[2]
 
-m = re.match( '^(\w+)'+TaskID.DELIM+'(\w+)$', dep )
+m = re.match( '^(\w+)'+TaskID.DELIM_RE+'(\w+)$', dep )
 if m:
     #name, ctime = m.groups()
     msg = dep + ' succeeded'

--- a/doc/changes.html
+++ b/doc/changes.html
@@ -17,6 +17,7 @@
 <ul>
 		<li><a href="#">TOP</a></li>
 		<li><a href="#pending">pending</a></li>
+		<li><a href="#5.1.1">5.1.1</a></li>
 		<li><a href="#5.1.0">5.1.0</a></li>
 		<li><a href="#5.0.3">5.0.3</a></li>
 		<li><a href="#5.0.2">5.0.2</a></li>
@@ -36,6 +37,12 @@ guide, command help, or post a question to the cylc mailing list. <p>
 		<h2>pending (in master but not tagged yet)</h2>
 
 		<p>(None)</p>
+
+<a name="5.1.1"/>
+		<h2>5.1.1</h2>
+
+		<li>Restored use of visualization settings, broken by
+		the task ID delimiter change in 5.0.0.</li>
 
 <a name="5.1.0"/>
 		<h2>5.1.0</h2>

--- a/lib/cylc/TaskID.py
+++ b/lib/cylc/TaskID.py
@@ -144,7 +144,7 @@ class TaskID(object):
     """
 
     DELIM = '.'
-    DELIM_RE = re.compile('\.')
+    DELIM_RE = '\.'
 
     def __init__( self, *args ):
         if len(args) == 1:

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -62,7 +62,7 @@ class CGraphPlain( pygraphviz.AGraph ):
         self.graph_attr['label'] = title
 
     def node_attr_by_taskname( self, n ):
-        name = re.sub( TaskID.DELIM+'.*', '', n )
+        name = re.sub( TaskID.DELIM_RE+'.*', '', n )
         if name in self.task_attr:
             return self.task_attr[name]
         else:

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -1202,7 +1202,7 @@ The Cylc Suite Engine.
 
     def add_prerequisite( self, w, entry, window, task_id ):
         dep = entry.get_text()
-        m = re.match( '^(\w+)'+TaskID.DELIM+'(\w+)$', dep )
+        m = re.match( '^(\w+)'+TaskID.DELIM_RE+'(\w+)$', dep )
         if m:
             #name, ctime = m.groups()
             msg = dep + ' succeeded'


### PR DESCRIPTION
This was caused by the recent task ID delimiter change from '%' to '.'.
The new delimiter has to be escaped for use in regular expressions.
Also fixed a couple of other instances of this problem.
