### PR TITLE
cylc suite global held state: fix trigger, release

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1568,7 +1568,7 @@ class scheduler(object):
             return
 
         # tasks beyond the runahead limit
-        if self.runahead_limit:
+        if is_newly_added and self.runahead_limit:
             ouct = self.get_runahead_base()
             foo = ct( new_task.c_time )
             foo.decrement( hours=self.runahead_limit )


### PR DESCRIPTION
At the moment, starting a suite with `cylc run --hold` (or holding a suite mid-run) blocks the release or manual trigger of any task. I think this is because of dde9c3ca, which continuously forces the held state for every 'waiting' task in the main loop. This isn't necessary under a suite hold state because the relevant `hold_suite` command holds all existing tasks - it's just necessary to make sure new tasks are treated properly.

This change makes sure that new tasks have their state recalculated before they are added.

It's possible that other if blocks in the `check_hold_waiting_tasks` method may need similar treatment - I'm thinking of the runahead block specifically.

@hjoliver, please review.
