### PR TITLE
cylc shutdown|stop: fix using a datetime for shutdown

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -531,10 +531,10 @@ class scheduler(object):
 
     def command_stop_after_clock_time( self, arg ):
         # format: YYYY/MM/DD-HH:mm
-        date, time = arg.split('-')
-        yyyy, mm, dd = date.split('/')
-        HH,MM = time.split(':')
-        dtime = datetime( int(yyyy), int(mm), int(dd), int(HH), int(MM) )
+        sdate, stime = arg.split('-')
+        yyyy, mm, dd = sdate.split('/')
+        HH,MM = stime.split(':')
+        dtime = datetime.datetime( int(yyyy), int(mm), int(dd), int(HH), int(MM) )
         self.set_stop_clock( dtime )
 
     def command_stop_after_task( self, tid ):


### PR DESCRIPTION
When using a datetime with `cylc shutdown` (e.g. `cylc shutdown 2013/08/14-15:00`) it was failing to work due to miscalling the datetime module:

```
2013/08/14 11:52:49 WARNING - 'module' object is not callable
2013/08/14 11:52:49 WARNING - Command failed: stop after clock time(2013/08/04-11:54)
```

This fixes the problem. I've also renamed date and time in the def concerned to sdate and stime just to clear up any confusion with the modules themselves.
