### PR TITLE
Future trigger final-cycle check should ignore async tasks.

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1582,10 +1582,14 @@ class scheduler(object):
     def task_has_future_trigger_overrun( self, itask ):
         # check for future triggers extending beyond the final cycle
         if not self.stop_tag:
-            return
+            return False
         for pct in itask.prerequisites.get_target_tags():
-            if int( ct(pct).get() ) > int(self.stop_tag):
-                return True
+            try:
+                if int( ct(pct).get() ) > int(self.stop_tag):
+                    return True
+            except:
+                # pct invalid cycle time => is an asynch trigger
+                pass
         return False
 
     def add_new_task_proxy( self, new_task, prev_instance=None ):


### PR DESCRIPTION
Else we get an illegal cycle time error. This only applies if the suite has a stop cycle.

This addresses a problem reported by email from @arjclark. 

This is related to #637 but slightly different.  After suite reload, new task proxies go through some checks, some of which are only relevant to cycling tasks (such as comparing task cycle time with suite stop cycle).  #637 prevented async tasks themselves from going through checks specific to cycling tasks (=> illegal cycle-time error).  This left open one loophole though - if the suite has a stop cycle, cycling tasks have their upstream prerequisites checked for future-triggers that extend beyond the stop cycle. And if the upstream task was asynchronous, this cycle time comparison also raised a cycle time error.
