### PR TITLE
Fix path that housekeeping.py think the __hk_* utitlities are in.

### DIFF
--- a/lib/cylc/housekeeping.py
+++ b/lib/cylc/housekeeping.py
@@ -303,7 +303,7 @@ class hkitem:
 
     def execute( self ):
         # construct the command to execute
-        command = os.path.join( os.environ['CYLC_DIR'], 'util', '__hk_' + self.operation ) 
+        command = os.path.join( os.environ['CYLC_DIR'], 'bin', '__hk_' + self.operation ) 
         # ... as a list, for the subprocess module
         comlist = [ command ]
 


### PR DESCRIPTION
The housekeeping.py script tries to execute the __hk_{copy,delete,move} command in a non-existent '$CYLC_DIR/util' directory. The correct location is '$CYLC_DIR/bin'.
