### PR TITLE
Task class not instance should hold sequences.

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -916,7 +916,7 @@ class config( object ):
                 continue
 
             # warn for purely-implicit-cycling tasks (these are deprecated).
-            if itask.sequences == itask.implicit_sequences:
+            if itask.__class__.sequences == itask.__class__.implicit_sequences:
                 print >> sys.stderr, (
                     "WARNING, " + name + ": not explicitly defined in " +
                     "dependency graphs (deprecated)"

--- a/lib/cylc/task_types/cycling.py
+++ b/lib/cylc/task_types/cycling.py
@@ -54,9 +54,10 @@ class cycling( task ):
         self.stop_point = stop_point
 
     def next_point( self ):
+        print self.__class__.name, self.__class__.sequences
         p_next = None
         adjusted = []
-        for seq in self.sequences:
+        for seq in self.__class__.sequences:
             nxt = seq.get_next_point(self.point)
             if nxt:
                 # may be None if beyond the sequence bounds

--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -130,6 +130,8 @@ class task( object ):
     SUITE_CONTACT_ENV_SSH_OPTS = ['-oBatchMode=yes', '-oConnectTimeout=10']
 
     mean_total_elapsed_time = None
+    sequences = []
+    implicit_sequences = []
 
     @classmethod
     def describe( cls ):

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -93,7 +93,6 @@ class taskdef(object):
         self.cond_triggers[ sequence ].append( [triggers,exp] )
 
     def add_sequence( self, sequence, is_implicit=False ):
-        # TODO ISO - SEQUENCES CAN BE HELD BY TASK CLASS NOT INSTANCE
         if sequence not in self.sequences:
             self.sequences.append( sequence )
             if is_implicit:
@@ -321,8 +320,8 @@ class taskdef(object):
                          startup=False, validate=False, submit_num=0,
                          exists=False ):
 
-            sself.sequences = self.sequences
-            sself.implicit_sequences = self.implicit_sequences
+            sself.__class__.sequences = self.sequences
+            sself.__class__.implicit_sequences = self.implicit_sequences
             sself.startup = startup
             sself.submit_num = submit_num
             sself.exists=exists
@@ -331,7 +330,7 @@ class taskdef(object):
             if startup:
                 # adjust up to the first on-sequence cycle point
                 adjusted = []
-                for seq in sself.sequences:
+                for seq in sself.__class__.sequences:
                     adj = seq.get_first_point( start_point )
                     if adj:
                         # may be None if out of sequence bounds


### PR DESCRIPTION
This addresses one of the remaining "TODO ISO" comments.  Currently each task proxy instance holds a list of all sequences (which embody the graph recurrence expressions) for the task.  The closest next instance of each sequence determines the true next instance of the task when it spawns, but the sequences do not know the task's cycle point (it is passed to them), so this (this list of sequences) should be a class variable, not an instance variable.  (Probably makes little difference in practice as I suppose the instance variables will all reference the same object).

Test battery passes.
