### PR TITLE
Add an alias link for the External Triggers section

### DIFF
--- a/doc/src/appendices/suiterc-config-ref.rst
+++ b/doc/src/appendices/suiterc-config-ref.rst
@@ -1010,7 +1010,7 @@ A list of member tasks, or task family names, to assign to this queue
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This section is for *External Trigger* function declarations -
-see :ref:`External Triggers`.
+see :ref:`Section External Triggers`.
 
 
 [scheduling] ``->`` [[xtriggers]] ``->`` \_\_MANY\_\_
@@ -1022,7 +1022,7 @@ declarations and corresponding labels for use in the graph:
 - *type*: string: function signature followed by optional call interval
 - *example*: ``trig_1 = my_trigger(arg1, arg2, kwarg1, kwarg2):PT10S``
 
-(See :ref:`External Triggers` for details).
+(See :ref:`Section External Triggers` for details).
 
 
 [scheduling] ``->`` [[special tasks]]
@@ -1037,7 +1037,7 @@ be used in special task lists as shorthand for listing all member tasks.
 
 .. note::
 
-   Please read :ref:`External Triggers` before
+   Please read :ref:`Section External Triggers` before
    using the older clock triggers described in this section.
 
 Clock-trigger tasks (see :ref:`ClockTriggerTasks`) wait on a wall clock time
@@ -1082,7 +1082,7 @@ see :ref:`ClockExpireTasks`.
 
 .. note::
 
-   Please read :ref:`External Triggers` before
+   Please read :ref:`Section External Triggers` before
    using the older mechanism described in this section.
 
 Externally triggered tasks (see :ref:`Old-Style External Triggers`) wait on

--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -1,4 +1,4 @@
-.. _External Triggers:
+.. _Section External Triggers:
 
 External Triggers
 =================
@@ -407,7 +407,7 @@ Old-Style External Triggers (Deprecated)
 .. note::
 
    This mechanism is now technically deprecated by the newer external
-   trigger functions (:ref:`External Triggers`). (However we don't recommend
+   trigger functions (:ref:`Section External Triggers`). (However we don't recommend
    wholesale conversion to the new method yet, until its interface has
    stabilized - see :ref:`Current Trigger Function Limitations`.)
 

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -1225,7 +1225,7 @@ Triggering Off Of Tasks In Other Suites
 
 .. note::
 
-   Please read :ref:`External Triggers` before using
+   Please read :ref:`Section External Triggers` before using
    the older inter-suite triggering mechanism described in this section.
 
 The ``cylc suite-state`` command interrogates suite run databases. It

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -1154,7 +1154,7 @@ be made to trigger off of the state of other tasks (indicated by a
 name in the graph) and, and off the clock, and arbitrary external events.
 
 External triggering is relatively more complicated, and is documented
-separately in :ref:`External Triggers`.
+separately in :ref:`Section External Triggers`.
 
 
 Success Triggers
@@ -1793,7 +1793,7 @@ Clock Triggers
 
 .. note::
 
-   Please read External Triggers (:ref:`External Triggers`) before
+   Please read External Triggers (:ref:`Section External Triggers`) before
    using the older clock triggers described in this section.
 
 By default, date-time cycle points are not connected to the real time "wall
@@ -1862,10 +1862,12 @@ workflow is skipped, if it is more than one day behind the wall-clock (see also
                  copy:expired => !proc"""
 
 
+.. _SuiteConfigExternalTriggers:
+
 External Triggers
 """""""""""""""""
 
-This is a substantial topic, documented in :ref:`External Triggers`.
+This is a substantial topic, documented in :ref:`Section External Triggers`.
 
 
 .. _ModelRestartDependencies:


### PR DESCRIPTION
In our documentation, there is a 9.3.5.16 section titled "External Triggers". There is also an 11 section titled "External Triggers", with a named link to `External Triggers`.

It appears sphinx creates links with the section name, and that the link created for 9.3.5.16 External Triggers takes precedence over others. We can try right now browsing our documentation in the section 9.3.5.16, where it contains a link to the named link `External Triggers`. 

https://cylc.github.io/doc/built-sphinx-single/index.html#external-triggers (repair that the has anchor link has the name of the section, and Sphinx creates links in the same way).

I believe the intention was actually to link to the section 11 "External Triggers", and not to itself.

This pull request changes the section 11 named link from simply `External Triggers` to `Section External Triggers` (my lack of creativity). It appears to fix the issue. It should be possible to review by checking out this pull request and running `cylc make-docs` to compare against our website.

Cheers
Bruno