### PR TITLE
Retain Jinja2 during inlined edit sessions.

### DIFF
--- a/lib/parsec/include.py
+++ b/lib/parsec/include.py
@@ -61,10 +61,15 @@ def inline( lines, dir, file, for_grep=False, for_edit=False, viewcfg={}, level=
     global modtimes
 
     outf = []
+    initial_line_index = 0
 
     if level == None:
         level = ''
         if for_edit:
+            m = re.match( '^(#![jJ]inja2)', lines[0])
+            if m:
+                outf.append( m.groups()[0] )
+                initial_line_index = 1
             outf.append("""# !WARNING! CYLC EDIT INLINED (DO NOT MODIFY THIS LINE).
 # !WARNING! This is an inlined parsec config file; include-files are split
 # !WARNING! out again on exiting the edit session.  If you are editing
@@ -83,7 +88,7 @@ def inline( lines, dir, file, for_grep=False, for_edit=False, viewcfg={}, level=
     else:
         msg = ''
 
-    for line in lines:
+    for line in lines[initial_line_index:]:
         m = include_re.match( line )
         if m:
             q1, match, q2 = m.groups()


### PR DESCRIPTION
`cylc edit -i` allows editing of suites with any include-files inlined, and then splits the suite definition up into include-files again on exiting the edit session. Special markers - for warnings and file-inclusion boundaries - are inserted into the file as comments so that the inlined suite remains valid during editing. However, initial warning comments are inserted at the very top of the file, which temporarily breaks Jinja2 suites during the edit session.  This small change keeps the Jinja2 shebang line, if there is one, at the top.

@matthewrmshin - please review.
