### PR TITLE
Allow job hook, kill and poll to continue on stop

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -516,8 +516,8 @@ class scheduler(object):
     
     def stop_submission_threads( self ):
         self.pool.worker.quit = True
-        self.evworker.quit = True
-        self.poll_and_kill_worker.quit = True
+        #self.evworker.quit = True
+        #self.poll_and_kill_worker.quit = True
 
      # CONTROL_COMMANDS__________________________________________________
 


### PR DESCRIPTION
An attempt to fix #737.
