### PR TITLE
Apply level zero (no section) defaults for suite.rc.

### DIFF
--- a/lib/cylc/cfgspec/suite_spec.py
+++ b/lib/cylc/cfgspec/suite_spec.py
@@ -236,7 +236,8 @@ def get_expand_nonrt( fpath, template_vars, template_vars_file, do_expand=False,
                     cfg[key] = expand( cfg[key], SPEC[key] )
             else:
                 # top level (no section) items
-                cfg[key] = val.args['default']
+                if key not in cfg:
+                    cfg[key] = val.args['default']
 
     return cfg
 


### PR DESCRIPTION
For suite definitions we do not load all default values at once, in
order to leave a sparse runtime structure for efficient inheritance.
However, in loading defaults for everything but [runtime] I had
neglected to load the top level non-section defaults (just title and
description).

@matthewrmshin, please review.
