### PR TITLE
parsec: string_list: fix handling of null value

### DIFF
--- a/lib/parsec/tests/synonyms/06-string_list/string_list.rc
+++ b/lib/parsec/tests/synonyms/06-string_list/string_list.rc
@@ -22,3 +22,7 @@
         item 2 = "the,c1", "quick , c2"  , "brown,c3", "fox,c4",   # comment
         item 3 = "the,c1", "quick , c2"  , "brown,c3",\
     "fox,c4",   # comment
+
+    [[NULL]]
+        item 1 =
+        item 2 = # comment

--- a/lib/parsec/tests/synonyms/bin/synonyms.py
+++ b/lib/parsec/tests/synonyms/bin/synonyms.py
@@ -24,7 +24,7 @@ res = cfg.get( sparse=True)
 for expected in res[rcname].keys():
 
     vals = cfg.get( [rcname, expected], sparse=True ).values()
-    expected = re.sub( 'COMMA', ',', expected )
+    expected = expected.replace('COMMA', ',').replace('NULL', '')
 
     if rcname == 'boolean':
         expected = ( expected == 'True' ) or False
@@ -42,7 +42,10 @@ for expected in res[rcname].keys():
         expected = [float(i) for i in expected.split('_')]
 
     elif rcname == 'string_list':
-        expected = expected.split('_')
+        if expected:
+            expected = expected.split('_')
+        else:
+            expected = []
 
     if vals.count(expected) != len( vals ):
         print >> sys.stderr, vals, ' is not all ', expected

--- a/lib/parsec/validate.py
+++ b/lib/parsec/validate.py
@@ -81,7 +81,7 @@ def validate( cfig, spec, keys=[] ):
         specval = spec[speckey]
         if isinstance( val, dict ) and isinstance( specval, dict):
             validate( val, spec[speckey], keys+[key] )
-        elif val and not isinstance( specval, dict):
+        elif val is not None and not isinstance( specval, dict):
             # (if val is null we're only checking item validity)
             cfig[key] = spec[speckey].check( val, keys+[key] )
         else:
@@ -148,14 +148,14 @@ def _strip_and_unquote( keys, value ):
         else:
             raise IllegalValueError( "string", keys, value )
 
-    elif value[0] == '"':
+    elif value.startswith('"'):
         m = re.match( _DQ_VALUE, value )
         if m:
             value = m.groups()[0]
         else:
             raise IllegalValueError( "string", keys, value )
 
-    elif value[0] == "'":
+    elif value.startswith("'"):
         m = re.match( _SQ_VALUE, value )
         if m:
             value = m.groups()[0]
@@ -182,13 +182,13 @@ def _unquoted_list_parse( keys, value ):
         pos = m.end(0)
 
 def _strip_and_unquote_list( keys, value ):
-    if value[0] == '"':
+    if value.startswith('"'):
         # double-quoted values
         m = _DQV.match( value )
         if m:
             value = m.groups()[0]
         values = re.findall( _DQ_L_VALUE, value )
-    elif value[0] == "'":
+    elif value.startswith("'"):
         # single-quoted values
         m = _SQV.match( value )
         if m:


### PR DESCRIPTION
A null value supplied to a `string_list` setting was not returning a
list of string, but a null string. This fixes the problem.
