### PR TITLE
Correct cylc jobfile Korn shell function definition syntax.

### DIFF
--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -205,9 +205,9 @@ set -u # Fail when using an undefined variable
 # Define the trap handler
 SIGNALS="EXIT ERR TERM XCPU"
 function HANDLE_TRAP {
-    local SIGNAL=$1
+    typeset SIGNAL=$1
     echo "Received signal $SIGNAL"
-    local S=
+    typeset S=
     for S in $SIGNALS; do
         trap "" $S
     done


### PR DESCRIPTION
The documentation notes that the shell command in the job submission
configuration section (i.e. the shell used to interpret the job script
submitted by cylc) allows for either Bourne shell (e.g. /bin/bash)
or a Korn shell (/bin/ksh) since they use similar styles for defining
environment variables.  However, switching this to use the Korn shell
results in a syntax error. The HANDLE_TRAP function written into
the cylc script uses Bourne shell syntax with a '()' following the
function name, which gives an error when parsed by the Korn shell.

This change modifies the function written out to the job file to use
the appropriate (Bourne/Korn) syntax depending on the shell specified
in the suite configuration file.
