### PR TITLE
#645: ungrouped views user config setting

### DIFF
--- a/conf/gcylcrc/cfgspec
+++ b/conf/gcylcrc/cfgspec
@@ -7,7 +7,7 @@ initial views = force_list( default=list("text", "dot") )
 
 # Views to load in a grouped-by-family state.
 # Any (or zero) of "text", "dot", "graph".
-grouped views = force_list( default=list("text", "dot") )
+ungrouped views = force_list( default=list() )
 
 # Task state color themes are defined in
 #   $CYLC_DIR/conf/gcylcrc/themes.rc

--- a/conf/gcylcrc/gcylc.rc.eg
+++ b/conf/gcylcrc/gcylc.rc.eg
@@ -8,7 +8,7 @@
 #     colors (see the "PinkRun" example below).
 
 initial views = text, dot     # set your default views
-grouped views = text, dot     # set your initially grouped views
+ungrouped views = graph       # set your initially ungrouped views
 use theme = PinkRun           # set your default theme
 
 [themes]

--- a/lib/cylc/cfgspec/gcylc_spec.py
+++ b/lib/cylc/cfgspec/gcylc_spec.py
@@ -32,7 +32,7 @@ cfg = None
 
 SPEC = {
     'initial views' : vdr( vtype='string_list', default=["text","dot"] ),
-    'grouped views' : vdr( vtype='string_list', default=["text","dot"] ),
+    'ungrouped views' : vdr( vtype='string_list', default=[] ),
     'use theme'     : vdr( vtype='string', default="default" ),
     'themes' : {
         '__MANY__' : {

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1279,17 +1279,20 @@ class config( object ):
 
         if self.first_graph:
             self.first_graph = False
-            if not self.collapsed_families_rc:
+            if not self.collapsed_families_rc and not ungroup_all:
                 # initially default to collapsing all families if
                 # "[visualization]collapsed families" not defined
                 group_all = True
 
         if group_all:
             # Group all family nodes
-            for fam in members:
-                if fam != 'root':
-                    if fam not in self.closed_families:
-                        self.closed_families.append( fam )
+            if self.collapsed_families_rc:
+                self.closed_families = copy(self.collapsed_families_rc)
+            else:
+                for fam in members:
+                    if fam != 'root':
+                        if fam not in self.closed_families:
+                            self.closed_families.append( fam )
         elif ungroup_all:
             # Ungroup all family nodes
             self.closed_families = []

--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -105,7 +105,7 @@ Class to hold initialisation data.
     """
     def __init__( self, suite, owner, host, port, db,
             pyro_timeout, template_vars, template_vars_file,
-            grouped_views ):
+            ungrouped_views ):
         self.suite = suite
         self.owner = owner
         self.host = host
@@ -123,7 +123,7 @@ Class to hold initialisation data.
             self.template_vars_opts += " --set-file " + template_vars_file
         self.template_vars = template_vars
         self.template_vars_file = template_vars_file
-        self.grouped_views = grouped_views
+        self.ungrouped_views = ungrouped_views
 
         self.gcfg = get_global_cfg()
         self.cylc_tmpdir = self.gcfg.get_tmpdir()
@@ -359,7 +359,7 @@ Main Control GUI that displays one or more views or interfaces to the suite.
 
         self.cfg = InitData( suite, owner, host, port, db, 
                 pyro_timeout, template_vars, template_vars_file,
-                self.usercfg["grouped views"] )
+                self.usercfg["ungrouped views"] )
 
         self.theme_name = self.usercfg['use theme'] 
         self.theme = self.usercfg['themes'][ self.theme_name ]

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -195,6 +195,8 @@ Dependency graph suite control interface.
 
     def grouping( self, w, name, group, rec=False ):
         self.t.ungroup_recursive = rec
+        self.t.group_all = False
+        self.t.ungroup_all = False
         if group:
             self.t.group.append(name)
         else:
@@ -331,12 +333,14 @@ Dependency graph suite control interface.
     def group_all( self, w, group ):
         if group:
             self.t.group_all = True
-            if "graph" not in self.cfg.grouped_views:
-                self.cfg.grouped_views.append("graph")
+            self.t.ungroup_all = False
+            if "graph" in self.cfg.ungrouped_views:
+                self.cfg.ungrouped_views.remove("graph")
         else:
             self.t.ungroup_all = True
-            if "graph" in self.cfg.grouped_views:
-                self.cfg.grouped_views.remove("graph")
+            self.t.group_all = False
+            if "graph" not in self.cfg.ungrouped_views:
+                self.cfg.ungrouped_views.append("graph")
         self.t.action_required = True
         self.t.best_fit = True
 

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -130,10 +130,10 @@ LED suite control interface.
         if group_on == self.t.should_group_families:
             return False
         if group_on:
-            if "dot" not in self.cfg.grouped_views:
-                self.cfg.grouped_views.append("dot")
-        elif "dot" in self.cfg.grouped_views:
-            self.cfg.grouped_views.remove("dot")
+            if "dot" in self.cfg.ungrouped_views:
+                self.cfg.ungrouped_views.remove("dot")
+        elif "dot" not in self.cfg.ungrouped_views:
+            self.cfg.ungrouped_views.append("dot")
         self.t.should_group_families = group_on
         if isinstance( toggle_item, gtk.ToggleToolButton ):
             if group_on:

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -125,10 +125,10 @@ Text Treeview suite control interface.
         if group_on == self.t.should_group_families:
             return False
         if group_on:
-            if "text" not in self.cfg.grouped_views:
-                self.cfg.grouped_views.append("text")
-        elif "text" in self.cfg.grouped_views:
-            self.cfg.grouped_views.remove("text")
+            if "text" in self.cfg.ungrouped_views:
+                self.cfg.ungrouped_views.remove("text")
+        elif "text" not in self.cfg.ungrouped_views:
+            self.cfg.ungrouped_views.append("text")
         self.t.should_group_families = group_on
         if isinstance( toggle_item, gtk.ToggleToolButton ):
             if group_on:

--- a/lib/cylc/gui/stateview.py
+++ b/lib/cylc/gui/stateview.py
@@ -91,7 +91,7 @@ class TreeUpdater(threading.Thread):
         self.autoexpand_states = [ 'queued', 'submitting', 'submitted', 'running', 'failed' ]
         self._last_autoexpand_me = []
         self.ttree_paths = ttree_paths  # Dict of paths vs all descendant node states
-        self.should_group_families = ("text" in self.cfg.grouped_views)
+        self.should_group_families = ("text" not in self.cfg.ungrouped_views)
         self.ttreeview = ttreeview
         # Hierarchy of models: view <- sorted <- filtered <- base model
         self.ttreestore = ttreeview.get_model().get_model().get_model()
@@ -388,7 +388,7 @@ class DotUpdater(threading.Thread):
         self.quit = False
         self.autoexpand = True
         self.should_hide_headings = False
-        self.should_group_families = ("dot" in cfg.grouped_views)
+        self.should_group_families = ("dot" not in cfg.ungrouped_views)
 
         self.cfg = cfg
         self.updater = updater

--- a/lib/cylc/gui/xstateview.py
+++ b/lib/cylc/gui/xstateview.py
@@ -86,11 +86,12 @@ class GraphUpdater(threading.Thread):
         self.group = []
         self.ungroup = []
         self.ungroup_recursive = False
-        self.ungroup_all = False
-        if "graph" in self.cfg.grouped_views:
-            self.group_all = True
-        else:
+        if "graph" in self.cfg.ungrouped_views:
+            self.ungroup_all = True
             self.group_all = False
+        else:
+            self.ungroup_all = False
+            self.group_all = True
 
         self.graph_frame_count = 0
 
@@ -296,12 +297,6 @@ class GraphUpdater(threading.Thread):
             n.attr['color'] = '#888888'
             n.attr['fillcolor'] = 'white'
             n.attr['fontcolor'] = '#888888'
-
-        self.group = []
-        self.ungroup = []
-        self.group_all = False
-        self.ungroup_all = False
-        self.ungroup_recursive = False
 
         self.rem_nodes = []
 


### PR DESCRIPTION
This addresses #645: `grouped views` is now `ungrouped views`, and the default for all views is grouped. I think it preserves the intended `collapsed families` visualisation behaviour, as a modification to `group all`.

@hjoliver, what do you think?
