### PR TITLE
bugfix: invalid host breaking suite

### DIFF
--- a/lib/cylc/batch_submit.py
+++ b/lib/cylc/batch_submit.py
@@ -194,7 +194,6 @@ class task_batcher( batcher ):
         try:
             p, launcher = itask.submit( overrides=self.wireless.get(itask.id) )
         except Exception, x:
-            #raise
             self.item_failed_hook( itask, str(x), "Job submission failed." )
             return
         if p:


### PR DESCRIPTION
If you have a suite def like this:

```
[scheduling]
    [[dependencies]]
        graph = """a => b
                   a => c => d"""

[runtime]
    [[root]]
        command scripting = "sleep 5"
        [[[event hooks]]]
            succeeded handler = "rose suite-hook"
            failed handler = "rose suite-hook"
    [[a, c, d]]
    [[b]]
        command scripting = "sleep 5; echo 'hello from afar'"
        [[[remote]]]
            host = "banana"
```

On running it the submit code for submit breaks, stopping the suite and you get the following traceback in the logs:

```
Exception in thread Job Submission:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/cylc/lib/cylc/batch_submit.py", line 101, in run
    self.submit( batches.pop(0), i, n )  # index 0 => pop from left
  File "/cylc/lib/cylc/batch_submit.py", line 189, in submit
    batcher.submit( self, batch, i, n )
  File "/cylc/lib/cylc/batch_submit.py", line 114, in submit
    self.submit_item( itask, psinfo )
  File "/cylc/lib/cylc/batch_submit.py", line 195, in submit_item
    p, launcher = itask.submit( overrides=self.wireless.get(itask.id) )
  File "/cylc/lib/cylc/task_types/task.py", line 603, in submit
    raise Exception("ERROR: " + str(cmd))
Exception: ERROR: ['ssh', '-oBatchMode=yes', 'user@banana', 'mkdir', '-p', '$HOME/cylc-run/suite']

```

I've tracked it down to a raise in `batch_submit.py`, which I have removed in this pull request as a hotfix.
