### PR TITLE
Deprecate runahead in gcylc.rc

### DIFF
--- a/lib/cylc/cfgspec/gcylc.py
+++ b/lib/cylc/cfgspec/gcylc.py
@@ -60,6 +60,7 @@ SPEC = {
 def upg( cfg, descr ):
     u = upgrader(cfg, descr )
     u.deprecate( '5.4.3', ['themes','__MANY__', 'submitting'], ['themes','__MANY__', 'ready'] )
+    u.deprecate( '5.4.3', ['themes','__MANY__', 'runahead'], ['themes','__MANY__', 'waiting'] )
     u.upgrade()
 
 class gconfig( config ):


### PR DESCRIPTION
If a user has a runahead entry in their gcylc.rc file it will fail to load under cylc 6.

This deprecates runahead as per submitting.
