### PR TITLE
zmq: support single port configuration

### DIFF
--- a/lib/cylc/network/client.py
+++ b/lib/cylc/network/client.py
@@ -232,9 +232,9 @@ class SuiteRuntimeClient:
 
         # create connection
         return ZMQClient(
-            host, port, encrypt, decrypt, partial(get_secret(suite)),
+            host, port, encrypt, decrypt, partial(get_secret, suite),
             timeout=timeout, header=cls.get_header(),
-            timeout_handler=partial(cls._timeout_handler(suite, host, port))
+            timeout_handler=partial(cls._timeout_handler, suite, host, port)
         )
 
     @staticmethod

--- a/lib/cylc/network/client.py
+++ b/lib/cylc/network/client.py
@@ -18,6 +18,7 @@
 """Client for suite runtime API."""
 
 import asyncio
+from functools import partial
 import os
 import socket
 import sys
@@ -231,9 +232,9 @@ class SuiteRuntimeClient:
 
         # create connection
         return ZMQClient(
-            host, port, encrypt, decrypt, lambda: get_secret(suite),
+            host, port, encrypt, decrypt, partial(get_secret(suite)),
             timeout=timeout, header=cls.get_header(),
-            timeout_handler=lambda: cls._timeout_handler(suite, host, port)
+            timeout_handler=partial(cls._timeout_handler(suite, host, port))
         )
 
     @staticmethod

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Server for suite runtime API."""
 
-from functools import wraps
+from functools import partial, wraps
 import getpass
 from queue import Queue
 from textwrap import dedent
@@ -286,7 +286,7 @@ class SuiteRuntimeServer(ZMQServer):
             self,
             encrypt,
             decrypt,
-            lambda: get_secret(schd.suite)
+            partial(get_secret, schd.suite)
         )
         self.schd = schd
         self.public_priv = None  # update in get_public_priv()

--- a/lib/cylc/network/server.py
+++ b/lib/cylc/network/server.py
@@ -104,7 +104,8 @@ class ZMQServer(object):
             else:
                 self.port = self.socket.bind_to_random_port(
                     'tcp://*', min_port, max_port)
-        except zmq.error.ZMQError as exc:
+        except (zmq.error.ZMQError, zmq.error.ZMQBindError) as exc:
+            self.socket.close()
             raise CylcError('could not start Cylc ZMQ server: %s' % str(exc))
 
         # start accepting requests
@@ -120,6 +121,7 @@ class ZMQServer(object):
         LOG.debug('stopping zmq server...')
         self.queue.put('STOP')
         self.thread.join()  # wait for the listener to return
+        self.socket.close()
         LOG.debug('...stopped')
 
     def register_endpoints(self):

--- a/lib/cylc/tests/test_zmq.py
+++ b/lib/cylc/tests/test_zmq.py
@@ -1,0 +1,36 @@
+"""Test abstract ZMQ interface."""
+import pytest
+import secrets
+
+from cylc.cfgspec.glbl_cfg import glbl_cfg
+from cylc.exceptions import CylcError
+from cylc.network import encrypt, decrypt
+from cylc.network.server import ZMQServer
+
+
+def get_port_range():
+    ports = glbl_cfg().get(['suite servers', 'run ports'])
+    return min(ports), max(ports)
+
+
+PORT_RANGE = get_port_range()
+SECRET = str(secrets.SystemRandom().randint(10**0, 10**100))
+
+
+def get_secret():
+    return SECRET
+
+
+def test_single_port():
+    """Test server on a single port and port in use exception."""
+    serv1 = ZMQServer(encrypt, decrypt, get_secret)
+    serv2 = ZMQServer(encrypt, decrypt, get_secret)
+
+    serv1.start(*PORT_RANGE)
+    port = serv1.port
+
+    with pytest.raises(CylcError) as exc:
+        serv2.start(port, port)
+    assert 'Address already in use' in str(exc)
+
+    serv1.stop()


### PR DESCRIPTION
closes #3075 

Also adds a nice error message in the event that ZMQ fails to bind to the specified port(s).