### PR TITLE
cylc suite db hostname bugfix

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -557,7 +557,7 @@ class task( object ):
                     print >> sys.stderr, '\n'.join(res[1])
                     # must still assign a name now or abort the suite?
                     host = "NO-HOST-SELECTED"
-
+            
             self.hostname = host
 
             if host not in gcfg.cfg['task hosts']:


### PR DESCRIPTION
Fixed indentation error that resulted in remote hosts not being recorded in the database (instead receiving values of "localhost").
