### PR TITLE
Correctly determine if a task host == localhost

### DIFF
--- a/bin/cylc-check-versions
+++ b/bin/cylc-check-versions
@@ -68,7 +68,7 @@ else:
     namespaces = result.keys()
     accounts = set()
     for name in namespaces:
-        host = get_task_host( config.get_config( ['runtime', name, 'remote', 'host'] )) or 'localhost'
+        host = get_task_host( config.get_config( ['runtime', name, 'remote', 'host'] ))
         owner = config.get_config( ['runtime', name, 'remote', 'owner'] )
         if owner:
             account = owner + '@' + host

--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -613,10 +613,8 @@ class task( object ):
 
         # host may be None (= run task on suite host)
         self.task_host = get_task_host( rtconfig['remote']['host'] )
-        if self.task_host:
+        if self.task_host != "localhost":
             self.log( "NORMAL", "Task host: " + self.task_host )
-        else:
-            self.task_host = "localhost"
 
         self.task_owner = rtconfig['remote']['owner']
 

--- a/tests/cylc-get-job-status/02-loadleveler.t
+++ b/tests/cylc-get-job-status/02-loadleveler.t
@@ -83,7 +83,7 @@ if ! ${IS_AT_T_HOST:-false}; then
     fi
     if [[ $T_HOST != 'localhost' ]]; then
         T_HOST_CYLC_DIR=$(ssh_mkdtemp $T_HOST)
-        rsync -a $CYLC_DIR/* $T_HOST:$T_HOST_CYLC_DIR/
+        rsync -a --exclude=*.pyc $CYLC_DIR/* $T_HOST:$T_HOST_CYLC_DIR/
         $SSH $T_HOST bash -l <<__BASH__
 echo "test" >$T_HOST_CYLC_DIR/VERSION
 IS_AT_T_HOST=true \


### PR DESCRIPTION
This change is the result of a recent attempt to install Cylc and Rose on a new machine. This particular problem comes up when we have a suite that is configured with a variable remote task host. On the machine, this variable is set to a string that contains the full `host.domain`, which is not being compared correctly as the `localhost`. It then tries to `ssh` to itself to install the suite contact file. (This then fails, because the machine is configured in such a way that it is unable to `ssh` to its own `host.domain` without a password.) This change ensures that the task host string is resolved as `localhost` and will therefore allow the system to skip the complexity of a remote task.
