### PR TITLE
gsummary - Host scan list should be taken from combined global config.

### DIFF
--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -56,7 +56,7 @@ class SummaryPanelApplet(object):
         setup_icons()
         if not hosts:
             try:
-                hosts = gcfg.sitecfg["suite host scanning"]["hosts"]
+                hosts = gcfg.cfg["suite host scanning"]["hosts"]
             except KeyError:
                 hosts = ["localhost"]
         self.is_compact = is_compact

--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -338,7 +338,7 @@ class SummaryApp(object):
         setup_icons()
         if not hosts:
             try:
-                hosts = gcfg.sitecfg["suite host scanning"]["hosts"]
+                hosts = gcfg.cfg["suite host scanning"]["hosts"]
             except KeyError:
                 hosts = ["localhost"]
         self.hosts = hosts


### PR DESCRIPTION
It was being taken specifically from site config, which would ignore any user override in the cylc user config file.

@benfitzpatrick - please review.
