### PR TITLE
Officially drop Python 2.4 support, which is already broken.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -388,19 +388,14 @@ run time.
 \begin{myitemize}
     \item {\bf Cylc}, the version associated with this document is: \input{cylc-version.txt}. % generated each time by doc/process
         \newline \url{http://cylc.github.com/cylc}
-    \item {\bf OS: Linux or Unix (including Mac OS X).} Cylc may assume
-        Unix-style file paths in places, a tiny minority of cylc
-        commands are Bash shell scripts (most are Python), and
-        cylc-generated task job scripts are written for Bash.
-    \item {\bf The Python Language, v 2.4$+$, preferably 2.5$+$,
-        latest tested 2.7.2}. 
-        Not Python 3.x yet; as of mid 2011 version 2.7 is the
-        standard for new Linux distributions.
+    \item {\bf OS: Linux, Unix, including OS X.}
+    \item {\bf The Python Language, version 2.5 or later, but 
+        not 3.x yet.
         \newline \url{http://python.org}
     \item {\bf Pyro (Python Remote Objects), version 3.10$+$, latest
         tested 3.16}; not Pyro 4.x as yet. Pyro is used by cylc
         for network communication between server processes (cylc suites)
-        and client programs (running tasks, gcylc, and commands).
+        and client programs (running tasks, gcylc, commands).
         \newline \url{http://irmen.home.xs4all.nl/pyro3}
     \item {\bf sqlite (a server-less, zero-configuration, SQL database
         engine}). This is likely included in your Linux distribution

--- a/lib/cylc/global_config.py
+++ b/lib/cylc/global_config.py
@@ -12,17 +12,6 @@ from tempfile import mkdtemp
 from envvar import expandvars
 from mkdir_p import mkdir_p
 
-# TODO: drop now-broken support for Python 2.4
-try:
-    any
-except NameError:
-    # any() appeared in Python 2.5
-    def any(iterable):
-        for entry in iterable:
-            if entry:
-                return True
-        return False
-
 class GlobalConfigError( Exception ):
     def __init__( self, msg ):
         self.msg = msg

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -26,16 +26,6 @@ from warning_dialog import warning_dialog, info_dialog
 from cylc.task_state import task_state
 from cylc.TaskID import TaskID
 
-try:
-    any
-except NameError:
-    # any() appeared in Python 2.5
-    def any(iterable):
-        for entry in iterable:
-            if entry:
-                return True
-        return False
-
 class ControlTree(object):
     """
 Text Treeview suite control interface.

--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -30,18 +30,6 @@ import sys
 import threading
 from time import sleep, time
 
-
-try:
-    any
-except NameError:
-    # any() appeared in Python 2.5
-    def any(iterable):
-        for entry in iterable:
-            if entry:
-                return True
-        return False
-
-
 class PollSchd(object):
     """Keep information on whether an updater should poll or not."""
 

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -30,18 +30,6 @@ import sys
 import threading
 from time import sleep
 
-
-try:
-    any
-except NameError:
-    # any() appeared in Python 2.5
-    def any(iterable):
-        for entry in iterable:
-            if entry:
-                return True
-        return False
-
-
 class xupdater(threading.Thread):
     def __init__(self, cfg, theme, info_bar, xdot ):
         super(xupdater, self).__init__()


### PR DESCRIPTION
Closes #389. This commit just:
- updates the user guide "requirements" section;
- removes a few back-ports of the python 2.5 'any' statement
