### PR TITLE
Fix continual setting of task state to queued.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -156,7 +156,7 @@ class pool(object):
                             readytogo.append(itask)
                         else:
                             # (direct task state reset ok: this executes in the main thread)
-                            if not itask.state.is_currently(['queued']):
+                            if not itask.state.is_currently('queued'):
                                 itask.set_state_queued()
                     else:
                         readytogo.append(itask)


### PR DESCRIPTION
Fixes problem reported by @dpmatthews whereby queued tasks would repeatedly be set to queued resulting in them logging the setting and filling up the suite log.

@hjoliver - please review.
