### PR TITLE
held suites and reload: Don't reset tasks in final states to held in held suites.

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -151,6 +151,7 @@ class TaskPool(object):
             self.held_future_tasks.append(itask.identity)
             itask.reset_state_held()
         elif self.is_held and itask.state.is_currently("waiting"):
+            # hold newly-spawned tasks in a held suite (e.g. due to manual triggering of a held task)
             itask.reset_state_held()
 
         # add to the runahead pool


### PR DESCRIPTION
Closes #1226 

This stops tasks in a held suite whose states are succeeded/failed from being reset to held on a reload.

Can be tested with the following suite by holding the suite once bar has failed and issuing a reload. On master this results in foo and bar being set to held. On this branch foo remains succeeded and bar remains failed.

```
[scheduling]
    initial cycle time = 2013010100
    [[dependencies]]
        [[[ 0 ]]]
            graph = "baz[T-24] => foo => bar => baz"
[runtime]
    [[bar,baz]]
        command scripting = false
    [[foo]]
        command scripting = true
```
