### PR TITLE
Fix polling on restart for running tasks.

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -394,7 +394,7 @@ where they got to while the suite was down."""
                 else:
                     # update the task proxy with submit ID etc.
                     itask.submit_method_id = submit_method_id
-                    itask.submit_num = try_num
+                    itask.try_number = try_num
                     itask.user_at_host = user_at_host
                     # poll the task
                     itask.poll()


### PR DESCRIPTION
Fixes a bug in restarting for running tasks whereby the wrong status file would be polled.

Sequence to replicate the bug is as follows:
- Task runs and fails
- Task is reset to waiting
- Suite shutdown once task running but before finishes
- Task succeeds
- Suite restarted
- Task.1.1.status incorrectly polled, setting task to failed state
