### PR TITLE
cylc.daemonize: more shell-friendly text

### DIFF
--- a/lib/cylc/daemonize.py
+++ b/lib/cylc/daemonize.py
@@ -37,7 +37,7 @@ def daemonize( suite, port ):
             print " + Name:", suite
             print " + PID: ", pid
             print " + Port:", port
-            print " + Logs: %s/(log|out|err)" % os.path.dirname( sout.get_path() )
+            print " + Logs: %s/{log,out,err}" % os.path.dirname( sout.get_path() )
             print
             print "To see if this suite is still running:"
             print " * cylc scan"


### PR DESCRIPTION
For the location of the logs. The `{log,out,err}` syntax can be recognised and expanded by the shell.
