### PR TITLE
Initialize ctimes list in gcylc dot view.

### DIFF
--- a/lib/cylc/gui/DotUpdater.py
+++ b/lib/cylc/gui/DotUpdater.py
@@ -55,6 +55,7 @@ class DotUpdater(threading.Thread):
         self.ancestors_pruned = {}
         self.descendants = []
         self.filter = ""
+        self.ctimes = []
 
         self.led_headings = []
         self.led_treeview = treeview


### PR DESCRIPTION
Bug fix: attempt to _View -> Transpose_ on an empty dot view (prior to starting the suite) results in

```
Traceback (most recent call last):
  File "/home/oliverh/cylc/cylc.git/lib/cylc/gui/DotUpdater.py", line 371, in update_gui
    self.ledview_widgets()
  File "/home/oliverh/cylc/cylc.git/lib/cylc/gui/DotUpdater.py", line 226, in ledview_widgets
    types = [str] + [gtk.gdk.Pixbuf] * len( self.ctimes )
AttributeError: 'DotUpdater' object has no attribute 'ctimes'
```
