### PR TITLE
Use os.path.realpath to resolve symlinks when finding cylc's location

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -19,7 +19,7 @@
 import os, re, sys
 import subprocess
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
 
 try:
     os.getcwd()

--- a/bin/cylc-dbviewer
+++ b/bin/cylc-dbviewer
@@ -24,8 +24,8 @@ if remrun().execute():
 import os
 from cylc.CylcOptionParsers import cop
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../')
 
 from cylc.global_config import gcfg
 from cylc.suite_logging import suite_log

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -27,8 +27,8 @@ import os
 from cylc.CylcOptionParsers import cop
 from copy import copy
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../')
 
 from cylc.global_config import gcfg
 from cylc.suite_host import is_remote_host

--- a/bin/gcapture
+++ b/bin/gcapture
@@ -19,7 +19,7 @@
 import os, sys
 from optparse import OptionParser
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../lib')
+sys.path.append(os.path.dirname(os.path.realpath(os.path.abspath(__file__))) + '/../lib')
 
 from cylc.global_config import gcfg
 

--- a/lib/cylc/__init__.py
+++ b/lib/cylc/__init__.py
@@ -32,7 +32,7 @@ def environ_init(argv0=None):
     # BAZ=$(python -c 'from cylc.foo import bar; print bar')
     # where argv0 will be '-c'.
 
-    cylc_dir = os.path.dirname(os.path.dirname(os.path.abspath(argv0)))
+    cylc_dir = os.path.dirname(os.path.dirname(os.path.realpath(os.path.abspath(argv0))))
     if cylc_dir != os.getenv('CYLC_DIR', ''):
         os.environ['CYLC_DIR'] = cylc_dir
 


### PR DESCRIPTION
Using os.path.abspath() with **file** or sys.argv[0] is not sufficient
when cylc is invoked via a symlink in $PATH, or a symlinked directory
that is listed in $PATH.  This is because os.path.dirname() is used
(and "/../" appended) to go "up" to parent directories - but this is
the parent of the symlink's location, not the actual location of cylc.

The solution is to call os.path.realpath() after os.path.abspath(),
but before os.path.dirname(), to ensure that all symlinks are resolved
prior to ascending to the parent directory.

Fixes #342.
