### PR TITLE
Fail use of family triggers on non-family namespaces.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1145,7 +1145,7 @@ class config( CylcConfigObj ):
         # on a non-family task, which is illegal.
         if '-a' in line: # ('-' is not legal in task names so this gets both cases)
             print >> sys.stderr, line
-            raise SuiteConfigError, "ERROR: family trigger cannot be used on non-family namespaces"
+            raise SuiteConfigError, "ERROR: family triggers cannot be used on non-family namespaces"
 
         # Replace "foo:finish" with "( foo:succeed | foo:fail )"
         line = re.sub(  r'\b(\w+(\[.*?]){0,1}):finish\b', r'( \1:succeed | \1:fail )', line )


### PR DESCRIPTION
Closes #394.
