### PR TITLE
Moved text view filter entry to filter box.

### DIFF
--- a/lib/cylc/gui/SuiteControlTree.py
+++ b/lib/cylc/gui/SuiteControlTree.py
@@ -236,7 +236,7 @@ Text Treeview suite control interface.
             cb = gtk.CheckButton(task_state.labels[st])
             tooltip = gtk.Tooltips()
             tooltip.enable()
-            tooltip.set_tip(cb, "Filter by task state %s" % st)
+            tooltip.set_tip(cb, "Filter by task state = %s" % st)
  
             box.pack_start(icon, expand=False)
             box.pack_start(cb, expand=False)


### PR DESCRIPTION
A small cosmetic change for cylc-6: move the text view task name filter entry into the task state filter box. IMO this is where it should be - all task filtering controls in one place, and more obvious.

![filter-box-moved](https://cloud.githubusercontent.com/assets/2362137/4184733/e1133c46-374d-11e4-9772-c175620db649.png)

@benfitzpatrick - please review.
