### PR TITLE
gcylc: fix viewing the suite err file

### DIFF
--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -2968,7 +2968,7 @@ For more Stop options use the Control menu.""" )
             if type == 'out':
                 xopts = ' --stdout '
             elif type == 'err':
-                xopts == ' --stderr '
+                xopts = ' --stderr '
             else:
                 xopts = ' '
 


### PR DESCRIPTION
This fixes the functionality launched from the menu `Suite -> Std Error`.

@hjoliver, please review (this is an easy one!).
