### PR TITLE
cylc gui (task proxy): Reset started and finished times on new submission.

### DIFF
--- a/lib/cylc/task_proxy.py
+++ b/lib/cylc/task_proxy.py
@@ -661,6 +661,14 @@ class TaskProxy(object):
             flags.pflag = True
 
         self.submitted_time = time.time()
+
+        self.summary['started_time'] = None
+        self.summary['started_time_string'] = None
+        self.started_time = None
+        self.summary['finished_time'] = None
+        self.summary['finished_time_string'] = None
+        self.finished_time = None
+
         self.summary['submitted_time'] = self.submitted_time
         self.summary['submitted_time_string'] = (
             get_time_string_from_unix_time(self.submitted_time))


### PR DESCRIPTION
Closes #1225 

This resets the start and finish times as seen in the cylc gui on a new submission.
