### PR TITLE
Improved vim syntax file.

### DIFF
--- a/conf/cylc.vim
+++ b/conf/cylc.vim
@@ -1,93 +1,97 @@
-" Simple syntax highlighting for cylc suite definition files.
-" Author: Hilary Oliver, 2011
+" Syntax highlighting for cylc suite.rc files.
+" Author: Hilary Oliver, 2011-2014
+" see :help syntax
 "______________________________________________________________________
-" 1/ Put this file in $HOME/.vim/syntax/ directory.
-
-" 2/ Put the following in $HOME/.vimrc for file type recognition:
-
-"augroup filetype
-"  au! BufRead,BufnewFile *suite.rc   set filetype=cylc
-"augroup END
-
+"
+"INSTRUCTIONS FOR USE
+"
+" 1) Put this file in $HOME/.vim/syntax/ directory.
+"
+" 2) Put the following in $HOME/.vimrc for file type recognition:
+"
+"|augroup filetype
+"|  au! BufRead,BufnewFile *suite.rc   set filetype=cylc
+"|augroup END
+"
 " (the wildcard in '*suite.rc' handles temporary files generated
 "  by the 'cylc view' command, e.g. /tmp/foo.bar.QYrZ0q.suite.rc)
 
-" 3/ If you want to open files with syntax folds initially open, then
+" 3) If you want to open files with syntax folds initially open, then
 "    also add the following line to your $HOME/.vimrc file:
-
-" set foldlevelstart=99
-"----------------------------------------------------------------------
-
-" see :help syntax
+"
+"| set foldlevelstart=99
+"
+" 4) Cylc syntax is linked to standard vim highlighting groups below (e.g.
+" comments: 'hi def link cylcComment Comment'). These can be customized in
+"  your .vimrc file for consistent highlighting across file types, e.g.:
+"
+"|hi Statement guifg=#22a8e3 gui=bold 
+"|hi Normal guifg=#9096a4
+"|hi Comment guifg=#ff6900
+"|hi Type guifg=#28d45b gui=bold"
+"
+"______________________________________________________________________
 
 " syncing from start of file is best, but may be slow for large files:
 syn sync fromstart
-
-" contained items are only recognized inside containing items
-syn match lineCon "\\$"
-syn match badLineCon "\\ \+$"
-syn match trailingWS " \+\(\n\)\@="
-
-syn region jinja2 start='{%' end='%}'
-syn region jinja2variable start='{{' end='}}'
-syn region jinja2comment start='{#' end='#}'
-
-syn region cylcSectionA start='\[' end='\]' contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
-syn region cylcSectionB start='\[\[' end='\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
-syn region cylcSectionC start='\[\[\[' end='\]\]\]' contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
 
 set foldmethod=syntax
 syn region myFold start='\_^ *\[\[\[\(\w\| \)' end='\ze\_^ *\[\{1,3}\(\w\| \)' transparent fold
 syn region myFold start='\_^ *\[\[\(\w\| \)' end='\ze\_^ *\[\{1,2}\(\w\| \)' transparent fold
 syn region myFold start='\_^ *\[\(\w\| \)' end='\_^ *\ze\[\(\w\| \)' transparent fold
 
-syn match cylcInlineMarker '\_^!\{1,}'
-syn match cylcItemKey ' *\zs\(\w\| \|\-\)*\> *='
+" note contained items are only recognized inside containing items
+syn match lineCon "\\$"
+syn match badLineCon "\\ \+$"
+syn match trailingWS " \+\(\n\)\@="
+
+syn region jinja2 start='{%' end='%}'
+syn region jinja2 start='{{' end='}}'
+syn region jinja2 start='{#' end='#}'
+
+syn region cylcSection start='\[' end='\]' contains=trailingWS,lineCon,badLineCon,jinja2
+syn region cylcSection start='\[\[' end='\]\]' contains=trailingWS,lineCon,badLineCon,jinja2
+syn region cylcSection start='\[\[\[' end='\]\]\]' contains=trailingWS,lineCon,badLineCon,jinja2
+
+syn match cylcItem ' *\zs\(\w\| \|\-\)*\> *=\@='
+syn match cylcEquals '='
+
 syn match trigger /=>/ contained
 syn match output /:[a-zA-Z0-9-]*\>/ contained
 syn match suicide /\!\w\+/ contained
 syn match offset /\[.\{-}\]/ contained
 
+"file inclusion:
 syn match cylcInclude '%include *\(\w\|\-\|\/\|\.\)*'
-syn match cylcInline '.*\(START INLINED\|END INLINED\).*'
+"inlined file markers:
+syn match cylcInclude '\_^!\{1,}'
+syn match cylcInclude '.*\(START INLINED\|END INLINED\).*'
 
-syn match cylcToDo /[Tt][Oo][Dd][Oo].*$/
-syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
-syn match cylcCommentInString /#.*/ contained contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
+syn match cylcToDo /[Tt][Oo][Dd][Oo]/
 
-syn region String start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
-syn region String start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable
-syn region String start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable,cylcCommentInString,trigger,output,suicide,offset
-syn region String start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,jinja2comment,jinja2variable,cylcCommentInString,trigger,output,suicide,offset
+syn match cylcComment /#.*/ contains=trailingWS,cylcToDo,lineCon,badLineCon,jinja2
 
-hi def link jinja2InString jinja2
-hi def link jinja2commentInString jinja2comment
-hi def link jinja2variableInString jinja2variable
-hi def link cylcInlineMarker cylcInlining
-hi def link cylcInline cylcInlining
-hi def link cylcInclude cylcInlining
+syn region cylcString start=+'+ skip=+\\'+ end=+'+ contains=trailingWS,lineCon,badLineCon,jinja2,cylcToDo
+syn region cylcString start=+"+ skip=+\\"+ end=+"+ contains=trailingWS,lineCon,badLineCon,jinja2,cylcToDo
+syn region cylcString start=+=\@<= *"""+ end=+"""+ contains=trailingWS,lineCon,badLineCon,jinja2,cylcComment,trigger,output,suicide,offset,cylcToDo
+syn region cylcString start=+=\@<= *'''+ end=+'''+ contains=trailingWS,lineCon,badLineCon,jinja2,cylcComment,trigger,output,suicide,offset,cylcToDo
 
-hi Normal ctermfg=DarkGrey guifg=#666666 gui=None
-hi String ctermfg=DarkGrey guifg=#666666 gui=None
+"de-emphasize strings as quoting is irrelevant in cylc
+hi def link cylcString Normal
 
-hi trailingWS ctermbg=Grey guibg=#aaa
-hi badLineCon ctermbg=Red guibg=red guifg=#fff
-hi lineCon ctermfg=Green guifg=DarkBlue guibg=SkyBlue
+hi def link cylcSection Statement
+hi def link cylcItem Type
+hi def link cylcComment Comment
 
-hi cylcSectionC ctermfg=Black guifg=#600 term=bold cterm=bold gui=bold
-hi cylcSectionB ctermfg=Black guifg=#600 term=bold cterm=bold gui=bold
-hi cylcSectionA ctermfg=Black guifg=#600 term=bold cterm=bold gui=bold
+hi def link lineCon Constant
+hi def link badLineCon Error
+hi def link trailingWS Underlined
 
-hi jinja2         ctermfg=Blue ctermbg=yellow guifg=slategray guibg=#d8ff6f gui=None
-hi jinja2comment  ctermfg=Red ctermbg=yellow guifg=white guibg=DeepPink gui=None 
-hi jinja2variable ctermfg=Magenta ctermbg=yellow guifg=slategray guibg=#aaffd8 gui=None
-
-hi cylcItemKey ctermfg=DarkBlue guifg=#28f cterm=bold gui=bold
-hi cylcCommentInString ctermfg=red guifg=#f42 gui=italic
-hi cylcComment ctermfg=red guifg=deeppink gui=italic
-hi cylcInlining ctermbg=LightGrey ctermfg=DarkBlue guibg=#aff guifg=#00a
-hi cylcToDo guibg=DeepPink
-hi trigger guifg=#00cc00 gui=bold
-hi output guifg=#aaaa3d
-hi suicide guifg=#cc3dcc
-hi offset guifg=#3d4ccc
+hi def link cylcToDo Todo
+hi def link cylcInclude MatchParen
+hi def link jinja2 CursorColumn
+hi def link cylcEquals LineNr
+hi def link output Special
+hi def link suicide Special
+hi def link offset Special
+hi def link trigger Constant 


### PR DESCRIPTION
This fixes a few problems with the old vim syntax file, and tones the colours down a bit.

@matthewrmshin et.al. (anyone use vim?) - please review.

Terminal:
![vim-syntax-term](https://cloud.githubusercontent.com/assets/2362137/3915886/5f808c0a-236c-11e4-93b7-a481ed83e278.png)

gvim:
![vim-syntax-gui](https://cloud.githubusercontent.com/assets/2362137/3915887/67ec09f0-236c-11e4-816f-ea3fe2ba6a97.png)
