### PR TITLE
Db tidy

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -194,7 +194,7 @@ class task( object ):
 
     def record_db_event(self, event="", message=""):
         user_at_host = ""
-        if event in ["submitted", "submit_failed"]:
+        if event in ["submitted", "submit failed"]:
             if self.owner is None:
                 self.owner = user
             if self.hostname is None:


### PR DESCRIPTION
This makes a number of minor changes to reduce the amount of redundant data recorded in the suite db as requested by @matthewrmshin and adds in some missing information:
- redundant messages removed from task events table e.g. we now have: `|submitted||` instead of `|submitted|task submitted|`
- in the task events table, the host is only recorded in the `submitted` event - this also fixes a bug whereby the owner@host value wasn't recorded right in the submitted event
- task signal messages are now recorded in the task events tables as a "signaled" event i.e. any message starting "Task job script received signal" is now recorded
- an entry is recorded in the task events table when a task enters the retry state
