### PR TITLE
Flag task processing on task submission.

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -942,6 +942,11 @@ class task( object ):
             # (A fake task message from the job submission thread).
             # (note it is possible for 'task started' to arrive first).
             
+            # flag another round through the task processing loop to
+            # allow submitted tasks to spawn even if nothing else is
+            # happening
+            flags.pflag = True
+ 
             # TODO - should we use the real event time from the message here?
             self.submitted_time = task.clock.get_datetime()
 


### PR DESCRIPTION
Task proxies are supposed to spawn once they achieve the 'submitted' state, but the flag for a pass through the main task processing loop (including spawning) was not being set on this state, which meant submitted tasks would not spawn immediately if nothing else was happening. Test: a single cycling task that submits to a non-active queue (e.g. 'at' job submission with atd turned off) should submit out to the runahead limit without requiring any suite nudging. This change achieves that.
