### PR TITLE
#865: restore initial graph name.

### DIFF
--- a/lib/cylc/gui/GraphUpdater.py
+++ b/lib/cylc/gui/GraphUpdater.py
@@ -59,7 +59,7 @@ class GraphUpdater(threading.Thread):
         super(GraphUpdater, self).__init__()
 
         self.quit = False
-        self.cleared = True
+        self.cleared = False
         self.ignore_suicide = False
         self.focus_start_ctime = None
         self.focus_stop_ctime = None


### PR DESCRIPTION
This tweaks the change in #865 to keep the suite name in the `cylc gui` graph view when loaded for a stopped suite.

@hjoliver, please review.
