### PR TITLE
Increase connection timeout and handle lock better in poll mode.

### DIFF
--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -25,7 +25,7 @@ if remrun().execute():
     sys.exit(0)
 
 from cylc.CylcOptionParsers import cop
-from cylc.dbstatecheck import CylcSuiteDBChecker, DBNotFoundError
+from cylc.dbstatecheck import CylcSuiteDBChecker, DBNotFoundError, DBOperationError
 from cylc.cfgspec.site import sitecfg
 from cylc.command_polling import poller
 import cylc.flags
@@ -57,11 +57,14 @@ class suite_poller( poller ):
                 connected = True
                 # ... but ensure at least one poll after connection:
                 self.n_polls -= 1
-            except DBNotFoundError:
+            except (DBNotFoundError, DBOperationError) as err:
                 if cylc.flags.verbose:
                     sys.stdout.write('.')
                 if self.n_polls >= max_polls:
-                    break
+                    if isinstance(err, DBOperationError):
+                        sys.exit("unable to query suite database: " + str(err))
+                    else:
+                        break
                 sleep(self.interval)
         if cylc.flags.verbose:
             sys.stdout.write('\n')

--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -105,7 +105,7 @@ class ThreadedCursor(Thread):
         self.generic_err_msg = ("%s:%s occurred while trying to run:\n"+
                               "\trequest: %s\n\targs: %s")
     def run(self):
-        cnx = sqlite3.connect(self.db)
+        cnx = sqlite3.connect(self.db, timeout=10.0)
         cursor = cnx.cursor()
         counter = 1
         while True:


### PR DESCRIPTION
This makes the following changes:
- increase the db connection timeout to 10s (from default 5s)
- catch errors raised by db locking and carry on if in polling mode
- if final poll has been reached and db locking has occurred then print the db locking error
