### PR TITLE
Run jobscript 00 test w/o global configuration

### DIFF
--- a/tests/jobscript/00-torture.t
+++ b/tests/jobscript/00-torture.t
@@ -30,7 +30,7 @@ CYLC_CONF_PATH= suite_run_ok $TEST_NAME \
     cylc run --reference-test --debug $SUITE_NAME
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-foo-jobscript-match
-run_ok $TEST_NAME cylc jobscript $SUITE_NAME foo.1
+CYLC_CONF_PATH= run_ok $TEST_NAME cylc jobscript $SUITE_NAME foo.1
 sed 's/\(export CYLC_.*=\).*/\1/g' $TEST_NAME.stdout >jobfile
 echo "" >> jobfile
 sed 's/##suitename##/'$SUITE_NAME'/' \


### PR DESCRIPTION
(The presence of global configuration can cause the job script to look
different.)
