### PR TITLE
Install cylc-suite-env with ssh -oConnectTimeout

### DIFF
--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -308,16 +308,16 @@ class scheduler(object):
         for user_at_host in self.old_user_at_host_set:
             # Reinstate suite contact file to each old job's user@host
             if '@' in user_at_host:
-                user, host = user_at_host.split('@', 1)
+                owner, host = user_at_host.split('@', 1)
             else:
-                user, host = None, user_at_host
-            if host == 'localhost':
+                owner, host = None, user_at_host
+            if (owner, host) in [(None, 'localhost'), (user, 'localhost')]:
                 continue
             r_suite_run_dir = sitecfg.get_derived_host_item(
                                 self.suite,
                                 'suite run directory',
                                 host,
-                                user)
+                                owner)
             r_env_file_path = '%s:%s/cylc-suite-env' % (
                                 user_at_host,
                                 r_suite_run_dir)

--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -604,7 +604,7 @@ class task( object ):
         self.execution_poll_timer.set_host( self.task_host )
 
         if self.task_host not in self.__class__.suite_contact_env_hosts and \
-                self.task_host != 'localhost' and cylc_mode == 'scheduler':
+                self.user_at_host != 'localhost' and cylc_mode == 'scheduler':
             # If the suite contact file has not been copied to user@host
             # host yet, do so. This will happen for the first task on
             # this remote account inside the job-submission thread just


### PR DESCRIPTION
Network issues can sometimes cause an attempted SSH connection to hang. This change allows the `ssh` and `scp` commands to timeout and fail if it is unable to connect after 10s. (As these are the 1st SSH commands a suite will run on job hosts, they should catch most problems.)
