### PR TITLE
Set initial debug flag.

### DIFF
--- a/lib/cylc/flags.py
+++ b/lib/cylc/flags.py
@@ -31,3 +31,6 @@ iflag = False
 # verbose mode
 verbose = False
 
+# debug mode
+debug = False
+


### PR DESCRIPTION
Corrects an accidental omission from c2ce8520df942beee6cb28ee91cc3cbb1735ab97.  Technically a bug, but it only affects aborts due to errors occurring prior to command line parsing (which sets the debug flag according to command line options).
