### PR TITLE
test-battery: don't hard code use of xxdiff

### DIFF
--- a/bin/cylc-test-battery
+++ b/bin/cylc-test-battery
@@ -47,9 +47,10 @@ In such cases, you can change the amount of concurrency by setting either:
   * the "process pool size = N" option in the site/user global
     configuration.
 
-To output stderr from failed tests to the terminal, export
-CYLC_TEST_DEBUG=true before running this command. To perform comparison
-tests using "xxdiff -D", export CYLC_TEST_DEBUG_CMP=true.
+To output stderr from failed tests to the terminal, "export CYLC_TEST_DEBUG=true"
+before running this command. By default, it uses "diff -u" to compare files.
+However, if an alternate command such as "xxdiff -D" is desirable (e.g. for
+debugging), "export CYLC_TEST_DIFF_CMD=xxdiff -D".
 
 For more information see "Reference Tests" in the User Guide.
 

--- a/tests/cyclers/23-multidaily_local.t
+++ b/tests/cyclers/23-multidaily_local.t
@@ -38,7 +38,6 @@ graph_suite "$SUITE_NAME" "$SUITE_NAME.graph.plain"
 sed "s/Z/$CURRENT_TZ_UTC_OFFSET/g" \
     "$TEST_SOURCE_DIR/$CHOSEN_SUITE/graph.plain.ref" > graph.plain.local.ref
 cmp_ok "$SUITE_NAME.graph.plain" graph.plain.local.ref
-xxdiff -D "$SUITE_NAME.graph.plain" graph.plain.local.ref
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-run
 suite_run_ok $TEST_NAME cylc run --reference-test --debug $SUITE_NAME

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -42,9 +42,11 @@
 #         and stderr in TEST_NAME.stdout and TEST_NAME.stderr.
 #         This is expected to have a non-zero return code, which ok's the test.
 #     cmp_ok FILE_TEST [FILE_CONTROL]
-#         Compare FILE_TEST with a file or stdin given by FILE_CONTROL
-#         (stdin if FILE_CONTROL is "-" or missing). If $CYLC_TEST_DEBUG_CMP
-#         is set, show differences using xxdiff.
+#         Compare FILE_TEST with a file or stdin given by FILE_CONTROL (stdin
+#         if FILE_CONTROL is "-" or missing). By default, it uses "diff -u" to
+#         compare files. However, if an alternate command such as "xxdiff -D"
+#         is desirable (e.g. for debugging),
+#         "export CYLC_TEST_DIFF_CMD=xxdiff -D".
 #     contains_ok FILE_TEST [FILE_CONTROL]
 #         Make sure that each line in FILE_TEST is present in FILE_CONTROL
 #         (stdin if FILE_CONTROL is "-" or missing).
@@ -177,12 +179,8 @@ function cmp_ok() {
     local FILE_TEST=$1
     local FILE_CONTROL=${2:--}
     local TEST_NAME=$(basename $FILE_TEST)-cmp-ok
-    local CMP_COMMAND="diff -u"
-    if [[ -n ${CYLC_TEST_DEBUG_CMP:-} ]]; then
-        CMP_COMMAND="xxdiff -D"
-    fi
-    if $CMP_COMMAND "$FILE_TEST" "$FILE_CONTROL" \
-            1>$TEST_NAME.stderr 2>&1; then
+    local DIFF_CMD=${CYLC_TEST_DIFF_CMD:-'diff -u'}
+    if ${DIFF_CMD} "$FILE_TEST" "$FILE_CONTROL" 1>$TEST_NAME.stderr 2>&1; then
         ok $TEST_NAME
         return
     fi


### PR DESCRIPTION
Allow use of new environment variable CYLC_TEST_DIFF_CMD to specify any
alternate `diff` command.
