### PR TITLE
Fix task kill post restart.

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -1287,14 +1287,14 @@ class task( object ):
 
         launcher = self.launcher
         if not launcher:
-            self.presubmit( self.task_owner, self.task_host, self.submit_num )
+            launcher = self.presubmit( self.task_owner, self.task_host, self.submit_num )
 
         if not hasattr( launcher, 'get_job_kill_command' ):
             # (for job submission methods that do not handle polling yet)
             self.log( 'WARNING', "'" + self.job_sub_method + "' job submission does not support killing" )
             return
 
-        cmd = self.launcher.get_job_kill_command( self.submit_method_id )
+        cmd = launcher.get_job_kill_command( self.submit_method_id )
         if self.user_at_host != user + '@localhost':
             cmd = cv_scripting_sl + "; " + cmd
             cmd = 'ssh -oBatchMode=yes ' + self.user_at_host + " '" + cmd + "'"


### PR DESCRIPTION
Closes #724.

This fixes a bug whereby you are unable to kill a running task from from a restarted suite (i.e. task running, suite stopped, restarted, kill attempted on said task).

This is basically a typo fix.
