### PR TITLE
Fix text in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -229,7 +229,7 @@ warnings emitted by `urllib3` under old Python versions (2.6). *We are
 aware of the security issues, but these warnings serve no purpose on affected
 platforms except to confuse and annoy users.*
 
-[#2676](https://github.com/cylc/cylc-flow/pull/2676) - use `#!/usr/bin/env python3`
+[#2676](https://github.com/cylc/cylc-flow/pull/2676) - use `#!/usr/bin/env python2`
 (i.e. Python-2 specific) in Cylc source files, to avoid issues with default
 Python 3 installations (note Cylc is going to Python 3 next year)
 


### PR DESCRIPTION
Small issue. While backporting #3124 to `7.8.x`, there was a cherry-pick merge conflict that made me open GitHub UI to really look at the files.

Took me a moment to understand why this text would be different in `master` and `7.8.x`, then I realized that this text was probably renamed by accident as we fixed the shebangs during the port Py2 to Py3.

But just for the sake of correctness, a quick PR to adjust the text. One review enough?