### PR TITLE
Support loadleveler job vacation: handle SIGUSR1

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -4503,6 +4503,12 @@ These are written to the top of the task job script like this:
 # @ queue
 \end{lstlisting}
 
+If restart=yes is specified as a directive for loadleveler, the job will
+automatically trap SIGUSR1, which loadleveler may use to preempt the job. On
+trapping SIGUSR1, the job will inform the suite that it has been vacated by
+loadleveler. This will put it back to the submitted state, until it starts
+running again.
+
 \subsubsection{pbs}
 
 Submits tasks to PBS (or Torque) by the \lstinline=qsub= command.  PBS

--- a/lib/cylc/job_submission/job_submit.py
+++ b/lib/cylc/job_submission/job_submit.py
@@ -145,9 +145,11 @@ class job_submit(object):
         self.jobconfig[ 'directive prefix'    ] = None
         self.jobconfig[ 'directive final'     ] = "# FINAL DIRECTIVE"
         self.jobconfig[ 'directive connector' ] = " "
+        self.jobconfig[ 'job vacation signal' ] = None
 
         # overrideable methods
         self.set_directives()
+        self.set_job_vacation_signal()
         self.set_scripting()
         self.set_environment()
 
@@ -172,6 +174,10 @@ class job_submit(object):
 
     def set_environment( self ):
         # Derived classes can use this to modify task execution environment
+        return
+
+    def set_job_vacation_signal( self ):
+        """Derived class can set self.jobconfig['job vacation signal']."""
         return
 
     def construct_jobfile_submission_command( self ):

--- a/lib/cylc/job_submission/loadleveler.py
+++ b/lib/cylc/job_submission/loadleveler.py
@@ -62,6 +62,15 @@ class loadleveler( job_submit ):
             defaults[ d ] = val
         self.jobconfig['directives'] = defaults
 
+    def set_job_vacation_signal( self ):
+        """Set self.jobconfig['job vacation signal'] = 'USR1'
+
+        (If restart=yes is defined in self.jobconfig['directives'])
+
+        """
+        if self.jobconfig['directives'].get('restart') == 'yes':
+            self.jobconfig['job vacation signal'] = 'USR1'
+
     def construct_jobfile_submission_command( self ):
         """
         Construct a command to submit this job to run.

--- a/tests/jobscript/torture/foo.ref-jobfile
+++ b/tests/jobscript/torture/foo.ref-jobfile
@@ -10,18 +10,16 @@ export CYLC_VERSION=
 test -f /etc/profile && . /etc/profile 1>/dev/null 2>&1
 test -f $HOME/.profile && . $HOME/.profile 1>/dev/null 2>&1
 
-# SET ERROR TRAPPING:
+# TRAP ERROR SIGNALS:
 set -u # Fail when using an undefined variable
-# Define the trap handler
-SIGNALS="EXIT ERR TERM XCPU"
-function HANDLE_TRAP {
+FAIL_SIGNALS='EXIT ERR TERM XCPU'
+TRAP_FAIL_SIGNAL() {
     typeset SIGNAL=$1
-    echo "Received signal $SIGNAL"
+    echo "Received signal $SIGNAL" >&2
     typeset S=
-    for S in $SIGNALS; do
+    for S in ${VACATION_SIGNALS:-} $FAIL_SIGNALS; do
         trap "" $S
     done
-    # SEND TASK FAILED MESSAGE
     if [[ -n ${CYLC_TASK_LOG_ROOT:-} ]]; then
         {
             echo "CYLC_JOB_EXIT=$SIGNAL"
@@ -31,10 +29,10 @@ function HANDLE_TRAP {
     cylc task failed "Task job script received signal $@"
     exit 1
 }
-# Trap signals that could cause this script to exit:
-for S in $SIGNALS; do
-    trap "HANDLE_TRAP $S" $S
+for S in $FAIL_SIGNALS; do
+    trap "TRAP_FAIL_SIGNAL $S" $S
 done
+unset S
 
 # INITIAL SCRIPTING:
 

--- a/tests/vacation/00-sigusr1.t
+++ b/tests/vacation/00-sigusr1.t
@@ -1,0 +1,85 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+#C: Test handle of SIGUSR1. (Handle a mock job vacation.)
+#C: Obviously, job vacation does not happen with background job, and the job
+#C: will no longer be poll-able after the kill.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 6
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+run_ok $TEST_NAME cylc run --reference-test $SUITE_NAME
+#-------------------------------------------------------------------------------
+SUITE_RUN_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME
+# Make sure t1.1.1's status file is in place
+T1_STATUS_FILE=$SUITE_RUN_DIR/log/job/t1.1.1.status
+TIMEOUT=$(($(date +%s) + 120))
+while [[ ! -f $T1_STATUS_FILE ]] && (($TIMEOUT > $(date +%s))); do
+    sleep 1
+done
+T1_PID=$(awk -F= '$1=="CYLC_JOB_PID" {print $2}' $T1_STATUS_FILE)
+# Kill the job and see what happens
+kill -s USR1 $T1_PID
+while ps $T1_PID 1>/dev/null 2>&1; do
+    sleep 1
+done
+exists_fail $T1_STATUS_FILE
+TIMEOUT=$(($(date +%s) + 120))
+while ! grep -q 'Task job script vacated by signal USR1' \
+            $SUITE_RUN_DIR/log/suite/log \
+        && (($TIMEOUT > $(date +%s)))
+do
+    sleep 1
+done
+TIMEOUT=$(($(date +%s) + 10))
+while ! sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
+            'SELECT status FROM task_states WHERE name=="t1";' \
+            >"$TEST_NAME-db-t1" 2>/dev/null \
+        && (($TIMEOUT > $(date +%s)))
+do
+    sleep 1
+done
+cmp_ok "$TEST_NAME-db-t1" - <<<'submitted'
+# Start the job again and see what happens
+mkdir -p $SUITE_RUN_DIR/work/t1.1/
+touch $SUITE_RUN_DIR/work/t1.1/file # Allow t1 to complete
+$SUITE_RUN_DIR/log/job/t1.1.1 </dev/null >/dev/null 2>&1 &
+# Wait for suite to complete
+TIMEOUT=$(($(date +%s) + 120))
+while [[ -f ~/.cylc/ports/$SUITE_NAME ]] && (($TIMEOUT > $(date +%s))); do
+    sleep 1
+done
+# Test t1 status in DB
+sqlite3 $SUITE_RUN_DIR/cylc-suite.db \
+    'SELECT status FROM task_states WHERE name=="t1";' >"$TEST_NAME-db-t1"
+cmp_ok "$TEST_NAME-db-t1" - <<<'succeeded'
+# Test reference
+TIMEOUT=$(($(date +%s) + 120))
+while ! grep -q 'DONE' $SUITE_RUN_DIR/log/suite/out \
+        && (($TIMEOUT > $(date +%s)))
+do
+    sleep 1
+done
+grep_ok 'SUITE REFERENCE TEST PASSED' $SUITE_RUN_DIR/log/suite/out
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME
+exit

--- a/tests/vacation/00-sigusr1/python/background_vacation.py
+++ b/tests/vacation/00-sigusr1/python/background_vacation.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from cylc.job_submission.background import background
+
+
+class background_vacation(background):
+
+    """Job submission class for use by test battery.
+
+    Allow a background submission to have a job vacation signal.
+
+    """
+
+    def set_job_vacation_signal( self ):
+        """Set self.jobconfig['job vacation signal'] = 'USR1'"""
+        self.jobconfig['job vacation signal'] = 'USR1'

--- a/tests/vacation/00-sigusr1/reference.log
+++ b/tests/vacation/00-sigusr1/reference.log
@@ -1,0 +1,30 @@
+2014/01/24 12:25:52 INFO - Thread-2 start (Event Handlers)
+2014/01/24 12:25:52 INFO - Thread-3 start (Poll & Kill Commands)
+2014/01/24 12:25:52 INFO - port:7766
+2014/01/24 12:25:52 INFO - Suite starting at 2014-01-24 12:25:52.354258
+2014/01/24 12:25:52 INFO - Log event clock: real time
+2014/01/24 12:25:52 INFO - Run mode: live
+2014/01/24 12:25:52 INFO - Start tag: None
+2014/01/24 12:25:52 INFO - Stop tag: None
+2014/01/24 12:25:52 INFO - Thread-4 start (Job Submission)
+2014/01/24 12:25:52 INFO - Thread-5 start (Request Handling)
+2014/01/24 12:25:52 INFO - [t1.1] -triggered off []
+2014/01/24 12:25:53 INFO - [t1.1] -(current:ready)> t1.1 submitting now
+2014/01/24 12:25:54 INFO - [t1.1] -(current:ready)> t1.1 submission succeeded
+2014/01/24 12:25:54 INFO - [t1.1] -(current:submitted)> t1.1 submit_method_id=7752
+2014/01/24 12:25:54 INFO - [t1.1] -(current:submitted)> t1.1 started at 2014-01-24T12:25:54
+2014/01/24 12:26:18 WARNING - [t1.1] -(current:running)> Task job script vacated by signal USR1 at 2014-01-24T12:26:17
+2014/01/24 12:26:37 INFO - [t1.1] -(current:submitted)> t1.1 started at 2014-01-24T12:26:37
+2014/01/24 12:26:37 WARNING - [t1.1] -Vacated job restarted: t1.1 started
+2014/01/24 12:26:47 INFO - [t1.1] -(current:running)> t1.1 succeeded at 2014-01-24T12:26:46
+2014/01/24 12:26:48 INFO - [t2.1] -triggered off ['t1.1']
+2014/01/24 12:26:49 INFO - [t2.1] -(current:ready)> t2.1 submitting now
+2014/01/24 12:26:49 INFO - [t2.1] -(current:ready)> t2.1 submission succeeded
+2014/01/24 12:26:49 INFO - [t2.1] -(current:submitted)> t2.1 submit_method_id=8032
+2014/01/24 12:26:49 INFO - [t2.1] -(current:submitted)> t2.1 started at 2014-01-24T12:26:49
+2014/01/24 12:26:50 INFO - [t2.1] -(current:running)> t2.1 succeeded at 2014-01-24T12:26:49
+2014/01/24 12:26:50 INFO - Stopping: 
+  + all non-cycling tasks have succeeded
+2014/01/24 12:26:50 INFO - Thread-4 exit (Job Submission)
+2014/01/24 12:26:51 INFO - Thread-2 exit (Event Handlers)
+2014/01/24 12:26:51 INFO - Thread-3 exit (Poll & Kill Commands)

--- a/tests/vacation/00-sigusr1/suite.rc
+++ b/tests/vacation/00-sigusr1/suite.rc
@@ -1,0 +1,17 @@
+#!jinja2
+[scheduling]
+    [[dependencies]]
+        graph=t1=>t2
+
+[runtime]
+    [[t1]]
+        command scripting="""
+TIMEOUT=$(($(date +%s) + 120))
+while [[ ! -e file ]] && (($TIMEOUT > $(date +%s))); do
+    sleep 1
+done
+"""
+        [[[job submission]]]
+            method=background_vacation
+    [[t2]]
+        command scripting=true

--- a/tests/vacation/01-loadleveler.t
+++ b/tests/vacation/01-loadleveler.t
@@ -1,0 +1,65 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+#C: Test whether job vacation trap is included in a loadleveler job or not.
+#C: A job for a task with the restart=yes directive will have the trap.
+#C: This does not test loadleveler job vacation itself, because the test will
+#C: require a site admin to pre-empt a job.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+export CYLC_TEST_HOST=$( \
+    cylc get-global-config -i '[test battery][directives]loadleveler host')
+if [[ -z $CYLC_TEST_HOST ]]; then
+    skip_all '[test battery][directives]loadleveler host: not defined'
+fi
+set_test_number 6
+export CYLC_TEST_DIRECTIVES=$( \
+    cylc get-global-config \
+    -i '[test battery][directives][loadleveler directives]')
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+set -eu
+if [[ $CYLC_TEST_HOST != 'localhost' ]]; then
+    SSH='ssh -oBatchMode=yes -oConnectTimeout=5'
+    $SSH $CYLC_TEST_HOST \
+        "mkdir -p .cylc/$SUITE_NAME/ && cat >.cylc/$SUITE_NAME/passphrase" \
+        <$TEST_DIR/$SUITE_NAME/passphrase
+fi
+set +eu
+SUITE_RUN_DIR=$(cylc get-global-config --print-run-dir)/$SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-t1.1
+T1_JOB_FILE=$SUITE_RUN_DIR/log/job/t1.1.1
+exists_ok $T1_JOB_FILE
+run_fail $TEST_NAME grep -q -e '^# TRAP VACATION SIGNALS:' $T1_JOB_FILE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-t2.1
+T2_JOB_FILE=$SUITE_RUN_DIR/log/job/t2.1.1
+exists_ok $T2_JOB_FILE
+grep_ok '^# TRAP VACATION SIGNALS:' $T2_JOB_FILE
+#-------------------------------------------------------------------------------
+if [[ $CYLC_TEST_HOST != 'localhost' ]]; then
+    $SSH $CYLC_TEST_HOST \
+        "rm -rf .cylc/$SUITE_NAME cylc-run/$SUITE_NAME"
+fi
+purge_suite $SUITE_NAME
+exit

--- a/tests/vacation/01-loadleveler/reference.log
+++ b/tests/vacation/01-loadleveler/reference.log
@@ -1,0 +1,55 @@
+2014/02/05 12:14:06 INFO - Thread-2 start (Event Handlers)
+2014/02/05 12:14:06 INFO - Thread-3 start (Poll & Kill Commands)
+2014/02/05 12:14:06 INFO - port:7766
+2014/02/05 12:14:06 INFO - Suite starting at 2014-02-05 12:14:06.923067
+2014/02/05 12:14:06 INFO - Log event clock: real time
+2014/02/05 12:14:06 INFO - Run mode: live
+2014/02/05 12:14:06 INFO - Start tag: None
+2014/02/05 12:14:06 INFO - Stop tag: None
+2014/02/05 12:14:06 INFO - Thread-4 start (Job Submission)
+2014/02/05 12:14:06 INFO - Thread-5 start (Request Handling)
+2014/02/05 12:14:06 DEBUG - [t2.1] -task proxy added to the pool
+2014/02/05 12:14:06 DEBUG - [t1.1] -task proxy added to the pool
+2014/02/05 12:14:06 DEBUG - BEGIN TASK PROCESSING
+2014/02/05 12:14:06 DEBUG - [t2.1] -(setting:queued)
+2014/02/05 12:14:06 DEBUG - [t1.1] -(setting:queued)
+2014/02/05 12:14:06 DEBUG - 2 task(s) ready
+2014/02/05 12:14:06 DEBUG - [t2.1] -(setting:ready)
+2014/02/05 12:14:06 DEBUG - [t1.1] -(setting:ready)
+2014/02/05 12:14:06 INFO - [t2.1] -triggered off []
+2014/02/05 12:14:06 INFO - [t1.1] -triggered off []
+2014/02/05 12:14:06 DEBUG - END TASK PROCESSING (took 0.006963 sec)
+2014/02/05 12:14:07 DEBUG - Job Submission batch 1/1 (2 members):
+2014/02/05 12:14:07 INFO - [t2.1] -(current:ready)> t2.1 submitting now
+2014/02/05 12:14:07 INFO - [t2.1] -Task host: hpc2e
+2014/02/05 12:14:07 INFO - [t2.1] -Copying suite contact file to hpc2e
+2014/02/05 12:14:09 INFO - [t1.1] -Task host: hpc2e
+2014/02/05 12:14:09 INFO - [t1.1] -(current:ready)> t1.1 submitting now
+2014/02/05 12:14:10 INFO - [t2.1] -(current:ready)> t2.1 submission succeeded
+2014/02/05 12:14:10 DEBUG - [t2.1] -(setting:submitted)
+2014/02/05 12:14:10 INFO - [t2.1] -(current:submitted)> t2.1 submit_method_id=e004.4359478
+2014/02/05 12:14:11 DEBUG - Job Submission: batch completed
+  Time taken: 0:00:03.615413
+  All 2 items succeeded
+2014/02/05 12:14:11 DEBUG - BEGIN TASK PROCESSING
+2014/02/05 12:14:11 DEBUG - END TASK PROCESSING (took 0.002104 sec)
+2014/02/05 12:14:11 INFO - [t1.1] -(current:ready)> t1.1 submission succeeded
+2014/02/05 12:14:11 DEBUG - [t1.1] -(setting:submitted)
+2014/02/05 12:14:11 INFO - [t1.1] -(current:submitted)> t1.1 submit_method_id=e001.4141304
+2014/02/05 12:14:12 DEBUG - BEGIN TASK PROCESSING
+2014/02/05 12:14:12 DEBUG - END TASK PROCESSING (took 0.001927 sec)
+2014/02/05 12:14:26 INFO - [t2.1] -(current:submitted)> t2.1 started at 2014-02-05T12:14:25
+2014/02/05 12:14:26 DEBUG - [t2.1] -(setting:running)
+2014/02/05 12:14:26 INFO - [t2.1] -(current:running)> t2.1 succeeded at 2014-02-05T12:14:26
+2014/02/05 12:14:26 DEBUG - [t2.1] -(setting:succeeded)
+2014/02/05 12:14:26 INFO - [t1.1] -(current:submitted)> t1.1 started at 2014-02-05T12:14:25
+2014/02/05 12:14:26 DEBUG - [t1.1] -(setting:running)
+2014/02/05 12:14:26 INFO - [t1.1] -(current:running)> t1.1 succeeded at 2014-02-05T12:14:26
+2014/02/05 12:14:26 DEBUG - [t1.1] -(setting:succeeded)
+2014/02/05 12:14:26 INFO - Stopping: 
+  + all non-cycling tasks have succeeded
+2014/02/05 12:14:27 INFO - Thread-4 exit (Job Submission)
+2014/02/05 12:14:27 INFO - Thread-2 exit (Event Handlers)
+2014/02/05 12:14:27 INFO - Thread-3 exit (Poll & Kill Commands)
+2014/02/05 12:14:27 DEBUG - BEGIN TASK PROCESSING
+2014/02/05 12:14:27 DEBUG - END TASK PROCESSING (took 0.002094 sec)

--- a/tests/vacation/01-loadleveler/suite.rc
+++ b/tests/vacation/01-loadleveler/suite.rc
@@ -1,0 +1,33 @@
+#!jinja2
+[cylc]
+   [[reference test]]
+       required run mode=live
+       live mode suite timeout=5 # minutes
+
+[scheduling]
+    [[dependencies]]
+        graph="""
+t1
+t2
+"""
+
+[runtime]
+    [[root]]
+        command scripting=true
+        [[[job submission]]]
+            method=loadleveler
+        [[[directives]]]
+            class=serial
+            job_type=serial
+            notification=never
+            resources=ConsumableCpus(1) ConsumableMemory(64mb)
+            wall_clock_limit=180,120
+{% if "CYLC_TEST_DIRECTIVES" in environ and environ["CYLC_TEST_DIRECTIVES"] %}
+            {{environ["CYLC_TEST_DIRECTIVES"]}}
+{% endif %}
+        [[[remote]]]
+            host={{environ["CYLC_TEST_HOST"]}}
+    [[t1]]
+    [[t2]]
+        [[[directives]]]
+            restart=yes

--- a/tests/vacation/test_header
+++ b/tests/vacation/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
On receiving a `SIGUSR1` signal, a job script will remove its status
file, and send a message to the suite to indicate that it has been
vacated. The server will reset the status of the task (job) to
`submitted`. This change resolve cylc/cylc#867.
