### PR TITLE
cylc.daemonize: reset umask after daemonized.

### DIFF
--- a/lib/cylc/daemonize.py
+++ b/lib/cylc/daemonize.py
@@ -10,7 +10,7 @@ def daemonize( suite, port ):
     http://code.activestate.com/recipes/66012-fork-a-daemon-process-on-unix/
     """
 
-    # Do the UNIX double-fork magic, see Stevens' "Advanced 
+    # Do the UNIX double-fork magic, see Stevens' "Advanced
     # Programming in the UNIX Environment" for details (ISBN 0201563177)
 
     sout = suite_output( suite )
@@ -19,31 +19,31 @@ def daemonize( suite, port ):
     except Exception, x:
         sys.exit( str(x) )
 
-    try: 
-        pid = os.fork() 
+    try:
+        pid = os.fork()
         if pid > 0:
             # exit first parent
-            sys.exit(0) 
-    except OSError, e: 
-        print >>sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror) 
+            sys.exit(0)
+    except OSError, e:
+        print >>sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror)
         sys.exit(1)
 
     # decouple from parent environment
-    os.chdir("/") 
-    os.setsid() 
-    os.umask(0) 
+    os.chdir("/")
+    os.setsid()
+    os.umask(0)
 
     # do second fork
-    try: 
-        pid = os.fork() 
+    try:
+        pid = os.fork()
         if pid > 0:
             # exit from second parent, print eventual PID before
             print "\nSuite Info:"
             print " + Name:", suite
-            print " + PID: ", pid 
+            print " + PID: ", pid
             print " + Port:", port
             print " + Logs: %s/(log|out|err)" % sout.get_dir()
-            print 
+            print
             print "To see if this suite is still running:"
             print " * cylc scan"
             print " * cylc ping -v", suite
@@ -52,11 +52,13 @@ def daemonize( suite, port ):
             print "To run in non-daemon mode use --debug."
             print "For more information type 'cylc --help'."
             print
-            sys.exit(0) 
-    except OSError, e: 
-        print >>sys.stderr, "fork #2 failed: %d (%s)" % (e.errno, e.strerror) 
-        sys.exit(1) 
+            sys.exit(0)
+    except OSError, e:
+        print >>sys.stderr, "fork #2 failed: %d (%s)" % (e.errno, e.strerror)
+        sys.exit(1)
+
+    # reset umask
+    os.umask(022) # octal
 
     # redirect output to the suite log files
     sout.redirect()
-


### PR DESCRIPTION
Reset `umask` so suite does not create world writeable files.

(This also removes trailing spaces from some lines.)
