### PR TITLE
Write processed suite.rc to suite dir.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -266,6 +266,12 @@ class config( CylcConfigObj ):
         # handle cylc continuation lines
         suiterc = join( suiterc )
 
+        if self.verbose:
+            print "Writing out the processed suite definition"
+        f = open( self.file + '.processed', 'w' )
+        f.write(''.join(suiterc))
+        f.close()
+
         # parse the file into a sparse data structure
         try:
             CylcConfigObj.__init__( self, suiterc, interpolation=False )


### PR DESCRIPTION
Addresses #548; @dpmatthews and @steoxley - please review.

Note this writes out `suite.rc.processed` to the suite definition directory every time the suite is parsed, which includes validation and "cylc graph", etc., in addition to running and reloading the suite. It would be easy enough to restrict this to running and reloading as you suggested, but it's not entirely clear to me that that's the more desirable behaviour - any strong opinions?
