### PR TITLE
Reverse SGE poll success logic.

### DIFF
--- a/lib/cylc/job_submission/sge.py
+++ b/lib/cylc/job_submission/sge.py
@@ -52,4 +52,4 @@ class sge(JobSubmit):
     @classmethod
     def poll(cls, jid):
         """Return True if jid is in the queueing system."""
-        return not Popen(["qstat", "-j", jid], stdout=PIPE).wait()
+        return Popen(["qstat", "-j", jid], stdout=PIPE).wait()


### PR DESCRIPTION
SGE job polling was broken again by #1166.
[update - no it didn't, see below!]

@matthewrmshin - please review.
