### PR TITLE
#551: fix cylc trigger in simulation mode

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -529,6 +529,9 @@ class task( object ):
         Run db updates as a result of such errors will also be done by
         the main thread in response to receiving the message."""
 
+        # (see ready_to_run() above)
+        self.manual_trigger = False
+
         if self.__class__.run_mode == 'simulation':
             self.started_time = task.clock.get_datetime()
             self.started_time_real = datetime.datetime.now()
@@ -540,9 +543,6 @@ class task( object ):
 
         self.submit_num += 1
         self.record_db_update("task_states", self.name, self.c_time, submit_num=self.submit_num)
-
-        # (see ready_to_run() above)
-        self.manual_trigger = False
 
         rtconfig = deepcopy( self.__class__.rtconfig )  # (TODO - replace deepcopy)
         self.override( rtconfig, overrides )


### PR DESCRIPTION
This fixes `cylc trigger` in CLI and GUI versions in simulation mode (manual trigger flag was not unset).

It _may_ prevent bugs in real time mode, as the `manual_trigger` flag was not unset until after a few time-intensive functions had been called in `submit` (e.g. updating the database, putting messages in a queue). It is now unset straight away. This may have led to the `submit()` function being called multiple times for a single task submit.

See 52207d7.

@arjclark, please review.
