### PR TITLE
Remove unused vars

### DIFF
--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -30,9 +30,6 @@ import cylc.flags
 
 "Cylc site and user configuration file spec."
 
-SITE_FILE = os.path.join( os.environ['CYLC_DIR'], 'conf', 'siterc', 'site.rc' )
-USER_FILE = os.path.join( os.environ['HOME'], '.cylc', 'user.rc' )
-
 SPEC = {
     'process pool size'                   : vdr( vtype='integer', default=None ),
     'temporary directory'                 : vdr( vtype='string' ),


### PR DESCRIPTION
Removed unused (SITE|USER)_FILE variables from global cfgspec.

These referred to the deprecated site/user config file locations.

@matthewrmshin - please review.
