### PR TITLE
Use fsync on state dump

### DIFF
--- a/lib/cylc/suite_state_dumping.py
+++ b/lib/cylc/suite_state_dumping.py
@@ -77,6 +77,7 @@ class dumper( object ):
             # task instance variables
             itask.dump_state( FILE )
 
+        os.fsync(FILE.fileno())
         FILE.close()
         # return the filename (minus path)
         return os.path.basename( filename )


### PR DESCRIPTION
This ensures that the state dump files would be on disk. Otherwise, with
a busy suite on the ext4 file system, they may be left as zero size
files on a power failure.
