### PR TITLE
Changed default command scripting.

### DIFF
--- a/lib/cylc/cfgspec/suite_spec.py
+++ b/lib/cylc/cfgspec/suite_spec.py
@@ -128,7 +128,7 @@ SPEC = {
             'initial scripting'               : vdr( vtype='string' ),
             'environment scripting'           : vdr( vtype='string' ),
             'pre-command scripting'           : vdr( vtype='string' ),
-            'command scripting'               : vdr( vtype='string', default='echo Default command scripting; sleep $(cylc rnd 1 16)'),
+            'command scripting'               : vdr( vtype='string', default='echo Hello World!; sleep $(cylc rnd 1 16)'),
             'post-command scripting'          : vdr( vtype='string' ),
             'retry delays'                    : vdr( vtype='m_float_list', default=[] ),
             'manual completion'               : vdr( vtype='boolean', default=False ),
@@ -144,7 +144,7 @@ SPEC = {
                 'disable retries'             : vdr( vtype='boolean', default=True ),
                 },
             'dummy mode' : {
-                'command scripting'              : vdr( vtype='string', default='echo Dummy command scripting; sleep $(cylc rnd 1 16)'),
+                'command scripting'              : vdr( vtype='string', default='echo Hello World!; sleep $(cylc rnd 1 16)'),
                 'disable pre-command scripting'  : vdr( vtype='boolean', default=True ),
                 'disable post-command scripting' : vdr( vtype='boolean', default=True ),
                 'disable task event hooks'       : vdr( vtype='boolean', default=True ),


### PR DESCRIPTION
A very minor change, useful for the new tutorial: makes the default command scripting "echo Hello World!" instead of "echo Default command scripting".  The default command scripting used to print task ID information, but that is now done automatically for all tasks, in another job script section; so the actual content of the default "command scripting" item doesn't matter much.

@arjclark et.al. - please review.
