### PR TITLE
gpanel: reset idle timer on re-activation

### DIFF
--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -698,6 +698,7 @@ class BaseSummaryTimeoutUpdater(object):
     def start(self):
         """Start looping."""
         self.quit = False
+        self._last_running_time = None
         gobject.timeout_add(1000, self.run)
         return False
 


### PR DESCRIPTION
This fixes a bug where re-activating of an idle gpanel instance does not reset the idle timer - so it idles again!

@matthewrmshin, please review.
