### PR TITLE
cylc show: fix output ordering by sorting it

### DIFF
--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -116,7 +116,7 @@ if prnt_id:
         print 'PREREQUISITES (- => not satisfied):'
         if len( pre ) == 0:
             print '  (None)'
-        for item in pre:
+        for item in sorted(pre):
             [ msg, state ] = item
             if state:
                 descr = '  + '
@@ -127,7 +127,7 @@ if prnt_id:
         print 'OUTPUTS (- => not completed):'
         if len( out ) == 0:
             print '  (None)'
-        for item in out:
+        for item in sorted(out):
             [ msg, state ] = item
             if state:
                 descr = '  + '

--- a/tests/cylc-show/00-simple.t
+++ b/tests/cylc-show/00-simple.t
@@ -40,9 +40,9 @@ TASK foo.20141106T0900Z in suite $SUITE_NAME:
 PREREQUISITES (- => not satisfied):
   - show.20141106T0900Z succeeded
 OUTPUTS (- => not completed):
+  - foo.20141106T0900Z started
   - foo.20141106T0900Z submitted
   - foo.20141106T0900Z succeeded
-  - foo.20141106T0900Z started
 
 NOTE: for tasks that have triggered already, prerequisites are
 shown here in the state they were in at the time of triggering.

--- a/tests/cylc-show/01-clock-triggered.t
+++ b/tests/cylc-show/01-clock-triggered.t
@@ -40,9 +40,9 @@ TASK foo.20141106T0900Z in suite $SUITE_NAME:
 PREREQUISITES (- => not satisfied):
   - show.20141106T0900Z succeeded
 OUTPUTS (- => not completed):
+  - foo.20141106T0900Z started
   - foo.20141106T0900Z submitted
   - foo.20141106T0900Z succeeded
-  - foo.20141106T0900Z started
 Other:
   o  Clock trigger time reached ... True
   o  Triggers at ... 2014-11-06T09:05:00Z

--- a/tests/cylc-show/02-clock-triggered-alt-tz.t
+++ b/tests/cylc-show/02-clock-triggered-alt-tz.t
@@ -40,9 +40,9 @@ TASK foo.20140808T0900Z in suite $SUITE_NAME:
 PREREQUISITES (- => not satisfied):
   - show.20140808T0900Z succeeded
 OUTPUTS (- => not completed):
-  - foo.20140808T0900Z succeeded
   - foo.20140808T0900Z started
   - foo.20140808T0900Z submitted
+  - foo.20140808T0900Z succeeded
 Other:
   o  Clock trigger time reached ... True
   o  Triggers at ... 2014-08-08T09:05:00Z

--- a/tests/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -52,8 +52,8 @@ TASK foo.20140808T0900$TZ_OFFSET_BASIC in suite $SUITE_NAME:
 PREREQUISITES (- => not satisfied):
   - show.20140808T0900$TZ_OFFSET_BASIC succeeded
 OUTPUTS (- => not completed):
-  - foo.20140808T0900$TZ_OFFSET_BASIC submitted
   - foo.20140808T0900$TZ_OFFSET_BASIC started
+  - foo.20140808T0900$TZ_OFFSET_BASIC submitted
   - foo.20140808T0900$TZ_OFFSET_BASIC succeeded
 Other:
   o  Clock trigger time reached ... True


### PR DESCRIPTION
This fixes the current trivially-failing tests for `cylc show`.

@hjoliver, please review.
