### PR TITLE
cylc.job_submission.job_submit: improve pylint score

### DIFF
--- a/bin/cylc-submit
+++ b/bin/cylc-submit
@@ -26,7 +26,7 @@ import subprocess
 from time import sleep
 from parsec.OrderedDict import OrderedDict
 from cylc.execute import execute
-from cylc.job_submission import jobfile
+from cylc.job_submission.jobfile import JobFile
 from cylc.config import config, SuiteConfigError, TaskNotDefinedError
 from cylc.CylcOptionParsers import cop
 import cylc.TaskID
@@ -160,8 +160,8 @@ suite_task_env = {
         }
 # (note sitecfg automatically expands environment variables in local paths)
 
-jobfile.jobfile.suite_env = suite_env
-jobfile.jobfile.suite_task_env = suite_task_env
+JobFile.suite_env = suite_env
+JobFile.suite_task_env = suite_task_env
 
 point = get_point(point_string)
 try:

--- a/lib/cylc/job_submission/at.py
+++ b/lib/cylc/job_submission/at.py
@@ -16,13 +16,13 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from job_submit import job_submit
+from job_submit import JobSubmit
 import os
 import re
 from signal import SIGKILL
 from subprocess import check_call, Popen, PIPE
 
-class at( job_submit ):
+class at( JobSubmit ):
     """
     Submit the task job script to the simple 'at' scheduler. Note that
     (1) the 'atd' daemon service must be running; (2) the atq command
@@ -50,7 +50,7 @@ class at( job_submit ):
     #   * queue is '=' if running
     #
 
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         """
         Construct a command to submit this job to run.
         """

--- a/lib/cylc/job_submission/fail.py
+++ b/lib/cylc/job_submission/fail.py
@@ -16,9 +16,9 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from job_submit import job_submit
+from job_submit import JobSubmit
 
-class fail( job_submit ):
+class fail( JobSubmit ):
     """
 This is a fake job submission that deliberately fails, used for cylc
 development purposes.
@@ -27,7 +27,7 @@ development purposes.
     # even on a remote host - ssh can exit without waiting for the
     # remote process to finish.
     COMMAND_TEMPLATE = "sleep 10; /bin/false"
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         command_template = self.job_submit_command_template
         if not command_template:
             command_template = self.__class__.COMMAND_TEMPLATE

--- a/lib/cylc/job_submission/jobfile.py
+++ b/lib/cylc/job_submission/jobfile.py
@@ -27,7 +27,7 @@ import signal
 from subprocess import Popen, PIPE
 from time import time, sleep
 
-class jobfile(object):
+class JobFile(object):
 
     # These are set by the scheduler object at start-up:
     suite_env = None       # static variables not be be changed below

--- a/lib/cylc/job_submission/loadleveler.py
+++ b/lib/cylc/job_submission/loadleveler.py
@@ -17,11 +17,11 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from job_submit import job_submit
+from job_submit import JobSubmit
 import cylc.TaskID
 from subprocess import check_call, Popen, PIPE
 
-class loadleveler( job_submit ):
+class loadleveler( JobSubmit ):
 
     "Loadleveler job submission"
 
@@ -71,7 +71,7 @@ class loadleveler( job_submit ):
         if self.jobconfig['directives'].get('restart') == 'yes':
             self.jobconfig['job vacation signal'] = 'USR1'
 
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         """
         Construct a command to submit this job to run.
         """

--- a/lib/cylc/job_submission/pbs.py
+++ b/lib/cylc/job_submission/pbs.py
@@ -17,10 +17,10 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from job_submit import job_submit
+from job_submit import JobSubmit
 from subprocess import check_call, Popen, PIPE
 
-class pbs( job_submit ):
+class pbs( JobSubmit ):
 
     "PBS qsub job submission."
 
@@ -50,7 +50,7 @@ class pbs( job_submit ):
             defaults[ '-N' ] = defaults[ '-N' ][:15]
         self.jobconfig['directives'] = defaults
 
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         """
         Construct a command to submit this job to run.
         """

--- a/lib/cylc/job_submission/sge.py
+++ b/lib/cylc/job_submission/sge.py
@@ -17,10 +17,10 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from job_submit import job_submit
+from job_submit import JobSubmit
 from subprocess import check_call, Popen, PIPE
 
-class sge( job_submit ):
+class sge( JobSubmit ):
 
     "SGE qsub job submission"
 
@@ -46,7 +46,7 @@ class sge( job_submit ):
             defaults[ d ] = val
         self.jobconfig['directives'] = defaults
 
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         """
         Construct a command to submit this job to run.
         """

--- a/lib/cylc/job_submission/slurm.py
+++ b/lib/cylc/job_submission/slurm.py
@@ -17,9 +17,9 @@
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from job_submit import job_submit
+from job_submit import JobSubmit
 
-class slurm( job_submit ):
+class slurm( JobSubmit ):
     """
 SLURM job submission.
     """
@@ -46,7 +46,7 @@ SLURM job submission.
             defaults[ d ] = val
         self.jobconfig['directives'] = defaults
 
-    def construct_jobfile_submission_command( self ):
+    def construct_job_submit_command( self ):
         command_template = self.job_submit_command_template
         if not command_template:
             command_template = self.__class__.COMMAND_TEMPLATE

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -18,7 +18,7 @@
 
 from cylc_pyro_server import pyro_server
 from task_types import task, clocktriggered
-from job_submission import jobfile
+from job_submission.jobfile import JobFile
 from suite_host import get_suite_host
 from owner import user
 from shutil import copy as shcopy
@@ -750,8 +750,8 @@ class scheduler(object):
         # (note global config automatically expands environment variables in local paths)
 
         # Pass these to the job script generation code.
-        jobfile.jobfile.suite_env = self.suite_env
-        jobfile.jobfile.suite_task_env = self.suite_task_env
+        JobFile.suite_env = self.suite_env
+        JobFile.suite_task_env = self.suite_task_env
         # And pass contact env to the task module
         task.task.suite_contact_env = self.suite_contact_env
 


### PR DESCRIPTION
This pull request contains changes that I have done as part of the log and work restructure change, but should really be separate.

The change is mainly to increase the pylint score and pep8 compliance for `cylc.job_submission.job_submit`.

I have also introduced a small change in `cylc.task_types.task.py` to create the remote job log directory at the point when it installs the suite contact environment file. (This prevents job submission failures when we have `mkdir -p` race condition - which can happen quite regularly on our AIX system.)
