### PR TITLE
Fix non-special clock trigger tasks.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -395,7 +395,7 @@ class config( CylcConfigObj ):
                         result.append( member + extn )
                         if type == 'clock-triggered':
                             self.clock_offsets[ member ] = float( offset )
-                else:
+                elif type == 'clock-triggered':
                     self.clock_offsets[ name ] = float( offset )
             self['scheduling']['special tasks'][type] = result
 


### PR DESCRIPTION
Looks like f289273b26056718da530d57efc5a7aa175544ca has broken it the
other way round.

Sorry, but it looks like my previous change has broken other special tasks.

@hjoliver please review.
