### PR TITLE
Fix gsummary gcylc launcher.

### DIFF
--- a/lib/cylc/gui/gsummary.py
+++ b/lib/cylc/gui/gsummary.py
@@ -471,7 +471,7 @@ class SummaryApp(object):
             host, suite = treemodel.get(iter_, 0, 1)
             if suite is None:
                 # On an expanded cycle point summary row, so get from parent.
-                host, suite = treemodel.get(treemodel.iter_parent(iter_),0,1)
+                host, suite = treemodel.get(treemodel.iter_parent(iter_), 0, 1)
             suite_host_tuples.append((suite, host))
 
         if event.type == gtk.gdk._2BUTTON_PRESS:


### PR DESCRIPTION
It was broken on the new cycle point summary rows: the drop-down menu had "launch gcylc: None - None".  This allows launching of gcylc from the point summary rows as well as the main suite row.
