### PR TITLE
Fixed T-N cycle offset bug for n > 24 (HoursOfTheDay cycling)

### DIFF
--- a/lib/cylc/cycling/HoursOfTheDay.py
+++ b/lib/cylc/cycling/HoursOfTheDay.py
@@ -47,7 +47,7 @@ class HoursOfTheDay( cycler ):
                 self.valid_hours.append( int(arg) )
             self.valid_hours.sort()
 
-        # smallest interval between successive cycle times.
+        # smallest interval between successive cycle times
         prev = self.valid_hours[0]
         sml = 24
         for h in self.valid_hours[1:]:


### PR DESCRIPTION
Example:

```
[[[0]]]
    graph = "foo[T-30] = bar"
```

This graph results in bar triggering off foo at T-30; but it is also
used to infer that one of the valid cycle hours of foo is 0z minus 30,
or 18z. Conversion of T-N back to the 0-23 range was broken for N > 24
with the result that foo could sometimes spawn into the wrong cycle.
