### PR TITLE
Don't retry task message send if task proxy not found in suite.

### DIFF
--- a/bin/cylc-succeeded
+++ b/bin/cylc-succeeded
@@ -33,7 +33,7 @@ which case it must be called explicitly by final task scripting.
 
 Suite and task identity are determined from the task execution
 environment supplied by the suite (or by the single task 'submit'
-command, in which case case the message is just printed to stdout).
+command, in which case the message is just printed to stdout).
 
 See also:
     cylc [task] message

--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -205,6 +205,7 @@ class message(object):
 
 
     def send_pyro( self, msg ):
+        from Pyro.errors import NamingError
         sent = False
         itry = 0
         while True:
@@ -213,7 +214,17 @@ class message(object):
                 # Get a proxy for the remote object and send the message.
                 self.load_suite_contact_file() # might have change between tries
                 self.get_proxy().put( self.priority, msg )
+            except NamingError, x:
+                print >> sys.stderr, x
+                print "Send message: try %s of %s failed: %s" % (
+                    itry,
+                    self.max_tries,
+                    x
+                )
+                print "Task proxy removed from suite daemon? Aborting."
+                break
             except Exception, x:
+                print >> sys.stderr, x
                 print "Send message: try %s of %s failed: %s" % (
                     itry,
                     self.max_tries,


### PR DESCRIPTION
Closes #836.

@arjclark - please review.
