### PR TITLE
documentation: Update time period entry in simulation mode documentation.

### DIFF
--- a/doc/cug.tex
+++ b/doc/cug.tex
@@ -5772,7 +5772,7 @@ groups of tasks:
 [runtime]
     [[foo]]
        [[[simulation mode]]]
-        run time range = 20,31 # (between 20 and 30 seconds)
+        run time range = PT20S,PT31S # (between 20 and 30 seconds)
 \end{lstlisting}
 Note that to get a failed simulation or dummy mode task to succeed on
 re-triggering, just change the suite.rc file appropriately and reload


### PR DESCRIPTION
This corrects the example use of run time range to be ISO8601 compliant.

@hjoliver - please review.
