### PR TITLE
Fix early shutdown

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -123,6 +123,7 @@ class scheduler(object):
 
         # initialize some items in case of early shutdown
         # (required in the shutdown() method)
+        self.suite_id = None
         self.clock = None
         self.wireless = None
         self.suite_state = None


### PR DESCRIPTION
If a suite has a `Jinja2TemplateError`, it can fail during the first part of `cylc run` and force a shutdown - however this currently fails with:

```
File: "/some/where/cylc/lib/cylc/scheduler.py", line 1289, in shutdown
    if self.suite.id:
AttributeError: 'start' object has no attribute 'suite_id'
```

This is because the `self.suite_id` property is not defined until `configure` in scheduler.py, and it needs a default `None` value to allow it to go through `shutdown`.

@hjoliver, please review.
