### PR TITLE
Fix releasing a suite with non-cycling tasks

### DIFF
--- a/lib/cylc/cycle_time.py
+++ b/lib/cylc/cycle_time.py
@@ -168,8 +168,14 @@ def memoize(function):
 @memoize
 def ctime_cmp(ctime_str_1, ctime_str_2):
     """Compare (cmp) two cycle time strings numerically."""
-    ctime_1 = ct(ctime_str_1).get()
-    ctime_2 = ct(ctime_str_2).get()
+    try:
+        ctime_1 = ct(ctime_str_1).get()
+    except InvalidCycleTimeError:
+        ctime_1 = ctime_str_1
+    try:
+        ctime_2 = ct(ctime_str_2).get()
+    except InvalidCycleTimeError:
+        ctime_2 = ctime_str_2
     return cmp(int(ctime_1), int(ctime_2))
 
 


### PR DESCRIPTION
#805 introduced some logic that fails for comparisons involving non-cycling cycle times (e.g. `foo.1`). This is nearly always invoked purely for cycling situations, but in two places in `scheduler.py`, `def release_suite` and `def command_purge_tree`, it will fail if there are tasks in the task pool that are not cycling tasks. This means that it is not possible to release a held suite if it has non-cycling tasks in the task pool that are in a `held` state.

We don't really test holding and releasing suites in the test battery, which is another issue that we should deal with.

This catches the `InvalidCycleTimeError` that is raised within the `def ctime_cmp` code in `cycle_time.py` - if the error arises, it reverts to comparing `int(ctime_string)` as it did before.

The change can be tested by running a suite like this:

```
[scheduling]
    [[dependencies]]
        graph = """
            FOO:succeed-all => bar
        """
[runtime]
    [[root]]
        command scripting = "sleep 100"
    [[FOO]]
    [[foo1, foo2, foo3]]
        inherit = FOO
    [[bar]]
```

and holding the suite as the `foo` tasks are running. The command to release the suite will fail with an exception in current master, and will succeed using this code.

@hjoliver, please review.
