### PR TITLE
#119: fix graphing exception

### DIFF
--- a/lib/cylc/cylc_xdot.py
+++ b/lib/cylc/cylc_xdot.py
@@ -286,8 +286,8 @@ class MyDotWindow( CylcDotViewerCommon ):
     </ui>
     '''
     def __init__(self, suite, suiterc, template_vars,
-                 template_vars_file,  watch, point_string, stop_point_string,
-                 orientation="TB" ):
+                 template_vars_file,  watch, start_point_string,
+                 stop_point_string, orientation="TB" ):
         self.outfile = None
         self.disable_output_image = False
         self.suite = suite


### PR DESCRIPTION
Currently, when running `cylc graph`, we get:

```
Traceback (most recent call last):
  File "/opt/cylc/bin/cylc-graph", line 217, in <module>
    start_point_string, stop_point_string )
  File "/opt/cylc/lib/cylc/cylc_xdot.py", line 296, in __init__
    self.start_point_string = start_point_string
NameError: global name 'start_point_string' is not defined
```

This fixes the traceback and allows all the tests to pass.

@matthewrmshin, please review.
