### PR TITLE
job poll callback: process only the relevant line

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -543,7 +543,10 @@ class TaskProxy(object):
             self.command_log("POLL", err=msg)
         else:
             # poll results emulate task messages
-            self.process_incoming_message(('NORMAL', out.strip()))
+            for line in out.splitlines():
+                if line.startswith('polled %s' % (self.identity)):
+                    self.process_incoming_message(('NORMAL', line))
+                    break
 
     def job_kill_callback(self, result):
         """Callback on job kill."""


### PR DESCRIPTION
This change ensures that only the relevant line is processed. E.g. If we
use a login shell to call cylc on a remote job host, we can end up with
garbage in the output.
