### PR TITLE
cylc gui: Fix sorting of log files

### DIFF
--- a/lib/cylc/gui/SuiteControl.py
+++ b/lib/cylc/gui/SuiteControl.py
@@ -2214,7 +2214,7 @@ or remove task definitions without restarting the suite."""
         window.show_all()
 
     def _sort_key_func(self, x):
-        return [int(w) if w.isdigit() else w for w in re.split("(\d+)", x)]
+        return [int(w) if w.isdigit() else w for w in re.split("(\d+)", x)[-2:]]
 
     def _set_tooltip( self, widget, tip_text ):
         tooltip = gtk.Tooltips()


### PR DESCRIPTION
Closes #1138

Changes the returned key from `_sort_key_func` so that it works from the last detected number onwards. This prevents numbers in a hostname being used for sorting in preference to the try number.

Tested as working.

A suite along these lines can be used to check the gui:

```
[scheduling]
    [[dependencies]]
        graph = "foo"
[runtime]
    [[foo]]
        command scripting = false
        retry delays = 5*0.1
        [[[remote]]]
            host = $(rose host-select --rank-method=random)
```

where rose host-select is picking from a number of alphanumeric hostnames (could be either servers of hostXXX format or perhaps hpc login nodes).
