### PR TITLE
gcylc: fix led treeview error

### DIFF
--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -536,7 +536,10 @@ class DotUpdater(threading.Thread):
             self.led_treeview.remove_column(tvc)
 
         self.led_treeview.set_model( self.led_liststore )
-        self.led_treeview.get_selection().set_mode( gtk.SELECTION_NONE )
+        selection = self.led_treeview.get_selection()
+        if selection is not None:
+            # Occasionally, selection can be None (perhaps on closing).
+            selection.set_mode( gtk.SELECTION_NONE )
 
         if hasattr(self.led_treeview, "set_has_tooltip"):
             self.led_treeview.set_has_tooltip(True)


### PR DESCRIPTION
I've noticed that you can sometimes get a traceback when closing the LED view in gcylc:

```
Traceback (most recent call last):
  File "......................./lib/cylc/gui/stateview.py", line 624, in update_gui
    self.ledview_widgets()
  File "...................../lib/cylc/gui/stateview.py", line 540, in ledview_widgets
    self.led_treeview.get_selection().set_mode( gtk.SELECTION_NONE )
AttributeError: 'NoneType' object has no attribute 'set_mode'
```

This seems to happen for very large suites when closing an ungrouped LED view. This change fixes it.

@hjoliver, please review.
