### PR TITLE
cylc gui: fix pure-families graph view

### DIFF
--- a/lib/cylc/gui/GraphUpdater.py
+++ b/lib/cylc/gui/GraphUpdater.py
@@ -379,7 +379,8 @@ class GraphUpdater(threading.Thread):
                 name, point_string = cylc.TaskID.split( node_id )
                 point_string_nodes.setdefault(point_string, [])
                 point_string_nodes[point_string].append(node)
-                if node_id in self.state_summary:
+                if (node_id in self.state_summary or
+                        node_id in self.fam_state_summary):
                     non_base_point_strings.add(point_string)
                 if name in self.all_families:
                     if name in self.triggering_families:


### PR DESCRIPTION
#1185 introduced a bug where the cylc gui graph view displayed nothing

in grouped mode if all nodes were families. This is due to the node ids
being checked just against the task summary.

@arjclark, please review.
