### PR TITLE
Default batch size 10, delay zero, for job, event, and poll/kill.

### DIFF
--- a/conf/suiterc/cylc.spec
+++ b/conf/suiterc/cylc.spec
@@ -6,12 +6,12 @@
     log resolved dependencies = boolean( default=False )
     [[job submission]]
         batch size = integer( min=1, default=10 )
-        delay between batches = integer( min=0, default=15 ) # seconds
+        delay between batches = integer( min=0, default=0 ) # seconds
     [[event handler submission]]
-        batch size = integer( min=1, default=5 )
+        batch size = integer( min=1, default=10 )
         delay between batches = integer( min=0, default=0 ) # seconds
     [[poll and kill command submission]]
-        batch size = integer( min=1, default=5 )
+        batch size = integer( min=1, default=10 )
         delay between batches = integer( min=0, default=0 ) # seconds
     [[lockserver]]
         enable = boolean( default=False )


### PR DESCRIPTION
@dpmatthews and @matthewrmshin - as requested.
