### PR TITLE
Updated the admin import-examples command.

### DIFF
--- a/bin/cylc-import-examples
+++ b/bin/cylc-import-examples
@@ -20,12 +20,14 @@ set -e
 
 usage() {
     echo ""
-    echo "USAGE: cylc [admin] import-examples TOPDIR"
+    echo "USAGE: cylc [admin] import-examples DIR [GROUP]"
     echo ""
-    echo "Copy the cylc example suites to TOPDIR and register them for use."
+    echo "Copy the cylc example suites to DIR/GROUP and register"
+    echo "them for use under the GROUP suite name group."
     echo ""
     echo "Arguments:"
-    echo "   TOPDIR     Example suite destination directory: TOPDIR/examples/."
+    echo "   DIR    destination directory"
+    echo "   GROUP  suite name group (default: cylc-<version>)"
 }
 
 if [[ $1 == '-h' ]] || [[ $1 == '--help' ]]; then
@@ -39,38 +41,45 @@ if [[ -z $CYLC_DIR ]]; then
     exit 1
 fi
 
-if [[ $# != 1 ]]; then
-    echo "ERROR: TOPDIR required"
-    exit 0
+if [[ $# > 2 ]] || [[ $# < 1 ]]; then
+    usage >&2
+    exit 1
 fi
 
-TOPDIR=$1
+DIR=$1
 
-CYLC_VERSION=$( cylc -v )
-SSE=$( date +%s )
-TOP=cylc-$( echo $CYLC_VERSION | tr '.' '-' )-$SSE
+if [[ $# == 2 ]]; then
+    TOPGRP=$2
+else
+    TOPGRP=cylc-$( cylc -v | tr '.' '-' )
+fi
 
-echo " + Copying example suites to $TOPDIR"
+if $( cylc db print --fail $TOPGRP > /dev/null 2>&1 ); then
+    echo "ERROR: the $TOPGRP name group already exists." >&2
+    echo " Reregister it, or choose another name group." >&2
+    exit 1
+fi
+
+TOPDIR=$DIR/$TOPGRP
+
+if [[ -d $TOPDIR ]]; then
+    echo "ERROR: directory $TOPDIR already exists." >&2
+    echo "Remove it, or choose another DIR ($DIR)." >&2
+    exit 1
+fi
+
+echo " + Copying example suites"
 mkdir -p $TOPDIR
-cp -r $CYLC_DIR/examples $TOPDIR
+cp -r $CYLC_DIR/examples/* $TOPDIR
 
 echo " + Registering example suites"
-cd $TOPDIR/examples
+cd $TOPDIR
 SUITE_RCS=$( find . -name suite.rc | sed -e 's@./@@' )
 for SUITE_RC in $SUITE_RCS; do
     SUITE_DEF_DIR=$( dirname $SUITE_RC )
-    SUITE_REG_NAME=${TOP}.$( echo $SUITE_DEF_DIR | tr '/' '.' )
+    SUITE_REG_NAME=${TOPGRP}.$( echo $SUITE_DEF_DIR | tr '/' '.' )
     cylc db register $SUITE_REG_NAME $SUITE_DEF_DIR
 done
 
-echo
-echo "______________________________________________________________________"
-echo "NOTE: the example suites have been registered with seconds since epoch"
-echo "appended to the cylc version group name: $TOP"
-echo "This is to ensure uniqueness in case you modify the example suites and"
-echo "import them again at the same cylc version. You may want to reregister"
-echo "the group to plain cylc-$CYLC_VERSION after deleting any older uploads."
-echo "----------------------------------------------------------------------"
-echo
-
 echo "DONE"
+


### PR DESCRIPTION
A minor tutorial related change - allows giving a sensible reg group name to the example suites at import time (`cylc import-examples`) instead of having to rename them after import.

@arjclark et.al. - please review. 
