### PR TITLE
Only write *.processed file for suite.rc

### DIFF
--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -300,12 +300,13 @@ def parse( fpath, verbose=False,
     flines = read_and_proc( fpath, verbose, 
             template_vars, template_vars_file )
     # write the processed 
-    fp = fpath + '.processed'
-    if verbose:
-        print "Writing file" + fp
-    f = open( fp, 'w' )
-    f.write('\n'.join(flines))
-    f.close()
+    if fpath.endswith("suite.rc"):
+        fp = fpath + '.processed'
+        if verbose:
+            print "Writing file" + fp
+        f = open( fp, 'w' )
+        f.write('\n'.join(flines))
+        f.close()
 
     nesting_level = 0
     config = OrderedDict()


### PR DESCRIPTION
Fix: `gcylc` does not start if user does not have permission to write to
`$CYLC_HOME/conf/gcylcrc/themes.rc.processed`.
