### PR TITLE
Some gui improvements

### DIFF
--- a/lib/cylc/gui/DotMaker.py
+++ b/lib/cylc/gui/DotMaker.py
@@ -18,7 +18,6 @@
 
 import gtk
 from copy import deepcopy
-from cylc.cfgspec.gcylc import gcfg
 from cylc.task_state import task_state
 
 stopped = {
@@ -165,9 +164,9 @@ class DotMaker(object):
 
     """Make dot icons to represent task and family states."""
 
-    def __init__(self, theme, size=None):
+    def __init__(self, theme, size='medium'):
         self.theme = theme
-        self.size = size or gcfg.get(['dot icon size'])
+        self.size = size
 
     def get_icon(self, state=None, is_stopped=False, is_family=False):
         """Generate a gtk.gdk.Pixbuf for a state.

--- a/lib/cylc/gui/DotUpdater.py
+++ b/lib/cylc/gui/DotUpdater.py
@@ -16,10 +16,6 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import cylc.TaskID
-from cylc.gui.DotMaker import DotMaker
-from cylc.state_summary import get_id_summary
-from copy import deepcopy
 import gobject
 import gtk
 import re
@@ -27,9 +23,15 @@ import string
 import threading
 from time import sleep
 
+import cylc.TaskID
+from cylc.gui.DotMaker import DotMaker
+from cylc.state_summary import get_id_summary
+from copy import deepcopy
+
+
 class DotUpdater(threading.Thread):
 
-    def __init__(self, cfg, updater, treeview, info_bar, theme ):
+    def __init__(self, cfg, updater, treeview, info_bar, theme, dot_size):
 
         super(DotUpdater, self).__init__()
 
@@ -72,7 +74,7 @@ class DotUpdater(threading.Thread):
         self.task_list = []
 
         # generate task state icons
-        dotm = DotMaker(theme)
+        dotm = DotMaker(theme, size=dot_size)
         self.dots = dotm.get_dots()
 
     def _set_tooltip(self, widget, tip_text):
@@ -354,7 +356,7 @@ class DotUpdater(threading.Thread):
                             dot_type = 'task'
                         state_list.append(self.dots[dot_type][state])
                     else:
-                        state_list.append(self.dots[dot_type]['empty'])
+                        state_list.append(self.dots['task']['empty'])
                 try:
                     self.led_liststore.append([name] + state_list)
                 except ValueError:

--- a/lib/cylc/gui/SuiteControlGraph.py
+++ b/lib/cylc/gui/SuiteControlGraph.py
@@ -31,8 +31,8 @@ class ControlGraph(object):
     """
 Dependency graph suite control interface.
     """
-    def __init__(self, cfg, updater, usercfg, info_bar, get_right_click_menu,
-                 log_colors, insert_task_popup ):
+    def __init__(self, cfg, updater, theme, dot_size, info_bar,
+            get_right_click_menu, log_colors, insert_task_popup):
         # NOTE: this view has separate family Group and Ungroup buttons
         # instead of a single Group/Ungroup toggle button, unlike the
         # other views the graph view can display intermediate states
@@ -42,7 +42,7 @@ Dependency graph suite control interface.
 
         self.cfg = cfg
         self.updater = updater
-        self.usercfg = usercfg
+        self.theme = theme
         self.info_bar = info_bar
         self.get_right_click_menu = get_right_click_menu
         self.log_colors = log_colors
@@ -56,7 +56,7 @@ Dependency graph suite control interface.
         self.last_url = None
 
     def get_control_widgets( self ):
-        self.t = GraphUpdater( self.cfg, self.updater, self.usercfg,
+        self.t = GraphUpdater( self.cfg, self.updater, self.theme,
                                self.info_bar, self.xdot )
         self.t.start()
         return self.xdot.get()

--- a/lib/cylc/gui/SuiteControlLED.py
+++ b/lib/cylc/gui/SuiteControlLED.py
@@ -30,12 +30,13 @@ class ControlLED(object):
     """
 LED suite control interface.
     """
-    def __init__(self, cfg, updater, theme, info_bar, get_right_click_menu,
+    def __init__(self, cfg, updater, theme, dot_size, info_bar, get_right_click_menu,
                  log_colors, insert_task_popup):
 
         self.cfg = cfg
         self.updater = updater
         self.theme = theme
+        self.dot_size = dot_size
         self.info_bar = info_bar
         self.get_right_click_menu = get_right_click_menu
         self.log_colors = log_colors
@@ -59,7 +60,8 @@ LED suite control interface.
         main_box.pack_start( sw, expand=True, fill=True )
 
         self.t = DotUpdater(
-                self.cfg, self.updater, treeview, self.info_bar, self.theme
+                self.cfg, self.updater, treeview, self.info_bar, self.theme,
+                self.dot_size
         )
         self.t.start()
 

--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -31,12 +31,13 @@ class ControlTree(object):
     """
 Text Treeview suite control interface.
     """
-    def __init__(self, cfg, updater, theme, info_bar, get_right_click_menu,
+    def __init__(self, cfg, updater, theme, dot_size, info_bar, get_right_click_menu,
                  log_colors, insert_task_popup ):
 
         self.cfg = cfg
         self.updater = updater
         self.theme = theme
+        self.dot_size = dot_size
         self.info_bar = info_bar
         self.get_right_click_menu = get_right_click_menu
         self.log_colors = log_colors
@@ -54,7 +55,7 @@ Text Treeview suite control interface.
 
         self.t = TreeUpdater(
                 self.cfg, self.updater, self.ttreeview, self.ttree_paths,
-                self.info_bar, self.theme
+                self.info_bar, self.theme, self.dot_size
         )
         self.t.start()
         return main_box
@@ -223,7 +224,7 @@ Text Treeview suite control interface.
 
         self.tfilter_states = []
 
-        dotm = DotMaker(self.theme,size='small')
+        dotm = DotMaker(self.theme, size='small')
         cnt = 0
         for st in task_state.legal:
             box = gtk.HBox()

--- a/lib/cylc/gui/TreeUpdater.py
+++ b/lib/cylc/gui/TreeUpdater.py
@@ -16,18 +16,19 @@
 #C: You should have received a copy of the GNU General Public License
 #C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from cylc.task_state import task_state
+from copy import deepcopy
+import datetime
+import gobject
+import threading
+from time import sleep
+
 import cylc.TaskID
 from cylc.gui.DotMaker import DotMaker
 from cylc.state_summary import get_id_summary
 from cylc.strftime import isoformat_strftime
 from cylc.wallclock import (
     get_time_string_from_unix_time, TIME_ZONE_STRING_LOCAL_BASIC)
-from copy import deepcopy
-import datetime
-import gobject
-import threading
-from time import sleep
+
 
 def _time_trim(time_value):
     if time_value is not None:
@@ -37,7 +38,7 @@ def _time_trim(time_value):
 
 class TreeUpdater(threading.Thread):
 
-    def __init__(self, cfg, updater, ttreeview, ttree_paths, info_bar, theme ):
+    def __init__(self, cfg, updater, ttreeview, ttree_paths, info_bar, theme, dot_size):
 
         super(TreeUpdater, self).__init__()
 
@@ -50,7 +51,6 @@ class TreeUpdater(threading.Thread):
 
         self.cfg = cfg
         self.updater = updater
-        self.theme = theme
         self.info_bar = info_bar
         self.last_update_time = None
         self.ancestors = {}
@@ -77,7 +77,7 @@ class TreeUpdater(threading.Thread):
         self._id_tetc_cache = {}
 
         # generate task state icons
-        dotm = DotMaker(theme)
+        dotm = DotMaker(theme, size=dot_size)
         self.dots = dotm.get_dots()
 
     def clear_tree( self ):

--- a/lib/cylc/gui/legend.py
+++ b/lib/cylc/gui/legend.py
@@ -29,7 +29,7 @@ class ThemeLegendWindow(gtk.Window):
 
     """This is a popup window displaying the theme state colors."""
 
-    def __init__( self, parent_window, theme_map ):
+    def __init__(self, parent_window, theme_map, dot_size):
         super(ThemeLegendWindow, self).__init__()
         self.set_border_width(5)
         self.set_title( "" )
@@ -42,6 +42,7 @@ class ThemeLegendWindow(gtk.Window):
         vbox = gtk.VBox()
 
         self._theme = theme_map
+        self._dot_size = dot_size
         self._key_liststore = gtk.ListStore( str, gtk.gdk.Pixbuf )
         treeview = gtk.TreeView( self._key_liststore )
         treeview.set_headers_visible(False)
@@ -64,14 +65,16 @@ class ThemeLegendWindow(gtk.Window):
         self.add( treeview )
         self.show_all()
 
-    def update( self, new_theme=None ):
+    def update(self, new_theme=None, new_dot_size=None):
         """Update, optionally with a new theme."""
         if new_theme is not None:
             self._theme = new_theme
+        if new_dot_size is not None:
+            self._dot_size = new_dot_size
         self._set_key_liststore()
 
-    def _set_key_liststore( self ):
-        dotm = DotMaker( self._theme )
+    def _set_key_liststore(self):
+        dotm = DotMaker(self._theme, self._dot_size)
         self._key_liststore.clear()
         for state in task_state.legal:
             dot = dotm.get_icon( state )


### PR DESCRIPTION
There was no way of telling if an icon in the dot view represented a task or a family, without toggling the family grouping.  This change adds a little family indicator to the corner of family state icons.  It also makes the icon size configurable by the View menu.

![gcylc-family-icons](https://cloud.githubusercontent.com/assets/2362137/4006882/35912718-29b8-11e4-85a9-7d9761deaa1d.png)
