### PR TITLE
cylc gui: remove extra HSeparator

### DIFF
--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -251,7 +251,6 @@ Text Treeview suite control interface.
         filter_hbox.pack_start(self.tfilterbox, True, True, 10)
         vbox = gtk.VBox()
         vbox.pack_start(sw, True)
-        vbox.pack_end(gtk.HSeparator(),False,False,5)
         vbox.pack_end(filter_hbox, False)
 
         return vbox


### PR DESCRIPTION
I wrote this as a bug fix, but then looked into it and the
separator was added intentionally in b4f03e9 - so this is
really just an opinion-thing.

@hjoliver, what do you reckon?
