### PR TITLE
Fix graph command for namespace graphing.

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -236,10 +236,13 @@ else:
 
 window.widget.connect( 'clicked', on_url_clicked, window )
 
-if not options.ungroup:
-    window.get_graph( group_all=True )
+if options.namespaces:
+    window.get_graph()
 else:
-    window.get_graph( ungroup_all=options.ungroup )
+    if not options.ungroup:
+        window.get_graph( group_all=True )
+    else:
+        window.get_graph( ungroup_all=options.ungroup )
     
 window.connect( 'destroy', gtk.main_quit)
 


### PR DESCRIPTION
The recent --ungroup option only applies to dependency graphs.
