### PR TITLE
cylc gui: dialog for log file read failure

### DIFF
--- a/lib/cylc/gui/tailer.py
+++ b/lib/cylc/gui/tailer.py
@@ -20,6 +20,7 @@ import gobject
 import threading, subprocess
 import os, sys, re, time
 from cylc import tail
+from warning_dialog import warning_dialog
 
 class tailer(threading.Thread):
     def __init__( self, logview, log, proc=None, tag=None, warning_re=None, critical_re=None ):
@@ -84,9 +85,10 @@ class tailer(threading.Thread):
             #    return
             try:
                 gen = tail.tail( open( self.logfile ))
-            except Exception, x:
+            except Exception as x:
                 # e.g. file not found
-                print >> sys.stderr, x
+                dialog = warning_dialog( type(x).__name__ + ": " + str(x) )
+                gobject.idle_add(dialog.warn)
                 return
 
             while not self.quit:

--- a/lib/cylc/gui/warning_dialog.py
+++ b/lib/cylc/gui/warning_dialog.py
@@ -19,12 +19,14 @@
 import gtk
 import pygtk
 ####pygtk.require('2.0')
+from util import get_icon
 
 class warning_dialog(object):
     def __init__( self, msg, parent=None ):
         self.dialog = gtk.MessageDialog( parent,
                 gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_WARNING,
                 gtk.BUTTONS_CLOSE, msg )
+        self.dialog.set_icon(get_icon())
 
     def warn( self ):
         self.dialog.run()
@@ -35,6 +37,7 @@ class info_dialog(object):
         self.dialog = gtk.MessageDialog( parent,
                 gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_INFO,
                 gtk.BUTTONS_OK, msg )
+        self.dialog.set_icon(get_icon())
 
     def inform( self ):
         self.dialog.run()
@@ -45,6 +48,7 @@ class question_dialog(object):
         self.dialog = gtk.MessageDialog( parent,
                 gtk.DIALOG_DESTROY_WITH_PARENT, gtk.MESSAGE_QUESTION,
                 gtk.BUTTONS_YES_NO, msg )
+        self.dialog.set_icon(get_icon())
 
     def ask( self ):
         response = self.dialog.run()


### PR DESCRIPTION
When a task log file cannot be read (for whatever reason), it is nicer to get a warning dialog rather than a stderr message.

@hjoliver, please review.
