### PR TITLE
cylc run: fix hung suite caused by bad START time.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -130,6 +130,7 @@ class scheduler(object):
         self.request_handler = None
         self.pyro = None
         self.state_dumper = None
+        self.runtime_graph_on = None
 
         # COMMANDLINE OPTIONS
 
@@ -690,7 +691,7 @@ class scheduler(object):
                 # async integer tag
                 int( tag )
             except ValueError:
-                raise SystemExit( "ERROR:, invalid task tag : " + tag )
+                raise Exception( "ERROR:, invalid task tag : " + tag )
             else:
                 pass
         else:


### PR DESCRIPTION
If we do `cylc run SUITE INVALID-START-STRING` where INVALID-START-STRING is not a valid cycle time string, the suite hangs (even in `--debug` mode). This change allows the suite to shut down.
