### PR TITLE
Always set the suite info update flag if a task state changes.

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -1067,6 +1067,7 @@ class task( object ):
 
     def set_status( self, status ):
         if status != self.state.get_status():
+            flags.iflag = True
             self.log( 'DEBUG', '(setting:' + status + ')' )
             self.state.set_status( status )
             self.record_db_update("task_states", self.name, self.c_time,


### PR DESCRIPTION
This fixes a minor bug in simulation mode: the suite state summary would not be updated for the task 'running' state if nothing else was happening at the time, because in sim mode this state change is not caused by an incoming task message (which does always result in a state summary update).
