### PR TITLE
cylc gpanel: fix updating

### DIFF
--- a/lib/cylc/gui/gpanel.py
+++ b/lib/cylc/gui/gpanel.py
@@ -35,9 +35,8 @@ import warnings
 
 from cylc.cfgspec.globalcfg import GLOBAL_CFG
 from cylc.cfgspec.gcylc import gcfg
-from cylc.gui.gsummary import (get_host_suites, get_status_tasks,
-                               get_summary_menu, launch_gcylc,
-                               launch_gsummary, BaseSummaryTimeoutUpdater)
+from cylc.gui.gsummary import (get_summary_menu, launch_gsummary,
+                               BaseSummaryTimeoutUpdater)
 from cylc.gui.SuiteControl import run_get_stdout
 from cylc.gui.DotMaker import DotMaker
 from cylc.gui.util import get_icon, setup_icons
@@ -196,12 +195,15 @@ class SummaryPanelAppletUpdater(BaseSummaryTimeoutUpdater):
         compact_suite_statuses = []
         for suite, host in suite_host_tuples:
             if suite in statuses.get(host, {}):
-                status_map = statuses[host][suite]
+                task_cycle_states = statuses[host][suite]
                 is_stopped = False
             else:
                 info = stop_summaries[host][suite]
-                status_map, suite_time = info
+                task_cycle_states, suite_time = info
                 is_stopped = True
+            status_map = {}
+            for task, cycle, status in task_cycle_states:
+                status_map.setdefault(status, []).append(task + "." + cycle)
             status = extract_group_state(status_map.keys(),
                                          is_stopped=is_stopped)
             if number_mode:

--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -70,8 +70,8 @@ def get_host_suites(hosts, timeout=None, owner=None):
     return host_suites_map
 
 
-def get_status_tasks(host, suite, owner=None):
-    """Return a dictionary of statuses and tasks, or None."""
+def get_task_cycle_statuses(host, suite, owner=None):
+    """Return a list of task, cycle, status tuples, or None."""
     if owner is None:
         owner = user
     command = ["cylc", "cat-state", "--host=%s" % host,
@@ -946,13 +946,13 @@ def get_new_statuses_and_stop_summaries(hosts, owner, prev_stop_summaries=None,
     current_suites = []
     for host, suites in host_suites.items():
         for suite in suites:
-            status_tasks = get_status_tasks(host, suite,
-                                            owner=owner)
-            if status_tasks is None:
+            task_cycle_statuses = get_task_cycle_statuses(host, suite,
+                                                          owner=owner)
+            if task_cycle_statuses is None:
                 continue
             statuses.setdefault(host, {})
             statuses[host].setdefault(suite, {})
-            statuses[host][suite] = status_tasks
+            statuses[host][suite] = task_cycle_statuses
             if (host in stop_summaries and
                 suite in stop_summaries[host]):
                 stop_summaries[host].pop(suite)
@@ -960,8 +960,8 @@ def get_new_statuses_and_stop_summaries(hosts, owner, prev_stop_summaries=None,
     for host, suite in prev_suites:
         if (host, suite) not in current_suites:
             stop_summaries.setdefault(host, {})
-            summary_statuses = get_status_tasks(host, suite,
-                                                owner=owner)
+            summary_statuses = get_task_cycle_statuses(host, suite,
+                                                       owner=owner)
             if summary_statuses is None:
                 continue
             stop_summaries[host][suite] = (summary_statuses,


### PR DESCRIPTION
cylc gpanel will currently fail on update with:

```
  File "/opt/cylc/lib/cylc/gui/gpanel.py", line 205, in update
    status = extract_group_state(status_map.keys(),
AttributeError: 'list' object has no attribute 'keys'
```

This is due to a change in the gsummary-provided data structures at #1245.
I've fixed the gpanel behaviour and changed a few names in gsummary.

@kaday, please review.
