### PR TITLE
Deprecated --non-daemon to --no-detach

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -37,7 +37,7 @@ class restart( scheduler ):
 Restart a cylc suite from a previous state. To start from scratch see
 the 'cylc run' command.
 
-Suites run in daemon mode unless -n/--non-daemon or --debug is used.
+Suites run in daemon mode unless -n/--no-detach or --debug is used.
 
 The most recent previous state is loaded by default, but other states
 can be specified on the command line (cylc writes special state dumps
@@ -51,10 +51,14 @@ where they got to while the suite was down."""
                         suite state dump directory unless an absolute path
                         is given. Defaults to the most recent suite state.""")]) 
 
-        self.parser.add_option( "-n", "--non-daemon",
-                help="Do not daemonize the suite",
+        self.parser.add_option( "--non-daemon",
+                help="(deprecated: use --no-detach)",
                 action="store_true", default=False, dest="no_detach" )
 
+        self.parser.add_option( "-n", "--no-detach",
+                help="Do not daemonize the suite",
+                action="store_true", default=False, dest="no_detach" )
+ 
         self.parser.add_option( "--ignore-final-cycle", 
             help="Ignore the final cycle time in the state dump. If one is"
             "specified in the suite definition it will be used, however.",

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -34,7 +34,7 @@ class start( scheduler ):
 Start a suite running at a specified initial cycle time. To restart from
 a previous state see the 'cylc restart' command.
 
-Suites run in daemon mode unless -n/--non-daemon or --debug is used.
+Suites run in daemon mode unless -n/--no-detach or --debug is used.
 
 The following are all equivalent if no intercycle dependence exists:
   1/ Cold start (default)    : use special cold-start tasks 
@@ -61,7 +61,11 @@ initial and final cycle time variables persists across suite restarts."""
                          the suite has no cycling tasks. Overrides an 
                          initial cycle time in the suite definition.""")])
 
-        self.parser.add_option( "-n", "--non-daemon",
+        self.parser.add_option( "--non-daemon",
+                help="(deprecated: use --no-detach)",
+                action="store_true", default=False, dest="no_detach" )
+
+        self.parser.add_option( "-n", "--no-detach",
                 help="Do not daemonize the suite",
                 action="store_true", default=False, dest="no_detach" )
 


### PR DESCRIPTION
A very minor change - I think `--no-detach` is better/more "standard" than `--non-daemon`. The latter still works in case anyone is using it though.

@arjclark et. al. - please review.
