### PR TITLE
#602: gcylc: add ungrouped usercfg

### DIFF
--- a/conf/gcylcrc/cfgspec
+++ b/conf/gcylcrc/cfgspec
@@ -5,6 +5,10 @@
 # One or two of "text", "dot", "graph".
 initial views = force_list( default=list("text", "dot") )
 
+# Views to load in a grouped-by-family state.
+# Any (or zero) of "text", "dot", "graph".
+grouped views = force_list( default=list("text", "dot") )
+
 # Task state color themes are defined in
 #   $CYLC_DIR/conf/gcylcrc/themes.rc
 # (note the "default" theme MUST be defined in themes.rc)

--- a/conf/gcylcrc/gcylc.rc.eg
+++ b/conf/gcylcrc/gcylc.rc.eg
@@ -7,8 +7,9 @@
 #    (b) inheriting from an existing theme and overriding specific
 #     colors (see the "PinkRun" example below).
 
-initial views = text, dot  # set your default views
-use theme = PinkRun        # set your default theme
+initial views = text, dot     # set your default views
+grouped views = text, dot     # set your initially grouped views
+use theme = PinkRun           # set your default theme
 
 [themes]
     [[PinkRun]] # override the 'running' color in the 'default' theme

--- a/lib/cylc/cfgspec/gcylc_spec.py
+++ b/lib/cylc/cfgspec/gcylc_spec.py
@@ -32,6 +32,7 @@ cfg = None
 
 SPEC = {
     'initial views' : vdr( vtype='string_list', default=["text","dot"] ),
+    'grouped views' : vdr( vtype='string_list', default=["text","dot"] ),
     'use theme'     : vdr( vtype='string', default="default" ),
     'themes' : {
         '__MANY__' : {

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -104,7 +104,8 @@ class InitData(object):
 Class to hold initialisation data.
     """
     def __init__( self, suite, owner, host, port, db,
-            pyro_timeout, template_vars, template_vars_file ):
+            pyro_timeout, template_vars, template_vars_file,
+            grouped_views ):
         self.suite = suite
         self.owner = owner
         self.host = host
@@ -122,6 +123,7 @@ Class to hold initialisation data.
             self.template_vars_opts += " --set-file " + template_vars_file
         self.template_vars = template_vars
         self.template_vars_file = template_vars_file
+        self.grouped_views = grouped_views
 
         self.gcfg = get_global_cfg()
         self.cylc_tmpdir = self.gcfg.get_tmpdir()
@@ -356,7 +358,8 @@ Main Control GUI that displays one or more views or interfaces to the suite.
         set_exception_hook_dialog("gcylc")
 
         self.cfg = InitData( suite, owner, host, port, db, 
-                pyro_timeout, template_vars, template_vars_file )
+                pyro_timeout, template_vars, template_vars_file,
+                self.usercfg["grouped views"] )
 
         self.theme_name = self.usercfg['use theme'] 
         self.theme = self.usercfg['themes'][ self.theme_name ]

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -331,8 +331,12 @@ Dependency graph suite control interface.
     def group_all( self, w, group ):
         if group:
             self.t.group_all = True
+            if "graph" not in self.cfg.grouped_views:
+                self.cfg.grouped_views.append("graph")
         else:
             self.t.ungroup_all = True
+            if "graph" in self.cfg.grouped_views:
+                self.cfg.grouped_views.remove("graph")
         self.t.action_required = True
         self.t.best_fit = True
 

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -129,6 +129,11 @@ LED suite control interface.
         group_on = toggle_item.get_active()
         if group_on == self.t.should_group_families:
             return False
+        if group_on:
+            if "dot" not in self.cfg.grouped_views:
+                self.cfg.grouped_views.append("dot")
+        elif "dot" in self.cfg.grouped_views:
+            self.cfg.grouped_views.remove("dot")
         self.t.should_group_families = group_on
         if isinstance( toggle_item, gtk.ToggleToolButton ):
             if group_on:

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -124,6 +124,11 @@ Text Treeview suite control interface.
         group_on = toggle_item.get_active()
         if group_on == self.t.should_group_families:
             return False
+        if group_on:
+            if "text" not in self.cfg.grouped_views:
+                self.cfg.grouped_views.append("text")
+        elif "text" in self.cfg.grouped_views:
+            self.cfg.grouped_views.remove("text")
         self.t.should_group_families = group_on
         if isinstance( toggle_item, gtk.ToggleToolButton ):
             if group_on:

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -53,7 +53,6 @@ class GraphUpdater(threading.Thread):
         self.filter_exclude = None
         self.state_filter = None
 
-        self.should_group_families = False
         self.descendants = {}
         self.all_families = []
         self.triggering_families = []
@@ -87,8 +86,12 @@ class GraphUpdater(threading.Thread):
         self.group = []
         self.ungroup = []
         self.ungroup_recursive = False
-        self.group_all = False
-        self.ungroup_all = False
+        if "graph" in self.cfg.grouped_views:
+            self.ungroup_all = False
+            self.group_all = True
+        else:
+            self.ungroup_all = True
+            self.group_all = False
 
         self.graph_frame_count = 0
 
@@ -122,10 +125,7 @@ class GraphUpdater(threading.Thread):
             return False
 
         self.updater.set_update(False)
-        if not self.should_group_families:
-            self.task_list = deepcopy(self.updater.task_list)
-        else:
-            self.task_list = []
+        self.task_list = deepcopy(self.updater.task_list)
         self.live_graph_movie = self.updater.live_graph_movie
         self.live_graph_dir = self.updater.live_graph_dir
         states_full = deepcopy(self.updater.state_summary)


### PR DESCRIPTION
This closes #602. It allows the user to configure the initial grouping of the gcylc views. It should also store the group choices if the grouping for a view is changed by the user and then the view is closed and reopened.

@hjoliver, please review.
