### PR TITLE
Minor bug fix: initialize the dot view task_list.

### DIFF
--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -550,6 +550,8 @@ class lupdater(threading.Thread):
         self.led_liststore = treeview.get_model()
         self._prev_tooltip_task_id = None
 
+        self.task_list = []
+
         self.reconnect()
 
         # generate task state icons


### PR DESCRIPTION
Toggling the family grouping button on an empty dot view panel
(prior to starting a suite) caused a traceback.

@arjclark - please review.
