### PR TITLE
#712: Catch exception on rolling_archive.

### DIFF
--- a/lib/cylc/rolling_archive.py
+++ b/lib/cylc/rolling_archive.py
@@ -39,7 +39,10 @@ class rolling_archive(object):
 
         for i in reversed( range( 1, self.archive_length )):
             if os.path.exists( self.__filename( i )):
-                os.rename( self.__filename(i), self.__filename(i+1) )
+                try:
+                    os.rename( self.__filename(i), self.__filename(i+1) )
+                except OSError:
+                    raise
 
         if os.path.exists( self.base_filename):
             os.rename( self.base_filename, self.__filename(1) )


### PR DESCRIPTION
Addresses #712.

This should correctly catch the OSError raised when a user runs out of quota.

@hjoliver - please review.
