### PR TITLE
Fix scp and ssh'ing to localhost.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -342,11 +342,12 @@ class scheduler(object):
             r_env_file_path = '%s:%s/cylc-suite-env' % (
                     user_at_host, r_suite_run_dir)
             # just in case the remote dir was deleted:
-            cmd1 = ['ssh', '-oBatchMode=yes', user_at_host, 'mkdir', '-p', r_suite_run_dir]
-            cmd2 = ['scp', '-oBatchMode=yes', env_file_path, r_env_file_path]
-            for cmd in [cmd1,cmd2]:
-                if subprocess.call(cmd): # return non-zero
-                    raise Exception("ERROR: " + str(cmd))
+            if host != 'localhost':
+                cmd1 = ['ssh', '-oBatchMode=yes', user_at_host, 'mkdir', '-p', r_suite_run_dir]
+                cmd2 = ['scp', '-oBatchMode=yes', env_file_path, r_env_file_path]
+                for cmd in [cmd1,cmd2]:
+                    if subprocess.call(cmd): # return non-zero
+                        raise Exception("ERROR: " + str(cmd))
             task.task.suite_contact_env_hosts.append( user_at_host )
 
         self.already_timed_out = False


### PR DESCRIPTION
Fixes a bug that can occur on performing a restart whereby, with tasks running on localhost and strict ssh checking, you can end up with the situation below. Solution is to remove scp and ssh to localhost.

```
2013/07/31 16:36:45 CRITICAL - Suite starting at 2013-07-31 16:36:45.793344
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!

Someone could be eavesdropping on you right now (man-in-the-middle attack)!

It is also possible that the RSA host key has just been changed.

The fingerprint for the RSA key sent by the remote host is
XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX.

Please contact your system administrator.

Add correct host key in /home/andy/.ssh/known_hosts to get rid of this message.

Offending key in /home/andy/.ssh/known_hosts:7

RSA host key for localhost has changed and you have requested strict checking.

Host key verification failed.

Traceback (most recent call last):
  File "/opt/cylc/lib/cylc/run.py", line 74, in main
    server.configure()
  File "/opt/cylc/lib/cylc/scheduler.py", line 351, in configure
    raise Exception("ERROR: " + str(cmd))
Exception: ERROR: ['ssh', '-oBatchMode=yes', 'user@localhost', 'mkdir', '-p', '/home/andy/cylc-run/mot-aa850']
ERROR CAUGHT: cleaning up before exit
THE ERROR WAS:
ERROR: ['ssh', '-oBatchMode=yes', 'user@localhost', 'mkdir', '-p', '/home/andy/cylc-run/mot-aa850']
use --debug to turn on exception tracebacks)
```
