### PR TITLE
rundb: replace sys.exit()

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -167,7 +167,7 @@ class CylcRuntimeDAO(object):
         try:
             mkdir_p( suite_dir )
         except Exception, x:
-            raise Exception( str(x) )
+            raise Exception( "ERROR: " + str(x) )
 
         if new_mode:
             if os.path.isdir(self.db_file_name):


### PR DESCRIPTION
Replaces a `sys.exit()` in the `rundb.py` code with a `raise Exception`.

Relates to #294
