### PR TITLE
task submit numbers: fix reset on reload

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -209,14 +209,14 @@ class CylcRuntimeDAO(object):
 
     def get_task_submit_num(self, name, cycle):
         s_fmt = "SELECT COUNT(*) FROM task_events WHERE name==? AND cycle==? AND event==?"
-        args = [name, cycle, "submitted"]
+        args = [name, cycle, "submitting now"]
         count = self.c.select(s_fmt, args).next()[0]
         submit_num = count + 1 #submission numbers should start at 0
         return submit_num
     
     def get_task_current_submit_num(self, name, cycle):
         s_fmt = "SELECT COUNT(*) FROM task_events WHERE name==? AND cycle==? AND event==?"
-        args = [name, cycle, "submitted"]
+        args = [name, cycle, "submitting now"]
         count = self.c.select(s_fmt, args).next()[0]
         return count
 


### PR DESCRIPTION
This fixes a bug whereby task submit numbers get reset to 0 on reload due to the change of the db event from `submitted` to `submitting now` and `submission succeeded`.

Tweaks the db code to use the event `submitting now` as the one to look for when determining a submit number on initialising a task proxy.

I will add a test to the battery for this in the near future.
