### PR TITLE
cylc validate: initial greater than final fail

### DIFF
--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -262,6 +262,8 @@ class config( object ):
         else:
             self.initial_point.standardise()
 
+        final_point = None
+
         if self.cfg['scheduling']['final cycle point'] is not None:
             if self.cfg['scheduling']['final cycle point'].strip() is "":
                 self.cfg['scheduling']['final cycle point'] = None
@@ -288,6 +290,11 @@ class config( object ):
                     final_point = get_point(
                             self.cfg['scheduling']['final cycle point']).standardise()
                 self.cfg['scheduling']['final cycle point'] = str(final_point)
+
+        if final_point is not None and self.initial_point > final_point:
+            raise SuiteConfigError("The initial cycle point:" +
+                str(self.initial_point) + " is after the final cycle point:" +
+                str(final_point) + ".")
 
         self.start_point = (
             get_point(self._cli_start_point_string) or self.initial_point)

--- a/tests/validate/26-fail-initial-greater-final.t
+++ b/tests/validate/26-fail-initial-greater-final.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validation fails for initial cycle point greater than the final.
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE
+run_fail $TEST_NAME cylc validate --debug -v -v $SUITE_NAME
+grep_ok "The initial cycle point:20141208T0000Z is after the final cycle \
+point:20141207T0000Z."    $TEST_NAME.stderr
+#-------------------------------------------------------------------------------
+exit

--- a/tests/validate/26-fail-initial-greater-final/suite.rc
+++ b/tests/validate/26-fail-initial-greater-final/suite.rc
@@ -1,0 +1,19 @@
+title = "Test suite for initial cycle point less than final."
+description = """Task are not important here but the cycl points are.
+Initial is set to greater than the final and the suite should report the
+error."""
+
+[cylc]
+   [[reference test]]
+       required run mode = live
+       
+[scheduling]
+    initial cycle point = 20141208T0000Z
+    final cycle point   = 20141207T0000Z
+    [[dependencies]]
+        [[[T00]]]
+            graph = A => B
+    
+[runtime]
+    [[A]]
+    [[B]]


### PR DESCRIPTION
Closes #1259 

Test added and all pass in my environment.

Validate now checks to see if the initial cycle point is greater than the final cycle point and if so fails with a helpful message. 
