### PR TITLE
Check redundant state updates

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -1107,7 +1107,9 @@ class task( object ):
         if status != self.state.get_status():
             self.log( 'NORMAL', '(setting:' + status + ')' )
             self.state.set_status( status )
-            self.record_db_update("task_states", self.name, self.c_time, try_num=self.try_number, status=status)
+            self.record_db_update("task_states", self.name, self.c_time, 
+                                  submit_num=self.submit_num, try_num=self.try_number, 
+                                  status=status)
 
     def update( self, reqs ):
         for req in reqs.get_list():


### PR DESCRIPTION
Closes #621

Database state table status updates in `task.py` are now redirected through `set_status`. This has an if statement in it to only carry out the update operation if the task status is not equal to the one being set to.
