### PR TITLE
[discussion] Api on the fly

### DIFF
--- a/bin/cylc-checkpoint
+++ b/bin/cylc-checkpoint
@@ -44,7 +44,7 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    pclient('take_checkpoints', {'items': [name]})
+    pclient('take_checkpoints', {'name': name})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -51,11 +51,10 @@ def main():
         help="Hold whole suite AFTER this cycle point.",
         metavar="CYCLE_POINT", action="store", dest="hold_point_string")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Hold task(s) %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Hold task(s) %s in %s' % (task_globs, suite), options.force)
     elif options.hold_point_string:
         prompt(
             'Hold suite after %s' % options.hold_point_string, options.force)
@@ -65,8 +64,7 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port)
 
-    if args:
-        task_globs = parser.parse_multitask_compat(options, args)
+    if task_globs:
         pclient(
             'hold_tasks',
             {'task_globs': task_globs},

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -18,7 +18,7 @@
 
 """cylc [control] hold [OPTIONS] ARGS
 
-Hold one or more waiting tasks (cylc hold REG TASKID ...), or
+Hold one or more waiting tasks (cylc hold REG TASK_GLOB ...), or
 a whole suite (cylc hold REG).
 
 Held tasks do not submit even if they are ready to run.
@@ -44,7 +44,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", "Suite name"),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "--after",
@@ -66,10 +66,10 @@ def main():
         suite, options.owner, options.host, options.port)
 
     if args:
-        items = parser.parse_multitask_compat(options, args)
+        task_globs = parser.parse_multitask_compat(options, args)
         pclient(
             'hold_tasks',
-            {'task_globs': items},
+            {'task_globs': task_globs},
             timeout=options.comms_timeout
         )
     elif options.hold_point_string:

--- a/bin/cylc-hold
+++ b/bin/cylc-hold
@@ -69,7 +69,7 @@ def main():
         items = parser.parse_multitask_compat(options, args)
         pclient(
             'hold_tasks',
-            {'items': items},
+            {'task_globs': items},
             timeout=options.comms_timeout
         )
     elif options.hold_point_string:

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -65,12 +65,9 @@ def main():
     options, args = parser.parse_args()
     suite = args.pop(0)
 
-    # See "cop.parse_multitask_compat" for back compat discussion
-    # "cop.parse_multitask_compat" cannot be used here because argument 3
-    # (after suite argument) used to be "options.stop_point_string".
-    if (options.multitask_compat and len(args) in [2, 3] and
-            all("/" not in arg for arg in args) and
-            all("." not in arg for arg in args[1:])):
+    if (len(args) in [2, 3]
+            and all("/" not in arg for arg in args)
+            and all("." not in arg for arg in args[1:])):
         items = [(args[0] + "." + args[1])]
         if len(args) == 3:
             options.stop_point_string = args[2]

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -56,7 +56,7 @@ def main():
         suite, options.owner, options.host, options.port)
     pclient(
         'kill_tasks',
-        {'items': parser.parse_multitask_compat(options, args)},
+        {'task_globs': parser.parse_multitask_compat(options, args)},
         timeout=options.comms_timeout
     )
 

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -45,18 +45,17 @@ def main():
             ('REG', 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Kill task %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Kill task %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Kill ALL tasks in %s' % (suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port)
     pclient(
         'kill_tasks',
-        {'task_globs': parser.parse_multitask_compat(options, args)},
+        {'task_globs': task_globs},
         timeout=options.comms_timeout
     )
 

--- a/bin/cylc-kill
+++ b/bin/cylc-kill
@@ -20,7 +20,7 @@
 
 Kill jobs of active tasks and update their statuses accordingly.
 
-To kill one or more tasks, "cylc kill REG TASKID ..."; to kill all active
+To kill one or more tasks, "cylc kill REG TASK_GLOB ..."; to kill all active
 tasks: "cylc kill REG".
 """
 
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
 

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -38,7 +38,7 @@ echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
 cd "$CYLC_DIR"/doc/
 echo "... Generating the command reference ..."
-./src/custom/make-commands.sh
+#./src/custom/make-commands.sh
 echo >&2
 
 echo "... Generating multi-page User Guide..."

--- a/bin/cylc-make-docs
+++ b/bin/cylc-make-docs
@@ -38,7 +38,7 @@ echo "Building the HTML Cylc Documentation with Sphinx:"
 echo >&2
 cd "$CYLC_DIR"/doc/
 echo "... Generating the command reference ..."
-#./src/custom/make-commands.sh
+./src/custom/make-commands.sh
 echo >&2
 
 echo "... Generating multi-page User Guide..."

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -48,19 +48,19 @@ def main():
         "-s", "--succeeded", help="Allow polling of succeeded tasks.",
         action="store_true", default=False, dest="poll_succ")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    if args:
-        prompt('Poll task %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Poll task %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Poll ALL tasks in %s' % (suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
-    pclient('poll_tasks',
-            {'task_globs': task_globs, 'poll_succ': options.poll_succ})
+    pclient(
+        'poll_tasks',
+        {'task_globs': task_globs, 'poll_succ': options.poll_succ}
+    )
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -62,9 +62,10 @@ def main():
     # Back compat: back_out introduced >7.5.0
     # So don't call with "poll_succ" if not necessary to avoid breakage.
     if options.poll_succ:
-        pclient('poll_tasks', {'items': items, 'poll_succ': options.poll_succ})
+        pclient('poll_tasks',
+                {'task_globs': items, 'poll_succ': options.poll_succ})
     else:
-        pclient('poll_tasks', {'items': items})
+        pclient('poll_tasks', {'task_globs': items})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-poll
+++ b/bin/cylc-poll
@@ -20,8 +20,8 @@
 
 Poll (query) task jobs to verify and update their statuses.
 
-Use "cylc poll REG" to poll all active tasks, or "cylc poll REG TASKID" to poll
-individual tasks or families, or groups of them.
+Use "cylc poll REG" to poll all active tasks, or "cylc poll REG TASK_GLOB"
+to poll individual tasks or families, or groups of them.
 """
 
 import sys
@@ -42,7 +42,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-s", "--succeeded", help="Allow polling of succeeded tasks.",
@@ -58,14 +58,9 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
-    # Back compat: back_out introduced >7.5.0
-    # So don't call with "poll_succ" if not necessary to avoid breakage.
-    if options.poll_succ:
-        pclient('poll_tasks',
-                {'task_globs': items, 'poll_succ': options.poll_succ})
-    else:
-        pclient('poll_tasks', {'task_globs': items})
+    task_globs = parser.parse_multitask_compat(options, args)
+    pclient('poll_tasks',
+            {'task_globs': task_globs, 'poll_succ': options.poll_succ})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -18,7 +18,7 @@
 
 """cylc [control] release|unhold [OPTIONS] ARGS
 
-Release one or more held tasks (cylc release REG TASKID)
+Release one or more held tasks (cylc release REG TASK_GLOB)
 or the whole suite (cylc release REG). Held tasks do not
 submit even if they are ready to run.
 
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
     suite = args.pop(0)
@@ -56,8 +56,8 @@ def main():
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
     if args:
-        items = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'task_globs': items})
+        task_globs = parser.parse_multitask_compat(options, args)
+        pclient('release_tasks', {'task_globs': task_globs})
     else:
         pclient('release_suite')
 

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -45,19 +45,20 @@ def main():
             ("REG", 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
-    if args:
-        prompt('Release task(s) %s in %s' % (args, suite), options.force)
+    if task_globs:
+        prompt('Release task(s) %s in %s' % (task_globs, suite), options.force)
     else:
         prompt('Release suite %s' % suite, options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    if args:
-        task_globs = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'task_globs': task_globs})
+    if task_globs:
+        pclient(
+            'release_tasks',
+            {'task_globs': task_globs}
+        )
     else:
         pclient('release_suite')
 

--- a/bin/cylc-release
+++ b/bin/cylc-release
@@ -57,7 +57,7 @@ def main():
         options.comms_timeout)
     if args:
         items = parser.parse_multitask_compat(options, args)
-        pclient('release_tasks', {'items': items})
+        pclient('release_tasks', {'task_globs': items})
     else:
         pclient('release_suite')
 

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -59,7 +59,7 @@ def main():
     items = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
-        {'items': items, 'spawn': (not options.no_spawn)}
+        {'task_globs': items, 'spawn': (not options.no_spawn)}
     )
 
 

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -49,14 +49,12 @@ def main():
         help="Do not spawn successors before removal.",
         action="store_true", default=False, dest="no_spawn")
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-    prompt('remove task(s) %s in %s' % (args, suite), options.force)
+    prompt('remove task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
         {'task_globs': task_globs, 'spawn': (not options.no_spawn)}

--- a/bin/cylc-remove
+++ b/bin/cylc-remove
@@ -18,7 +18,7 @@
 
 """cylc [control] remove [OPTIONS] ARGS
 
-Remove one or more tasks (cylc remove REG TASKID), or all tasks with a
+Remove one or more tasks (cylc remove REG TASK_GLOB), or all tasks with a
 given cycle point (cylc remove REG *.POINT) from a running suite.
 
 Tasks will spawn successors first if they have not done so already.
@@ -42,7 +42,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ("REG", "Suite name"),
-            ('TASKID [...]', 'Task identifiers')])
+            ('TASK_GLOB [...]', 'Task matching patterns')])
 
     parser.add_option(
         "--no-spawn",
@@ -56,10 +56,10 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
+    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'remove_tasks',
-        {'task_globs': items, 'spawn': (not options.no_spawn)}
+        {'task_globs': task_globs, 'spawn': (not options.no_spawn)}
     )
 
 

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -99,7 +99,8 @@ def main():
     items = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
-        {'items': items, 'state': options.state, 'outputs': options.outputs}
+        {'task_globs': items, 'state': options.state,
+         'outputs': options.outputs}
     )
 
 

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -52,7 +52,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-s", "--state", metavar="STATE",
@@ -96,10 +96,10 @@ def main():
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    items = parser.parse_multitask_compat(options, args)
+    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
-        {'task_globs': items, 'state': options.state,
+        {'task_globs': task_globs, 'state': options.state,
          'outputs': options.outputs}
     )
 

--- a/bin/cylc-reset
+++ b/bin/cylc-reset
@@ -70,9 +70,7 @@ def main():
               "Can be used more than once to reset multiple task outputs."),
         action="append", default=[], dest="outputs")
 
-    options, args = parser.parse_args()
-
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
     if not options.state and not options.outputs:
         parser.error("Neither --state=STATE nor --output=OUTPUT is set")
@@ -83,7 +81,7 @@ def main():
             "'cylc reset -s spawn' is deprecated; calling 'cylc spawn'\n")
         cmd = sys.argv[0].replace('reset', 'spawn')
         try:
-            os.execvp(cmd, [cmd] + args)
+            os.execvp(cmd, [cmd] + task_globs)
         except OSError as exc:
             if exc.filename is None:
                 exc.filename = cmd
@@ -92,11 +90,10 @@ def main():
     if not options.state:
         options.state = ''
 
-    prompt('Reset task(s) %s in %s' % (args, suite), options.force)
+    prompt('Reset task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
-    task_globs = parser.parse_multitask_compat(options, args)
     pclient(
         'reset_task_states',
         {'task_globs': task_globs, 'state': options.state,

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, noforce=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task names or identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option('--list-prereqs', action="store_true", default=False,
                       help="Print a task's pre-requisites as a list.")

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -43,7 +43,7 @@ def main():
         __doc__, comms=True, noforce=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASK_GLOB ...]', 'Task matching patterns')])
+            ('[TASKS ...]', 'Task names or ids (name.cycle)')])
 
     parser.add_option('--list-prereqs', action="store_true", default=False,
                       help="Print a task's pre-requisites as a list.")
@@ -51,9 +51,8 @@ def main():
     parser.add_option('--json', action="store_true", default=False,
                       help="Print output in JSON format.")
 
-    options, args = parser.parse_args()
-    suite = args[0]
-    task_args = args[1:]
+    options, (suite, *task_args) = parser.parse_args()
+
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
@@ -83,8 +82,10 @@ def main():
                     print("%s: %s" % (key, value or "(not given)"))
 
     if task_ids:
-        results, bad_items = pclient('get_task_requisites', {
-            'task_globs': task_ids, 'list_prereqs': options.list_prereqs})
+        results, bad_items = pclient(
+            'get_task_requisites',
+            {'task_globs': task_ids, 'list_prereqs': options.list_prereqs}
+        )
         if options.json:
             json_filter.append(results)
         else:

--- a/bin/cylc-show
+++ b/bin/cylc-show
@@ -84,7 +84,7 @@ def main():
 
     if task_ids:
         results, bad_items = pclient('get_task_requisites', {
-            'items': task_ids, 'list_prereqs': options.list_prereqs})
+            'task_globs': task_ids, 'list_prereqs': options.list_prereqs})
         if options.json:
             json_filter.append(results)
         else:

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -41,7 +41,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     options, args = parser.parse_args()
 

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -54,7 +54,7 @@ def main():
 
     pclient(
         'spawn_tasks',
-        {'items': parser.parse_multitask_compat(options, args)}
+        {'task_globs': parser.parse_multitask_compat(options, args)}
     )
 
 

--- a/bin/cylc-spawn
+++ b/bin/cylc-spawn
@@ -43,18 +43,16 @@ def main():
             ('REG', 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    options, args = parser.parse_args()
+    options, (suite, *task_globs) = parser.parse_args()
 
-    suite = args.pop(0)
-
-    prompt('Spawn task(s) %s in %s' % (args, suite), options.force)
+    prompt('Spawn task(s) %s in %s' % (task_globs, suite), options.force)
     pclient = SuiteRuntimeClient(
         suite, options.owner, options.host, options.port,
         options.comms_timeout)
 
     pclient(
         'spawn_tasks',
-        {'task_globs': parser.parse_multitask_compat(options, args)}
+        {'task_globs': task_globs}
     )
 
 

--- a/bin/cylc-suite
+++ b/bin/cylc-suite
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""cylc client [OPTIONS] ARGS
+
+(This command is for internal use.)
+Invoke suite runtime client, expect JSON from STDIN for keyword arguments.
+Use the -n option if client function requires no keyword arguments.
+"""
+
+import argparse
+import json
+import sys
+
+from sphinx.ext.napoleon import Config
+from sphinx.ext.napoleon.docstring import GoogleDocstring
+
+from cylc.network.client import SuiteRuntimeClient
+
+
+class ArgumentBuilder:
+    """"Abstract interface for building a CLI."""
+
+    def __init__(self, prog):
+        self.parser = argparse.ArgumentParser(
+            prog,
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+        self.description_lines = []
+        self.section_type = None
+        self.all = []
+
+    def notify(self, section_type):
+        self.section_type = section_type.lower()
+
+    def add(self, args):
+        if not self.section_type:
+            self.description_lines += args
+        elif self.section_type in ['args', 'arguments', 'params']:
+            self.add_argument(args)
+        elif self.section_type in ['return', 'returns', 'yield', 'yields']:
+            args = args[0]
+            if isinstance(args, str):
+                return
+            _, ret_type, lines = args
+            self.description_lines += ['', '']
+            self.description_lines += [
+                '%s: %s - %s' % (self.section_type, ret_type, lines[0])]
+            self.description_lines.extend(
+                ['    %s' % line for line in lines[1:]])
+
+    def add_argument(self, args):
+        name, typestring, lines = args
+        name = name.replace('\\', '')
+        self.all.append(name)
+        types = [type_.strip() for type_ in typestring.split(',')]
+        if 'optional' in types:
+            name = '--%s' % name
+            types.remove('optional')
+
+        if len(types) != 1:
+            raise Exception('len(types)')  # TODO
+
+        typ = types[0]
+        if not typ:  # TODO: this better
+            typ = None
+        elif typ == 'bool':
+            typ = bool
+        elif typ == 'int':
+            typ = int
+        elif typ == 'str':
+            typ = str
+        elif typ == 'float':
+            typ = float
+        elif typ == 'list':
+            typ = list
+        elif typ == 'dict':
+            typ = dict
+        else:
+            raise Exception('type: %s' % typ)  # TODO
+
+        args = (name,)
+        kwargs = {
+            'help': '\n'.join(lines).strip(),
+            'type': typ
+        }
+
+        self.parser.add_argument(*args, **kwargs)
+
+    def close(self):
+        # TODO: context manager
+        self.parser.description = '\n'.join(self.description_lines)
+        return self.parser, self.all
+
+
+def wrap(host, before=None, after=None):
+    """Wrap host function with parasites.
+
+    Args:
+        host (function):
+            The function to wrap
+        before (function, optional):
+            Called before ``host``. Takes no arguments, provides no return.
+        after (function, optional):
+            Called after ``host``. Takes one argument (the return value
+            of ``host``), provides no return.
+
+    Returns:
+        function: The wrapped function
+
+    """
+    def wrapper(self, *args, **kwargs):
+        if before:
+            before()
+        ret = host(self, *args, **kwargs)
+        if after:
+            after(ret)
+        return ret
+    return wrapper
+
+
+def docstring_to_argument_parser(docstring, prog):
+    """Convert a docstring into a :py:class:`argparse.ArgumentParser`.
+
+    Args:
+        docstring (str): The docstring with indentation removed.
+        prog (str): The program name (for argparse)
+
+    Returns
+        tuple: (parser, arg_list)
+
+        parser (argparse.ArgumentParser):
+            Parser with opts and args scraped from the docstring.
+        arg_list (list):
+            List of all arguments (as strings) scraped from the docstring.
+
+    """
+    builder = ArgumentBuilder(prog)
+    GoogleDocstring._consume_field = wrap(
+        GoogleDocstring._consume_field,
+        after=builder.add
+    )
+    GoogleDocstring._consume_section_header = wrap(
+        GoogleDocstring._consume_section_header,
+        after=builder.notify
+    )
+    GoogleDocstring._consume_contiguous = wrap(
+        GoogleDocstring._consume_contiguous,
+        after=builder.add
+    )
+    GoogleDocstring._consume_returns_section = wrap(
+        GoogleDocstring._consume_returns_section,
+        after=builder.add
+    )
+    config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
+    GoogleDocstring(docstring, config)
+    return builder.close()
+
+
+def parse_client_args():
+    """Pass arguments for this executable."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('suite')
+    parser.add_argument('endpoint')
+    parser.add_argument('--owner', action='store')
+    parser.add_argument('--host', action='store')
+    parser.add_argument('--port', action='store')
+    parser.add_argument('--help', action='store_true')
+    parser.add_argument('--no-input', action='store_true')
+    try:
+        known, unknown = parser.parse_known_args()
+    except SystemExit:
+        # TODO: this much nicer
+        if '--help' in sys.argv:
+            parser.print_help()
+            sys.exit()
+    if known.help:
+        unknown.append('--help')
+    return known, unknown
+
+
+def main():
+    """implement cylc client2.
+
+    TODO:
+
+    * Get docstrings from cylc.network.server.SuiteRuntimeServer when suite
+      isn't provided.
+    * Make the argument stuff nicer.
+    * Nicer output.
+    * Better handling of --help.
+
+    """
+    client_args, api_args = parse_client_args()
+
+    pclient = SuiteRuntimeClient(
+        client_args.suite, client_args.owner, client_args.host,
+        client_args.port
+    )
+
+    docstring = pclient('api', {'endpoint': client_args.endpoint})
+    api_parser, arg_list = docstring_to_argument_parser(
+        docstring, client_args.endpoint)
+    api_args = api_parser.parse_args(api_args)
+
+    print(json.dumps(
+        pclient(
+            client_args.endpoint,
+            {arg: getattr(api_args, arg) for arg in arg_list}
+        )
+    ))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -115,7 +115,8 @@ def main():
             old_mtime = None
 
         # Tell the suite server program to generate the job file.
-        pclient('dry_run_tasks', {'items': [task_id], 'check_syntax': False})
+        pclient('dry_run_tasks', {
+                'task_globs': [task_id], 'check_syntax': False})
 
         # Wait for the new job file to be written. Use mtime because the same
         # file could potentially exist already, left from a previous run.
@@ -194,9 +195,9 @@ def main():
     # Back compat: back_out introduced >7.5.0
     # So don't call with "back_out" if not necessary to avoid breakage.
     if aborted:
-        pclient('trigger_tasks', {'items': items, 'back_out': aborted})
+        pclient('trigger_tasks', {'task_globs': items, 'back_out': aborted})
     else:
-        pclient('trigger_tasks', {'items': items})
+        pclient('trigger_tasks', {'task_globs': items})
 
 
 if __name__ == "__main__":

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -74,10 +74,9 @@ def main():
         help="(with --edit) force use of the configured GUI editor.",
         action="store_true", default=False, dest="geditor")
 
-    options, args = parser.parse_args()
-    suite = args.pop(0)
+    options, (suite, *task_globs) = parser.parse_args()
 
-    msg = 'Trigger task(s) %s in %s' % (args, suite)
+    msg = 'Trigger task(s) %s in %s' % (task_globs, suite)
     prompt(msg, options.force)
 
     pclient = SuiteRuntimeClient(
@@ -86,7 +85,6 @@ def main():
 
     aborted = False
     if options.edit_run:
-        task_globs = parser.parse_multitask_compat(options, args)
         task_id = task_globs[0]
         # Check that TASK is a unique task.
         success, msg = pclient(
@@ -191,10 +189,10 @@ def main():
             aborted = True
 
     # Trigger the task proxy(s).
-    pclient('trigger_tasks', {
-        'task_globs': parser.parse_multitask_compat(options, args),
-        'back_out': aborted
-    })
+    pclient(
+        'trigger_tasks',
+        {'task_globs': task_globs, 'back_out': aborted}
+    )
 
 
 if __name__ == "__main__":

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -62,7 +62,7 @@ def main():
         __doc__, comms=True, multitask=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('[TASKID ...]', 'Task identifiers')])
+            ('[TASK_GLOB ...]', 'Task matching patterns')])
 
     parser.add_option(
         "-e", "--edit",
@@ -86,8 +86,8 @@ def main():
 
     aborted = False
     if options.edit_run:
-        items = parser.parse_multitask_compat(options, args)
-        task_id = items[0]
+        task_globs = parser.parse_multitask_compat(options, args)
+        task_id = task_globs[0]
         # Check that TASK is a unique task.
         success, msg = pclient(
             'ping_task',
@@ -191,13 +191,10 @@ def main():
             aborted = True
 
     # Trigger the task proxy(s).
-    items = parser.parse_multitask_compat(options, args)
-    # Back compat: back_out introduced >7.5.0
-    # So don't call with "back_out" if not necessary to avoid breakage.
-    if aborted:
-        pclient('trigger_tasks', {'task_globs': items, 'back_out': aborted})
-    else:
-        pclient('trigger_tasks', {'task_globs': items})
+    pclient('trigger_tasks', {
+        'task_globs': parser.parse_multitask_compat(options, args),
+        'back_out': aborted
+    })
 
 
 if __name__ == "__main__":

--- a/doc/src/api/index.rst
+++ b/doc/src/api/index.rst
@@ -1,0 +1,7 @@
+Cylc API
+========
+
+
+.. toctree::
+
+   zmq

--- a/doc/src/api/zmq.rst
+++ b/doc/src/api/zmq.rst
@@ -1,0 +1,40 @@
+Suite Runtime Interface
+=======================
+
+
+Cylc suites are TCP servers which use the ZeroMQ protocol to communicate with
+clients and jobs.
+
+Cylc provides a Python client to communicate with this server
+:py:class:`cylc.network.client.SuiteRuntimeClient`
+
+.. code-block:: python
+
+   >>> from cylc.network.client import SuiteRuntimeClient
+   >>> client = SuiteRuntimeClient('my-suite')
+   >>> client('ping_suite')
+   True
+
+Cylc also provides sub-command called ``cylc client`` which is a simple
+wrapper of the Python client.
+
+.. code-block:: console
+
+   $ cylc client generic ping_suite -n
+   true
+
+The available "commands" or ("endpoints") are contained in
+:py:class:`cylc.network.server.SuiteRuntimeServer` class.
+
+
+Client
+------
+
+.. autoclass:: cylc.network.client.SuiteRuntimeClient
+
+
+Server
+------
+
+.. autoclass:: cylc.network.server.SuiteRuntimeServer
+   :members:

--- a/doc/src/api/zmq.rst
+++ b/doc/src/api/zmq.rst
@@ -27,6 +27,16 @@ The available "commands" or ("endpoints") are contained in
 :py:class:`cylc.network.server.SuiteRuntimeServer` class.
 
 
+Privilege Levels
+----------------
+
+Cylc protects its network interface with configurable privilege levels which
+can be used to allocate different levels of control to different users.
+
+.. autoclass:: cylc.network.Priv
+   :members:
+
+
 Client
 ------
 

--- a/doc/src/appendices/site-user-config-ref.rst
+++ b/doc/src/appendices/site-user-config-ref.rst
@@ -1095,23 +1095,7 @@ password.
 This sets the client privilege level for public access - i.e. no
 suite passphrase required.
 
-- *type*: string (must be one of the following options)
-- *options*:
+- *type*: string (must be one of the following options).
+- *options*: A Cylc privilege level: :py:obj:`cylc.network.Priv`.
 
-  none
-     Permit no public suite access.
-  identity
-     Only suite and owner names revealed.
-  description
-     Identity plus suite title and description.
-  state-totals
-     Identity, description, and task state totals.
-  read
-     Full read-only access.
-  shutdown
-     *Not yet implemented*
-     Full read access plus shutdown, but no other control.
-  control
-     Permit full control (not recommended).
-
-- *default*: state-totals
+- *default*: :py:obj:`cylc.network.Priv.STATE_TOTALS`

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -1,5 +1,3 @@
-.. cylc documentation master file.
-
 Cylc documentation
 ==================
 
@@ -41,6 +39,8 @@ indefinitely.
    external-triggers
    running-suites
    suite-storage-etc
+
+   api/index
 
    appendices/appendices-master
 

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -504,23 +504,9 @@ server program is determined by the public access privilege level set in global
 site/user config (:ref:`GlobalAuth`) and optionally overridden in suites
 (:ref:`SuiteAuth`):
 
-none
-   Permit no public suite access.
-identity
-   Only suite and owner names revealed.
-description
-   Identity plus suite title and description.
-state-totals
-   Identity, description, and task state totals.
-read
-   Full read-only access.
-shutdown
-   *Not yet implemented*
-   Full read access plus shutdown, but no other control.
-control
-   Permit full control (not recommended).
+See Cylc privilege levels: :py:obj:`cylc.network.Priv`.
 
-The default public access level is *state-totals*.
+The default public access level is :py:obj:`cylc.network.Priv.STATE_TOTALS`.
 
 The ``cylc scan`` command can print
 descriptions and task state totals in addition to basic suite identity, if the

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -33,7 +33,7 @@ class Priv(IntEnum):
     """Cylc privilege levels.
 
     In Cylc configurations use the lower-case form of each privilege level
-    e.g. ``control`` for ``Priv.CONTORL``.
+    e.g. ``control`` for ``Priv.CONTROL``.
 
     These levels are ordered (by the integer associated with each) from 0.
     Each privilege level grants access to the levels below it.

--- a/lib/cylc/network/__init__.py
+++ b/lib/cylc/network/__init__.py
@@ -30,18 +30,36 @@ HASH = 'HS256'  # Encoding for JWT
 
 
 class Priv(IntEnum):
-    """Cylc privilege level."""
+    """Cylc privilege levels.
 
-    # TODO - autodocument from this class.
-    # TODO - revert name changes?
+    In Cylc configurations use the lower-case form of each privilege level
+    e.g. ``control`` for ``Priv.CONTORL``.
+
+    These levels are ordered (by the integer associated with each) from 0.
+    Each privilege level grants access to the levels below it.
+
+    """
 
     CONTROL = 6
+    """Provides full control of a suite."""
+
     SHUTDOWN = 5  # (Not used yet - for the post-passphrase era.)
+    """Allows issuing of the shutdown command."""
+
     READ = 4
+    """Permits read access to the suite's state."""
+
     STATE_TOTALS = 3
+    """Provides access to the count of tasks in each state."""
+
     DESCRIPTION = 2
+    """Permits reading of suite metadata."""
+
     IDENTITY = 1
+    """Provides read access to the suite name, owner and Cylc version."""
+
     NONE = 0
+    """No access."""
 
     @classmethod
     def parse(cls, key):

--- a/lib/cylc/network/client.py
+++ b/lib/cylc/network/client.py
@@ -128,23 +128,9 @@ class ZMQClient(object):
             self.header = dict(header)
 
     async def async_request(self, command, args=None, timeout=None):
-        """Send a request.
+        """Send an asynchronous request using asyncio.
 
-        For convenience use __call__ to call this method.
-
-        Args:
-            command (str): The name of the endpoint to call.
-            args (dict): Arguments to pass to the endpoint function.
-            timeout (float): Override the default timeout (seconds).
-
-        Raises:
-            ClientTimeout: If a response takes longer than timeout to arrive.
-            ClientError: Coverall for all other issues including failed
-                authentication.
-
-        Returns:
-            object: The data exactly as returned from the endpoint function,
-                nothing more, nothing less.
+        Has the same arguments and return values as ``serial_request``.
 
         """
         if timeout:
@@ -190,6 +176,24 @@ class ZMQClient(object):
             raise ClientError(response['error'])
 
     def serial_request(self, command, args=None, timeout=None):
+        """Send a request.
+
+        For convenience use ``__call__`` to call this method.
+
+        Args:
+            command (str): The name of the endpoint to call.
+            args (dict): Arguments to pass to the endpoint function.
+            timeout (float): Override the default timeout (seconds).
+
+        Raises:
+            ClientTimeout: If a response takes longer than timeout to arrive.
+            ClientError: Coverall for all other issues including failed auth.
+
+        Returns:
+            object: The data exactly as returned from the endpoint function,
+                nothing more, nothing less.
+
+        """
         return asyncio.run(
             self.async_request(command, args, timeout))
 
@@ -218,6 +222,16 @@ class SuiteRuntimeClient:
 
     If there is no socket bound to the specified host/port the client will
     bail after ``timeout`` seconds.
+
+    Call server "endpoints" using:
+
+    ``__call__``, ``serial_request``
+
+       .. automethod:: cylc.network.client.ZMQClient.serial_request
+
+    ``async_request``
+
+       .. automethod:: cylc.network.client.ZMQClient.async_request
 
     """
 

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -20,6 +20,7 @@
 from functools import wraps
 import getpass
 from queue import Queue
+from textwrap import dedent
 from time import sleep
 from threading import Thread
 
@@ -227,6 +228,8 @@ def authorise(req_priv_level):
         @wraps(fcn)  # preserve args and docstrings
         def _authorise(self, *args, user='?', meta=None, **kwargs):
             """Aurt"""
+            if not meta:
+                meta = {}
             host = meta.get('host', '?')
             prog = meta.get('prog', '?')
 
@@ -304,6 +307,39 @@ class SuiteRuntimeServer(ZMQServer):
             self.public_priv = self._get_public_priv()
         return self.public_priv
 
+    @authorise(Priv.IDENTITY)
+    @ZMQServer.expose
+    def api(self, endpoint=None):
+        """Return information about this API.
+
+        Returns a list of callable endpoints.
+
+        Args:
+            endpoint (str, optional):
+                If specified the documentation for the endpoint
+                will be returned instead.
+
+        Returns:
+            list/str: List of endpoints or string documentation of the
+            requested endpoint.
+
+        """
+        if not endpoint:
+            return [
+                method for method in dir(self)
+                if getattr(getattr(self, method), 'exposed', False)
+            ]
+
+        try:
+            method = getattr(self, endpoint)
+        except AttributeError:
+            return 'No method by name "%s"' % endpoint
+        if method.exposed:
+            head, tail = method.__doc__.split('\n', 1)
+            tail = dedent(tail)
+            return '%s\n%s' % (head, tail)
+        return 'No method by name "%s"' % endpoint
+
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def clear_broadcast(
@@ -311,13 +347,13 @@ class SuiteRuntimeServer(ZMQServer):
         """Clear settings globally, or for listed namespaces and/or points.
 
         Args:
-            point_strings (list):
+            point_strings (list, optional):
                 List of point strings for this operation to apply to or
                 ``None`` to apply to all cycle points.
-            namespaces (list):
+            namespaces (list, optional):
                 List of namespace string (task / family names) for this
                 operation to apply to or ``None`` to apply to all namespaces.
-            cancel_settings (list):
+            cancel_settings (list, optional):
                 List of broadcast keys to cancel.
 
         Returns:
@@ -348,7 +384,7 @@ class SuiteRuntimeServer(ZMQServer):
 
         Args:
             task_globs (list): List of identifiers, see `task globs`_
-            check_syntax (bool): Check shell syntax.
+            check_syntax (bool, optional): Check shell syntax.
 
         Returns:
             tuple: (outcome, message)
@@ -369,7 +405,7 @@ class SuiteRuntimeServer(ZMQServer):
         """Clear all settings targeting cycle points earlier than cutoff.
 
         Args:
-            cutoff (str):
+            cutoff (str, optional):
                 Cycle point, broadcasts earlier than but not inclusive of the
                 cutoff will be canceled.
 
@@ -382,7 +418,7 @@ class SuiteRuntimeServer(ZMQServer):
         """Retrieve all broadcast variables that target a given task ID.
 
         Args:
-            task_id (str): A `task identifier`_
+            task_id (str, optional): A `task identifier`_
 
         Returns:
             dict: all broadcast variables that target the given task ID.
@@ -422,17 +458,17 @@ class SuiteRuntimeServer(ZMQServer):
             stop_point_string (str):
                 Cycle point as a string to define the window of view of the
                 suite graph.
-            group_nodes (list):
+            group_nodes (list, optional):
                 List of (graph nodes) family names to group (collapse according
                 to inheritance) in the output graph.
-            ungroup_nodes (list):
+            ungroup_nodes (list, optional):
                 List of (graph nodes) family names to ungroup (expand according
                 to inheritance) in the output graph.
-            ungroup_recursive (bool):
+            ungroup_recursive (bool, optional):
                 Recursively ungroup families.
-            group_all (bool):
+            group_all (bool, optional):
                 Group all families (collapse according to inheritance).
-            ungroup_all (bool):
+            ungroup_all (bool, optional):
                 Ungroup all families (expand according to inheritance).
 
         Returns:
@@ -525,7 +561,8 @@ class SuiteRuntimeServer(ZMQServer):
         """Return prerequisites of a task.
 
         Args:
-            task_globs (list): List of identifiers, see `task globs`_
+            task_globs (list, optional):
+                List of identifiers, see `task globs`_
 
         Returns:
             list: Dictionary of `task identifiers <task identifier>`_
@@ -533,7 +570,7 @@ class SuiteRuntimeServer(ZMQServer):
 
         """
         return self.schd.info_get_task_requisites(
-            items, list_prereqs=list_prereqs)
+            task_globs, list_prereqs=list_prereqs)
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
@@ -665,7 +702,11 @@ class SuiteRuntimeServer(ZMQServer):
             items (list):
                 A list of `task globs`_ (strings) which *cannot* contain
                 any glob characters (``*``).
-
+            stop_point_string (str, optional):
+                Optional hold/stop cycle point for inserted task.
+            no_check (bool, optional):
+                Add task even if the provided cycle point is not valid
+                for the given task.
         Returns:
             tuple: (outcome, message)
 
@@ -744,7 +785,7 @@ class SuiteRuntimeServer(ZMQServer):
         Args:
             task_id:
                 A `task identifier`_
-            exists_only (bool):
+            exists_only (bool, optional):
                 If True only test that the task exists, if False check both
                 that the task exists and that it is running.
 
@@ -765,7 +806,10 @@ class SuiteRuntimeServer(ZMQServer):
         """Request the suite to poll task jobs.
 
         Args:
-            task_globs (list): List of identifiers, see `task globs`_
+            task_globs (list, optional):
+                List of identifiers, see `task globs`_
+            poll_succ (bool, optional):
+                Allow polling of remote tasks if True.
 
         Returns:
             tuple: (outcome, message)
@@ -777,7 +821,7 @@ class SuiteRuntimeServer(ZMQServer):
 
         """
         self.schd.command_queue.put(
-            ("poll_tasks", (items,), {"poll_succ": poll_succ}))
+            ("poll_tasks", (task_globs,), {"poll_succ": poll_succ}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
@@ -787,13 +831,13 @@ class SuiteRuntimeServer(ZMQServer):
         """Add new broadcast settings (server side interface).
 
         Args:
-            point_strings (list):
+            point_strings (list, optional):
                 List of point strings for this operation to apply to or
                 ``None`` to apply to all cycle points.
-            namespaces (list):
+            namespaces (list, optional):
                 List of namespace string (task / family names) for this
                 operation to apply to or ``None`` to apply to all namespaces.
-            settings (list):
+            settings (list, optional):
                 List of strings in the format ``key=value`` where ``key`` is a
                 Cylc configuration including section names e.g.
                 ``[section][subsection]item``.
@@ -846,11 +890,11 @@ class SuiteRuntimeServer(ZMQServer):
         """Put task messages in queue for processing later by the main loop.
 
         Arguments:
-            task_job (str):
+            task_job (str, optional):
                 Task job in the format ``CYCLE/TASK_NAME/SUBMIT_NUM``.
-            event_time (str):
+            event_time (str, optional):
                 Event time as an ISO8601 string.
-            messages (list):
+            messages (list, optional):
                 List in the format ``[[severity, message], ...]``.
 
         Returns:
@@ -929,8 +973,10 @@ class SuiteRuntimeServer(ZMQServer):
         """Remove tasks from task pool.
 
         Args:
-            task_globs (list): List of identifiers, see `task globs`_
-            spawn (bool): If True ensure task has spawned before removal.
+            task_globs (list):
+                List of identifiers, see `task globs`_
+            spawn (bool, optional):
+                If True ensure task has spawned before removal.
 
         Returns:
             tuple: (outcome, message)
@@ -953,10 +999,10 @@ class SuiteRuntimeServer(ZMQServer):
         Args:
             task_globs (list):
                 List of identifiers, see `task globs`_
-            state (str):
+            state (str, optional):
                 Task state to reset task to.
                 See ``cylc.task_state.TASK_STATUSES_CAN_RESET_TO``.
-            outputs (list):
+            outputs (list, optional):
                 Find task output by message string or trigger string
                 set complete or incomplete with !OUTPUT
                 ``*`` to set all complete, ``!*`` to set all incomplete.
@@ -1051,7 +1097,7 @@ class SuiteRuntimeServer(ZMQServer):
         to complete before stopping.
 
         Args:
-            kill_active_tasks (bool):
+            kill_active_tasks (bool, optional):
                 If True the suite will attempt to kill any active
                 (running, submitted) tasks
 
@@ -1114,7 +1160,7 @@ class SuiteRuntimeServer(ZMQServer):
         """Stop suite on event handler completion, or terminate right away.
 
         Args:
-            terminate (bool):
+            terminate (bool, optional):
                 If False Cylc will run event handlers, if True it will not.
 
         Returns:
@@ -1157,7 +1203,7 @@ class SuiteRuntimeServer(ZMQServer):
         Args:
             task_globs (list):
                 List of identifiers, see `task globs`_
-            back_out (bool):
+            back_out (bool, optional):
                 Abort e.g. in the event of a rejected trigger-edit.
 
         Returns:

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -242,6 +242,9 @@ def authorise(req_priv_level):
             LOG.info(
                 '[client-command] %s %s@%s:%s', fcn.__name__, user, host, prog)
             return fcn(self, *args, **kwargs)
+        _authorise.__doc__ += (  # add auth level to docstring
+            'Authentication:\n%s:py:obj:`cylc.network.%s`\n' % (
+                ' ' * 12, req_priv_level))
         return _authorise
     return wrapper
 

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Server for suite runtime API."""
 
+from functools import wraps
 import getpass
 from queue import Queue
 from time import sleep
@@ -222,11 +223,14 @@ def authorise(req_priv_level):
 
     """
     def wrapper(fcn):
+        """Warp"""
+        @wraps(fcn)  # preserve args and docstrings
         def _authorise(self, *args, user='?', meta=None, **kwargs):
+            """Aurt"""
             host = meta.get('host', '?')
             prog = meta.get('prog', '?')
 
-            usr_priv_level = self.get_priv_level(user)
+            usr_priv_level = self._get_priv_level(user)
             if usr_priv_level < req_priv_level:
                 LOG.warn(
                     "[client-connect] DENIED (privilege '%s' < '%s') %s@%s:%s",
@@ -242,7 +246,32 @@ def authorise(req_priv_level):
 class SuiteRuntimeServer(ZMQServer):
     """Suite runtime service API facade exposed via zmq.
 
-    This class contains the cylc endpoints.
+    This class contains the Cylc endpoints.
+
+    Common Arguments:
+        Arguments which are shared between multiple commands.
+
+        .. _task identifier:
+
+        task identifier (str):
+            A task identifier in the format ``task.cycle-point``
+            e.g. ``foo.1`` or ``bar.20000101T0000Z``.
+
+        .. _task globs:
+
+        task globs (list):
+            A list of strings in the format
+            ``name[.cycle_point][:task_state]`` where ``name`` could be a
+            task or family name.
+
+             Glob-like patterns may be used to match multiple items e.g.
+
+             ``*``
+                Matches everything.
+             ``*.1``
+                Matches everything in cycle ``1``.
+             ``*.*:failed``
+                Matches all failed tasks.
 
     """
 
@@ -258,21 +287,21 @@ class SuiteRuntimeServer(ZMQServer):
         self.schd = schd
         self.public_priv = None  # update in get_public_priv()
 
-    def get_public_priv(self):
+    def _get_public_priv(self):
         """Return the public privilege level of this suite."""
         if self.schd.config.cfg['cylc']['authentication']['public']:
             return Priv.parse(
                 self.schd.config.cfg['cylc']['authentication']['public'])
         return Priv.parse(glbl_cfg().get(['authentication', 'public']))
 
-    def get_priv_level(self, user):
+    def _get_priv_level(self, user):
         """Return the privilege level for the given user for this suite."""
         if user == getpass.getuser():
             return Priv.CONTROL
         if self.public_priv is None:
             # cannot do this on initialisation as the suite configuration has
             # not yet been parsed
-            self.public_priv = self.get_public_priv()
+            self.public_priv = self._get_public_priv()
         return self.public_priv
 
     @authorise(Priv.CONTROL)
@@ -281,42 +310,84 @@ class SuiteRuntimeServer(ZMQServer):
             self, point_strings=None, namespaces=None, cancel_settings=None):
         """Clear settings globally, or for listed namespaces and/or points.
 
-        Return a tuple (modified_settings, bad_options), where:
-        * modified_settings is similar to the return value of the "put" method,
-          but for removed settings.
-        * bad_options is a dict in the form:
-              {"point_strings": ["20020202", ..."], ...}
-          The dict is only populated if there are options not associated with
-          previous broadcasts. The keys can be:
-          * point_strings: a list of bad point strings.
-          * namespaces: a list of bad namespaces.
-          * cancel: a list of tuples. Each tuple contains the keys of a bad
-            setting.
+        Args:
+            point_strings (list):
+                List of point strings for this operation to apply to or
+                ``None`` to apply to all cycle points.
+            namespaces (list):
+                List of namespace string (task / family names) for this
+                operation to apply to or ``None`` to apply to all namespaces.
+            cancel_settings (list):
+                List of broadcast keys to cancel.
+
+        Returns:
+            tuple: (modified_settings, bad_options)
+
+                modified_settings
+                   similar to the return value of the "put" method, but for
+                   removed settings.
+                bad_options
+                   A dict in the form:
+                   ``{"point_strings": ["20020202", ..."], ...}``.
+                   The dict is only populated if there are options not
+                   associated with previous broadcasts. The keys can be:
+
+                   * point_strings: a list of bad point strings.
+                   * namespaces: a list of bad namespaces.
+                   * cancel: a list of tuples. Each tuple contains the keys of
+                     a bad setting.
+
         """
         return self.schd.task_events_mgr.broadcast_mgr.clear_broadcast(
             point_strings, namespaces, cancel_settings)
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def dry_run_tasks(self, items, check_syntax=True):
+    def dry_run_tasks(self, task_globs, check_syntax=True):
         """Prepare job file for a task.
 
-        items[0] is an identifier for matching a task proxy.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+            check_syntax (bool): Check shell syntax.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(('dry_run_tasks', (items,),
+        self.schd.command_queue.put(('dry_run_tasks', (task_glob,),
                                     {'check_syntax': check_syntax}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def expire_broadcast(self, cutoff=None):
-        """Clear all settings targeting cycle points earlier than cutoff."""
+        """Clear all settings targeting cycle points earlier than cutoff.
+
+        Args:
+            cutoff (str):
+                Cycle point, broadcasts earlier than but not inclusive of the
+                cutoff will be canceled.
+
+        """
         return self.schd.task_events_mgr.broadcast_mgr.expire_broadcast(cutoff)
 
     @authorise(Priv.READ)
     @ZMQServer.expose
     def get_broadcast(self, task_id=None):
-        """Retrieve all broadcast variables that target a given task ID."""
+        """Retrieve all broadcast variables that target a given task ID.
+
+        Args:
+            task_id (str): A `task identifier`_
+
+        Returns:
+            dict: all broadcast variables that target the given task ID.
+
+        """
         return self.schd.task_events_mgr.broadcast_mgr.get_broadcast(task_id)
 
     @authorise(Priv.IDENTITY)
@@ -331,7 +402,55 @@ class SuiteRuntimeServer(ZMQServer):
                       group_nodes=None, ungroup_nodes=None,
                       ungroup_recursive=False, group_all=False,
                       ungroup_all=False):
-        """Return raw suite graph."""
+        """Return a textural representation of the suite graph.
+
+        .. warning::
+
+           The grouping options:
+
+           * ``group_nodes``
+           * ``ungroup_nodes``
+           * ``group_all``
+           * ``ungroup_all``
+
+           Are mutually exclusive.
+
+        Args:
+            start_point_string (str):
+                Cycle point as a string to define the window of view of the
+                suite graph.
+            stop_point_string (str):
+                Cycle point as a string to define the window of view of the
+                suite graph.
+            group_nodes (list):
+                List of (graph nodes) family names to group (collapse according
+                to inheritance) in the output graph.
+            ungroup_nodes (list):
+                List of (graph nodes) family names to ungroup (expand according
+                to inheritance) in the output graph.
+            ungroup_recursive (bool):
+                Recursively ungroup families.
+            group_all (bool):
+                Group all families (collapse according to inheritance).
+            ungroup_all (bool):
+                Ungroup all families (expand according to inheritance).
+
+        Returns:
+            list: [left, right, None, is_suicide, condition]
+
+            left (str):
+                `Task identifier <task identifier>` for the dependency of
+                an edge.
+            right (str):
+                `Task identifier <task identifier>` for the dependant task
+                of an edge.
+            is_suicide (bool):
+                True if edge represents a suicide trigger.
+            condition:
+                Conditional expression if edge represents a conditional trigger
+                else ``None``.
+
+        """
         # Ensure that a "None" str is converted to the None value.
         return self.schd.info_get_graph_raw(
             start_point_string, stop_point_string,
@@ -344,38 +463,95 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.DESCRIPTION)
     @ZMQServer.expose
     def get_suite_info(self):
-        """Return a dict containing the suite title and description."""
+        """Return a dictionary containing the suite title and description.
+
+        Returns:
+            dict: The `[meta]` section of a suite configuration
+
+        """
         return self.schd.info_get_suite_info()
 
     @authorise(Priv.READ)
     @ZMQServer.expose
     def get_suite_state_summary(self):
-        """Return the global, task, and family summary data structures."""
+        """Return the global, task, and family summary data summaries.
+
+        Returns:
+            tuple: (global_summary, task_summary, family_summary)
+
+            global_summary (dict):
+                Contains suite status items e.g. ``last_updated``.
+            task_summary (dict):
+                A dictionary of `task identifiers <task identifier>`_
+                in the format ``{task_id: {...}, ...}``.
+            family_summary (dict):
+                Contains task family information in the format
+                ``{family_id: {...}, ...}``.
+
+        """
         return self.schd.info_get_suite_state_summary()
 
     @authorise(Priv.READ)
     @ZMQServer.expose
     def get_task_info(self, names):
-        """Return info of a task."""
+        """Return the configurations for the provided tasks.
+
+        Args:
+            names (list): A list of task names to request information for.
+
+        Returns:
+            dict: Dictionary in the format ``{'task': {...}, ...}``
+
+        """
         return self.schd.info_get_task_info(names)
 
     @authorise(Priv.READ)
     @ZMQServer.expose
     def get_task_jobfile_path(self, task_id):
-        """Return task job file path."""
+        """Return task job file path.
+
+        Args:
+            task_id: A `task identifier`_
+
+        Returns:
+            str: The jobfile path.
+
+        """
         return self.schd.info_get_task_jobfile_path(task_id)
 
     @authorise(Priv.READ)
     @ZMQServer.expose
-    def get_task_requisites(self, items=None, list_prereqs=False):
-        """Return prerequisites of a task."""
+    def get_task_requisites(self, task_globs=None, list_prereqs=False):
+        """Return prerequisites of a task.
+
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            list: Dictionary of `task identifiers <task identifier>`_
+            in the format ``{task_id: { ... }, ...}``.
+
+        """
         return self.schd.info_get_task_requisites(
             items, list_prereqs=list_prereqs)
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def hold_after_point_string(self, point_string):
-        """Set hold point of suite."""
+        """Set hold point of suite.
+
+        Args:
+            point_string (str): The cycle point to hold the suite *after.*
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(
             ("hold_after_point_string", (point_string,), {}))
         return (True, 'Command queued')
@@ -383,23 +559,56 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def hold_suite(self):
-        """Hold the suite."""
+        """Hold the suite.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("hold_suite", (), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def hold_tasks(self, items):
+    def hold_tasks(self, task_globs):
         """Hold tasks.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(("hold_tasks", (items,), {}))
+        self.schd.command_queue.put(("hold_tasks", (task_globs,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.IDENTITY)
     @ZMQServer.expose
     def identify(self):
+        """Return basic information about the suite.
+
+        Returns:
+            dict: Dictionary containing the keys
+
+            cylc.suite_status.KEY_NAME
+               The suite name.
+            cylc.suite_status.KEY_OWNER
+               The user account the suite is running under.
+            cylc.suite_status.KEY_VERSION
+               The Cylc version the suite is runnin with.
+
+        """
         return {
             KEY_NAME: self.schd.suite,
             KEY_OWNER: self.schd.owner,
@@ -409,11 +618,37 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.DESCRIPTION)
     @ZMQServer.expose
     def describe(self):
+        """Return the suite metadata.]
+
+        Returns:
+            dict: ``{cylc.suite_status: { ... }}``
+
+        """
         return {KEY_META: self.schd.config.cfg[KEY_META]}
 
     @authorise(Priv.STATE_TOTALS)
     @ZMQServer.expose
     def state_totals(self):
+        """Returns counts of the task states present in the suite.
+
+        Returns:
+            dict: Dictionary with the keys:
+
+            cylc.suite_status.KEY_UPDATE_TIME
+               ISO8601 timestamp of when this data snapshot was made.
+            cylc.suite_status.KEY_STATES
+               Tuple of the form ``(state_count_totals, state_count_cycles)``
+
+               state_count_totals (dict):
+                  Dictionary of the form ``{task_state: task_count}``.
+               state_count_cycles (dict):
+                  Dictionary of the form ``{cycle_point: task_count}``.
+            cylc.suite_status.KEY_TASKS_BY_STATE
+               Dictionary in the form
+               ``{state: [(most_recent_time_string, task_name, point_string),``
+               ``...]}``.
+
+        """
         return {
             KEY_UPDATE_TIME: self.schd.state_summary_mgr.update_time,
             KEY_STATES: self.schd.state_summary_mgr.get_state_totals(),
@@ -426,7 +661,19 @@ class SuiteRuntimeServer(ZMQServer):
     def insert_tasks(self, items, stop_point_string=None, no_check=False):
         """Insert task proxies.
 
-        items is a list of identifiers of (families of) task instances.
+        Args:
+            items (list):
+                A list of `task globs`_ (strings) which *cannot* contain
+                any glob characters (``*``).
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
         self.schd.command_queue.put((
             "insert_tasks",
@@ -436,39 +683,98 @@ class SuiteRuntimeServer(ZMQServer):
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def kill_tasks(self, items):
+    def kill_tasks(self, task_globs):
         """Kill task jobs.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(("kill_tasks", (items,), {}))
+        self.schd.command_queue.put(("kill_tasks", (task_globs,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def nudge(self):
-        """Tell suite to try task processing."""
+        """Tell suite to try task processing.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("nudge", (), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.IDENTITY)
     @ZMQServer.expose
     def ping_suite(self):
-        """Return True."""
+        """Return True.
+
+        This serves as a basic network comms tests.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         return True
 
     @authorise(Priv.READ)
     @ZMQServer.expose
     def ping_task(self, task_id, exists_only=False):
-        """Return True if task_id exists (and running)."""
+        """Return True if task_id exists (and is running).
+
+        Args:
+            task_id:
+                A `task identifier`_
+            exists_only (bool):
+                If True only test that the task exists, if False check both
+                that the task exists and that it is running.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool):
+                True if task exists (and is running).
+            message (str):
+                A string describing the outcome / state of the task.
+
+        """
         return self.schd.info_ping_task(task_id, exists_only=exists_only)
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def poll_tasks(self, items=None, poll_succ=False):
-        """Poll task jobs.
+    def poll_tasks(self, task_globs=None, poll_succ=False):
+        """Request the suite to poll task jobs.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
         self.schd.command_queue.put(
             ("poll_tasks", (items,), {"poll_succ": poll_succ}))
@@ -480,10 +786,35 @@ class SuiteRuntimeServer(ZMQServer):
             self, point_strings=None, namespaces=None, settings=None):
         """Add new broadcast settings (server side interface).
 
-        Return a tuple (modified_settings, bad_options) where:
-          modified_settings is list of modified settings in the form:
-            [("20200202", "foo", {"command scripting": "true"}, ...]
-          bad_options is as described in the docstring for self.clear().
+        Args:
+            point_strings (list):
+                List of point strings for this operation to apply to or
+                ``None`` to apply to all cycle points.
+            namespaces (list):
+                List of namespace string (task / family names) for this
+                operation to apply to or ``None`` to apply to all namespaces.
+            settings (list):
+                List of strings in the format ``key=value`` where ``key`` is a
+                Cylc configuration including section names e.g.
+                ``[section][subsection]item``.
+
+        Returns:
+            tuple: (modified_settings, bad_options)
+
+                modified_settings
+                   similar to the return value of the "put" method, but for
+                   removed settings.
+                bad_options
+                   A dict in the form:
+                   ``{"point_strings": ["20020202", ..."], ...}``.
+                   The dict is only populated if there are options not
+                   associated with previous broadcasts. The keys can be:
+
+                   * point_strings: a list of bad point strings.
+                   * namespaces: a list of bad namespaces.
+                   * cancel: a list of tuples. Each tuple contains the keys of
+                     a bad setting.
+
         """
         return self.schd.task_events_mgr.broadcast_mgr.put_broadcast(
             point_strings, namespaces, settings)
@@ -491,7 +822,21 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def put_ext_trigger(self, event_message, event_id):
-        """Server-side external event trigger interface."""
+        """Server-side external event trigger interface.
+
+        Args:
+            event_message (str): The external trigger message.
+            event_id (str): The unique trigger ID.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.ext_trigger_queue.put((event_message, event_id))
         return (True, 'Event queued')
 
@@ -501,10 +846,24 @@ class SuiteRuntimeServer(ZMQServer):
         """Put task messages in queue for processing later by the main loop.
 
         Arguments:
-            task_job (str): Task job in the form "CYCLE/TASK_NAME/SUBMIT_NUM".
-            event_time (str): Event time as string.
-            messages (list): List in the form [[severity, message], ...].
+            task_job (str):
+                Task job in the format ``CYCLE/TASK_NAME/SUBMIT_NUM``.
+            event_time (str):
+                Event time as an ISO8601 string.
+            messages (list):
+                List in the format ``[[severity, message], ...]``.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
+        #  TODO: standardise the task_job interface to one of the other
+        #        systems
         for severity, message in messages:
             self.schd.message_queue.put(
                 (task_job, event_time, severity, message))
@@ -513,54 +872,129 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def reload_suite(self):
-        """Tell suite to reload the suite definition."""
+        """Tell suite to reload the suite definition.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("reload_suite", (), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def release_suite(self):
-        """Unhold suite."""
+        """Unhold suite.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("release_suite", (), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def release_tasks(self, items):
+    def release_tasks(self, task_globs):
         """Unhold tasks.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(("release_tasks", (items,), {}))
+        self.schd.command_queue.put(("release_tasks", (task_globs,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def remove_tasks(self, items, spawn=False):
+    def remove_tasks(self, task_globs, spawn=False):
         """Remove tasks from task pool.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+            spawn (bool): If True ensure task has spawned before removal.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
         self.schd.command_queue.put(
-            ("remove_tasks", (items,), {"spawn": spawn}))
+            ("remove_tasks", (task_globs,), {"spawn": spawn}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def reset_task_states(self, items, state=None, outputs=None):
+    def reset_task_states(self, task_globs, state=None, outputs=None):
         """Reset statuses tasks.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list):
+                List of identifiers, see `task globs`_
+            state (str):
+                Task state to reset task to.
+                See ``cylc.task_state.TASK_STATUSES_CAN_RESET_TO``.
+            outputs (list):
+                Find task output by message string or trigger string
+                set complete or incomplete with !OUTPUT
+                ``*`` to set all complete, ``!*`` to set all incomplete.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
         self.schd.command_queue.put((
             "reset_task_states",
-            (items,), {"state": state, "outputs": outputs}))
+            (task_globs,), {"state": state, "outputs": outputs}))
         return (True, 'Command queued')
 
     @authorise(Priv.SHUTDOWN)
     @ZMQServer.expose
     def set_stop_after_clock_time(self, datetime_string):
-        """Set suite to stop after wallclock time."""
+        """Set suite to stop after wallclock time.
+
+        Args:
+            datetime_string (str):
+                An ISO8601 formatted date-time of the wallclock
+                (real-world as opposed to simulation) time
+                to stop the suite after.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(
             ("set_stop_after_clock_time", (datetime_string,), {}))
         return (True, 'Command queued')
@@ -568,7 +1002,21 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.SHUTDOWN)
     @ZMQServer.expose
     def set_stop_after_point(self, point_string):
-        """Set suite to stop after cycle point."""
+        """Set suite to stop after cycle point.
+
+        Args:
+            point_string (str):
+                The cycle point to stop the suite after.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(
             ("set_stop_after_point", (point_string,), {}))
         return (True, 'Command queued')
@@ -576,7 +1024,20 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.SHUTDOWN)
     @ZMQServer.expose
     def set_stop_after_task(self, task_id):
-        """Set suite to stop after an instance of a task."""
+        """Set suite to stop after an instance of a task.
+
+        Args:
+            task_id (str): A `task identifier`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(
             ("set_stop_after_task", (task_id,), {}))
         return (True, 'Command queued')
@@ -584,7 +1045,25 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.SHUTDOWN)
     @ZMQServer.expose
     def set_stop_cleanly(self, kill_active_tasks=False):
-        """Set suite to stop cleanly or after kill active tasks."""
+        """Set suite to stop cleanly or after kill active tasks.
+
+        The suite will wait for all active (running, submitted) tasks
+        to complete before stopping.
+
+        Args:
+            kill_active_tasks (bool):
+                If True the suite will attempt to kill any active
+                (running, submitted) tasks
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(
             ("set_stop_cleanly", (), {"kill_active_tasks": kill_active_tasks}))
         return (True, 'Command queued')
@@ -592,44 +1071,104 @@ class SuiteRuntimeServer(ZMQServer):
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
     def set_verbosity(self, level):
-        """Set suite verbosity to new level."""
+        """Set suite verbosity to new level (for suite logs).
+
+        Args:
+            level (str): A logging level e.g. ``INFO`` or ``ERROR``.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("set_verbosity", (level,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def spawn_tasks(self, items):
+    def spawn_tasks(self, task_globs):
         """Spawn tasks.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list): List of identifiers, see `task globs`_
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(("spawn_tasks", (items,), {}))
+        self.schd.command_queue.put(("spawn_tasks", (task_globs,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.SHUTDOWN)
     @ZMQServer.expose
     def stop_now(self, terminate=False):
-        """Stop suite on event handler completion, or terminate right away."""
+        """Stop suite on event handler completion, or terminate right away.
+
+        Args:
+            terminate (bool):
+                If False Cylc will run event handlers, if True it will not.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
+        """
         self.schd.command_queue.put(("stop_now", (), {"terminate": terminate}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def take_checkpoints(self, items):
+    def take_checkpoints(self, name):
         """Checkpoint current task pool.
 
-        items[0] is the name of the checkpoint.
+        Args:
+            name (str): The checkpoint name
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
-        self.schd.command_queue.put(("take_checkpoints", (items,), {}))
+        self.schd.command_queue.put(("take_checkpoints", (name,), {}))
         return (True, 'Command queued')
 
     @authorise(Priv.CONTROL)
     @ZMQServer.expose
-    def trigger_tasks(self, items, back_out=False):
+    def trigger_tasks(self, task_globs, back_out=False):
         """Trigger submission of task jobs where possible.
 
-        items is a list of identifiers for matching task proxies.
+        Args:
+            task_globs (list):
+                List of identifiers, see `task globs`_
+            back_out (bool):
+                Abort e.g. in the event of a rejected trigger-edit.
+
+        Returns:
+            tuple: (outcome, message)
+
+            outcome (bool)
+                True if command successfully queued.
+            message (str)
+                Information about outcome.
+
         """
         self.schd.command_queue.put(
-            ("trigger_tasks", (items,), {"back_out": back_out}))
+            ("trigger_tasks", (task_globs,), {"back_out": back_out}))
         return (True, 'Command queued')

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -398,7 +398,7 @@ class SuiteRuntimeServer(ZMQServer):
                 Information about outcome.
 
         """
-        self.schd.command_queue.put(('dry_run_tasks', (task_glob,),
+        self.schd.command_queue.put(('dry_run_tasks', (task_globs,),
                                     {'check_syntax': check_syntax}))
         return (True, 'Command queued')
 

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -155,8 +155,9 @@ class ZMQServer(object):
             except Exception as exc:  # purposefully catch generic exception
                 # failed to decode message, possibly resulting from failed
                 # authentication
-                response = self.encode(
-                    {'error': {'message': str(exc)}}, self.secret())
+                import traceback
+                return {'error': {
+                    'message': str(exc), 'traceback': traceback.format_exc()}}
             else:
                 # success case - serve the request
                 LOG.debug('zmq:recv %s', message)
@@ -224,10 +225,8 @@ def authorise(req_priv_level):
 
     """
     def wrapper(fcn):
-        """Warp"""
         @wraps(fcn)  # preserve args and docstrings
         def _authorise(self, *args, user='?', meta=None, **kwargs):
-            """Aurt"""
             if not meta:
                 meta = {}
             host = meta.get('host', '?')

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -46,11 +46,7 @@ For example, to match:
   '*0000Z/foo*:retrying'
 * retrying tasks in 'BAR' family: '*/BAR:retrying' or 'BAR.*:retrying'
 * retrying tasks in 'BAR' or 'BAZ' families: '*/BA[RZ]:retrying' or
-  'BA[RZ].*:retrying'
-
-The old 'MATCH POINT' syntax will be automatically detected and supported. To
-avoid this, use the '--no-multitask-compat' option, or use the new syntax
-(with a '/' or a '.') when specifying 2 TASK_GLOB arguments."""
+  'BA[RZ].*:retrying'"""
 
     def __init__(self, usage, argdoc=None, comms=False, noforce=False,
                  jset=False, multitask=False, prep=False, auto_add=True,
@@ -75,7 +71,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
         self.comms = comms
         self.jset = jset
         self.noforce = noforce
-        self.multitask = multitask
         self.prep = prep
         self.icp = icp
         self.suite_info = []
@@ -212,13 +207,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
                 ),
                 action="store", default=None, dest="templatevars_file")
 
-        if self.multitask:
-            self.add_std_option(
-                "--no-multitask-compat",
-                help="Disallow backward compatible multitask interface.",
-                action="store_false", default=True,
-                dest="multitask_compat")
-
         if self.icp:
             self.add_option(
                 "--icp",
@@ -276,26 +264,3 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
         LOG.addHandler(errhandler)
 
         return (options, args)
-
-    @classmethod
-    def parse_multitask_compat(cls, options, mtask_args):
-        """Parse argument items for multitask backward compatibility.
-
-        If options.multitask_compat is False, return (mtask_args, None).
-
-        If options.multitask_compat is True, it checks if mtask_args is a
-        2-element array and if the 1st and 2nd arguments look like the old
-        "MATCH" "POINT" CLI arguments.
-        If so, it returns (mtask_args[0], mtask_args[1]).
-        Otherwise, it return (mtask_args, None).
-
-        """
-        if (options.multitask_compat and len(mtask_args) == 2 and
-                not any("/" in mtask_arg for mtask_arg in mtask_args) and
-                "." not in mtask_args[1]):
-            # For backward compat, argument list should have 2 elements.
-            # Element 1 may be a regular expression, so it may contain "." but
-            # should not contain a "/".
-            # All other elements should contain no "." and "/".
-            return (mtask_args[0] + "." + mtask_args[1],)
-        return mtask_args

--- a/lib/cylc/option_parsers.py
+++ b/lib/cylc/option_parsers.py
@@ -32,7 +32,8 @@ class CylcOptionParser(OptionParser):
     """Common options for all cylc CLI commands."""
 
     MULTITASK_USAGE = """
-TASKID is a pattern to match task proxies or task families, or groups of them:
+TASK_GLOB is a pattern to match task proxies or task families,
+or groups of them:
 * [CYCLE-POINT-GLOB/]TASK-NAME-GLOB[:TASK-STATE]
 * [CYCLE-POINT-GLOB/]FAMILY-NAME-GLOB[:TASK-STATE]
 * TASK-NAME-GLOB[.CYCLE-POINT-GLOB][:TASK-STATE]
@@ -49,7 +50,7 @@ For example, to match:
 
 The old 'MATCH POINT' syntax will be automatically detected and supported. To
 avoid this, use the '--no-multitask-compat' option, or use the new syntax
-(with a '/' or a '.') when specifying 2 TASKID arguments."""
+(with a '/' or a '.') when specifying 2 TASK_GLOB arguments."""
 
     def __init__(self, usage, argdoc=None, comms=False, noforce=False,
                  jset=False, multitask=False, prep=False, auto_add=True,
@@ -212,15 +213,6 @@ avoid this, use the '--no-multitask-compat' option, or use the new syntax
                 action="store", default=None, dest="templatevars_file")
 
         if self.multitask:
-            self.add_std_option(
-                "-m", "--family",
-                help=(
-                    "(Obsolete) This option is now ignored "
-                    "and is retained for backward compatibility only. "
-                    "TASKID in the argument list can be used to match "
-                    "task and family names regardless of this option."),
-                action="store_true", default=False, dest="is_family")
-
             self.add_std_option(
                 "--no-multitask-compat",
                 help="Disallow backward compatible multitask interface.",

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1852,9 +1852,9 @@ conditions; see `cylc conditions`.
         """Force spawn task successors."""
         return self.pool.spawn_tasks(items)
 
-    def command_take_checkpoints(self, items):
+    def command_take_checkpoints(self, name):
         """Insert current task_pool, etc to checkpoints tables."""
-        return self.suite_db_mgr.checkpoint(items[0])
+        return self.suite_db_mgr.checkpoint(name)
 
     def filter_initial_task_list(self, inlist):
         """Return list of initial tasks after applying a filter."""

--- a/tests/cylc-insert/08-insert-family-compat/suite.rc
+++ b/tests/cylc-insert/08-insert-family-compat/suite.rc
@@ -26,9 +26,7 @@ cylc remove --no-spawn "$CYLC_SUITE_NAME" "FAM-?.$CYLC_TASK_CYCLE_POINT"
 """
     [[inserter]]
         # Re-insert one family.
-        script = """
-cylc insert -m $CYLC_SUITE_NAME FAM-A $CYLC_TASK_CYCLE_POINT
-"""
+        script = cylc insert $CYLC_SUITE_NAME FAM-A $CYLC_TASK_CYCLE_POINT
     [[FAM-A, FAM-B]]
     [[a1, a2]]
         inherit = FAM-A

--- a/tests/cylc-kill/00-multi-hosts-compat/suite.rc
+++ b/tests/cylc-kill/00-multi-hosts-compat/suite.rc
@@ -21,6 +21,6 @@ KILLABLE:start-all => killer
             host={{CYLC_TEST_HOST}}
     [[killer]]
         script="""
-cylc kill -m "${CYLC_SUITE_NAME}" KILLABLE 1
+cylc kill "${CYLC_SUITE_NAME}" KILLABLE 1
 cylc stop "${CYLC_SUITE_NAME}"
 """

--- a/tests/cylc-kill/01-multi-hosts/suite.rc
+++ b/tests/cylc-kill/01-multi-hosts/suite.rc
@@ -21,6 +21,6 @@ KILLABLE:start-all => killer
             host={{CYLC_TEST_HOST}}
     [[killer]]
         script="""
-cylc kill -m "${CYLC_SUITE_NAME}" KILLABLE.1
+cylc kill "${CYLC_SUITE_NAME}" KILLABLE.1
 cylc stop "${CYLC_SUITE_NAME}"
 """

--- a/tests/cylc-kill/02-submitted/suite.rc
+++ b/tests/cylc-kill/02-submitted/suite.rc
@@ -24,7 +24,7 @@ sleep 60
         script="""
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 sleep 5
-cylc kill -m "${CYLC_SUITE_NAME}" '*:submitted'
+cylc kill "${CYLC_SUITE_NAME}" '*:submitted'
 """
     [[sleeper]]
         script=sleep 20

--- a/tests/cylc-take-checkpoints/00-basic/suite.rc
+++ b/tests/cylc-take-checkpoints/00-basic/suite.rc
@@ -20,7 +20,7 @@ if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
     sleep 2  # state of current task should be recorded after 2 seconds
     cylc checkpoint "${CYLC_SUITE_NAME}" 'snappy'
     LOG="${CYLC_SUITE_LOG_DIR}/log"
-    while ! grep -qF "INFO - Command succeeded: take_checkpoints(['snappy'])" \
+    while ! grep -qF "INFO - Command succeeded: take_checkpoints(snappy)" \
         "${LOG}"
     do
         sleep 1  # make sure take_checkpoints command completes

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -18,13 +18,13 @@ second task fixes and retriggers it with an edit-run."""
         script = /bin/false
     [[fixer-task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END__
 y
 __END__"""
     [[syntax_errored_task]]
         script = $(
     [[syntax_fixer_task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME syntax_errored_task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'syntax_errored_task.1' << __END__
 y
 __END__"""

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -17,6 +17,6 @@ second task fixes and retriggers it with an edit-run."""
             host = $(echo localhost)
     [[fixer-task]]
         script = """
-cylc trigger --edit $CYLC_SUITE_NAME broken-task 1 << __END__
+cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END__
 y
 __END__"""

--- a/tests/restart/25-hold-suite/suite.rc
+++ b/tests/restart/25-hold-suite/suite.rc
@@ -12,15 +12,15 @@
     [[dependencies]]
         [[[P1Y]]]
             graph = """
-t1[-P1Y] => t1 => t2
-"""
+                t1[-P1Y] => t1 => t2
+            """
 [runtime]
     [[t1]]
         script = """
-if [[ "${CYLC_TASK_CYCLE_POINT}" == '2016' ]]; then
-    cylc hold "${CYLC_SUITE_NAME}"
-    cylc stop "${CYLC_SUITE_NAME}"
-fi
-"""
+            if [[ "${CYLC_TASK_CYCLE_POINT}" == '2016' ]]; then
+                cylc hold "${CYLC_SUITE_NAME}"
+                cylc stop "${CYLC_SUITE_NAME}"
+            fi
+        """
     [[t2]]
         script = true


### PR DESCRIPTION
closes the CLI component of #2123 

**This is built atop #3004** (look at last commit).

**This is a quick (<2hr) demonstration** to show just how easy it is to bring api-on-the-fly to the Cylc CLI in the new network framework.

**Api-on-the-fly in a nutshell** (for those not in the meeting when this was discussed (2 years back?)):

* Request the suite runtime API from the suite itself.
* Version independence between clients.
  * No need to change cylc versions (`export CYLC_VERSION=...`) to work with suites at different Cylc version on the CLI.
   * No need to hard-code GUI forms (e.g. control=>stop_suite or control=insert_tasks) let the suite provide the interface.
* No more duplication of documentation, all APIs derive from the docstrings defined at the endpoints.
* No more inconsistency between GUI, CLI and network functionality, add a feature in the network and its available everywhere.
* No more type errors, strings getting interpreted as lists or other nonsense.
* Restricted to user-orientated commands, internal commands like `cylc message` would suffer performance wise.

**Examples**

Note we would probably symlink commands (e.g. `cylc stop <suite>` to `cylc client <suite> stop`). An endpoint rationalisation would be needed too.

```console
$ # get list of endpoints supported by the suite
$ cylc suite suite api
["api", "clear_broadcast", "describe", "dry_run_tasks", "expire_broadcast", ...]
```

```console
$ # get the CLI help for the set_stop_cleanly endpoint
$ cylc suite generic set_stop_cleanly --help
usage: set_stop_cleanly [-h] [--kill_active_tasks KILL_ACTIVE_TASKS]

Set suite to stop cleanly or after kill active tasks.

returns: tuple - (outcome, message)
    
    outcome (bool)
        True if command successfully queued.
    message (str)
        Information about outcome.
    

optional arguments:
  -h, --help            show this help message and exit
  --kill_active_tasks KILL_ACTIVE_TASKS
                        If True the suite will attempt to kill any active
                        (running, submitted) tasks
```

```console
$ # call the set_stop_cleanly endpoint
$ cylc suite generic set_stop_cleanly       
[true, "Command queued"]
```

#### Loose ends

* Validation / client-side casting
* Generate HTML forms for the GUI?
* Niceness (see TODOs in code)

#### Questions

Will GraphQL replace everything or do we want to keep some (simplified/tidied) endpoints for Cylc "transactions" (e.g. stop)? Or should this be re-developed on-top of the GraphQL endpoint?