### PR TITLE
Restore retention of collapsed state in graph viewer on reload.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -186,15 +186,19 @@ class config( object ):
             self.cfg['scheduling']['special tasks'][type] = result
 
         self.collapsed_families_rc = self.cfg['visualization']['collapsed families']
-        if len( collapsed ) > 0:
-            # this overrides the rc file item
+        if is_reload:
+            # on suite reload retain an existing state of collapse
+            # (used by the "cylc graph" viewer)
             self.closed_families = collapsed
+            fromrc = False
         else:
             self.closed_families = self.collapsed_families_rc
+            fromrc = True
         for cfam in self.closed_families:
-            if cfam not in self.runtime['descendants'] and self.verbose:
-                print >> sys.stderr, 'WARNING, [visualization][collapsed families]: family ' + cfam + ' not defined'
+            if cfam not in self.runtime['descendants']:
                 self.closed_families.remove( cfam )
+                if fromrc and self.verbose:
+                    print >> sys.stderr, 'WARNING, [visualization][collapsed families]: family ' + cfam + ' not defined'
 
         # check for run mode override at suite level
         if self.cfg['cylc']['force run mode']:

--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -28,8 +28,35 @@ from cycle_time import ct
 from graphing import CGraphPlain
 from TaskID import TaskID
 
-class MyDotWindow2( xdot.DotWindow ):
+"""
+Cylc-modified xdot windows for the "cylc graph" command.
+TODO - factor more commonality out of MyDotWindow, MyDotWindow2
+"""
+
+class CylcDotViewerCommon( xdot.DotWindow ):
+    def load_config( self ):
+        print 'loading the suite definition'
+        if self.suiterc:
+            is_reload = True
+            collapsed = self.suiterc.closed_families
+        else:
+            is_reload = False
+            collapsed = []
+        try:
+            self.suiterc = config.config( self.suite, self.file,
+                    template_vars=self.template_vars,
+                    template_vars_file=self.template_vars_file,
+                    is_reload=is_reload, collapsed=collapsed )
+        except Exception, x:
+            print >> sys.stderr, "Failed - parsing error?"
+            print >> sys.stderr, x
+            return False
+        self.inherit = self.suiterc.get_parent_lists()
+        return True
+ 
+class MyDotWindow2( CylcDotViewerCommon ):
     """Override xdot to get rid of some buttons and parse graph from suite.rc"""
+    # used by "cylc graph" to plot runtime namespace graphs
 
     ui = '''
     <ui>
@@ -52,6 +79,7 @@ class MyDotWindow2( xdot.DotWindow ):
         self.disable_output_image = False
         self.suite = suite
         self.file = suiterc
+        self.suiterc = None
         self.watch = []
         self.orientation = orientation
         self.template_vars = template_vars
@@ -149,30 +177,6 @@ class MyDotWindow2( xdot.DotWindow ):
             else:
                 time.sleep(1)
 
-    def load_config( self, reload=False ):
-        if reload:
-            print 'Reloading the suite.rc file.'
-            try:
-                self.suiterc = config.config( self.suite, self.file,
-                        template_vars=self.template_vars,
-                        template_vars_file=self.template_vars_file,
-                        collapsed=self.suiterc.closed_families )
-            except Exception, x:
-                print >> sys.stderr, "Failed to reload suite.rc file (parsing error?)."
-                print >> sys.stderr, x
-                return False
-        else:
-            try:
-                self.suiterc = config.config( self.suite, self.file,
-                        template_vars=self.template_vars,
-                        template_vars_file=self.template_vars_file )
-            except Exception, x:
-                print >> sys.stderr, "Failed to load suite.rc file (parsing error?)."
-                print >> sys.stderr, x
-                return False
-        self.inherit = self.suiterc.get_parent_lists()
-        return True
-
     def get_graph( self ):
         title = self.suite + ' runtime namespace inheritance graph'
         graph = CGraphPlain( title )
@@ -251,15 +255,16 @@ class MyDotWindow2( xdot.DotWindow ):
                     break
         if reparse:
             while True:
-                if self.load_config(reload=True):
+                if self.load_config():
                     break
                 else:
                     time.sleep(1)
             self.get_graph()
         return True
 
-class MyDotWindow( xdot.DotWindow ):
+class MyDotWindow( CylcDotViewerCommon ):
     """Override xdot to get rid of some buttons and parse graph from suite.rc"""
+    # used by "cylc graph" to plot dependency graphs
 
     ui = '''
     <ui>
@@ -287,6 +292,7 @@ class MyDotWindow( xdot.DotWindow ):
         self.disable_output_image = False
         self.suite = suite
         self.file = suiterc
+        self.suiterc = None
         self.ctime = ctime
         self.raw = False
         self.stop_after = stop_after
@@ -395,29 +401,6 @@ class MyDotWindow( xdot.DotWindow ):
             else:
                 time.sleep(1)
 
-    def load_config( self, reload=False ):
-        if reload:
-            print 'Reloading the suite.rc file.'
-            try:
-                self.suiterc = config.config( self.suite, self.file, 
-                        template_vars=self.template_vars,
-                        template_vars_file=self.template_vars_file,
-                        collapsed=self.suiterc.closed_families )
-            except Exception, x:
-                print >> sys.stderr, "Failed to reload suite.rc file (parsing error?):"
-                print >> sys.stderr, x
-                return False
-        else:
-            try:
-                self.suiterc = config.config( self.suite, self.file,
-                        template_vars=self.template_vars,
-                        template_vars_file=self.template_vars_file )
-            except Exception, x:
-                print >> sys.stderr, "Failed to load suite.rc file (parsing error?):"
-                print >> sys.stderr, x
-                return False
-        return True
-
     def group_all( self, w ):
         self.get_graph( group_all=True )
 
@@ -523,7 +506,7 @@ class MyDotWindow( xdot.DotWindow ):
                     break
         if reparse:
             while True:
-                if self.load_config(reload=True):
+                if self.load_config():
                     break
                 else:
                     time.sleep(1)
@@ -656,6 +639,4 @@ class xdot_widgets(object):
 
     def on_reload(self, action):
         self.widget.reload()
-        
-
 


### PR DESCRIPTION
And do a little refactoring in the cylc_xdot module.

Since dumping configobj (I think) the graph viewer ("cylc graph" not gcylc graph view) was not retaining an  existing family-collapsed if the suite.rc file changed and was reloaded.  Also factored out some redundancy from the two classes derived from xdot.DotWindow - one for dependency graphs, one for runtime namespace graphs - although more could be done there (back in the day namespace graph functionality was quickly tacked on by copying the dep graph window class and making a few minor changes, and I never got back to clean up properly :-(
