### PR TITLE
Fix parsec.fileparse

### DIFF
--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -81,7 +81,7 @@ r"""
       )*                  # finish {(special normal*)*} construct.
     )                     # end string contents.
     ')             # closing quote
-    (?:\s*\#.*)?$    # optional trailing comment
+    (?:\s*(?:\#.*)?)?$    # optional trailing comment
     """, re.VERBOSE )
 
 _DQ_VALUE = re.compile( 
@@ -95,7 +95,7 @@ r"""
       )*                  # finish {(special normal*)*} construct.
     )                     # end string contents.
     ")             # closing quote
-    (?:\s*\#.*)?$    # optional trailing comment
+    (?:\s*(?:\#.*)?)?$    # optional trailing comment
     """, re.VERBOSE )
 
 


### PR DESCRIPTION
Write `suite.rc.processed` only if `suite.rc` lives in a directory writeable by the current process.

Allow and ignore white spaces after a quoted string. This is currently a syntax error. (Please feel free to reject this, as trailing white space is not good style.)

@hjoliver please review.
