### PR TITLE
Fix gcylc tree view initial updating

### DIFF
--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -102,8 +102,6 @@ class TreeUpdater(threading.Thread):
             self.dots[ state ] = dotm.get_icon( state )
         self.dots['empty'] = dotm.get_icon()
 
-        self.update()
-
     def connection_lost( self ):
         # clear the ttreestore ...
         self.ttreestore.clear()

--- a/lib/cylc/gui/updater.py
+++ b/lib/cylc/gui/updater.py
@@ -109,6 +109,7 @@ class Updater(threading.Thread):
         self.global_summary = {}
         self.stop_summary = None
         self.ancestors = {}
+        self.ancestors_pruned = {}
         self.descendants = []
         self.god = None
         self.mode = "waiting..."


### PR DESCRIPTION
#554 introduced a change that meant if no states changed then the tree view would not update. This is sensible, except that the first update for the tree updater is at initialisation (unlike the other views) and is made without a corresponding `update_gui`. This means that the tree view then thinks it has nothing left to do (waiting for the next state update).

@matthewrmshin, please review.
