### PR TITLE
Fix bad task host selection

### DIFF
--- a/lib/cylc/host_select.py
+++ b/lib/cylc/host_select.py
@@ -68,10 +68,9 @@ def get_task_host( cfg_item ):
             raise Exception( "Host selection by " + host + " failed:\n  Variable not defined: " + str(x) )
 
     try:
-        is_remote = is_remote_host(host)
+        if is_remote_host(host):
+            return host
+        else:
+            return "localhost"
     except:
-        is_remote = False
-    if is_remote:
         return host
-    else:
-        return "localhost"


### PR DESCRIPTION
It looks like #873 has broken the test battery where the tests concern
bad task hosts.

Sorry, but I must have run the test battery in _dream_ mode yesterday.
