### PR TITLE
Unbreak "[viz]collapsed families" for initial gcylc graph view.

### DIFF
--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -86,11 +86,10 @@ class GraphUpdater(threading.Thread):
         self.group = []
         self.ungroup = []
         self.ungroup_recursive = False
+        self.ungroup_all = False
         if "graph" in self.cfg.grouped_views:
-            self.ungroup_all = False
             self.group_all = True
         else:
-            self.ungroup_all = True
             self.group_all = False
 
         self.graph_frame_count = 0


### PR DESCRIPTION
Broken by the previous merge. 

If `[visualization]collapsed families` is defined in a suite, the listed families should be grouped at start-up. Otherwise all families should be collapsed or not, depending on the new gcylc.rc settings.  This works so long as the ungroup_all flag is always False at start-up.
