### PR TITLE
Keep the ssh tunnel alive while background tasks run.

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -16,15 +16,6 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# This module uses the @classmethod decorator, introduced in Python 2.4.
-# . @classmethod
-# . def foo( bar ):
-# .   pass
-# Equivalent Python<2.4 form:
-# . def foo( bar ):
-# .   pass
-# . foo = classmethod( foo )
-
 import os, sys, re
 import datetime
 import subprocess
@@ -184,6 +175,9 @@ class task( object ):
         self.task_host = 'localhost'
         self.task_owner = user 
         self.user_at_host = self.task_owner + "@" + self.task_host
+
+        self.submit_method_id = None
+        self.job_sub_method = None
 
         # sets submit num for restarts or when triggering state prior to submission
         if self.validate: # if in validate mode bypass db operations
@@ -503,6 +497,8 @@ class task( object ):
 
         # dynamic instantiation - don't know job sub method till run time.
         module_name = rtconfig['job submission']['method']
+        self.job_sub_method = module_name
+
         class_name  = module_name
         # NOTE: not using__import__() keyword arguments:
         #mod = __import__( module_name, fromlist=[class_name] )


### PR DESCRIPTION
@matthewrmshin - please review, with reference to email exchange with Yi Xiao yesterday - it turns out we can read remote background PID without blocking until the job finishes. So this allows remote background job submission to work even at sites that do not allow "unattended" user processes on login nodes.  Cherry-piced from my poll-and-kill branch.
