### PR TITLE
Fixed reload of async tasks in mixed suites, and sequential tasks.

### DIFF
--- a/lib/cylc/task_state.py
+++ b/lib/cylc/task_state.py
@@ -107,6 +107,9 @@ class task_state(object):
     def set_spawned( self ):
         self.state[ 'spawned' ] = 'true'
 
+    def set_unspawned( self ):
+        self.state[ 'spawned' ] = 'false'
+
     def has_spawned( self ):
         return self.state[ 'spawned' ] == 'true'
 


### PR DESCRIPTION
From @arjclark:

> we've come across a bug with reloading suites which mix cycling with asynchronous tasks ...

New task proxies have their cycle time checked against suite stop times etc. This check was also being applied to async tasks, which have no cycle time.

Also found that sequential tasks, which don't spawned until finished, stalled on reload because task proxy init for the reloaded task assumed succeeded tasks had spawned already.

@arjclark - please review.
