### PR TITLE
cylc test-battery: fix get-global-config for site.rc hosts.

### DIFF
--- a/tests/cylc-get-global-config/00-basic.t
+++ b/tests/cylc-get-global-config/00-basic.t
@@ -36,7 +36,8 @@ run_ok $TEST_NAME cylc get-global-config --print-run-dir
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-check-output
 VAL1=$(cylc get-global-config --item '[hosts][localhost]use login shell')
-VAL2=$(cylc get-global-config --print | grep "use login shell" |  sed -e 's/^[ \t]*//')
+VAL2=$(cylc get-global-config --print | sed -n '/\[\[localhost\]\]/,$p' | \
+    sed -n "0,/use login shell/s/^[ \t]*\(use login shell =.*\)/\1/p")
 echo use login shell = $VAL1 > testout
 echo $VAL2 > refout
 cmp_ok testout refout


### PR DESCRIPTION
This fixes the `get-global-config` test when more than one
`site.rc` host is specified. This is due to the `use login
shell` line appearing once per host, not just once.

The `sed` change takes the first occurrence of `use login
shell` following a line that looks like `[[localhost]]`.

A site.rc file that contains the following text:

```
[hosts]
    [[some_network_machine]]
        run directory = $HOME/cylc-run
        work directory = $HOME/cylc-run
        task communication method = pyro
        remote shell template = ssh -oBatchMode=yes %s
        use login shell = True
```

will cause this test to fail in current master, but will be
OK for this branch.

@hjoliver, please review. Is this what #795 refers to? (`cylc-get-global-config` vs `cylc-get-config`?)
