### PR TITLE
Don't reload tasks in the 'ready' state.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -516,7 +516,7 @@ class pool(object):
     def reload_taskdefs(self):
         found = False
         for itask in self.get_tasks(all=True):
-            if itask.state.is_currently('submitted','running'):
+            if itask.state.is_currently('ready', 'submitted','running'):
                 # do not reload active tasks as it would be possible to
                 # get a task proxy incompatible with the running task
                 if itask.reconfigure_me:


### PR DESCRIPTION
The 'ready' state means "job submission command already queued to the process pool".  Currently if a retrying  task gets reloaded _while it is in the (normally very brief) 'ready' state_ its retry delays get reset. To fix this we could determine if a ready task is also a retrying task, and give it special treatment like tasks in the 'retrying' state in `cylc.task_pool.pool.reload_taskdefs()`, but it is more straightforward to just delay reload of 'ready' tasks (and not unreasonable - they're as good as submitted, and submitted tasks do get their reload delayed).

@matthewrmshin - please review.
