### PR TITLE
1043 warm start follow up

### DIFF
--- a/bin/cylc-restart
+++ b/bin/cylc-restart
@@ -39,17 +39,16 @@ class restart( scheduler ):
     def __init__( self ):
         usage = """cylc [control] restart [OPTIONS] ARGS
 
-Restart a suite from a previous state. To start from scratch see the
-'cylc run' command.
+Start a suite run from a previous state. To start from scratch (cold or warm
+start) see the 'cylc run' command.
 
-Suites run in daemon mode unless -n/--no-detach or --debug is used.
+The scheduler runs in daemon mode unless you specify n/--no-detach or --debug.
 
-The most recent previous state is loaded by default, but other states
-can be specified on the command line (cylc writes special state dumps
-and logs their filenames before actioning intervention commands).
+The most recent previous suite state is loaded by default, but earlier state
+files in the suite state directory can be specified on the command line.
 
-Tasks recorded as 'submitted' or 'running' will be polled to determine
-where they got to while the suite was down."""
+Tasks recorded as 'submitted' or 'running' will be polled at start-up to
+determine what happened to them while the suite was down."""
 
         self.parser = cop( usage, jset=True, argdoc=[("REG", "Suite name"),
    ( "[FILE]", """Optional state dump file, assumed to reside in the

--- a/bin/cylc-run
+++ b/bin/cylc-run
@@ -32,27 +32,24 @@ class start( scheduler ):
     def __init__( self ):
         usage = """cylc [control] run|start [OPTIONS] ARGS
 
-Start a suite from scratch. To restart from a previous state see the
-'cylc restart' command.
+Start a suite run from scratch, wiping out any previous suite state. To
+restart from a previous state see 'cylc restart --help'.
 
-Suites run in daemon mode unless -n/--no-detach or --debug is used.
+The scheduler runs in daemon mode unless you specify n/--no-detach or --debug.
 
-The following are all equivalent if no intercycle dependence exists:
-  1/ Cold start (default)    : use special cold-start tasks
-  2/ Warm start (-w,--warm)  : assume a previous cycle
+Any dependence on cycle points earlier than the start cycle point is ignored.
 
-1/ COLD START -- start at the initial cycle point of the suite,
-specified via the suite.rc or via the first argument (ARGS). Any
-dependencies on earlier cycles will be ignored.
+A "cold start" (the default) starts from the suite's initial cycle point
+(specified in the suite.rc or on the command line), and loads any special
+one-off cold-start tasks (see below).
 
-2/ WARM START -- start from a cycle point later than the initial cycle
-point, supplied via the first argument (ARGS). The initial cycle point
-should be specified via the suite.rc. Any dependencies on earlier
-cycles will be ignored.
+A "warm start" (-w/--warm) starts from a given cycle point that is later than
+the initial cycle point (specified in the suite.rc), and loads any cold-start
+tasks in the 'succeeded' state just to satisfy initial dependence on them.
 
-In task environments, $CYLC_SUITE_FINAL_CYCLE_POINT is always set to the
-final cycle point if one is set (by suite.rc file or command line). The
-initial and final cycle point variables persists across suite restarts."""
+Aside from the starting cycle point there is no difference between cold and
+warm start unless you use special cold-start tasks. See "Suite Start-up" and
+"Cold-Start Tasks" in the User Guide for more."""
 
         self.parser = cop( usage, jset=True, argdoc=[ ("REG", "Suite name"),
                 ("[START_POINT]", """Initial cycle point or 'now'; overrides the
@@ -70,7 +67,8 @@ initial and final cycle point variables persists across suite restarts."""
                 help="Output profiling (performance) information",
                 action="store_true", default=False, dest="profile_mode" )
 
-        self.parser.add_option( "-w", "--warm", help="Warm start the suite",
+        self.parser.add_option( "-w", "--warm", help="Warm start the suite. "
+                "The default is to cold start.",
                 action="store_true", default=False, dest="warm" )
 
         self.parser.add_option( "--ict",
@@ -118,28 +116,23 @@ initial and final cycle point variables persists across suite restarts."""
         coldstart_tasks = self.config.get_coldstart_task_list()
 
         for name in task_list:
-            if self.start_point is not None:
-                point = self.start_point
-            else:
-                # no initial cycle point: we can't load cycling tasks
+            if self.start_point is None:
+                # No start cycle point at which to load cycling tasks.
                 continue
             itask = self.config.get_task_proxy(
-                name, point, 'waiting', stop_point=None, startup=True,
-                submit_num=0, exists=False
+                name, self.start_point, 'waiting', stop_point=None,
+                startup=True, submit_num=0, exists=False
             )
-
+            if not itask.point:
+                self.log.debug( "Not loading " + name + " (out of sequence bounds)" )
+                del itask
+                continue
             if name in coldstart_tasks and self.options.warm:
-                itask.log("NORMAL",
-                          "warm start: starting in succeeded state")
                 itask.state.set_status( 'succeeded' )
                 itask.prerequisites.set_all_satisfied()
                 itask.outputs.set_all_completed()
-
-            if itask.point:
-                self.pool.add_to_runahead_pool( itask )
-            else:
-                self.log.info( "Not loading " + name + " (out of sequence bounds)" )
-                del itask
+            # Load task.
+            self.pool.add_to_runahead_pool( itask )
 
 if __name__ == '__main__':
     main("run", start)

--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -1757,14 +1757,12 @@ initial cycle point) provided that the initial cycle point was always at 00 and
 Experiment with this suite to see how inter-cycle-point triggers work.
 Note that the first instance of \lstinline=foo=, at suite start-up, will
 trigger immediately in spite of its inter-cycle-point trigger, because cylc
-ignores triggers that reach back beyond the initial cycle point.
-
-The presence of an inter-cycle-point trigger usually implies something
-special has to happen at start-up, however. If a model depends on its
-own previous instance for restart files, for instance, then some special
-process will typically have to generate the initial set of restart files when
-there is no previous cycle point to do it. The following sections illustrate
-several ways of handling this in cylc suites.
+ignores dependence on points earlier than the initial cycle point.
+However, the presence of an inter-cycle-point trigger usually implies something
+special has to happen at start-up. If a model depends on its own previous
+instance for restart files, for example, then some special process has to
+generate the initial set of restart files when there is no previous cycle point
+to do it. The following section shows one way to handle this in cylc suites.
 
 \subsubsection{Initial Non-Repeating (R1) Tasks}
 \label{initial-non-repeating-r1-tasks}
@@ -1849,6 +1847,9 @@ prep.20130808T0000+13 => foo.20130808T0000+13
     \caption{The \lstinline=tut.cycling.three= suite}
 \label{fig-tut-three}
 \end{figure}
+
+For another way to make something different happen at start-up, see 
+{\em cold start tasks} in Section~\ref{SpecialColdStartTasks}.
 
 \subsection{Jinja2}
 
@@ -3378,20 +3379,39 @@ depends on its previous (12 hours ago) instance.
 This is quite different to the non-preferred \lstinline=cold-start tasks=
 way of working.
 
-When using \lstinline=cold-start tasks=, unlike for asynchronous and start-up
-initial tasks, however, the cold-start ``OR'' construct means that cold-start
-triggers don't have to be ignored by cylc after the first cycle point, so it
-is possible to insert cold-start task into a suite mid-run to do mid-stream
-cold-starts after problems that preclude continued normal warm cycling.
+\paragraph{Special Cold-Start Tasks}
+\label{SpecialColdStartTasks}
 
-Initial tasks can invoke real processing to generate the files
-that are subsequently produced by a tasks in the previous cycle point; or
-they could be dummy tasks that represent some external process that does the
-same before the suite is started - in which case the initial task can
-just report itself successfully completed after checking that the
-required files are present.
+Special cold-start tasks are non-spawning tasks intended for use in general
+cycling sections, so they must be declared as special tasks. Dependence on them
+is retained throughout the suite run so they must be in conditional triggers to
+avoid stalling the suite. For example:
+\lstset{language=suiterc}
+\begin{lstlisting}
+[scheduling]
+    initial cycle point = 20140808T00
+    [[special tasks]]
+        cold-start = cold_model
+    [[[T00]]]
+        graph = cold_model | model[-P1D] => model
+\end{lstlisting}
 
-\paragraph{Sequential Tasks}
+This allows the \lstinline=cold_model= task to be inserted manually in the
+middle of a suite run to cold-start \lstinline=model= again after problems that
+require skipping one or more cycles.
+If you do not need this late cold start functionality then it is easier to
+use a normal task in an initial R1 recurrence:
+\lstset{language=suiterc}
+\begin{lstlisting}
+[scheduling]
+    initial cycle point = 20140808T00
+    [[[R1]]]
+        graph = start_model => model
+    [[[T00]]]
+        graph = model[-P1D] => model
+    \end{lstlisting}
+
+\paragraph{Special Sequential Tasks}
 \label{SequentialTasks}
 
 If a cycling task does not generate files required by its own successor,
@@ -3448,17 +3468,6 @@ is equivalent to this one:
             graph = "foo[-PT8H] => foo"
 \end{lstlisting}
 
-\paragraph{Warm Start}
-
-For suites with inter-cycle-point dependence a {\em warm start} is essentially
-an implicit restart. Rather than loading tasks from a previous recorded
-suite state, cylc loads all cycling tasks at a given cycle point assuming
-that the previous cycle was completed in an earlier suite run. Any initial
-tasks therefore may not need to run again. Dependence on tasks from before
-the start cycle is still ignored, but cold-start tasks have to be loaded in
-the {\em succeeded} state because dependence on them (in the cold-start OR
-construct) is retained throughout the suite run as is explained above in
-Section~\ref{InterCyclePointTriggers}.
 
 \paragraph{Future Triggers}
 
@@ -4290,7 +4299,7 @@ use one or both of [scheduling][[special task]] lists, {\em include at
 start-up} or {\em exclude at start-up} (documented in
 Sections~\ref{IASU} and~\ref{EASU}). Then the graph still defines the
 validity of the tasks and their dependencies, but they are not actually
-inserted into the suite at start-up. Other tasks that depend on the
+loaded into the suite at start-up. Other tasks that depend on the
 omitted ones, if any, will have to wait on their insertion at a later
 time or otherwise be triggered manually.
 
@@ -4874,10 +4883,68 @@ at the top of the example file above).
 \section{Running Suites}
 \label{RunningSuites}
 
-To learn how to control running suites please also see the Tutorial
-(Section~\ref{Tutorial}, command documentation
-(Section~\ref{CommandReference}), and experiment with plenty of test
-suites.
+This chapter currently features a rather diverse collection of topics related
+to running suites. Please also see the Tutorial (Section~\ref{Tutorial} and 
+command documentation (Section~\ref{CommandReference}), and experiment with
+plenty of examples.
+
+\subsection{Suite Start-up}
+\label{SuiteStartUp}
+
+There are three ways to start a suite running: cold start and warm start, which
+start from scratch; and restart, which loads a prior suite state. If a suite
+does not contain any special cold-start tasks there is no difference
+between cold and warm start, except that a warm start should start from a
+point beyond the original initial cycle point of the suite. You may not need
+to use special cold start tasks - see Section~\ref{SpecialColdStartTasks}.
+
+Once a suite is up and running it is typically a restart that is needed most
+often (but see also \lstinline=cylc reload=). Be aware that cold and warm
+starts wipe out any prior suite state, which prevents returning to a restart
+if you decide that's what you really intended.
+
+
+\subsubsection{Cold Start}
+
+A cold start is the primary way to start a suite run from scratch:
+\begin{lstlisting}
+shell$ cylc run SUITE [INITIAL_CYCLE_POINT]
+\end{lstlisting}
+The initial cycle point may be specified on the command line or in the suite.rc
+file. The scheduler starts by loading an initial instance of each task at
+the initial cycle point, or at the next valid point for the task, including any
+special ``cold-start tasks''.
+
+\subsubsection{Restart}
+
+A restart starts a suite run from the state it recorded at the end of a
+previous run. This allows restarting a suite that was shut down or killed,
+without rerunning any tasks that already ran.
+\begin{lstlisting}
+shell$ cylc restart SUITE [STATE_FILE]
+\end{lstlisting}
+For a restart, the scheduler starts by loading each task in its recorded state.
+The most recent state is loaded by default, but earlier state files can be
+specified on the command line. Any tasks recorded as `submitted' or `running'
+will be polled automatically to determined what happened to them while the
+suite was down.
+
+\subsubsection{Warm Start}
+
+A warm start runs from a cycle point later than the suite's initial cycle
+point, but without referencing any previous suite state. It can be considered
+an inferior alternative to a restart because it may result in some tasks
+rerunning.  A warm start may be required if a restart is not possible because
+the suite state files were accidentally deleted (for instance). The warm start
+cycle point must be given on the command line:
+\begin{lstlisting}
+shell$ cylc run --warm SUITE [START_CYCLE_POINT]
+\end{lstlisting}
+In this case the scheduler starts by loading an initial instance of each 
+task at the warm start cycle point (or at the next valid point for the task),
+and any special cold-start tasks are loaded in the `succeeded' state (this is
+merely a device to satisfy any initial dependence on the cold-start tasks which
+are assumed not to be needed for a warm start).
 
 \subsection{How Tasks Interact With Running Suites}
 \label{TaskComms}
@@ -5869,9 +5936,6 @@ This results in \lstinline=DOG= having cycle points of
 The following topics have yet to be documented in detail.
 
 \begin{myitemize}
-    \item The difference between cold-, warm-, raw-, and re-starting, a suite:
-        see \lstinline=cylc run help=.
-
     \item Intervening in suites, e.g.\ stopping, removing, inserting tasks:
         see \lstinline=cylc control help=.
 

--- a/doc/suiterc.tex
+++ b/doc/suiterc.tex
@@ -421,13 +421,12 @@ This section allows cylc to determine when tasks are ready to run.
 
 \subsubsection[initial cycle point]{[scheduling] $\rightarrow$ initial cycle point}
 
-At startup each cycling task (unless specifically excluded under
-[special tasks]) will be inserted into the suite with this cycle point,
+In a cold start each cycling task (unless specifically excluded under
+[special tasks]) will be loaded into the suite with this cycle point,
 or with the closest subsequent valid cycle point for the task. Note that
-whether or not {\em cold-start tasks}, specified under [special tasks],
-are inserted, and in what state they are inserted, depends on the start
-up method - cold, warm, or raw.  If this item is provided you can
-override it on the command line or in the gcylc suite start panel.
+special {\em cold-start tasks} are not loaded in a warm start. If this item is
+provided you can override it on the command line or in the gcylc suite start
+panel.
 
 In date-time cycling, if you do not provide time zone information for this,
 it will be assumed to be local time, or in UTC if \ref{UTC-mode} is set, or in

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -932,8 +932,6 @@ class config( object ):
 
 
     def get_coldstart_task_list( self ):
-        # TODO - automatically determine this by parsing the dependency graph?
-        # For now user must define this:
         return self.cfg['scheduling']['special tasks']['cold-start']
 
     def get_task_name_list( self ):
@@ -1781,7 +1779,7 @@ class config( object ):
             name, rtcfg, self.run_mode, self.start_point)
 
         # TODO - put all taskd.foo items in a single config dict
-        # SET COLD-START TASK INDICATORS
+        # Set cold-start task indicators.
         if name in self.cfg['scheduling']['special tasks']['cold-start']:
             taskd.modifiers.append( 'oneoff' )
             taskd.is_coldstart = True


### PR DESCRIPTION
This follows on from #1043, for #119.  It [now!] just attempts to more clearly document the difference between cold and warm start, and the sole reason for using old-style cold-start tasks.
