### PR TITLE
#861: fix validation of hyphenated family trigger in graph.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1021,7 +1021,9 @@ class config( object ):
             self.suite_polling_tasks[ l_task ] = ( r_suite, r_task, r_status, r_all )
 
         # REPLACE FAMILY NAMES WITH MEMBER DEPENDENCIES
-        for fam in self.runtime['descendants']:
+        # Sort so that longer family names get expanded first.
+        # This expands e.g. FOO-BAR before FOO in FOO-BAR:succeed-all => baz.
+        for fam in reversed(sorted(self.runtime['descendants'])):
             members = copy(self.runtime['descendants'][fam])
             for member in copy(members):
                 # (another copy here: don't remove items from the iterating list) 


### PR DESCRIPTION
This fixes #861.

This fixes the problem of checking the family 'FOO'
against the line 'FOO-BAR:succeed-all => baz'. This
fails validation because the '-' looks like a line
break and therefore looks like a bare 'FOO' family
trigger. This change fixes the problem by reverse
sorting the family names before checking each one.

As a shorter subset of a name sorts before a name,
and we're reverse-sorting, this means that
'FOO-BAR' is expanded before 'FOO' gets to it.
