### PR TITLE
Added a battery test for suite hold and release.

### DIFF
--- a/tests/hold-release/00-suite.t
+++ b/tests/hold-release/00-suite.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2013 Hilary Oliver, NIWA
+#C: 
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suite hold and release, with cycling and async tasks present.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE suite
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-val
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME
+

--- a/tests/hold-release/suite/reference.log
+++ b/tests/hold-release/suite/reference.log
@@ -1,0 +1,41 @@
+2014/01/10 08:41:32 INFO - Thread-2 start (Event Handlers)
+2014/01/10 08:41:32 INFO - port:7766
+2014/01/10 08:41:32 INFO - Suite starting at 2014-01-10 08:41:32.557075
+2014/01/10 08:41:32 INFO - Log event clock: real time
+2014/01/10 08:41:32 INFO - Run mode: live
+2014/01/10 08:41:32 INFO - Start tag: 2014010100
+2014/01/10 08:41:32 INFO - Stop tag: 2014010100
+2014/01/10 08:41:32 INFO - Thread-3 start (Poll & Kill Commands)
+2014/01/10 08:41:32 INFO - Thread-5 start (Request Handling)
+2014/01/10 08:41:32 INFO - Thread-4 start (Job Submission)
+2014/01/10 08:41:32 INFO - Cold Start 2014010100
+2014/01/10 08:41:32 INFO - [holdrelease.1] -triggered off []
+2014/01/10 08:41:33 INFO - [holdrelease.1] -(current:ready)> holdrelease.1 submitting now
+2014/01/10 08:41:34 INFO - [holdrelease.1] -(current:ready)> holdrelease.1 submission succeeded
+2014/01/10 08:41:34 INFO - [holdrelease.1] -(current:submitted)> holdrelease.1 submit_method_id=56971
+2014/01/10 08:41:34 INFO - [holdrelease.1] -(current:submitted)> holdrelease.1 started at 2014-01-10T08:41:33
+2014/01/10 08:41:39 INFO - Holding all waiting or queued tasks now
+2014/01/10 08:41:39 INFO - Command succeeded: hold suite now()
+2014/01/10 08:41:44 INFO - RELEASE: new tasks will be queued when ready
+2014/01/10 08:41:44 INFO - Command succeeded: release suite()
+2014/01/10 08:41:49 INFO - [holdrelease.1] -(current:running)> holdrelease.1 succeeded at 2014-01-10T08:41:49
+2014/01/10 08:41:50 INFO - [foo.1] -triggered off ['holdrelease.1']
+2014/01/10 08:41:50 INFO - [bar.2014010100] -triggered off ['holdrelease.1']
+2014/01/10 08:41:51 INFO - [foo.1] -(current:ready)> foo.1 submitting now
+2014/01/10 08:41:51 INFO - [foo.1] -(current:ready)> foo.1 submission succeeded
+2014/01/10 08:41:51 INFO - [foo.1] -(current:submitted)> foo.1 submit_method_id=57051
+2014/01/10 08:41:51 INFO - [foo.1] -(current:submitted)> foo.1 started at 2014-01-10T08:41:51
+2014/01/10 08:41:51 INFO - [foo.1] -(current:running)> foo.1 succeeded at 2014-01-10T08:41:51
+2014/01/10 08:41:51 INFO - [bar.2014010100] -(current:ready)> bar.2014010100 submitting now
+2014/01/10 08:41:51 INFO - [bar.2014010100] -(current:ready)> bar.2014010100 started at 2014-01-10T08:41:51
+2014/01/10 08:41:52 INFO - [bar.2014010100] -(current:running)> bar.2014010100 succeeded at 2014-01-10T08:41:51
+2014/01/10 08:41:52 WARNING - [bar.2014010100] -Assuming non-reported outputs were completed:
+bar.2014010100 submitted
+2014/01/10 08:41:52 INFO - [bar.2014010100] -(current:succeeded)> bar.2014010100 submission succeeded
+2014/01/10 08:41:52 INFO - [bar.2014010100] -(current:succeeded)> bar.2014010100 submit_method_id=57075
+2014/01/10 08:41:52 INFO - Stopping: 
+  + all cycling tasks have spawned past the final cycle 2014010100
+  + all non-cycling tasks have succeeded
+2014/01/10 08:41:53 INFO - Thread-4 exit (Job Submission)
+2014/01/10 08:41:53 INFO - Thread-2 exit (Event Handlers)
+2014/01/10 08:41:53 INFO - Thread-3 exit (Poll & Kill Commands)

--- a/tests/hold-release/suite/suite.rc
+++ b/tests/hold-release/suite/suite.rc
@@ -1,0 +1,31 @@
+
+title = "hold/release test suite"
+
+description = """One task that holds then releases the suite, with
+short sleeps to make the effect on the downstream task obvious in the
+GUI (waiting to held to waiting)"""
+
+# ref: bug-fix GitHub Pull Request #843 (5412d01)
+
+[cylc]
+    [[reference test]]
+        live mode suite timeout = 0.5
+
+[scheduling]
+    initial cycle time = 2014010100
+    final cycle time   = 2014010100
+    [[dependencies]]
+        graph = "holdrelease => foo"
+        [[[0,6]]]
+            graph = "holdrelease => bar"
+[runtime]
+    [[holdrelease]]
+        command scripting = """
+sleep 5
+cylc hold $CYLC_SUITE_NAME
+sleep 5
+cylc release $CYLC_SUITE_NAME
+sleep 5"""
+    [[foo,bar]]
+        command scripting = true
+

--- a/tests/hold-release/test_header
+++ b/tests/hold-release/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
Test that holding and releasing a suite works with waiting async and cycling tasks present.  Passes on current master, fails with the bug fixed by #843.

@benfitzpatrick - please review.
