### PR TITLE
Fix missing num expanded year digit setting error

### DIFF
--- a/lib/cylc/cycling/__init__.py
+++ b/lib/cylc/cycling/__init__.py
@@ -33,7 +33,7 @@ class PointParsingError(ValueError):
 
     """An error raised when a point has an incorrect value."""
 
-    ERROR_MESSAGE = "Incompatible value for {0}: {1}"
+    ERROR_MESSAGE = "Incompatible value for {0}: {1}: {2}"
 
     def __str__(self):
         return self.ERROR_MESSAGE.format(*self.args)

--- a/lib/cylc/cycling/integer.py
+++ b/lib/cylc/cycling/integer.py
@@ -129,8 +129,8 @@ class IntegerPoint(PointBase):
         """Format self.value into a standard representation and check it."""
         try:
             self.value = str(int(self))
-        except (TypeError, ValueError):
-            raise PointParsingError(type(self), self.value)
+        except (TypeError, ValueError) as exc:
+            raise PointParsingError(type(self), self.value, exc)
         return self
 
     def __int__(self):

--- a/lib/cylc/cycling/iso8601.py
+++ b/lib/cylc/cycling/iso8601.py
@@ -50,6 +50,9 @@ PREV_DATE_TIME_FORMAT = "%Y%m%d%H"
 PREV_DATE_TIME_REC = re.compile("^\d{10}$")
 NEW_DATE_TIME_REC = re.compile("T")
 
+WARNING_PARSE_EXPANDED_YEAR_DIGITS = (
+    "(incompatible with [cylc]cycle point num expanded year digits = %s ?)")
+
 
 class SuiteSpecifics(object):
 
@@ -117,8 +120,12 @@ class ISO8601Point(PointBase):
         try:
             self.value = str(point_parse(self.value))
         except ValueError as exc:
-            print "standardise %s" % exc
-            raise PointParsingError(type(self), self.value)
+            if self.value.startswith("+") or self.value.startswith("-"):
+                message = WARNING_PARSE_EXPANDED_YEAR_DIGITS % (
+                    SuiteSpecifics.NUM_EXPANDED_YEAR_DIGITS)
+            else:
+                message = str(exc)
+            raise PointParsingError(type(self), self.value, message)
         return self
 
     def sub(self, other):

--- a/tests/validate/24-fail-year-bounds.t
+++ b/tests/validate/24-fail-year-bounds.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 Hilary Oliver, NIWA
+#C: 
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validation with a new-style cycle point and an async graph.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE
+run_fail $TEST_NAME cylc validate --debug -v -v $SUITE_NAME
+grep_ok "incompatible with \[cylc\]cycle point num expanded year digits = 0" \
+    $TEST_NAME.stderr
+#-------------------------------------------------------------------------------
+exit

--- a/tests/validate/24-fail-year-bounds/suite.rc
+++ b/tests/validate/24-fail-year-bounds/suite.rc
@@ -1,0 +1,5 @@
+[scheduling]
+    initial cycle point = +10000-01-01T00
+    [[dependencies]]
+        [[[T00]]]
+            graph = foo


### PR DESCRIPTION
This fixes an error where the user specifies a date outside the range
allowed by the `[cylc]cycle point num expanded year digits` setting.

@hjoliver, please review.
