### PR TITLE
run db: Log db retries and operation being tried.

### DIFF
--- a/lib/cylc/rundb.py
+++ b/lib/cylc/rundb.py
@@ -110,7 +110,7 @@ class ThreadedCursor(Thread):
                               "\trequest: %s\n\targs: %s")
         self.db_not_found_err = ("Database Not Found Error:\n"+
                                  "\tNo database found at %s")
-        self.retry_warning = ("[WARNING] retrying database operation - retry %s \n"+
+        self.retry_warning = ("[WARNING] retrying database operation on %s - retry %s \n"+
                               "\trequest: %s\n\targs: %s")
     def run(self):
         cnx = sqlite3.connect(self.db, timeout=10.0)
@@ -154,7 +154,7 @@ class ThreadedCursor(Thread):
                     if attempt >= self.max_commit_attempts:
                         self.exception = e
                         raise Exception(self.generic_err_msg%(type(e),str(e),req,arg))
-                    print >> sys.stderr, self.retry_warning%(str(attempt), req, arg)
+                    print >> sys.stderr, self.retry_warning%(self.db, str(attempt), req, arg)
                     sleep(1)
                 except Exception as e:
                     # Capture all other integrity errors and raise more helpful message
@@ -162,7 +162,7 @@ class ThreadedCursor(Thread):
                     if attempt >= self.max_commit_attempts:
                         self.exception = e
                         raise Exception(self.generic_err_msg%(type(e),str(e),req,arg))
-                    print >> sys.stderr, self.retry_warning%(str(attempt), req, arg)
+                    print >> sys.stderr, self.retry_warning%(self.db, str(attempt), req, arg)
                     sleep(1)
             counter += 1
         cnx.commit()


### PR DESCRIPTION
@dpmatthews has suggested it would be useful to know when a database retry has occurred for purposes of debugging.

This adds a warning message to the error logs when a retry of writing to the database occurs (much the same as when a INSERT becomes INSERT or REPLACE). As this shouldn't be happening as a regular thing it shouldn't pollute the logs but will allow us to see whether, in situations when a db lock _does_ shut down the db, the problem is ongoing, causing the odd retry here and there, or if it is a single bad event.
