### PR TITLE
Tweaked cylc-list logic.

### DIFF
--- a/bin/cylc-list
+++ b/bin/cylc-list
@@ -80,7 +80,7 @@ else:
     which = "graphed tasks"
 
 if options.tree:
-    if os.environ['LANG'] == 'C':
+    if os.environ['LANG'] == 'C' and options.box:
         print >> sys.stderr, "WARNING, ignoring -t/--tree: $LANG=C"
         options.tree = False
 


### PR DESCRIPTION
The changes in cylc/cylc#336 mean that `-t` will no longer work under a `LANG=C` environment rather than when `-t` AND `-b` are used.

This change tweaks the logic so `cylc list -t` will work again under a `LANG=C` environment but will correctly give a warning and disable tree if `cylc list -t -b` is used.
