### PR TITLE
Sensible suite-dependent default visualization cycles.

### DIFF
--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -1526,21 +1526,18 @@ http://www.graphviz.org/Documentation.php.
 
 \subsubsection[initial cycle time]{[visualization] $\rightarrow$ initial cycle time}
 
-The first cycle time to use when plotting the suite dependency graph.
+The cycle time from which to start the suite graph.
 \begin{myitemize}
-    \item {\em type:} integer
-    \item {\em default:} 2999010100
+    \item {\em type:} integer (YYYY[MM[DD[HH[mm[ss]]]]])
+    \item {\em default:} the suite initial cycle time or 2999010100
 \end{myitemize}
 
 \subsubsection[final cycle time]{[visualization] $\rightarrow$ final cycle time}
 
-The last cycle time to use when plotting the suite dependency graph.
-Typically this should be just far enough ahead of the initial cycle to
-show the full suite.
-
+The cycle time at which to end the suite graph.
 \begin{myitemize}
-    \item {\em type:} integer
-    \item {\em default:} 2999010123
+    \item {\em type:} integer (YYYY[MM[DD[HH[mm[ss]]]]])
+    \item {\em default:} the visualization initial cycle time plus the default runahead limit
 \end{myitemize}
 
 \subsubsection[collapsed families]{[visualization] $\rightarrow$ collapsed families}

--- a/lib/cylc/cfgspec/suite_spec.py
+++ b/lib/cylc/cfgspec/suite_spec.py
@@ -196,8 +196,8 @@ SPEC = {
             },
         },
     'visualization' : {
-        'initial cycle time'                  : vdr( vtype='integer' ),
-        'final cycle time'                    : vdr( vtype='integer' ),
+        'initial cycle time'                  : vdr( vtype='cycletime' ),
+        'final cycle time'                    : vdr( vtype='cycletime' ),
         'collapsed families'                  : vdr( vtype='string_list', default=[] ),
         'use node color for edges'            : vdr( vtype='boolean', default=True ),
         'use node color for labels'           : vdr( vtype='boolean', default=False ),


### PR DESCRIPTION
Another small enhancement: `[visualization]initial cycle time` defaults to the suite initial cycle time, if there is one; and `[visualization]final cycle time` defaults to the initial cycle time plus the computed default runahead limit. 
