### PR TITLE
Fix inheritance with quotes using shlex

### DIFF
--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -356,8 +356,12 @@ class ParsecValidator(object):
             Processed value as a list.
         """
         if value.startswith('"') or value.startswith("'"):
-            lexer = shlex.shlex(value, posix=True)
-            values = [t for t in lexer if t != ","]
+            lexer = shlex.shlex(value, posix=True, punctuation_chars=",")
+            lexer.commenters = '#'
+            lexer.whitespace_split = False
+            lexer.whitespace = "\t\n\r"
+            lexer.wordchars += " "
+            values = [t.strip() for t in lexer if t != ","]
         else:
             # unquoted values (may contain internal quoted strings with list
             # delimiters inside 'em!)

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -361,7 +361,7 @@ class ParsecValidator(object):
             lexer.whitespace_split = False
             lexer.whitespace = "\t\n\r"
             lexer.wordchars += " "
-            values = [t.strip() for t in lexer if t != ","]
+            values = [t.strip() for t in lexer if t != "," and t.strip()]
         else:
             # unquoted values (may contain internal quoted strings with list
             # delimiters inside 'em!)

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -25,6 +25,7 @@ Also provides default values from the spec as a nested dict.
 """
 
 import re
+import shlex
 from collections import deque
 from textwrap import dedent
 
@@ -354,18 +355,9 @@ class ParsecValidator(object):
         Return (list):
             Processed value as a list.
         """
-        if value.startswith('"'):
-            # double-quoted values
-            match = cls._REC_DQV.match(value)
-            if match:
-                value = match.groups()[0]
-            values = cls._REC_DQ_L_VALUE.findall(value)
-        elif value.startswith("'"):
-            # single-quoted values
-            match = cls._REC_SQV.match(value)
-            if match:
-                value = match.groups()[0]
-            values = cls._REC_SQ_L_VALUE.findall(value)
+        if value.startswith('"') or value.startswith("'"):
+            lexer = shlex.shlex(value, posix=True)
+            values = [t for t in lexer if t != ","]
         else:
             # unquoted values (may contain internal quoted strings with list
             # delimiters inside 'em!)

--- a/cylc/flow/tests/parsec/test_validate.py
+++ b/cylc/flow/tests/parsec/test_validate.py
@@ -107,6 +107,27 @@ def get_parsec_validator_invalid_values():
     return values
 
 
+def get_test_strip_and_unquote_list():
+    return [
+        [
+            '"a,b", c, "d e"',  # input
+            ["a,b", "c", "d e"]  # expected
+        ],
+        [
+            'foo bar baz',  # input
+            ["foo bar baz"]  # expected
+        ],
+        [
+            '"a", \'b\', c',  # input
+            ["a", "b", "c"]  # expected
+        ],
+        [
+            'a b c, d e f',  # input
+            ["a b c", "d e f"]  # expected
+        ],
+    ]
+
+
 class TestValidate(unittest.TestCase):
     """Unit Tests for cylc.flow.parsec.validate.ParsecValidator.coerce*
     methods."""
@@ -596,6 +617,15 @@ class TestValidate(unittest.TestCase):
             self.assertRaises(
                 IllegalValueError,
                 validator.coerce_xtrigger, value, ['whatever'])
+
+    def test_strip_and_unquote_list(self):
+        """Test strip_and_unquote_list"""
+        validator = VDR()
+        for values in get_test_strip_and_unquote_list():
+            value = values[0]
+            expected = values[1]
+            output = validator.strip_and_unquote_list(keys=[], value=value)
+            self.assertEqual(expected, output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

I was doing some clean up in my local branches, and found one with a fix for #2700. As I am waiting for some code to be fixed for the `setup.py`, decided to work on this issue today in the afternoon.

The issue #2700 happens due to the regex used, which misses the second unquoted value of the `inherit` configuration. 

Here's an example of what happens: https://pythex.org/?regex=%27(%5B%5E%27%5C%5C%5D*(%3F%3A%5C%5C.%5B%5E%27%5C%5C%5D*)*)%27&test_string=%27BIGFAM%27%2C%20SOMEFAM&ignorecase=1&multiline=1&dotall=1&verbose=0

I think we could try to fix that regex... possibly combining more regexes to match other cases? But an alternative solution would be to use the `shlex` module (used in other parts of Cylc I believe) in `strip_and_unquote_list()`.

>The shlex class makes it easy to write lexical analyzers for simple syntaxes resembling that of the Unix shell. This will often be useful for writing minilanguages, (for example, in run control files for Python applications) or for parsing quoted strings.

Passing the raw configuration string value through shlex removes quotes as per POSIX. And I believe it uses lookup tables to parse the values, and only uses regex for putting quotes back (which we are not doing here). So there could be a tiny performance improvement too (maybe?).

Added some unit tests too. Will add @oliver-sanders as one of the reviewers as I've seen him working on even harder issues with regexes, and I think I saw the `shlex` module in his Python 3 pull request.

Not sure if it will be fixed in time for next Cylc 7.x, so setting milestone as 8.0a1.

Cheers
Bruno

