### PR TITLE
cylc review: URL encode links

### DIFF
--- a/lib/cylc/cylc-review/template/broadcast-events.html
+++ b/lib/cylc/cylc-review/template/broadcast-events.html
@@ -6,7 +6,7 @@
 
 <div class="row"><div class="col-md-12">
 <ul class="list-inline pull-right">
-  <li><a href="{{script}}/broadcast_states/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}">states</a></li>
+  <li><a href="{{script}}/broadcast_states/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}">states</a></li>
   <li>events</li>
 </ul>
 

--- a/lib/cylc/cylc-review/template/broadcast-states.html
+++ b/lib/cylc/cylc-review/template/broadcast-states.html
@@ -7,7 +7,7 @@
 <div class="row"><div class="col-md-12">
 <ul class="list-inline pull-right">
   <li>states</li>
-  <li><a href="{{script}}/broadcast_events/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}">events</a></li>
+  <li><a href="{{script}}/broadcast_events/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}">events</a></li>
 </ul>
 
 {% if broadcast_states %}

--- a/lib/cylc/cylc-review/template/cycles.html
+++ b/lib/cylc/cylc-review/template/cycles.html
@@ -17,7 +17,7 @@
         <div class="panel-body">
           <form action="{{script}}/{{method}}">
             <input type="hidden" name="user" value="{{user}}" />
-            <input type="hidden" name="suite" value="{{suite|replace("/", "%2F")}}" />
+            <input type="hidden" name="suite" value="{{suite}}" />
             <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
 
             <div class="row">
@@ -141,7 +141,7 @@ class="table table-bordered table-condensed table-striped">
   {% set cycle_in_url = entry.cycle|replace('+', '%2B') -%}
   {% set task_jobs_url = (
       (script ~ "/taskjobs/" ~ user ~ "?&amp;suite=" ~
-       suite|replace('+', '%2F') ~ "&amp;cycles=" ~ cycle_in_url) | safe
+       suite|urlencode|replace('/', '%2F') ~ "&amp;cycles=" ~ cycle_in_url) | safe
   ) -%}
     <tr class="entry">
 
@@ -208,11 +208,11 @@ class="table table-bordered table-condensed table-striped">
   {% if entry.has_log_job_tar_gz -%}
     {% set download = (
         (script ~ "/view/" ~ user ~ "?&amp;suite=" ~
-         suite|replace('+', '%2F') ~ "&amp;path=log/job-" ~ cycle_in_url ~
+         suite|urlencode|replace('+', '%2F') ~ "&amp;path=log/job-" ~ cycle_in_url ~
          ".tar.gz&amp;mode=download") | safe
     ) -%}
       <a href="{{download}}"
-      download="{{user}}-{{suite|replace("/", "%2F")}}-log-job-{{entry.cycle}}.tar.gz">
+      download="{{user}}-{{suite|urlencode|replace("/", "%2F")}}-log-job-{{entry.cycle}}.tar.gz">
         <i class="glyphicon glyphicon-download"
         title="download log/job-{{entry.cycle}}.tar.gz"></i>
         <small>

--- a/lib/cylc/cylc-review/template/job-entry.html
+++ b/lib/cylc/cylc-review/template/job-entry.html
@@ -6,10 +6,10 @@
 {% set cycle_str = entry.cycle|replace('+', '%2B') -%}
 {% set taskjobs_link = (
     (script ~ "/taskjobs/" ~ user ~ "?&amp;suite=" ~
-     suite|replace('+', '%2F') ~ no_fuzzy_time_str) | safe
+     suite|urlencode|replace('/', '%2F') ~ no_fuzzy_time_str) | safe
 ) -%}
 {% set view_link = (
-    (script ~ "/view/" ~ user ~ "?&amp;suite=" ~ suite|replace('+', '%2F') ~
+    (script ~ "/view/" ~ user ~ "?&amp;suite=" ~ suite|urlencode|replace('/', '%2F') ~
      no_fuzzy_time_str) | safe
 ) -%}
 <tr class="entry"><!-- entry row -->
@@ -50,7 +50,7 @@
     <small>
     {% set link = (
         (script ~ "/taskjobs/" ~ user ~ "?&amp;suite=" ~
-         suite|replace('+', '%2F') ~ no_fuzzy_time_str) | safe
+         suite|urlencode|replace('/', '%2F') ~ no_fuzzy_time_str) | safe
     ) -%}
     {% if entry.run_status == 0 -%}
       <a href="{{taskjobs_link}}&amp;job_status=succeeded"
@@ -102,7 +102,7 @@
     <!-- entry: name -->
     <small>
       <a
-      href="{{taskjobs_link}}&amp;tasks={{entry.name}}"
+      href="{{taskjobs_link}}&amp;tasks={{entry.name|urlencode}}"
       title="{{entry.name}}">{{entry.name}}</a>
     </small>
   </td>
@@ -111,7 +111,7 @@
     <small>
     {% if entry.submit_num > 0 %}
       <a
-      href="{{taskjobs_link}}&amp;cycles={{cycle_str}}&amp;tasks={{entry.name}}"
+      href="{{taskjobs_link}}&amp;cycles={{cycle_str}}&amp;tasks={{entry.name|urlencode}}"
       >{{entry.submit_num}} of {{entry.submit_num_max}}</a>
     {% endif %}
     </small>
@@ -170,12 +170,12 @@
               {% set key_str = key -%}
             {% endif -%}
             <li>
-              {% set path_arg = log.path|replace('+', '%2B') -%}
+              {% set path_arg = log.path|urlencode -%}
               {% if log.path_in_tar -%}
                 {% if path_in_tar is defined and path_in_tar == log.path_in_tar -%}
                   {{key_str}}
                 {% else -%}
-                  {% set path_in_tar_arg = log.path_in_tar|replace('+', '%2B') -%}
+                  {% set path_in_tar_arg = log.path_in_tar|urlencode -%}
                   <a
                   {% if log.size == "?" or not log.size -%}class="text-muted" {% endif -%}
                   href="{{view_link}}&amp;path={{path_arg}}&amp;path_in_tar={{path_in_tar_arg}}"
@@ -202,7 +202,7 @@
               <form action="{{script}}/view" class="form-inline"
                 autocomplete="off">
                 <input type="hidden" name="user" value="{{user}}"/>
-                <input type="hidden" name="suite" value="{{suite|replace("/", "%2F")}}"/>
+                <input type="hidden" name="suite" value="{{suite|urlencode|replace("/", "%2F")}}"/>
                 <input type="hidden" name="no_fuzzy_time"
                 value="{{no_fuzzy_time}}"/>
                 {% if entry.logs[indexes.values()|first].path_in_tar -%}

--- a/lib/cylc/cylc-review/template/pager.html
+++ b/lib/cylc/cylc-review/template/pager.html
@@ -26,7 +26,7 @@
               <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
             {% endif -%}
             {% if suite -%}
-              <input type="hidden" name="suite" value="{{suite|replace("/", "%2F")}}" />
+              <input type="hidden" name="suite" value="{{suite|urlencode|replace("/", "%2F")}}" />
             {% endif -%}
             {% if cycles -%}
               <input type="hidden" name="cycles" value="{{cycles}}" />

--- a/lib/cylc/cylc-review/template/search-form.html
+++ b/lib/cylc/cylc-review/template/search-form.html
@@ -2,7 +2,7 @@
   <form name="file-search" role="search" action="#" onsubmit="return false">
     <input type="hidden" name="search-mode" value="TEXT">
     <input type="hidden" value="{{user}}" name="user">
-    <input type="hidden" value="{{suite|replace("/", "%2F")}}" name="suite">
+    <input type="hidden" value="{{suite|urlencode|replace("/", "%2F")}}" name="suite">
     <input type="hidden" value="{{path}}" name="path">
     <input type="hidden" value="{{path_in_tar}}" name="path_in_tar">
     <input type="hidden" value="{{mode}}" name="mode">

--- a/lib/cylc/cylc-review/template/suite-base.html
+++ b/lib/cylc/cylc-review/template/suite-base.html
@@ -54,7 +54,7 @@ rel="stylesheet" media="screen" />
         </li>
         {% else %}
         <li>
-          <a href="{{script}}/{{method}}/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}">
+          <a href="{{script}}/{{method}}/{{user}}?&amp;suite={{suite|urlencode|replace("/", "%2F")}}">
             <i class="glyphicon {{icon}}" title="{{name}}"></i>
             {{name}}
           </a>
@@ -76,7 +76,7 @@ rel="stylesheet" media="screen" />
               <ul class="dropdown-menu">
         {% for log_path in log.paths -%}
                 <li>
-                  <a href="{{script}}/view/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{log_path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
+                  <a href="{{script}}/view/{{user}}?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{log_path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
                   title="{{log.size}} bytes">{{log_path}}</a>
                 </li>
         {% endfor -%}
@@ -84,7 +84,7 @@ rel="stylesheet" media="screen" />
             </li>
         {% else -%}
             <li>
-              <a href="{{script}}/view/{{user}}?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{log.path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
+              <a href="{{script}}/view/{{user}}?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{log.path}}&amp;no_fuzzy_time={{no_fuzzy_time}}"
               title="{{log.size}} bytes">{{key}}</a></li>
         {% endif -%}
         {% endfor -%}

--- a/lib/cylc/cylc-review/template/suites.html
+++ b/lib/cylc/cylc-review/template/suites.html
@@ -170,13 +170,13 @@ class="table table-bordered table-condensed table-striped">
       <td><small>{{entry.name}}</small></td>
       <td>
         <small>
-          <a href="{{script}}/cycles/{{user}}/?suite={{entry.name|replace('/', '%2F')}}">cycles list</a>
+          <a href="{{script}}/cycles/{{user}}/?suite={{entry.name|urlencode}}">cycles list</a>
         </small>
       </td>
 
       <td>
         <small>
-          <a href="{{script}}/taskjobs/{{user}}/?suite={{entry.name|replace('/', '%2F')}}">task jobs list</a>
+          <a href="{{script}}/taskjobs/{{user}}/?suite={{entry.name|urlencode}}">task jobs list</a>
         </small>
       </td>
 

--- a/lib/cylc/cylc-review/template/suites.html
+++ b/lib/cylc/cylc-review/template/suites.html
@@ -170,13 +170,13 @@ class="table table-bordered table-condensed table-striped">
       <td><small>{{entry.name}}</small></td>
       <td>
         <small>
-          <a href="{{script}}/cycles/{{user}}/?suite={{entry.name|urlencode}}">cycles list</a>
+          <a href="{{script}}/cycles/{{user}}/?suite={{entry.name|urlencode|replace('/', '%2F')}}">cycles list</a>
         </small>
       </td>
 
       <td>
         <small>
-          <a href="{{script}}/taskjobs/{{user}}/?suite={{entry.name|urlencode}}">task jobs list</a>
+          <a href="{{script}}/taskjobs/{{user}}/?suite={{entry.name|urlencode|replace('/', '%2F')}}">task jobs list</a>
         </small>
       </td>
 

--- a/lib/cylc/cylc-review/template/taskjobs.html
+++ b/lib/cylc/cylc-review/template/taskjobs.html
@@ -19,7 +19,7 @@
     <div class="panel-body">
       <form action="{{script}}/{{method}}">
         <input type="hidden" name="user" value="{{user}}" />
-        <input type="hidden" name="suite" value="{{suite|replace("/", "%2F")}}" />
+        <input type="hidden" name="suite" value="{{suite}}" />
         <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
         <fieldset class="container-fluid">
           <div class="row">

--- a/lib/cylc/cylc-review/template/view-mode.html
+++ b/lib/cylc/cylc-review/template/view-mode.html
@@ -1,10 +1,10 @@
 <ul class="nav navbar-nav pull-right">
 {% if mode == "tags" -%}
-<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=text">Text</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=text">Text</a></li>
 <li class="active"><a>Tags</a></li>
 {% else -%}
 <li class="active"><a>Text</a></li>
-<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=tags">Tags</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=tags">Tags</a></li>
 {% endif -%}
-<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=download">Raw</a></li>
+<li><a href="{{script}}/view/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{path}}{%- if path_in_tar -%}&amp;path_in_tar={{path_in_tar}}{%- endif -%}&amp;mode=download">Raw</a></li>
 </ul>

--- a/lib/cylc/cylc-review/template/view.html
+++ b/lib/cylc/cylc-review/template/view.html
@@ -16,7 +16,7 @@
   </div>
   <div>
     <small>
-      <a href="{{script}}/view/{{user}}/?&amp;suite={{suite|replace("/", "%2F")}}&amp;path={{path}}">{{f_name}}</a>
+      <a href="{{script}}/view/{{user}}/?&amp;suite={{suite|urlencode|replace("/", "%2F")}}&amp;path={{path}}">{{f_name}}</a>
       <span class="label label-default">Content loaded
       <abbr class="livestamp" title="{{time}}">{{time}}</abbr></span>
     </small>


### PR DESCRIPTION
Close #3121 

Close #3119 

Use Jinja2's `urlencode` filter instead of replacing characters individually. Tested with Cylc suites "cylc1" and "%63ylc1". Links working as below.

![image](https://user-images.githubusercontent.com/304786/56772125-18b6af80-680d-11e9-88c6-e6d78283c90e.png)

![image](https://user-images.githubusercontent.com/304786/56772155-3552e780-680d-11e9-9a68-32f9ecdbd963.png)

EDIT: added another close #3119 as it appears to fix both issues :+1: 
