### PR TITLE
job file: fsync to file system before close

### DIFF
--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -89,6 +89,15 @@ class jobfile(object):
 
         self.write_task_succeeded()
         self.write_eof()
+
+        # Ensure that the job file is flushed and synced to the file system.
+        # This is to prevent errors that look like this:
+        #     /bin/bash: SCRIPT: /bin/bash: bad interpreter: Text file busy
+        # which means that the OS thinks that the job file is still being
+        # written to when it is being executed.
+        self.FILE.flush()
+        os.fsync(self.FILE.fileno())
+
         self.FILE.close()
 
     def write_header( self ):


### PR DESCRIPTION
Flush and fsync job file to file system before close. This is an attempt
to prevent this type of error (seen on virtual machines) when we execute
the job file:

```
/bin/bash: SCRIPT: /bin/bash: bad interpreter: Text file busy
```
