### PR TITLE
Convert gcylc stopped state to str in case it is None.

### DIFF
--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -269,9 +269,9 @@ Class to create an information bar.
             icon.show()
             self.state_widget.pack_start( icon, False, False )
             if self._is_suite_stopped:
-                text = str(num) + " tasks stopped with " + state
+                text = str(num) + " tasks stopped with " + str(state)
             else:
-                text = str(num) + " tasks " + state
+                text = str(num) + " tasks " + str(state)
             self._set_tooltip( icon, text )
 
     def set_status(self, status):


### PR DESCRIPTION
@benfitzpatrick - I have a suite that stops with a value of None in your "stopped state", for reasons I don't understand.  This prevents gcylc starting up again - it continually spawns the new error dialogs until killed.

This small change fixes the symptom, which is probably sufficient for now as I can't see any other deleterious effects.  But I'll tar up the suite and email it to you in case it's obvious to you what the root cause is.

```
```
