### PR TITLE
Use natural sort order in graph tests.

### DIFF
--- a/tests/cyclers/integer1/graph.plain.ref
+++ b/tests/cyclers/integer1/graph.plain.ref
@@ -1,6 +1,13 @@
 edge "foo.1" "bar.1" solid slateblue
 edge "foo.1" "foo.4" solid slateblue
 edge "foo.1" "on_toast.4" solid slateblue
+edge "foo.4" "bar.4" solid slateblue
+edge "foo.4" "foo.7" solid slateblue
+edge "foo.4" "on_toast.7" solid slateblue
+edge "foo.4" "qux.7" solid slateblue
+edge "foo.7" "bar.7" solid slateblue
+edge "foo.7" "foo.10" solid slateblue
+edge "foo.7" "on_toast.10" solid slateblue
 edge "foo.10" "bar.10" solid slateblue
 edge "foo.10" "foo.13" solid slateblue
 edge "foo.10" "on_toast.13" solid slateblue
@@ -9,27 +16,12 @@ edge "foo.13" "bar.13" solid slateblue
 edge "foo.13" "foo.16" solid slateblue
 edge "foo.13" "on_toast.16" solid slateblue
 edge "foo.16" "bar.16" solid slateblue
-edge "foo.4" "bar.4" solid slateblue
-edge "foo.4" "foo.7" solid slateblue
-edge "foo.4" "on_toast.7" solid slateblue
-edge "foo.4" "qux.7" solid slateblue
-edge "foo.7" "bar.7" solid slateblue
-edge "foo.7" "foo.10" solid slateblue
-edge "foo.7" "on_toast.10" solid slateblue
 edge "seq.1" "foo.1" solid navajowhite
+edge "seq.4" "foo.4" solid navajowhite
+edge "seq.7" "foo.7" solid navajowhite
 edge "seq.10" "foo.10" solid navajowhite
 edge "seq.13" "foo.13" solid navajowhite
 edge "seq.16" "foo.16" solid navajowhite
-edge "seq.4" "foo.4" solid navajowhite
-edge "seq.7" "foo.7" solid navajowhite
-edge "woo.11" "bar.10" solid limegreen
-edge "woo.11" "foo.10" solid limegreen
-edge "woo.12" "foo.13" solid limegreen
-edge "woo.14" "bar.13" solid limegreen
-edge "woo.14" "foo.13" solid limegreen
-edge "woo.15" "foo.16" solid limegreen
-edge "woo.17" "bar.16" solid limegreen
-edge "woo.17" "foo.16" solid limegreen
 edge "woo.2" "bar.1" solid limegreen
 edge "woo.2" "foo.1" solid limegreen
 edge "woo.3" "foo.4" solid limegreen
@@ -39,41 +31,49 @@ edge "woo.6" "foo.7" solid limegreen
 edge "woo.8" "bar.7" solid limegreen
 edge "woo.8" "foo.7" solid limegreen
 edge "woo.9" "foo.10" solid limegreen
+edge "woo.11" "bar.10" solid limegreen
+edge "woo.11" "foo.10" solid limegreen
+edge "woo.12" "foo.13" solid limegreen
+edge "woo.14" "bar.13" solid limegreen
+edge "woo.14" "foo.13" solid limegreen
+edge "woo.15" "foo.16" solid limegreen
+edge "woo.17" "bar.16" solid limegreen
+edge "woo.17" "foo.16" solid limegreen
 graph 
 node "bar.1" "bar\n1" filled ellipse black orange
+node "bar.4" "bar\n4" filled ellipse black orange
+node "bar.7" "bar\n7" filled ellipse black orange
 node "bar.10" "bar\n10" filled ellipse black orange
 node "bar.13" "bar\n13" filled ellipse black orange
 node "bar.16" "bar\n16" filled ellipse black orange
-node "bar.4" "bar\n4" filled ellipse black orange
-node "bar.7" "bar\n7" filled ellipse black orange
 node "foo.1" "foo\n1" filled ellipse black slateblue
+node "foo.4" "foo\n4" filled ellipse black slateblue
+node "foo.7" "foo\n7" filled ellipse black slateblue
 node "foo.10" "foo\n10" filled ellipse black slateblue
 node "foo.13" "foo\n13" filled ellipse black slateblue
 node "foo.16" "foo\n16" filled ellipse black slateblue
-node "foo.4" "foo\n4" filled ellipse black slateblue
-node "foo.7" "foo\n7" filled ellipse black slateblue
+node "on_toast.4" "on_toast\n4" filled ellipse black beige
+node "on_toast.7" "on_toast\n7" filled ellipse black beige
 node "on_toast.10" "on_toast\n10" filled ellipse black beige
 node "on_toast.13" "on_toast\n13" filled ellipse black beige
 node "on_toast.16" "on_toast\n16" filled ellipse black beige
-node "on_toast.4" "on_toast\n4" filled ellipse black beige
-node "on_toast.7" "on_toast\n7" filled ellipse black beige
-node "qux.13" "qux\n13" filled ellipse black orangered
 node "qux.7" "qux\n7" filled ellipse black orangered
+node "qux.13" "qux\n13" filled ellipse black orangered
 node "seq.1" "seq\n1" filled ellipse black navajowhite
+node "seq.4" "seq\n4" filled ellipse black navajowhite
+node "seq.7" "seq\n7" filled ellipse black navajowhite
 node "seq.10" "seq\n10" filled ellipse black navajowhite
 node "seq.13" "seq\n13" filled ellipse black navajowhite
 node "seq.16" "seq\n16" filled ellipse black navajowhite
-node "seq.4" "seq\n4" filled ellipse black navajowhite
-node "seq.7" "seq\n7" filled ellipse black navajowhite
-node "woo.11" "woo\n11" filled ellipse black limegreen
-node "woo.12" "woo\n12" filled ellipse black limegreen
-node "woo.14" "woo\n14" filled ellipse black limegreen
-node "woo.15" "woo\n15" filled ellipse black limegreen
-node "woo.17" "woo\n17" filled ellipse black limegreen
 node "woo.2" "woo\n2" filled ellipse black limegreen
 node "woo.3" "woo\n3" filled ellipse black limegreen
 node "woo.5" "woo\n5" filled ellipse black limegreen
 node "woo.6" "woo\n6" filled ellipse black limegreen
 node "woo.8" "woo\n8" filled ellipse black limegreen
 node "woo.9" "woo\n9" filled ellipse black limegreen
+node "woo.11" "woo\n11" filled ellipse black limegreen
+node "woo.12" "woo\n12" filled ellipse black limegreen
+node "woo.14" "woo\n14" filled ellipse black limegreen
+node "woo.15" "woo\n15" filled ellipse black limegreen
+node "woo.17" "woo\n17" filled ellipse black limegreen
 stop

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -249,7 +249,7 @@ function graph_suite() {
     # coordinates instead of one in the "plain" graph output format; we need to
     # make the output consistent here for comparing tests graphs.
     sed -i "s/  / /g" "$TEMP_OUTPUT_FILE"
-    sort $TEMP_OUTPUT_FILE >$OUTPUT_FILE
+    sort -V $TEMP_OUTPUT_FILE >$OUTPUT_FILE
 }
 
 function init_suite() {


### PR DESCRIPTION
The integer cycling graph test is failing (in my environment at least) because of different sort order in the new and ref `.plain` graph files, although the content is otherwise the same by inspection. "Natural sort order" by `sort -V` cures the problem.

@benfitzpatrick - please review.
