### PR TITLE
Expand tilde in templatevars_file args.

### DIFF
--- a/lib/cylc/CylcOptionParsers.py
+++ b/lib/cylc/CylcOptionParsers.py
@@ -216,7 +216,7 @@ Arguments:"""
 
         if self.jset:
             if options.templatevars_file:
-                options.templatevars_file = os.path.abspath( options.templatevars_file )
+                options.templatevars_file = os.path.abspath( os.path.expanduser( options.templatevars_file ))
 
         if self.prep:
             # allow file path or suite name 


### PR DESCRIPTION
A small change - allow `cylc val --set-file=~/path/to/jinja2.vars SUITE`, for example.

@arjclark, please review.
