### PR TITLE
cylc reload: fix daemon task logfiles reporting

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -535,6 +535,7 @@ class pool(object):
                         new_task.reset_state_succeeded(manual=False)
 
                     # carry some task proxy state over to the new instance
+                    new_task.logfiles = itask.logfiles
                     new_task.summary = itask.summary
                     new_task.started_time = itask.started_time
                     new_task.submitted_time = itask.submitted_time


### PR DESCRIPTION
Task logfiles were not being correctly reported by the daemon after a `cylc reload`.

To replicate this, reload a suite and trigger a task (re-trigger or first-time-trigger).
The log files shown in `cylc gui` for that task will now not match the ones on disk.

This fixes the problem.

@hjoliver, please review.
