### PR TITLE
Fix clock triggered task

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -395,6 +395,8 @@ class config( CylcConfigObj ):
                         result.append( member + extn )
                         if type == 'clock-triggered':
                             self.clock_offsets[ member ] = float( offset )
+                else:
+                    self.clock_offsets[ name ] = float( offset )
             self['scheduling']['special tasks'][type] = result
 
         self.collapsed_families_rc = self['visualization']['collapsed families']


### PR DESCRIPTION
cbc86d6b560183c5a281dc6c3b8ec10691a47e02 broke clock triggered tasks.
(It only worked with clock triggered families but not individual tasks.)
