### PR TITLE
cylc gui: restore submit id message

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -1009,7 +1009,6 @@ class task( object ):
         # Log incoming messages with '>' to distinguish non-message log entries.
         self.log( priority, '(current:' + self.state.get_status() + ')> ' + message )
 
-        print "id, priority, message:", self.id, priority, message
         # always update the suite state summary for latest message
         self.latest_message = message
         self.latest_message_priority = priority


### PR DESCRIPTION
This restores the submit id message that appeared in the "message" column
in cylc gui.

@hjoliver, please review.
