### PR TITLE
cylc test-battery: fix no_initial_but_final_cycle_point test

### DIFF
--- a/tests/cyclers/27-no_initial_but_final_cycle_point.t
+++ b/tests/cyclers/27-no_initial_but_final_cycle_point.t
@@ -24,12 +24,12 @@ install_suite $TEST_NAME_BASE no_initial_but_final_cycle_point
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_fail $TEST_NAME cylc validate $SUITE_NAME
-grep_ok "This suite requires a final cycle point\." \
+grep_ok "This suite requires an initial cycle point\." \
     $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run
 run_fail $TEST_NAME cylc run --debug $SUITE_NAME
-grep_ok "This suite requires a final cycle point\." \
+grep_ok "This suite requires an initial cycle point\." \
     $TEST_NAME.stderr
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME


### PR DESCRIPTION
This fixes a mistake in the tests/cyclers/27-no_initial_but_final_cycle_point.t test.

@matthewrmshin, please review.
