### PR TITLE
cylc trigger - fix for duplicate submission

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -297,7 +297,7 @@ class task( object ):
         if self.manual_trigger:
             self.retry_delay_timer_start = None
             self.sub_retry_delay_timer_start = None
-            # unset manual trigger flag in submit() because
+            # unset manual trigger flag at set_state_submitting because
             # ready_to_run() is currently called more than once
             # before submission (to test if clock-triggers are ready).
             return True
@@ -407,6 +407,8 @@ class task( object ):
     def set_state_submitting( self ):
         # called by scheduler main thread
         self.set_status( 'submitting' )
+        # See "def ready_to_run" above.
+        self.manual_trigger = False
         self.record_db_update("task_states", self.name, self.c_time, status="submitting")
 
     def set_state_queued( self ):
@@ -528,9 +530,6 @@ class task( object ):
         task failed message being sent for handling by the main thread.
         Run db updates as a result of such errors will also be done by
         the main thread in response to receiving the message."""
-
-        # (see ready_to_run() above)
-        self.manual_trigger = False
 
         if self.__class__.run_mode == 'simulation':
             self.started_time = task.clock.get_datetime()


### PR DESCRIPTION
This follows on from #551, which only addressed problems with cylc trigger in simulation mode.

When a few tasks are triggered nearly at once, there can be a delay before the `batch_submitter` `task_batcher` thread resets the `manual_trigger` attribute in the task by calling the task `submit` method - this delay can be enough to allow it to resubmit the task (still has a  `True` `manual_trigger`) again on the next pass through the `task_pool.py` `process` loop. This moves the `manual_trigger` unsetting step outside the particular batch submitting thread so that there should not be problems with the delay.

@arjclark, please review.
