### PR TITLE
cylc logging: alter verbosity of some commonly-output messages

### DIFF
--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -141,7 +141,7 @@ initial and final cycle time variables persists across suite restarts."""
         coldstart_tasks = self.config.get_coldstart_task_list()
         startup_tasks = self.config.get_startup_task_list()
         if len( coldstart_tasks ) == 0:
-            self.log.warning( "This suite has not defined any cold start tasks" )
+            self.log.info( "This suite has not defined any cold start tasks" )
         for name in task_list:
             # (startup=True is only for cold start)
             if name in self.asynchronous_task_list:

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -1034,7 +1034,6 @@ shell$ cylc run --no-detach tut.oneoff.basic
 * you are welcome to redistribute it under certain conditions. Details: *
 *           `cylc license conditions'; `cylc license warranty'          *
 *************************************************************************
-WARNING: No initial cycle time provided - no cycling tasks will be loaded.
 
 1 task ready
   * hello.1 submitting now
@@ -1377,8 +1376,6 @@ shell$ cat ~/cylc-run/tut.oneoff.goodbye/log/job/goodbye.1.1.out
 # (or cylc log -o tut.oneoff.goodbye goodbye.1
 JOB SCRIPT STARTING
 cylc (scheduler - 2013/09/23 18:15:09): goodbye.1 started at 2013-09-23T18:15:09
-Sending message (connection timeout is 30) ...
-   Try 1 of 7 ... succeeded
 cylc Suite and Task Identity:
   Suite Name  : tut.oneoff.goodbye
   Suite Host  : server0
@@ -1392,8 +1389,6 @@ cylc Suite and Task Identity:
 Goodbye World!
 
 cylc (scheduler - 2013/09/23 18:15:20): hello.1 succeeded at 2013-09-23T18:15:20
-Sending message (connection timeout is 30) ...
-   Try 1 of 7 ... succeeded
 JOB SCRIPT EXITING (TASK SUCCEEDED)
 \end{lstlisting}
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -772,7 +772,8 @@ class scheduler(object):
         if self.stop_tag:
             self.stop_tag = ct(self.stop_tag).get()
 
-        if not self.start_tag and not self.is_restart:
+        if (not self.start_tag and not self.is_restart and
+            self.config.cycling_tasks):
             print >> sys.stderr, 'WARNING: No initial cycle time provided - no cycling tasks will be loaded.'
 
         if self.run_mode != self.config.run_mode:

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -205,24 +205,33 @@ class message(object):
 
 
     def send_pyro( self, msg ):
-        print "Sending message (connection timeout is", str(self.try_timeout) + ") ..."
         sent = False
         itry = 0
         while True:
             itry += 1
-            print '  ', "Try", itry, "of", str(self.max_tries), "...",  
             try:
                 # Get a proxy for the remote object and send the message.
                 self.load_suite_contact_file() # might have change between tries
                 self.get_proxy().put( self.priority, msg )
             except Exception, x:
-                print "failed:", str(x)
+                print "Send message: try %s of %s failed: %s" % (
+                    itry,
+                    self.max_tries,
+                    x
+                )
                 if itry >= self.max_tries:
                     break
-                print "   retry in", str(self.retry_seconds), "seconds ..."
+                print "   retry in %s seconds, timeout is %s" % (
+                    self.retry_seconds,
+                    self.try_timeout
+                )
                 sleep( self.retry_seconds )
             else:
-                print "succeeded"
+                if itry > 0:
+                    print "Send message: try %s of %s succeeded" % (
+                        itry,
+                        self.max_tries
+                    )
                 sent = True
                 break
         if not sent:


### PR DESCRIPTION
This reduces the visibility of some very common (or expected) messages in cylc.

@hjoliver, please review.
