### PR TITLE
cylc graph --ungroup option

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -236,7 +236,11 @@ else:
 
 window.widget.connect( 'clicked', on_url_clicked, window )
 
-window.get_graph(ungroup_all=options.ungroup)
+if not options.ungroup:
+    window.get_graph( group_all=True )
+else:
+    window.get_graph( ungroup_all=options.ungroup )
+    
 window.connect( 'destroy', gtk.main_quit)
 
 #if options.updatelive:


### PR DESCRIPTION
For purposes of generating images (i.e. using output=X.pdf) some users would like to have the graph plotted ungrouped.

This adds a --ungroup option to `cylc graph` that allows you to start it up with the graph ungrouped.
