### PR TITLE
Source profiles in detaching tasks, for cylc version selection.

### DIFF
--- a/lib/cylc/command_env.py
+++ b/lib/cylc/command_env.py
@@ -44,8 +44,5 @@ cv_scripting_sl = cv_export + '; ' + '; '.join(s_profile)
 # multi line cylc version scripting:
 cv_scripting_ml = """
 """ + cv_export + """
-
-# Source .profile before turning on error trapping
-# so that errors here do not abort the job script.
 """ + '\n'.join( s_profile )
 

--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -22,7 +22,7 @@ import re, os
 import StringIO
 from copy import deepcopy
 from cylc.global_config import gcfg
-from cylc.command_env import cv_scripting_ml, cv_export
+from cylc.command_env import cv_scripting_ml
 from subprocess import call, PIPE
 from time import sleep 
 
@@ -126,7 +126,8 @@ class jobfile(object):
 
     def write_prelude( self ):
         self.FILE.write( '\n\necho "JOB SCRIPT STARTING"\n')
-        # set cylc version and source profile scripts:
+        # set cylc version and source profile scripts before turning on
+        # error trapping so that profile errors do not abort the job
         self.FILE.write( cv_scripting_ml )
 
     def write_initial_scripting( self, BUFFER=None ):
@@ -321,7 +322,8 @@ cd $CYLC_TASK_WORK_DIR""" )
         # now escape quotes in the environment string
         str = strio.getvalue()
         strio.close()
-        str += '\n' + cv_export
+        # set cylc version and source profiles in the detached job
+        str += '\n' + cv_scripting_ml + '\n'
         str = re.sub('"', '\\"', str )
         self.FILE.write( '\n\n# TRANSPLANTABLE SUITE ENVIRONMENT FOR CUSTOM TASK WRAPPERS:')
         self.FILE.write( '\n# (contains embedded newlines, use may require "QUOTES")' )


### PR DESCRIPTION
Minor change, affects only the "cylc environment" string provided to detaching tasks.  CYLC_VERSION was set in this, but profiles weren't being sourced to allow users to choose between cylc versions based on the value of the variable.
