### PR TITLE
Fix hold and release of a retrying task

### DIFF
--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -641,7 +641,7 @@ class TaskPool(object):
     def release_tasks(self, ids):
         for itask in self.get_tasks(incl_runahead=True):
             if itask.identity in ids and itask.state.is_currently('held'):
-                itask.reset_state_waiting()
+                itask.reset_state_unheld()
 
     def hold_all_tasks(self):
         self.log.info("Holding all waiting or queued tasks now")
@@ -660,7 +660,7 @@ class TaskPool(object):
                     continue
                 else:
                     # Release task.
-                    itask.reset_state_waiting()
+                    itask.reset_state_unheld()
 
     def get_failed_tasks(self):
         failed = []

--- a/tests/hold-release/11-retrying.t
+++ b/tests/hold-release/11-retrying.t
@@ -1,0 +1,28 @@
+#!/bin/bash
+#C: THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+#C: Copyright (C) 2008-2014 NIWA
+#C:
+#C: This program is free software: you can redistribute it and/or modify
+#C: it under the terms of the GNU General Public License as published by
+#C: the Free Software Foundation, either version 3 of the License, or
+#C: (at your option) any later version.
+#C:
+#C: This program is distributed in the hope that it will be useful,
+#C: but WITHOUT ANY WARRANTY; without even the implied warranty of
+#C: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#C: GNU General Public License for more details.
+#C:
+#C: You should have received a copy of the GNU General Public License
+#C: along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test hold and release of a retrying task.
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}" cylc run --reference-test --debug $SUITE_NAME
+
+purge_suite "${TEST_NAME_BASE}"
+exit

--- a/tests/hold-release/11-retrying/bin/my-log-grepper
+++ b/tests/hold-release/11-retrying/bin/my-log-grepper
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+while ! grep -q -F "$@" "${CYLC_SUITE_LOG_DIR}/log"; do
+    sleep 1
+done
+exit

--- a/tests/hold-release/11-retrying/reference.log
+++ b/tests/hold-release/11-retrying/reference.log
@@ -1,0 +1,15 @@
+2014-12-17T15:48:59Z INFO - Initial point: 1
+2014-12-17T15:48:59Z INFO - Final point: 1
+2014-12-17T15:48:59Z INFO - Cold Start 1
+2014-12-17T15:48:59Z INFO - [t-retry-able.1] -triggered off []
+2014-12-17T15:49:00Z INFO - [t-hold-release.1] -triggered off ['t-retry-able.1']
+2014-12-17T15:49:01Z INFO - [t-retry-able.1] -job failed, retrying in PT15S
+2014-12-17T15:49:02Z INFO - [t-retry-able.1] -retrying => held
+2014-12-17T15:49:02Z INFO - Command succeeded: hold task now(t-retry-able,1,False)
+2014-12-17T15:49:03Z INFO - [t-retry-able.1] -held => retrying
+2014-12-17T15:49:03Z INFO - Command succeeded: release task(t-retry-able,1,False)
+2014-12-17T15:49:16Z INFO - [t-retry-able.1] -initiate job-submit
+2014-12-17T15:49:16Z INFO - [t-retry-able.1] -triggered off []
+2014-12-17T15:49:18Z INFO - [t-retry-able.1] -job failed, retrying in PT1S
+2014-12-17T15:49:19Z INFO - [t-retry-able.1] -triggered off []
+2014-12-17T15:49:22Z INFO - [t-analyse.1] -triggered off ['t-retry-able.1']

--- a/tests/hold-release/11-retrying/suite.rc
+++ b/tests/hold-release/11-retrying/suite.rc
@@ -1,0 +1,31 @@
+title = Test task retry - hold - release
+
+[cylc]
+    [[reference test]]
+        live mode suite timeout = PT1M30S
+        dummy mode suite timeout = PT1M30S
+        simulation mode suite timeout = PT1M30S
+
+[scheduling]
+    [[dependencies]]
+            graph = """
+t-retry-able:submit => t-hold-release
+t-retry-able => t-analyse
+"""
+
+[runtime]
+    [[t-retry-able]]
+        command scripting = ((CYLC_TASK_TRY_NUMBER >= 3))
+        retry delays = PT15S, 2*PT1S
+    [[t-hold-release]]
+        command scripting = """
+timeout 30s my-log-grepper '[t-retry-able.1] -job failed, retrying in PT15S'
+cylc hold "${CYLC_SUITE_NAME}" 't-retry-able' '1'
+timeout 30s my-log-grepper '[t-retry-able.1] -retrying => held'
+cylc release "${CYLC_SUITE_NAME}" 't-retry-able' '1'
+timeout 30s my-log-grepper '[t-retry-able.1] -held => retrying'
+"""
+    [[t-analyse]]
+        command scripting = """
+test "$(readlink "$(dirname "$0")/../../t-retry-able/NN")" = '03'
+"""


### PR DESCRIPTION
Previously, on release, it will reset the task's state to `waiting`. Now it will reset back to `retrying`.

See also #355.
