### PR TITLE
Fix gcylc

### DIFF
--- a/lib/cylc/gui/gcylc_config.py
+++ b/lib/cylc/gui/gcylc_config.py
@@ -19,7 +19,7 @@
 import os, sys, gtk
 from copy import deepcopy, copy
 from cylc.task_state import task_state
-from cylc.cfgspec.gcylc_spec import cfg
+from cylc.cfgspec.gcylc_spec import get_cfg
 
 class config( object ):
     """gcylc user configuration - default view panels, task themes etc."""
@@ -27,7 +27,7 @@ class config( object ):
     def __init__( self, prntcfg=False ):
 
         self.default_theme = "default"
-        cfg.printcfg()
+        cfg = get_cfg()
 
         # select the start-up theme
         self.use_theme = cfg['use theme']


### PR DESCRIPTION
Following b1f7bc69c929b3507dabffd5aad8fdf04e74d7ab, `gcylc` with no
argument returns 'NoneType' object has no attribute 'printcfg'. This
fixes the problem.
