### PR TITLE
cylc gui: alter displayed time zones.

### DIFF
--- a/lib/cylc/state_summary.py
+++ b/lib/cylc/state_summary.py
@@ -21,7 +21,9 @@ import logging
 import TaskID
 import time
 from datetime import datetime
-from wallclock import now, TIME_ZONE_STRING_LOCAL_BASIC
+import flags
+from wallclock import now, TIME_ZONE_LOCAL_INFO, TIME_ZONE_UTC_INFO
+
 
 
 class state_summary( Pyro.core.ObjBase ):
@@ -103,7 +105,10 @@ class state_summary( Pyro.core.ObjBase ):
             self.str_or_None(oldest))
         global_summary[ 'newest cycle point string' ] = (
             self.str_or_None(newest))
-        global_summary[ 'daemon time zone' ] = TIME_ZONE_STRING_LOCAL_BASIC
+        if flags.utc:
+            global_summary[ 'daemon time zone info' ] = TIME_ZONE_UTC_INFO
+        else:
+            global_summary[ 'daemon time zone info' ] = TIME_ZONE_LOCAL_INFO
         global_summary[ 'last_updated' ] = time.time()
         global_summary[ 'run_mode' ] = self.run_mode
         global_summary[ 'paused' ] = paused

--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -534,9 +534,7 @@ class task( object ):
             self.started_time = time.time()
             self.summary[ 'started_time' ] = self.started_time
             self.summary[ 'started_time_string' ] = (
-                get_time_string_from_unix_time(
-                    self.started_time, no_display_time_zone=True
-                )
+                get_time_string_from_unix_time(self.started_time)
             )
             self.outputs.set_completed( self.id + " started" )
             self.set_status( 'running' )
@@ -552,9 +550,7 @@ class task( object ):
         self.submitted_time = time.time()
         self.summary[ 'submitted_time' ] = self.submitted_time
         self.summary[ 'submitted_time_string' ] = (
-            get_time_string_from_unix_time(
-                self.submitted_time, no_display_time_zone=True
-            )
+            get_time_string_from_unix_time(self.submitted_time)
         )
         self.handle_event( 'submitted', 'job submitted', db_event='submission succeeded' )
 
@@ -1071,9 +1067,7 @@ class task( object ):
             self.started_time = time.time()
             self.summary[ 'started_time' ] = self.started_time
             self.summary[ 'started_time_string' ] = (
-                get_time_string_from_unix_time(
-                    self.started_time, no_display_time_zone=True
-                )
+                get_time_string_from_unix_time(self.started_time)
             )
 
             # TODO - should we use the real event time extracted from the message here:
@@ -1099,9 +1093,7 @@ class task( object ):
             self.succeeded_time = time.time()
             self.summary[ 'succeeded_time' ] = self.succeeded_time
             self.summary[ 'succeeded_time_string' ] = (
-                get_time_string_from_unix_time(
-                    self.succeeded_time, no_display_time_zone=True
-                )
+                get_time_string_from_unix_time(self.succeeded_time)
             )
             self.__class__.update_mean_total_elapsed_time( self.started_time, self.succeeded_time )
             self.set_status( 'succeeded' )


### PR DESCRIPTION
This change:
- displays `ETC` in daemon time zone
- adds time zone info to `Tstart` and `Tsubmit`
- makes `mean dt` ISO 8601-compatible
- removes unused switches from wallclock.py functions (so I could add another one).

@hjoliver, please review.
