### PR TITLE
Add SLURM mention to documentation.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -4228,6 +4228,32 @@ These are written to the top of the task job script like this:
 #$ -l h_data=1024M,h_rt=24:00:00
 \end{lstlisting}
 
+\subsubsection{slurm}
+
+This job submission method submits tasks to Simple Linux Utility for
+Resource Management using the \lstinline=sbatch= command.  SLURM
+directives can be provided in the suite.rc file (note that since
+not all SLURM commands have a short form, cylc requires the long
+form directives):
+\lstset{language=suiterc}
+\begin{lstlisting}
+# SUITE.RC
+[runtime]
+    [[__NAME__]]
+        [[[directives]]]
+            --nodes = 5
+            --time = 1:00:00
+            --account = QXZ5W2
+\end{lstlisting}
+These are written to the top of the task job script like this:
+\lstset{language=bash}
+\begin{lstlisting}
+#!/bin/bash
+#SBATCH --nodes=5
+#SBATCH --time=1:00:00
+#SBATCH --account=QXZ5W2
+\end{lstlisting}
+
 \subsubsection{Default Directives Provided}
 
 For loadleveler, pbs, and sge job submission, default directives

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -1087,6 +1087,7 @@ Cylc has a number of built in job submission methods:
        \item {\em loadleveler} - \lstinline=llsubmit=, with directives defined in the suite.rc file 
        \item {\em pbs} - PBS \lstinline=qsub=, with directives defined in the suite.rc file 
        \item {\em sge} - Sun Grid Engine \lstinline=qsub=, with directives defined in the suite.rc file 
+       \item {\em slurm} - Simple Linux Utility for Resource Management \lstinline=sbatch=, with directives defined in the suite.rc file.
    \end{myitemize}
 \item {\em default:} \lstinline=background=
 \end{myitemize}


### PR DESCRIPTION
Modify the LaTeX documentation to add a section for SLURM both in
the reference for the suite.rc file as well as the main section on
job submission in the user guide.
