### PR TITLE
cylc suite state: verbose mode

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -114,8 +114,6 @@ suite = args[0]
 # re-invocation on the db host account).
 run_dir = os.path.expandvars( os.path.expanduser( options.run_dir ))
 
-print options
-
 spoller = suite_poller( "requested state", options.timeout,
         options.interval, args={
             'suite'   : suite,


### PR DESCRIPTION
Have `cylc suite-state` make use of the verbose mode to aid in debugging.

In particular, prints out information as to what database is to be connected to and messages when database not found.

This makes it easier to diagnose a mistyped `REG` or `suite_dir` value and/or the lack of a suite database in the suite concerned.
