### PR TITLE
Use the normal suite run directory for "cylc submit" tasks.

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -44,12 +44,12 @@ from cylc.global_config import get_global_cfg
 
 usage = """cylc [task] submit|single [OPTIONS] ARGS
 
-Submit a single task to run exactly as it would be submitted by its 
-parent suite, in terms of both execution environment and job submission
-method. This can be used as an easy way to run single tasks for any
-reason, but it is particularly useful during suite development.
+Submit a single task to run just as it would be submitted by its suite.
+Task messaging commands will print to stdout but will not attempt to
+communicate with the suite (which does not even need to be running).
+Note that job log file paths are the same as for in-suite tasks.
 
-If the parent suite is running at the same time and it has acquired an
+If the suite is running at the same time and it has acquired an
 exclusive suite lock (which means you cannot running multiple instances
 of the suite at once, even under different registrations) then the
 lockserver will let you 'submit' a task from the suite only under the

--- a/lib/cylc/global_config.py
+++ b/lib/cylc/global_config.py
@@ -117,15 +117,6 @@ class globalcfg( object ):
         # suite workspace
         swdir = os.path.join( self.get_host_item( 'work directory', host, owner, replace ), suite )
 
-        # if invoked by the "cylc submit" command we modify the top
-        # level directory names to avoid contaminating suite output.
-        try:
-            if os.environ['CYLC_MODE'] == 'submit':
-                srdir += '-submit'
-                swdir += '-submit'
-        except:
-            pass
-
         if item == 'suite run directory':
             value = srdir
 


### PR DESCRIPTION
Tasks executed sans suite via `cylc submit` currently use a non-standard suite run directory (namely the standard location with '-submit' appended.  This was meant to avoid contaminating the suite log directory, but it can break `cylc submit`'ed tasks belonging to Rose-style suites that self-deploy into their own run directory (because the '-submit' run directory does not have the deployed files). This small change just removes the special treatment, and notes in the submit command help that the log location will now be the same as for suite-submitted tasks.

(wait on test for `cylc subm` before merge...)
