### PR TITLE
Avoid use of temporary variable called DOMAIN in task job scripts.

### DIFF
--- a/lib/cylc/job_file.py
+++ b/lib/cylc/job_file.py
@@ -410,8 +410,8 @@ echo "  Suite Owner : $CYLC_SUITE_OWNER"
 echo "  Task ID     : $CYLC_TASK_ID"
 if [[ $(uname) == AIX ]]; then
     # on AIX the hostname command has no '-f' option
-    CYLC_DOMAIN=$(namerslv -sn 2>/dev/null | awk '{print $2}')
-    echo "  Task Host   : $(hostname).${CYLC_DOMAIN}"
+    __TMP_DOMAIN=$(namerslv -sn 2>/dev/null | awk '{print $2}')
+    echo "  Task Host   : $(hostname).${__TMP_DOMAIN}"
 else
     echo "  Task Host   : $(hostname -f)"
 fi


### PR DESCRIPTION
(This affects AIX task hosts only). DOMAIN is a commonly used variable name in
earth systems modeling, and users may want to pass it to tasks.

This actually caused a problem for our wave modeling expert today.

@matthewrmshin - please review. 
