### PR TITLE
cylc graph: use visualization settings

### DIFF
--- a/bin/cylc-graph
+++ b/bin/cylc-graph
@@ -208,10 +208,7 @@ window.widget.connect( 'clicked', on_url_clicked, window )
 if options.namespaces:
     window.get_graph()
 else:
-    if not window.suiterc.vis_families:
-        window.get_graph( group_all=True )
-    else:
-        window.get_graph()
+    window.get_graph( group_all=not window.suiterc.vis_families )
     
 window.connect( 'destroy', gtk.main_quit)
 


### PR DESCRIPTION
Makes it so if visualization settings are specified they are used by cylc graph on startup rather than the current default group all behaviour.

Addresses the cylc graph part of #538 but not cylc gui part. 
