### PR TITLE
Pass $CYLC_SUITE_RUN_DIR to ssh-invoked message commands.

### DIFF
--- a/lib/cylc/task_message.py
+++ b/lib/cylc/task_message.py
@@ -181,6 +181,7 @@ class message(object):
             env = {}
             for var in ['CYLC_MODE', 'CYLC_TASK_ID', 'CYLC_VERBOSE',
                     'CYLC_SUITE_DEF_PATH_ON_SUITE_HOST',
+                    'CYLC_SUITE_RUN_DIR',
                     'CYLC_SUITE_NAME', 'CYLC_SUITE_OWNER',
                     'CYLC_SUITE_HOST', 'CYLC_SUITE_PORT', 'CYLC_UTC',
                     'CYLC_TASK_MSG_MAX_TRIES', 'CYLC_TASK_MSG_TIMEOUT',


### PR DESCRIPTION
With _task communication method = ssh_ this bug causes the suite env file to be ignored by messaging commands re-invoked by ssh on the suite host, because the file path defaults wrongly to
`./cylc-suite-env` if the suite run directory is not known.   This bug should have no effect under normal circumstances because the suite env file on the task host will still determine the suite variables passed to the environment of the re-invoked message command on the suite host - but it's still a bug.

@arjclark - please review.
