### PR TITLE
gcylc: fix logfile sorting above 10 retries

### DIFF
--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -2177,8 +2177,10 @@ or remove task definitions without restarting the suite."""
 
         # for re-tries this sorts in time order due to filename:
         # (TODO - does this still work, post secs-since-epoch file extensions?)
-        err.sort( reverse=True )
-        out.sort( reverse=True )
+        key_func = lambda x: [int(w) if w.isdigit() else w for w in
+                              re.split("(\d+)", x)]
+        err.sort(key=key_func, reverse=True)
+        out.sort(key=key_func, reverse=True)
         window.set_size_request(800, 400)
         if choice == 'job script':
             window.set_title( task_id + ": Job Script" )


### PR DESCRIPTION
When a task has a try number greater than 9, the sorting
of the logfiles in the gcylc log viewer doesn't quite work as
we get the following kind of order:

```
foo.1.9.out
foo.1.8.out
foo.1.7.out
foo.1.6.out
foo.1.5.out
foo.1.4.out
foo.1.3.out
foo.1.22.out
foo.1.21.out
foo.1.20.out
foo.1.2.out
foo.1.19.out
foo.1.18.out
foo.1.17.out
foo.1.16.out
foo.1.15.out
foo.1.14.out
foo.1.13.out
foo.1.12.out
foo.1.11.out
foo.1.10.out
foo.1.1.out
foo.1.0.out
```

This change fixes the problem.

@hjoliver, please review when you have spare time.
