### PR TITLE
Corrected a typo in suite host hard-wiring code.

### DIFF
--- a/lib/cylc/suite_host.py
+++ b/lib/cylc/suite_host.py
@@ -87,7 +87,7 @@ elif method == 'address':
 elif method == 'hardwired':
     if not hardwired:
         sys.exit( 'ERROR, no hardwired hostname is configured' )
-    suite_host = manual
+    suite_host = hardwired
 else:
     sys.exit( 'ERROR, unknown host method: ' + method )
  


### PR DESCRIPTION
Closes #259.

The second problem mentioned in #259 is a property of `task.py`, not `suite_host.py`, fixed earlier by @arjclark.
