### PR TITLE
Fix site/user config under parsec

### DIFF
--- a/lib/cylc/cfgspec/site_spec.py
+++ b/lib/cylc/cfgspec/site_spec.py
@@ -17,6 +17,7 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from parsec.validate import get_defaults
 from parsec.validate import validator as vdr
 from parsec.upgrade import upgrader, converter
 from parsec.loadcfg import load_combined
@@ -81,18 +82,11 @@ SPEC = {
         },
 
     'hosts' : {
-        'localhost' : {
+        '__MANY__' : {
             'run directory'               : vdr( vtype='string', default="$HOME/cylc-run" ),
             'work directory'              : vdr( vtype='string', default="$HOME/cylc-run" ),
             'task communication method'   : vdr( vtype='string', options=[ "pyro", "ssh", "poll"], default="pyro" ),
             'remote shell template'       : vdr( vtype='string', default='ssh -oBatchMode=yes %s' ),
-            'use login shell'             : vdr( vtype='boolean', default=True ),
-            },
-        '__MANY__' : {
-            'run directory'               : vdr( vtype='string', default=None ),
-            'work directory'              : vdr( vtype='string', default=None),
-            'task communication method'   : vdr( vtype='string', options=["pyro","ssh","poll"] ),
-            'remote shell template'       : vdr( vtype='string' ),
             'use login shell'             : vdr( vtype='boolean', default=True ),
             },
         },
@@ -124,9 +118,15 @@ def upg( cfg, descr, verbose ):
 def get_cfg( verbose=False ):
     global cfg
     if not cfg:
-        cfg = load_combined( SITE_FILE, "site config",
-                             USER_FILE, "user config",
-                             SPEC, upg, True, verbose )
+        cfg = load_combined(
+                SITE_FILE, "site config",
+                USER_FILE, "user config",
+                SPEC, upg, True, verbose )
+
+    if 'localhost' not in cfg['hosts']:
+        # localhosts section is required
+        cfg['hosts']['localhost'] = get_defaults( SPEC['hosts']['__MANY__'] )
+
     return cfg
 
 def print_cfg():


### PR DESCRIPTION
Bug: if a host listed in site or user config files does not explicitly define a host item, that item will get the value None, whereas it should default to the intended localhost value.  Under configobj I had to define distinct 'localhost' and '**many**' sections, then override any unset non-localhost items after parsing.  On converting to parsec I broke the final override bit by using dense host structures (with defaults added) instead of sparse ones (just what's in the file).  Anyhow, under parsec we can simply have all host items default to localhost values from the outset, then create a localhost section if necessary after parsing the files (which is what this branch does).

E.g. for this site file:

```
[hosts]
    [[bob]]
        # no items defined
```

On current master `cylc get-global-config --print` shows localhost's run dir etc. as expected, but bob's None. Which will break all job submissions to bob.   On this branch, run dire etc. are as expected for both hosts. 
