### PR TITLE
Remove an unnecessary bad statement

### DIFF
--- a/lib/cylc/task_types/task.py
+++ b/lib/cylc/task_types/task.py
@@ -467,8 +467,6 @@ class task( object ):
             msg = ('ignoring job kill result, unexpected task state: %s'
                     % self.state.get_status())
             self.log(WARNING, msg)
-            with open(file_err, 'a') as f:
-                f.write("WARNING:" + msg)
  
     def event_handler_callback(self, result):
         out   = result['OUT']


### PR DESCRIPTION
Probably missed by #1118. The functionality should now be provided in the activity log code.
