### PR TITLE
Don't unnecessarily import from modules depending on pygraphviz.

### DIFF
--- a/lib/cylc/graphing.py
+++ b/lib/cylc/graphing.py
@@ -22,13 +22,11 @@ ImportError due to pygraphviz/graphviz not being installed."""
 import re
 import pygraphviz
 from TaskID import TaskID, AsyncTag
-
+from graphnode import OFFSET_RE
 # TODO: Do we still need autoURL below?
 
 ddmmhh = TaskID.DELIM_RE
 tformat = r'\\n'
-
-OFFSET_RE =re.compile('(\w+)\s*\[\s*T\s*([+-]\s*\d+)\s*\]')
 
 class CGraphPlain( pygraphviz.AGraph ):
     """Directed Acyclic Graph class for cylc dependency graphs."""

--- a/lib/cylc/graphnode.py
+++ b/lib/cylc/graphnode.py
@@ -17,7 +17,7 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from graphing import OFFSET_RE
+OFFSET_RE =re.compile('(\w+)\s*\[\s*T\s*([+-]\s*\d+)\s*\]')
 
 class GraphNodeError( Exception ):
     """


### PR DESCRIPTION
Closes #525.  Two modules use the same compiled regex; store it in the module that does not import pygraphviz.
