### PR TITLE
Use command templates for batch system commands

### DIFF
--- a/examples/polling/suite.rc
+++ b/examples/polling/suite.rc
@@ -21,4 +21,4 @@ as the suite runs, filtering for the word 'poll'.
         [[[job submission]]]
             method = at
             # stay 'submitted' for up to a minute:
-            command template = 'echo "%(job)s 1>%(job)s 2>%(job)s" | at now + 1 minutes'
+            command template = at now + 1 minutes

--- a/lib/cylc/batch_sys_handlers/at.py
+++ b/lib/cylc/batch_sys_handlers/at.py
@@ -33,19 +33,20 @@ class AtCommandHandler(object):
       [[MyTask]]
         [[[job submission]]]
            method = at
-           command template = 'echo "%(job)s 1>%(job)s 2>%(job)s" | at teatime'
+           command template = at teatime
     """
 
     CAN_KILL_PROC_GROUP = True
     # N.B. The perl command ensures that the job script is executed in its own
     # process group, which allows the job script and its child processes to be
     # killed correctly.
-    KILL_CMD = "atrm"
-    POLL_CMD = "atq"
+    KILL_CMD_TMPL = "atrm '%(job_id)s'"
+    POLL_CMD_TMPL = "atq"
     REC_ERR_FILTERS = [
         re.compile("warning: commands will be executed using /bin/sh")]
     REC_ID_FROM_SUBMIT_ERR = re.compile(r"\Ajob\s(?P<id>\S+)\sat")
-    _CMD_TMPL = (
+    SUBMIT_CMD_TMPL = "at now"
+    SUBMIT_CMD_STDIN_TMPL = (
         r"exec perl -e 'setpgrp(0,0);exec(@ARGV)'" +
         r" '%(job)s' 1>'%(job)s.out' 2>'%(job)s.err'")
 
@@ -90,12 +91,6 @@ class AtCommandHandler(object):
             if items and items[0] == job_id:
                 return True
         return False
-
-    def submit(self, job_file_path):
-        """Run the "job_file_path" with "at now"."""
-        proc = Popen(["at", "now"], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        proc.stdin.write(self._CMD_TMPL % {"job": job_file_path})
-        return proc
 
 
 BATCH_SYS_HANDLER = AtCommandHandler()

--- a/lib/cylc/batch_sys_handlers/background.py
+++ b/lib/cylc/batch_sys_handlers/background.py
@@ -35,7 +35,7 @@ class BgCommandHandler(object):
 
     CAN_KILL_PROC_GROUP = True
     IS_BG_SUBMIT = True
-    POLL_CMD = "ps"
+    POLL_CMD_TMPL = "ps '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A(?P<id>\d+)\Z""")
 
     @classmethod

--- a/lib/cylc/batch_sys_handlers/loadleveler.py
+++ b/lib/cylc/batch_sys_handlers/loadleveler.py
@@ -25,13 +25,13 @@ class LoadlevelerHandler(object):
     "Loadleveler job submission"
 
     DIRECTIVE_PREFIX = "# @ "
-    KILL_CMD = "llcancel"
-    POLL_CMD = "llq -f%id"
+    KILL_CMD_TMPL = "llcancel '%(job_id)s'"
+    POLL_CMD_TMPL = "llq -f%%id '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(
         r"""\Allsubmit:\sThe\sjob\s"(?P<id>[^"]+)"\s""")
     REC_ERR_FILTERS = [
         re.compile("^llsubmit: Processed command file through Submit Filter:")]
-    SUBMIT_CMD = "llsubmit"
+    SUBMIT_CMD_TMPL = "llsubmit '%(job)s'"
     VACATION_SIGNAL = "USR1"
 
     def format_directives(self, job_conf):

--- a/lib/cylc/batch_sys_handlers/pbs.py
+++ b/lib/cylc/batch_sys_handlers/pbs.py
@@ -25,12 +25,12 @@ class PBSHandler(object):
     "PBS batch system job submission and manipulation."
 
     DIRECTIVE_PREFIX = "#PBS "
-    KILL_CMD = "qdel"
+    KILL_CMD_TMPL = "qdel '%(job_id)s'"
     # N.B. The "qstat JOB_ID" command returns 1 if JOB_ID is no longer in the
     # system, so there is no need to filter its output.
-    POLL_CMD = "qstat"
+    POLL_CMD_TMPL = "qstat '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"""\A\s*(?P<id>\S+)\s*\Z""")
-    SUBMIT_CMD = "qsub"
+    SUBMIT_CMD_TMPL = "qsub '%(job)s'"
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""

--- a/lib/cylc/batch_sys_handlers/sge.py
+++ b/lib/cylc/batch_sys_handlers/sge.py
@@ -25,12 +25,12 @@ class SGEHandler(object):
     "SGE qsub job submission"
 
     DIRECTIVE_PREFIX = "#$ "
-    KILL_CMD = "qdel"
+    KILL_CMD_TMPL = "qdel '%(job_id)s'"
     # N.B. The "qstat -j JOB_ID" command returns 1 if JOB_ID is no longer in
     # the system, so there is no need to filter its output.
-    POLL_CMD = "qstat -j"
+    POLL_CMD_TMPL = "qstat -j '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"\D+(?P<id>\d+)\D+")
-    SUBMIT_CMD = "qsub"
+    SUBMIT_CMD_TMPL = "qsub '%(job)s'"
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -24,13 +24,13 @@ class SLURMHandler(object):
     """SLURM job submission and manipulation."""
 
     DIRECTIVE_PREFIX = "#SBATCH "
-    KILL_CMD = "scancel"
+    KILL_CMD_TMPL = "scancel '%(job_id)s'"
     # N.B. The "squeue -j JOB_ID" command returns 1 if JOB_ID is no longer in
     # the system, so there is no need to filter its output.
-    POLL_CMD = "squeue -j"
+    POLL_CMD_TMPL = "squeue -j '%(job_id)s'"
     REC_ID_FROM_SUBMIT_OUT = re.compile(
         r"\ASubmitted\sbatch\sjob\s(?P<id>\d+)")
-    SUBMIT_CMD = "sbatch"
+    SUBMIT_CMD_TMPL = "sbatch '%(job)s'"
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""

--- a/tests/cylc-poll/02-task-submit-failed/suite.rc
+++ b/tests/cylc-poll/02-task-submit-failed/suite.rc
@@ -13,7 +13,7 @@
     [[foo]]
         [[[job submission]]] 
             method = at
-            command template = 'echo "%s" | at noon tomorrow'
+            command template = at noon tomorrow
     [[poll_foo]]
         command scripting = sleep 5; cylc poll $CYLC_SUITE_NAME foo 1
     [[stop]]

--- a/tests/restart/submit-failed/suite.rc
+++ b/tests/restart/submit-failed/suite.rc
@@ -46,7 +46,7 @@
         [[[job submission]]] 
             method = at
             # 'yesterday' is an invalid at time!
-            command template = echo '%(job)s 1>%(job)s.out 2>%(job)s.err' | at yesterday
+            command template = at yesterday
     [[force_restart]]
         pre-command scripting = """
             # We need to make sure that the results stay consistent.


### PR DESCRIPTION
@hjoliver This change should address another concern you raised at #1183. It should improve the user interface for the command template of `at`. I have also modified the logic to accept string templates for the poll and kill commands. (In theory this should make it possible for us to expose those commands as configurable settings in the future.)
