### PR TITLE
Xtrigger minor improvements

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -451,7 +451,7 @@ see `COPYING' in the Cylc source distribution.
 
         self.pool = TaskPool(
             self.config, self.final_point, self.suite_db_mgr,
-            self.task_events_mgr, self.proc_pool, self.xtrigger_mgr)
+            self.task_events_mgr)
 
         self.profiler.log_memory("scheduler.py: before load_tasks")
         if self.is_restart:
@@ -1634,7 +1634,8 @@ see `COPYING' in the Cylc source distribution.
         process = False
 
         # New-style xtriggers.
-        self.pool.check_xtriggers()
+        self.xtrigger_mgr.check_xtriggers(
+            self.pool.get_tasks(), self.proc_pool)
         if self.xtrigger_mgr.pflag:
             process = True
             self.xtrigger_mgr.pflag = False  # reset

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -220,9 +220,8 @@ class Scheduler(object):
             self.suite_srv_files_mgr.get_suite_srv_dir(self.suite),  # pri_d
             os.path.join(self.suite_run_dir, 'log'))                 # pub_d
         self.broadcast_mgr = BroadcastMgr(self.suite_db_mgr)
-        self.xtrigger_mgr = XtriggerManager(
-            self.suite, self.owner, self.broadcast_mgr, self.suite_run_dir,
-            self.suite_share_dir, self.suite_dir)
+        self.xtrigger_mgr = None
+
         self.ref_test_allowed_failures = []
         # Last 10 durations (in seconds) of the main loop
         self.main_loop_intervals = deque(maxlen=10)
@@ -363,6 +362,10 @@ see `COPYING' in the Cylc source distribution.
             self.suite, self.proc_pool, self.suite_db_mgr,
             self.suite_srv_files_mgr, self.task_events_mgr)
         self.task_job_mgr.task_remote_mgr.uuid_str = self.uuid_str
+
+        self.xtrigger_mgr = XtriggerManager(
+            self.suite, self.owner, self.broadcast_mgr, self.proc_pool,
+            self.suite_run_dir, self.suite_share_dir, self.suite_dir)
 
         if self.is_restart:
             # This logic handles the lack of initial cycle point in "suite.rc".
@@ -1635,7 +1638,7 @@ see `COPYING' in the Cylc source distribution.
 
         # New-style xtriggers.
         self.xtrigger_mgr.check_xtriggers(
-            self.pool.get_tasks(), self.proc_pool)
+            self.pool.get_tasks())
         if self.xtrigger_mgr.pflag:
             process = True
             self.xtrigger_mgr.pflag = False  # reset

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -222,7 +222,7 @@ class Scheduler(object):
         self.broadcast_mgr = BroadcastMgr(self.suite_db_mgr)
         self.xtrigger_mgr = XtriggerManager(
             self.suite, self.owner, self.broadcast_mgr, self.suite_run_dir,
-            self.suite_share_dir, self.suite_work_dir, self.suite_dir)
+            self.suite_share_dir, self.suite_dir)
         self.ref_test_allowed_failures = []
         # Last 10 durations (in seconds) of the main loop
         self.main_loop_intervals = deque(maxlen=10)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -220,7 +220,7 @@ class Scheduler(object):
             self.suite_srv_files_mgr.get_suite_srv_dir(self.suite),  # pri_d
             os.path.join(self.suite_run_dir, 'log'))                 # pub_d
         self.broadcast_mgr = BroadcastMgr(self.suite_db_mgr)
-        self.xtrigger_mgr = None
+        self.xtrigger_mgr = None  # type: XtriggerManager
 
         self.ref_test_allowed_failures = []
         # Last 10 durations (in seconds) of the main loop
@@ -364,8 +364,12 @@ see `COPYING' in the Cylc source distribution.
         self.task_job_mgr.task_remote_mgr.uuid_str = self.uuid_str
 
         self.xtrigger_mgr = XtriggerManager(
-            self.suite, self.owner, self.broadcast_mgr, self.proc_pool,
-            self.suite_run_dir, self.suite_share_dir, self.suite_dir)
+            self.suite, self.owner,
+            broadcast_mgr=self.broadcast_mgr,
+            proc_pool=self.proc_pool,
+            suite_run_dir=self.suite_run_dir,
+            suite_share_dir=self.suite_share_dir,
+            suite_source_dir=self.suite_dir)
 
         if self.is_restart:
             # This logic handles the lack of initial cycle point in "suite.rc".
@@ -1637,8 +1641,7 @@ see `COPYING' in the Cylc source distribution.
         process = False
 
         # New-style xtriggers.
-        self.xtrigger_mgr.check_xtriggers(
-            self.pool.get_tasks())
+        self.xtrigger_mgr.check_xtriggers(self.pool.get_tasks())
         if self.xtrigger_mgr.pflag:
             process = True
             self.xtrigger_mgr.pflag = False  # reset

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -70,14 +70,11 @@ class TaskPool(object):
     STOP_REQUEST_NOW = 'REQUEST(NOW)'
     STOP_REQUEST_NOW_NOW = 'REQUEST(NOW-NOW)'
 
-    def __init__(self, config, stop_point, suite_db_mgr, task_events_mgr,
-                 proc_pool, xtrigger_mgr):
+    def __init__(self, config, stop_point, suite_db_mgr, task_events_mgr):
         self.config = config
         self.stop_point = stop_point
         self.suite_db_mgr = suite_db_mgr
         self.task_events_mgr = task_events_mgr
-        self.proc_pool = proc_pool
-        self.xtrigger_mgr = xtrigger_mgr
 
         self.do_reload = False
         self.custom_runahead_limit = self.config.get_custom_runahead_limit()
@@ -1299,16 +1296,6 @@ class TaskPool(object):
                 "outputs": outputs,
                 "extras": extras}
         return results, bad_items
-
-    def check_xtriggers(self):
-        """See if any xtriggers are satisfied."""
-        itasks = self.get_tasks()
-        self.xtrigger_mgr.collate(itasks)
-        for itask in itasks:
-            if itask.state.xclock is not None:
-                self.xtrigger_mgr.satisfy_xclock(itask)
-            if itask.state.xtriggers:
-                self.xtrigger_mgr.satisfy_xtriggers(itask, self.proc_pool)
 
     def filter_task_proxies(self, items):
         """Return task proxies that match names, points, states in items.

--- a/cylc/flow/tests/test_xtrigger_mgr.py
+++ b/cylc/flow/tests/test_xtrigger_mgr.py
@@ -1,0 +1,564 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from cylc.flow.broadcast_mgr import BroadcastMgr
+from cylc.flow.cycling.iso8601 import ISO8601Point, init
+from cylc.flow.subprocctx import SubFuncContext
+from cylc.flow.subprocpool import SubProcPool
+from cylc.flow.task_proxy import TaskProxy
+from cylc.flow.taskdef import TaskDef
+from cylc.flow.xtrigger_mgr import XtriggerManager
+
+
+def test_constructor():
+    """Test creating a XtriggerManager, and its initial state."""
+    xtrigger_mgr = XtriggerManager(suite="suitea", user="john-foo")
+    # the dict with clock xtriggers starts empty
+    assert not xtrigger_mgr.clockx_map
+    # the dict with normal xtriggers starts empty
+    assert not xtrigger_mgr.functx_map
+
+
+def test_add_clock_xtrigger():
+    """Test for adding a clock xtrigger. Clock xtriggers go to a different
+    dict than normal xtriggers. This is useful as the execution varies
+    for clock/non-clock xtriggers (e.g. sync vs. async)."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    xtrig = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrigger_mgr.add_clock("xtrig", xtrig)
+    assert xtrig == xtrigger_mgr.clockx_map["xtrig"]
+
+
+def test_add_xtrigger():
+    """Test for adding a xtrigger."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    xtrig = SubFuncContext(
+        label="echo",
+        func_name="echo",
+        func_args=["name", "age"],
+        func_kwargs={"location": "soweto"}
+    )
+    xtrigger_mgr.add_trig("xtrig", xtrig)
+    assert xtrig == xtrigger_mgr.functx_map["xtrig"]
+
+
+def test_add_xtrigger_with_params():
+    """Test for adding a xtrigger."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    xtrig = SubFuncContext(
+        label="echo",
+        func_name="echo",
+        func_args=["name", "%(point)s"],
+        func_kwargs={"%(location)s": "soweto"}  # no problem with the key!
+    )
+    xtrigger_mgr.add_trig("xtrig", xtrig)
+    assert xtrig == xtrigger_mgr.functx_map["xtrig"]
+
+
+def test_add_xtrigger_with_unkonwn_params():
+    """Test for adding a xtrigger with an unknown parameter.
+
+    The XTriggerManager contains a list of specific parameters that are
+    available in the function template.
+
+    Values that are not strings raise a TypeError during regex matching, but
+    are ignored, so we should not have any issue with TypeError.
+
+    If a value in the format %(foo)s appears in the parameters, and 'foo'
+    is not in this list of parameters, then a ValueError is expected.
+    """
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    xtrig = SubFuncContext(
+        label="echo",
+        func_name="echo",
+        func_args=[1, "name", "%(what_is_this)s"],
+        func_kwargs={"location": "soweto"}
+    )
+    with pytest.raises(ValueError):
+        xtrigger_mgr.add_trig("xtrig", xtrig)
+
+    # TODO: is it intentional? At the moment when we fail to validate the
+    #       function parameters, we add it to the dict anyway.
+    assert xtrigger_mgr.functx_map["xtrig"] == xtrig
+
+
+def test_load_xtrigger_for_restart():
+    """Test loading a xtrigger for restart.
+
+    The function is loaded from database, where the value is formatted
+    as JSON."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    row = "get_name", "{\"name\": \"function\"}"
+    xtrigger_mgr.load_xtrigger_for_restart(row_idx=0, row=row)
+    assert xtrigger_mgr.sat_xtrig["get_name"]["name"] == "function"
+
+
+def test_load_invalid_xtrigger_for_restart():
+    """Test loading an invalid xtrigger for restart.
+
+    It simulates that the DB has a value that is not valid JSON.
+    """
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    row = "get_name", "{name: \"function\"}"  # missing double quotes
+    with pytest.raises(ValueError):
+        xtrigger_mgr.load_xtrigger_for_restart(row_idx=0, row=row)
+
+
+def test_housekeeping_nothing_satisfied():
+    """The housekeeping method makes sure only satisfied xtrigger function
+    are kept."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    row = "get_name", "{\"name\": \"function\"}"
+    # now XtriggerManager#sat_xtrigger will contain the get_name xtrigger
+    xtrigger_mgr.load_xtrigger_for_restart(row_idx=0, row=row)
+    # but we have nothing in the XtriggerManager#all_xclock, which means
+    # nothing was satisfied yet
+    xtrigger_mgr.all_xclock.clear()
+    assert xtrigger_mgr.sat_xtrig
+    xtrigger_mgr.housekeep()
+    assert not xtrigger_mgr.sat_xtrig
+
+
+def test_housekeeping_with_xtrigger_satisfied():
+    """The housekeeping method makes sure only satisfied xtrigger function
+    are kept."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    xtrig = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrigger_mgr.add_trig("get_name", xtrig)
+    xtrig.out = "[\"True\", {\"name\": \"Yossarian\"}]"
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xtrig_labels.add("get_name")
+    start_point = ISO8601Point('20000101T0000+05')
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    xtrigger_mgr.collate([itask])
+    # pretend the function has been activated
+    xtrigger_mgr.active.append(xtrig.get_signature())
+    xtrigger_mgr.callback(xtrig)
+    assert xtrigger_mgr.sat_xtrig
+    xtrigger_mgr.housekeep()
+    # here we still have the same number as before
+    assert xtrigger_mgr.sat_xtrig
+    # however, we have no xclock trigger satisfied
+    assert not xtrigger_mgr.sat_xclock
+
+
+def test_housekeeping_with_xclock_satisfied():
+    """The housekeeping method makes sure only satisfied xclock function
+    are kept."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    # the clock xtrigger
+    xtrig = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrig.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.add_clock("wall_clock", xtrig)
+    # create a task
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xclock_label = "wall_clock"
+    # cycle point for task proxy
+    # TODO: we need to call init, before we can use ISO8601 points in Cylc,
+    #       why?
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    itask.state.xclock = "wall_clock", False  # satisfied?
+    # satisfy xclock
+    xtrigger_mgr.satisfy_xclock(itask)
+    # tally
+    xtrigger_mgr.collate([itask])
+    assert xtrigger_mgr.sat_xclock
+    xtrigger_mgr.housekeep()
+    # here we still have the same number as before
+    assert xtrigger_mgr.sat_xclock
+
+
+def test_satisfy_xclock_satisfied_xclock():
+    """Test satisfy_xclock for a satisfied clock trigger."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    # the clock xtrigger
+    xtrig = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrig.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.add_clock("wall_clock", xtrig)
+    # create a task
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xclock_label = "wall_clock"
+    # cycle point for task proxy
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    itask.state.xclock = "wall_clock", True  # satisfied?
+    # we are defining in the state of the TaskProxy. that its xclock trigger
+    # has been satisfied, without actually adding it to the right dict.
+    assert not xtrigger_mgr.sat_xclock
+    xtrigger_mgr.satisfy_xclock(itask)
+    # as it was already satisfied, the function should return immediately,
+    # without touching sat_xclock, therefore, it must remain empty
+    assert not xtrigger_mgr.sat_xclock
+
+
+def test_satisfy_xclock_unsatisfied_xclock():
+    """Test satisfy_xclock for an unsatisfied clock trigger."""
+    xtrigger_mgr = XtriggerManager(suite="sample_suite", user="john-foo")
+    # the clock xtrigger
+    xtrig = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrig.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.add_clock("wall_clock", xtrig)
+    # create a task
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xclock_label = "wall_clock"
+    # cycle point for task proxy
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    itask.state.xclock = "wall_clock", False  # satisfied?
+    # we are defining in the state of the TaskProxy. that its xclock trigger
+    # has **not** been satisfied.
+    assert not xtrigger_mgr.sat_xclock
+    xtrigger_mgr.satisfy_xclock(itask)
+    # as it was satisfied by the satisfy_clock function, we must have its
+    # signature in the dict. NB the signature is not the same as
+    # get_signature(), as it is actually the signature for that moment
+    # when it was satisfied.
+    assert xtrigger_mgr.sat_xclock
+
+
+class MockedProcPool(SubProcPool):
+
+    def put_command(self, ctx, callback=None, callback_args=None):
+        return True
+
+
+class MockedBroadcastMgr(BroadcastMgr):
+
+    def put_broadcast(
+            self, point_strings=None, namespaces=None, settings=None):
+        return True
+
+
+def test_satisfy_xtrigger():
+    """Test satisfy_xtriggers"""
+    # the XtriggerManager instance
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo",
+        proc_pool=MockedProcPool(),
+        broadcast_mgr=MockedBroadcastMgr(suite_db_mgr=None)
+    )
+    # the echo1 xtrig (not satisfied)
+    echo1_xtrig = SubFuncContext(
+        label="echo1",
+        func_name="echo1",
+        func_args=[],
+        func_kwargs={}
+    )
+    echo1_xtrig.out = "[\"True\", {\"name\": \"herminia\"}]"
+    xtrigger_mgr.add_trig("echo1", echo1_xtrig)
+    # the echo2 xtrig (satisfied through callback later)
+    echo2_xtrig = SubFuncContext(
+        label="echo2",
+        func_name="echo2",
+        func_args=[],
+        func_kwargs={}
+    )
+    echo2_xtrig.out = "[\"True\", {\"name\": \"herminia\"}]"
+    xtrigger_mgr.add_trig("echo2", echo2_xtrig)
+    # create a task
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xtrig_labels.add("echo1")
+    tdef.xtrig_labels.add("echo2")
+    # cycle point for task proxy
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+
+    # we start with no satisfied xtriggers, and nothing active
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 0
+
+    # after calling satisfy_xtriggers the first time, we get two active
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 2
+
+    # calling satisfy_xtriggers again does not change anything
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 2
+
+    # now we call callback manually as the proc_pool we passed is a mock
+    # then both should be satisfied
+    xtrigger_mgr.callback(echo1_xtrig)
+    xtrigger_mgr.callback(echo2_xtrig)
+    # so both were satisfied, and nothing is active
+    assert len(xtrigger_mgr.sat_xtrig) == 2
+    assert len(xtrigger_mgr.active) == 0
+
+    # calling satisfy_xtriggers again still does not change anything
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 2
+    assert len(xtrigger_mgr.active) == 0
+
+
+def test_collate():
+    """Test that collate properly tallies the totals of current xtriggers."""
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo"
+    )
+    xtrigger_mgr.collate(itasks=[])
+    assert not xtrigger_mgr.all_xclock
+    assert not xtrigger_mgr.all_xtrig
+
+    # add a xtrigger
+    # that will cause all_xtrig to be populated, but not all_xclock
+    get_name = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrigger_mgr.add_trig("get_name", get_name)
+    get_name.out = "[\"True\", {\"name\": \"Yossarian\"}]"
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xtrig_labels.add("get_name")
+    start_point = ISO8601Point('20000101T0000+05')
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    itask.state.xtriggers["get_name"] = get_name
+
+    xtrigger_mgr.collate([itask])
+    assert not xtrigger_mgr.all_xclock
+    assert xtrigger_mgr.all_xtrig
+
+    # add a clock xtrigger
+    # that will cause both all_xclock to be populated but not all_xtrig
+    wall_clock = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    wall_clock.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.add_clock("wall_clock", wall_clock)
+    # create a task
+    tdef = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef.xclock_label = "wall_clock"
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask = TaskProxy(tdef=tdef, start_point=start_point)
+    itask.state.xclock = "wall_clock", True
+
+    xtrigger_mgr.collate([itask])
+    assert xtrigger_mgr.all_xclock
+    assert not xtrigger_mgr.all_xtrig
+
+
+def test_callback_not_active():
+    """Test callback with no active contexts."""
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo"
+    )
+    # calling callback with a SubFuncContext with none active
+    # results in a ValueError
+
+    get_name = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    with pytest.raises(ValueError):
+        xtrigger_mgr.callback(get_name)
+
+
+def test_callback_invalid_json():
+    """Test callback with invalid JSON."""
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo"
+    )
+    get_name = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    get_name.out = "{no_quotes: \"mom!\"}"
+    xtrigger_mgr.active.append(get_name.get_signature())
+    xtrigger_mgr.callback(get_name)
+    # this means that the xtrigger was not satisfied
+    # TODO: this means site admins are only aware of this if they
+    #       look at the debug log. Is that OK?
+    assert not xtrigger_mgr.sat_xtrig
+
+
+def test_callback():
+    """Test callback."""
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo"
+    )
+    get_name = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    get_name.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.active.append(get_name.get_signature())
+    xtrigger_mgr.callback(get_name)
+    # this means that the xtrigger was satisfied
+    assert xtrigger_mgr.sat_xtrig
+
+
+def test_check_xtriggers():
+    """Test check_xtriggers call.
+
+    check_xtriggers does pretty much the same as collate. The
+    difference is that besides tallying on all the xtriggers and
+    clock xtriggers available, it then proceeds to trying to
+    satisfy them."""
+    xtrigger_mgr = XtriggerManager(
+        suite="sample_suite",
+        user="john-foo",
+        proc_pool=MockedProcPool()
+    )
+
+    # add a xtrigger
+    # that will cause all_xtrig to be populated, but not all_xclock
+    get_name = SubFuncContext(
+        label="get_name",
+        func_name="get_name",
+        func_args=[],
+        func_kwargs={}
+    )
+    xtrigger_mgr.add_trig("get_name", get_name)
+    get_name.out = "[\"True\", {\"name\": \"Yossarian\"}]"
+    tdef1 = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef1.xtrig_labels.add("get_name")
+    start_point = ISO8601Point('20000101T0000+05')
+    itask1 = TaskProxy(tdef=tdef1, start_point=start_point)
+    itask1.state.xtriggers["get_name"] = False  # satisfied?
+
+    # add a clock xtrigger
+    # that will cause both all_xclock to be populated but not all_xtrig
+    wall_clock = SubFuncContext(
+        label="wall_clock",
+        func_name="wall_clock",
+        func_args=[],
+        func_kwargs={}
+    )
+    wall_clock.out = "[\"True\", \"1\"]"
+    xtrigger_mgr.add_clock("wall_clock", wall_clock)
+    # create a task
+    tdef2 = TaskDef(
+        name="foo",
+        rtcfg=None,
+        run_mode="live",
+        start_point=1,
+        spawn_ahead=False
+    )
+    tdef2.xclock_label = "wall_clock"
+    init()
+    start_point = ISO8601Point('20000101T0000+05')
+    # create task proxy
+    itask2 = TaskProxy(tdef=tdef2, start_point=start_point)
+    itask2.state.xclock = "wall_clock", False  # satisfied?
+
+    xtrigger_mgr.check_xtriggers([itask1, itask2])
+    assert xtrigger_mgr.sat_xclock
+    assert xtrigger_mgr.all_xclock
+    # won't be satisfied, as it is async, we are are not calling callback
+    assert not xtrigger_mgr.sat_xtrig
+    assert xtrigger_mgr.all_xtrig

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -16,15 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from copy import deepcopy
 import json
 import re
+from copy import deepcopy
 from time import time
 
-from cylc.flow import LOG
 import cylc.flow.flags
+from cylc.flow import LOG
 from cylc.flow.xtriggers.wall_clock import wall_clock
-
 
 # Templates for string replacement in function arg values.
 TMPL_USER_NAME = 'user_name'

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -82,7 +82,7 @@ class XtriggerManager(object):
 
     """
 
-    def __init__(self, suite, user, broadcast_mgr=None, proc_pool=None,
+    def __init__(self, suite, user, *, broadcast_mgr=None, proc_pool=None,
                  suite_run_dir=None, suite_share_dir=None,
                  suite_source_dir=None):
         """Initialize the xtrigger manager."""

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -243,7 +243,7 @@ class XtriggerManager(object):
                 # Already waiting on this result.
                 continue
             now = time()
-            if (sig in self.t_next_call and now < self.t_next_call[sig]):
+            if sig in self.t_next_call and now < self.t_next_call[sig]:
                 # Too soon to call this one again.
                 continue
             self.t_next_call[sig] = now + ctx.intvl

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -156,7 +156,6 @@ class XtriggerManager(object):
         if satisfied:
             return
         if wall_clock(*ctx.func_args, **ctx.func_kwargs):
-            satisfied = True
             itask.state.xclock = (label, True)
             self.sat_xclock.append(sig)
             LOG.info('clock xtrigger satisfied: %s = %s' % (label, str(ctx)))

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -242,10 +242,11 @@ class XtriggerManager(object):
                 label, signature, function context, and flag for satisfied.
         """
         res = []
-        farg_templ = {}
-        farg_templ[TMPL_TASK_CYCLE_POINT] = str(itask.point)
-        farg_templ[TMPL_TASK_NAME] = str(itask.tdef.name)
-        farg_templ[TMPL_TASK_IDENT] = str(itask.identity)
+        farg_templ = {
+            TMPL_TASK_CYCLE_POINT: str(itask.point),
+            TMPL_TASK_NAME: str(itask.tdef.name),
+            TMPL_TASK_IDENT: str(itask.identity)
+        }
         farg_templ.update(self.farg_templ)
         for label, satisfied in itask.state.xtriggers.items():
             if unsat_only and satisfied:

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -83,8 +83,7 @@ class XtriggerManager(object):
     """
 
     def __init__(self, suite, user, broadcast_mgr=None, suite_run_dir=None,
-                 suite_share_dir=None, suite_work_dir=None,
-                 suite_source_dir=None):
+                 suite_share_dir=None, suite_source_dir=None):
         """Initialize the xtrigger manager."""
         # Suite function and clock triggers by label.
         self.functx_map = {}

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -26,10 +26,10 @@ import cylc.flow.flags
 from cylc.flow import LOG
 from cylc.flow.xtriggers.wall_clock import wall_clock
 
-from cylc.subprocctx import SubFuncContext
-from cylc.broadcast_mgr import BroadcastMgr
-from cylc.subprocpool import SubProcPool
-from cylc.task_proxy import TaskProxy
+from cylc.flow.subprocctx import SubFuncContext
+from cylc.flow.broadcast_mgr import BroadcastMgr
+from cylc.flow.subprocpool import SubProcPool
+from cylc.flow.task_proxy import TaskProxy
 
 # Templates for string replacement in function arg values.
 TMPL_USER_NAME = 'user_name'

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -224,7 +224,7 @@ class XtriggerManager(object):
         if sig_only:
             return sig
         else:
-            return (label, sig, ctx, satisfied)
+            return label, sig, ctx, satisfied
 
     def _get_xtrig(self, itask: TaskProxy, unsat_only: bool = False,
                    sigs_only: bool = False):

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -267,3 +267,12 @@ class XtriggerManager(object):
         if satisfied:
             self.pflag = True
             self.sat_xtrig[sig] = results
+
+    def check_xtriggers(self, itasks, proc_pool):
+        """See if any xtriggers are satisfied."""
+        self.collate(itasks)
+        for itask in itasks:
+            if itask.state.xclock is not None:
+                self.satisfy_xclock(itask)
+            if itask.state.xtriggers:
+                self.satisfy_xtriggers(itask, proc_pool)


### PR DESCRIPTION
Fix for #3057 

Removes one dependency from `TaskPool`, moving the `check_xtriggers` code from there to the `XtriggerManager` in `cylc.xtrigger_mgr.py`.

A few more changes added here, including:

- removal of unnecessary parentheses
- organized imports
- removed unused parameter of `XtriggerManager` constructor `suite_work_dir`
- forced named parameters for `XtriggerManager`'s constructor, to avoid assigning variables incorrectly
- added docstrings with PEP-484 types
- add first unit tests for `XtriggerManager`