### PR TITLE
Fix gcylc group/ungroup action triggering

### DIFF
--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -113,6 +113,8 @@ class GraphUpdater(threading.Thread):
         #print "Attempting Update"
         if ( self.last_update_time is not None and
              self.last_update_time >= self.updater.last_update_time ):
+            if self.action_required:
+                return True
             return False
         
         if self.updater.status == "stopped":


### PR DESCRIPTION
The change made in #554 did not protect the "action_required" flag in the `gcylc` graph view updater - this meant that selecting "Group All Families" did not take effect until the next task state change.

@matthewrmshin, please review.
