### PR TITLE
347 dependence on graphviz

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -155,9 +155,10 @@ import gtk, gobject
 from xdot import DotWindow
 try:
     from cylc.cylc_xdot import MyDotWindow, MyDotWindow2
-except Exception, x:
+except ImportError, x:
+    # this imports pygraphviz via cylc.graphing
     print >> sys.stderr, str(x)
-    raise SystemExit( "Cylc graphing disabled" )
+    raise SystemExit( "ERROR: please install pygraphviz." )
 
 if options.filename:
     if len(args) != 0:

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -313,10 +313,6 @@ class config( CylcConfigObj ):
         if self.validation:
             self.check_tasks()
 
-        if self['visualization']['runtime graph']['enable'] and graphing_disabled:
-            print >> sys.stderr, 'WARNING: disabling runtime graphing (graphing not available).'
-            self['visualization']['runtime graph']['enable'] = False
-
         # Default visualization start and stop cycles (defined here
         # rather than in the spec file so we can set a sensible stop
         # time if only the start time is specified by the user).
@@ -1217,7 +1213,7 @@ class config( CylcConfigObj ):
                             m = re.match( '^ASYNCID:(.*)$', section )
                             asyncid_pattern = m.groups()[0]
                
-                if not self.validation:
+                if not self.validation and not graphing_disabled:
                     # edges not needed for validation
                     self.generate_edges( lexpression, lnames, r, ttype, cyclr, suicide )
                 self.generate_taskdefs( orig_line, lnames, r, ttype, section, cyclr, asyncid_pattern )

--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -16,37 +16,14 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Cylc suite graphing module. Modules relying on this should test for 
+ImportError due to pygraphviz/graphviz not being installed."""
+
 import re
+import pygraphviz
 from TaskID import TaskID, AsyncTag
 
-class GraphvizError( Exception ):
-    """
-    Attributes:
-        message - what the problem is. 
-        TO DO: element - config element causing the problem
-    """
-    def __init__( self, msg ):
-        self.msg = msg
-    def __str__( self ):
-        return repr(self.msg)
-
-# TO DO:
-# 1/ Consolidate graph-disabling tests within cylc.
-# 2/ Do we still need autoURL below?
-
-try:
-    import pygraphviz
-except ImportError:
-    # This allows us to carry on with graphing disabled if
-    # pygraphviz is not installed.
-    raise GraphvizError, 'graphviz and/or pygraphviz are not accessible.'
-
-# Not needed as 'import pygraphviz' fails if graphviz is not installed.
-#try:
-#    testG = pygraphviz.AGraph(directed=True)
-#    testG.layout()  # this invokes the pygraphviz 'dot' program
-#except ValueError:
-#    raise GraphvizError, 'graphviz is not installed or not accessible'
+# TODO: Do we still need autoURL below?
 
 ddmmhh = TaskID.DELIM_RE
 tformat = r'\\n'


### PR DESCRIPTION
This addresses #347.

Dependence on graphviz had crept back into the main program some time ago via "runtime graphing" (generating a graph of resolved dependencies on the fly). This commit fixes that problem so that we can run suites even in graphviz is not installed, and does the same for gcylc (i.e. gcylc will run with the graph view disabled if graphviz is not installed).
