### PR TITLE
Print blanks instead of 'None' in get-[global-]config output

### DIFF
--- a/bin/cylc-get-config
+++ b/bin/cylc-get-config
@@ -180,5 +180,8 @@ else:
             else:
                 printcfg( d, level=len(args[1:]), prefix=prefix)
         else:
-            print prefix + str(d)
+            if d is not None:
+                print prefix + str(d)
+            else:
+                print prefix
 

--- a/bin/cylc-get-global-config
+++ b/bin/cylc-get-global-config
@@ -98,7 +98,10 @@ try:
                 else:
                     printcfg( value, level=len(args[1:]) )
             else:
-                print value
+                if value is not None:
+                    print value
+                else:
+                    print ""
     else:
         print "Combined site/user config is valid for cylc-" + cylc_version
 

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -743,7 +743,7 @@ if any, overridden by user settings, if any. To generate an
 initial site or user config file:
 \lstset{language=transcript}
 \begin{lstlisting}
-shell$ cylc get-global-config --print > user.rc
+shell$ cylc get-global-config --print > $HOME/.cylc/user.rc
 \end{lstlisting}
 Settings that do not need to be changed should be deleted or commented
 out of user config files so that they don't override future changes to

--- a/lib/parsec/util.py
+++ b/lib/parsec/util.py
@@ -38,7 +38,10 @@ def printcfg( dct, level=0, indent=0, prefix='', omitNone=False ):
             if isinstance( val, list ):
                 v = ', '.join([str(f) for f in val])
             else:
-                v = str(val)
+                if val is not None:
+                    v = str(val)
+                else:
+                    v = ''
             print prefix + '   '*indent + str(key) + ' = ' + v
     for key,val in delayed:
         if val != None:

--- a/tests/cylc-get-config/00-simple.t
+++ b/tests/cylc-get-config/00-simple.t
@@ -92,9 +92,9 @@ TEST_NAME=$TEST_NAME_BASE-section1
 run_ok $TEST_NAME cylc get-config --item=[scheduling] $SUITE_NAME
 cmp_ok $TEST_NAME.stdout - <<__OUT__
 cycling = HoursOfTheDay
-initial cycle time = None
-runahead limit = None
-final cycle time = None
+initial cycle time = 
+runahead limit = 
+final cycle time = 
 [queues]
    [[default]]
       limit = 0
@@ -135,31 +135,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = 
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
    [[dummy mode]]
@@ -175,19 +175,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [ops_s1]
@@ -195,31 +195,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = OPS, SERIAL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = serial
@@ -236,19 +236,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [ops_s2]
@@ -256,31 +256,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = OPS, SERIAL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = serial
@@ -297,19 +297,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [ops_p1]
@@ -317,31 +317,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = OPS, PARALLEL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = parallel
@@ -358,19 +358,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [root]
@@ -378,31 +378,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = 
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
    [[dummy mode]]
@@ -418,19 +418,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [ops_p2]
@@ -438,31 +438,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = OPS, PARALLEL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = parallel
@@ -479,19 +479,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [PARALLEL]
@@ -499,31 +499,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = 
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = parallel
@@ -540,19 +540,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [VAR]
@@ -560,31 +560,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = 
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
    [[dummy mode]]
@@ -600,19 +600,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [var_p1]
@@ -620,31 +620,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = VAR, PARALLEL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = parallel
@@ -661,19 +661,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [var_p2]
@@ -681,31 +681,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = VAR, PARALLEL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = parallel
@@ -722,19 +722,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [var_s1]
@@ -742,31 +742,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = VAR, SERIAL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = serial
@@ -783,19 +783,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [SERIAL]
@@ -803,31 +803,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = 
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = serial
@@ -844,19 +844,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 [var_s2]
@@ -864,31 +864,31 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
    enable resurrection = False
    manual completion = False
    retry delays = 
-   environment scripting = None
+   environment scripting = 
    execution polling intervals = 
    title = No title provided
    extra log files = 
    work sub-directory = $CYLC_TASK_ID
    submission polling intervals = 
    description = No description provided
-   initial scripting = None
-   pre-command scripting = None
-   post-command scripting = None
+   initial scripting = 
+   pre-command scripting = 
+   post-command scripting = 
    inherit = VAR, SERIAL
    [[event hooks]]
-      submission timeout handler = None
-      submitted handler = None
-      started handler = None
-      execution timeout handler = None
-      submission failed handler = None
-      submission retry handler = None
-      warning handler = None
-      succeeded handler = None
-      retry handler = None
+      submission timeout handler = 
+      submitted handler = 
+      started handler = 
+      execution timeout handler = 
+      submission failed handler = 
+      submission retry handler = 
+      warning handler = 
+      succeeded handler = 
+      retry handler = 
       reset timer = False
-      execution timeout = None
-      failed handler = None
-      submission timeout = None
+      execution timeout = 
+      failed handler = 
+      submission timeout = 
    [[environment]]
    [[directives]]
       job_type = serial
@@ -905,19 +905,19 @@ cmp_ok $TEST_NAME.stdout - <<'__OUT__'
       disable retries = True
       disable task event hooks = True
    [[suite state polling]]
-      interval = None
-      host = None
-      max-polls = None
-      run-dir = None
-      user = None
-      verbose mode = None
+      interval = 
+      host = 
+      max-polls = 
+      run-dir = 
+      user = 
+      verbose mode = 
    [[remote]]
-      owner = None
-      suite definition directory = None
-      host = None
+      owner = 
+      suite definition directory = 
+      host = 
    [[job submission]]
       shell = /bin/bash
-      command template = None
+      command template = 
       method = background
       retry delays = 
 __OUT__


### PR DESCRIPTION
If a config item is unset, the `get-config` commands currently print
`item = None`
but they should print 
`item =`
(for fairly obvious reasons)

Test battery passes.

@matthewrmshin - please review.
