### PR TITLE
Restore support for user-defined job submission methods.

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -85,6 +85,9 @@ where they got to while the suite was down."""
 
         self.suite_dir = os.path.dirname( self.suiterc )
 
+        # For user-defined job submission methods:
+        sys.path.append( os.path.join( self.suite_dir, 'python' ))
+
         self.restart_from = None
         if len( self.args ) == 2:
             self.restart_from = self.args[1]

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -93,6 +93,9 @@ initial and final cycle time variables persists across suite restarts."""
 
         self.suite_dir = os.path.dirname( self.suiterc )
 
+        # For user-defined job submission methods:
+        sys.path.append( os.path.join( self.suite_dir, 'python' ))
+
         if len( self.args ) == 2:
             self.cli_start_tag = self.args[1]
             if self.cli_start_tag == "now":

--- a/tests/job-submission/00-user.t
+++ b/tests/job-submission/00-user.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test user-defined job submission methods can be used.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-run
+suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME
+

--- a/tests/job-submission/00-user/python/my_background.py
+++ b/tests/job-submission/00-user/python/my_background.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cylc.job_submission.background import background
+from subprocess import Popen, PIPE
+
+class my_background( background ):
+    pass
+

--- a/tests/job-submission/00-user/reference.log
+++ b/tests/job-submission/00-user/reference.log
@@ -1,0 +1,21 @@
+2014/02/04 16:27:40 INFO - Thread-2 start (Event Handlers)
+2014/02/04 16:27:40 INFO - Thread-3 start (Poll & Kill Commands)
+2014/02/04 16:27:40 INFO - port:7766
+2014/02/04 16:27:40 INFO - Suite starting at 2014-02-04 16:27:40.360630
+2014/02/04 16:27:40 INFO - Log event clock: real time
+2014/02/04 16:27:40 INFO - Run mode: live
+2014/02/04 16:27:40 INFO - Start tag: None
+2014/02/04 16:27:40 INFO - Stop tag: None
+2014/02/04 16:27:40 INFO - Thread-4 start (Job Submission)
+2014/02/04 16:27:40 INFO - Thread-5 start (Request Handling)
+2014/02/04 16:27:40 INFO - [foo.1] -triggered off []
+2014/02/04 16:27:41 INFO - [foo.1] -(current:ready)> foo.1 submitting now
+2014/02/04 16:27:43 INFO - [foo.1] -(current:ready)> foo.1 started at 2014-02-04T16:27:43
+2014/02/04 16:27:45 INFO - [foo.1] -(current:running)> foo.1 succeeded at 2014-02-04T16:27:44
+2014/02/04 16:27:45 WARNING - [foo.1] -Assuming non-reported outputs were completed:
+foo.1 submitted
+2014/02/04 16:27:45 INFO - Stopping: 
+  + all non-cycling tasks have succeeded
+2014/02/04 16:27:45 INFO - Thread-4 exit (Job Submission)
+2014/02/04 16:27:46 INFO - Thread-2 exit (Event Handlers)
+2014/02/04 16:27:46 INFO - Thread-3 exit (Poll & Kill Commands)

--- a/tests/job-submission/00-user/suite.rc
+++ b/tests/job-submission/00-user/suite.rc
@@ -1,0 +1,16 @@
+[cylc]
+   [[reference test]]
+       required run mode = live
+       live mode suite timeout = 0.5 # minutes
+
+[scheduling]
+    [[dependencies]]
+        graph = "foo"
+
+[runtime]
+    [[foo]]
+        command scripting = "true" # quick
+        [[[job submission]]]
+            # use python/my_background.py:my_background
+            method = my_background
+

--- a/tests/job-submission/test_header
+++ b/tests/job-submission/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
As documented in the user guide but probably lost quite some time ago, we're supposed to be able to add new job submission methods (or derive from the existing ones) in a `python` sub-dir of the suite definition directory.

This restores the `python` sub-directory to `sys.path`, and adds a test.

@matthewrmshin - please review.

(background: I may need this in order to make a test for #880)
