### PR TITLE
task/suite name validity: consistency & explicitness

### DIFF
--- a/doc/src/appendices/suiterc-config-ref.rst
+++ b/doc/src/appendices/suiterc-config-ref.rst
@@ -1252,15 +1252,11 @@ hierarchies. For details and examples see :ref:`NIORP`.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Replace ``\_\_NAME\_\_`` with a namespace name, or a comma-separated list of
-names, and repeat as needed to define all tasks in the suite. Names may
-contain letters, digits, underscores, and hyphens. A namespace
-represents a group or family of tasks if other namespaces inherit from
-it, or a task if no others inherit from it.
+names, and repeat as needed to define all tasks in the suite. Names must
+be valid according to the restrictions outlined in :ref:`TaskNames`.
 
-  Names may not contain colons (which would preclude use of directory paths
-  involving the registration name in ``$PATH`` variables). They
-  may not contain the "." character (it will be interpreted as the
-  namespace hierarchy delimiter, separating groups and names -huh?).
+A namespace represents a group or family of tasks if other namespaces
+inherit from it, or a task if no others inherit from it.
 
 - *legal values*:
   - ``[[foo]]``

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -2073,10 +2073,10 @@ must:
    - alphanumeric characters or underscores (as above);
    - any of these additional character symbols:
 
-     - dashes (``-``);
+     - hyphens (``-``);
      - plus characters (``+``);
-     - the percent sign (``%``);
-     - the "at" sign (``@``).
+     - percent signs (``%``);
+     - "at" signs (``@``).
 
 3. not be so long, typically over ``255`` characters, as to raise errors
    from exceeding maximum filename length on the operating system for

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -2052,10 +2052,47 @@ namespace (as for single-inheritance) is used for suite visualization
 purposes.
 
 
-Namespace Names
-^^^^^^^^^^^^^^^
+.. _TaskNames:
 
-Namespace names may contain letters, digits, underscores, and hyphens.
+Task and Namespace Names
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are restrictions on names that can be used for tasks and namespaces
+to ensure all tasks are processed and implemented correctly. Valid names
+must:
+
+1. *begin with* (or consist only of, as single-character task names are
+   allowed) either:
+
+   - an alphanumeric character, i.e. a letter in either upper or lower case
+     (``a-z`` or ``A-Z``), or a digit (``0-9``);
+   - an underscore (``_``).
+
+2. *otherwise* contain *only* characters from the following options:
+
+   - alphanumeric characters or underscores (as above);
+   - any of these additional character symbols:
+
+     - dashes (``-``);
+     - plus characters (``+``);
+     - the percent sign (``%``);
+     - the "at" sign (``@``).
+
+3. not be so long, typically over ``255`` characters, as to raise errors
+   from exceeding maximum filename length on the operating system for
+   generated outputs e.g. directories named (in part) after the task they
+   concern.
+
+.. warning::
+
+   Task and namespace names may not contain colons (``:``), which would
+   preclude use of directory paths involving the registration name in
+   ``$PATH`` variables). They also may not contain the dot (``.``) character,
+   as it will be interpreted as the delimiter separating the task name from
+   an appended cycle point (see :ref:`TaskIdentifiers`).
+
+Invalid names for tasks or namespaces will be raised as errors
+by ``cylc validate``.
 
 .. note::
 

--- a/doc/src/suite-name-reg.rst
+++ b/doc/src/suite-name-reg.rst
@@ -31,9 +31,16 @@ Suite Names
 -----------
 
 Suite names are not validated. Names for suites can be anything that is a
-`valid filename <https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations>`_ within your operating system's file system,
-e.g. for Linux any name that does not contain any forward slash characters
-(``/``) and is not too long (as described under :ref:`TaskNames`).
+`valid filename <https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations>`_ within your operating system's file system, which includes
+restrictions on name length (as described under :ref:`TaskNames`), with the
+exceptions of:
+
+- ``/``, which is not supported for general filenames on e.g. Linux systems
+  but is allowed for suite names to generate hierarchical suites
+  (see :ref:`command-register`);
+- while possible in filenames on many systems, it is strongly advised that
+  suite names do not contain any whitespace characters (e.g. as
+  in ``my suite``).
 
 
 .. only:: builder_html

--- a/doc/src/suite-name-reg.rst
+++ b/doc/src/suite-name-reg.rst
@@ -3,6 +3,9 @@
 Suite Name Registration
 =======================
 
+Suite Registration
+------------------
+
 Cylc commands target suites via their names, which are relative path names
 under the suite run directory (``~/cylc-run/`` by default). Suites can
 be grouped together under sub-directories. E.g.:
@@ -20,6 +23,17 @@ be grouped together under sub-directories. E.g.:
 Suite names can be pre-registered with the ``cylc register`` command,
 which creates the suite run directory structure and some service files
 underneath it. Otherwise, ``cylc run`` will do this at suite start up.
+
+
+.. _SuiteNames:
+
+Suite Names
+-----------
+
+Suite names are not validated. Names for suites can be anything that is a
+`valid filename <https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations>`_ within your operating system's file system,
+e.g. for Linux any name that does not contain any forward slash characters
+(``/``) and is not too long (as described under :ref:`TaskNames`).
 
 
 .. only:: builder_html

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -363,12 +363,14 @@ The scan GUI is shown in :numref:`fig-gscan`; clicking on a suite in
 it opens gcylc.
 
 
+.. _TaskIdentifiers:
+
 Task Identifiers
 ----------------
 
-At run time, task instances are identified by *name*, which is
-determined entirely by the suite configuration, and a *cycle point* which is
-usually a date-time or an integer:
+At run time, task instances are identified by their *name* (see
+:ref:`TaskNames`), which is determined entirely by the suite configuration,
+and a *cycle point* which is usually a date-time or an integer:
 
 .. code-block:: bash
 


### PR DESCRIPTION
For task names with including one or more ``+`` characters (which I anticipate could be quite common to include date-time records e.g. ``mytask_T+030`` etc.), clicking the hyperlinked name under the "task name" column of the table on the task jobs page directs to a page (with the URL having the identical query parameter ``&tasks=mytask_T+030``) where the plus characters are converted to whitespace characters for the task name glob displayed, leading to no recognition of such named tasks & hence a blank table. (This is probably clearer to understand visually, so see the screenshots below).

This is a bug deriving from Rose Bush, as I have tested & observed it on that original utility too.

#### Minimal example to recreate

1. Define this **suite.rc**:
    ```ini
    [scheduling]
        [[dependencies]]
            graph = "mytask_T+030"
    [runtime]
        [[mytask_T+030]]
    
    ```
2. **View this in Cylc Review** by running it on an ad-hoc server via ``cylc review start``.
3. Go to the **task jobs page** for that suite (``.../cylc-review/taskjobs/...``) & **click** as shown: 
    
    ![plus_bug_scr_ed](https://user-images.githubusercontent.com/30274190/56377235-d9cb9d00-6201-11e9-8cf5-e17d61d9c0c0.png)
    
4. You should see a *blank table*.
    
    ![plus_bug_scr_2_ed](https://user-images.githubusercontent.com/30274190/56377234-d9cb9d00-6201-11e9-8fe3-89c746b4bab3.png)
    
5. However, if you **amend the URL to replace ``+`` -> ``%2B`` in the task name** query parameter, you *should see the task listed*, the outcome we want for the above case too.

#### Fix

In this PR:

* ``+`` -> ``%2B`` is encoded automatically for task names;
* & then for the plain text display in the auto-filled "Task Name Globs" input box, it is decoded again to display in its true form to the user.

#### Note on testing

It is not trivial with respect to the current JSON dump comparison & ``curl`` based tests set up for Cylc Review (``tests/cylc-review/``) to test that clicking on the task name from the taskjobs table will lead to a URL with the above encoding.

So all I have done for now is to adapt a current test to contain a task with a ``+`` character in the name & check it is recognised via the encoded URL. This is not strictly the test we need as it also passes on the current master, so does not pick up on his bug; I'll add creation of a true coverage test to #2833.