### PR TITLE
cylc validate: multiple inheritance broken

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -63,10 +63,12 @@ else:
     jinja2_disabled = False
 
 def str2list( st ):
+    if isinstance(st, list):
+        return st
     return re.split( '[, ]+', st )
 
 def str2bool( st ):
-    return st.lower() in ( 'true' )
+    return str(st).lower() in ( 'true' )
 
 def str2float( st ):
     return float( st )

--- a/tests/validate/multi-inherit/reference.log
+++ b/tests/validate/multi-inherit/reference.log
@@ -1,0 +1,13 @@
+2013/04/30 09:18:53 CRITICAL - Suite starting at 2013-04-30 09:18:53.515014
+2013/04/30 09:18:53 INFO - Log event clock: real time
+2013/04/30 09:18:53 INFO - Run mode: live
+2013/04/30 09:18:53 INFO - Start tag: None
+2013/04/30 09:18:53 INFO - Stop tag: None
+2013/04/30 09:18:54 INFO - TASK READY: foo.1
+2013/04/30 09:18:54 INFO - [foo.1] -triggered off []
+2013/04/30 09:18:54 INFO - [foo.1] -> foo.1 submitting now
+2013/04/30 09:18:55 INFO - [foo.1] -> foo.1 submission succeeded
+2013/04/30 09:18:55 INFO - [foo.1] -> foo.1 submit_method_id=11749
+2013/04/30 09:18:55 INFO - [foo.1] -> foo.1 started at 2013-04-30T09:18:54
+2013/04/30 09:19:05 INFO - [foo.1] -> foo.1 succeeded at 2013-04-30T09:19:04
+2013/04/30 09:19:05 CRITICAL - Suite shutting down at 2013-04-30 09:19:05.596576

--- a/tests/validate/multi-inherit/suite.rc
+++ b/tests/validate/multi-inherit/suite.rc
@@ -1,0 +1,16 @@
+title = "Test validation of simple multiple inheritance"
+ 
+description = """Bug identified at 5.1.1-314-g4960684."""
+
+[cylc]
+[[reference test]]
+required run mode = live
+live mode suite timeout = 1.0 # minutes
+[scheduling]
+[[dependencies]]
+graph = """foo"""
+[runtime]
+[[FOO]]
+[[BAR]]
+[[foo]]
+inherit = FOO, BAR


### PR DESCRIPTION
With something like this:

```
# my-suite
[scheduling]
[[dependencies]]
graph = """foo"""
[runtime]
[[FOO]]
[[BAR]]
[[foo]]
inherit = FOO, BAR
```

`cylc validate --debug my-suite` gives::

```
Traceback (most recent call last):
  File "/opt/cylc/bin/cylc-validate", line 60, in <module>
    verbose=options.verbose )
  File "/opt/cylc/lib/cylc/config.py", line 277, in __init__
    coerce_runtime_values( self['runtime'][ns] )
  File "/opt/cylc/lib/cylc/config.py", line 90, in coerce_runtime_values
    rdict[item] = str2list( rdict[item] )
  File "/opt/cylc/lib/cylc/config.py", line 67, in str2list
    return re.split( '[, ]+', st )
  File "/usr/lib64/python2.6/re.py", line 167, in split
    return _compile(pattern, 0).split(string, maxsplit)
TypeError: expected string or buffer
```

This change should fix it.
