### PR TITLE
Allow filename argument for cylc graph.

### DIFF
--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -220,9 +220,17 @@ Arguments:"""
 
         if self.prep:
             # allow file path or suite name 
-            self.suite_info.append( self._getdef( args[0], options ))
-            if self.twosuites:
-                self.suite_info.append( self._getdef( args[1], options ))
+            try:
+                self.suite_info.append( self._getdef( args[0], options ))
+                if self.twosuites:
+                    self.suite_info.append( self._getdef( args[1], options ))
+            except IndexError:
+                if options.filename:
+                    # Empty args list is OK if we supplied a filename
+                    pass
+                else:
+                    # No filename, so we're expecting an argument
+                    self.error( "Need either a filename or suite name(s)" )
 
         return ( options, args )
 


### PR DESCRIPTION
If no filename or suite name is specified for the cylc graph command,
it will unelegantly exit with an index error when it reads the argument
list.  Also, if you use the `-f` option to supply a filename, the parser
will attempt to read the arguments which are blank (and if you supply
anything it will fail validation later).  This means that you cannot
currently supply a filename argument to cylc graph.

This update tolerates an empty suite name if a filename is specified.
If a filename is not specified (and therefore a suite name would be
required) we now exit gracefully printing a usage message rather than
a Python error/traceback.
