### PR TITLE
Added SECURITY.md (master)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,6 @@ project.
   * [Reporting a Bug](#reporting-a-bug)
   * [Disclosure Policy](#disclosure-policy)
   * [Comments on this Policy](#comments-on-this-policy)
-  * [Current Alerts](#current-alerts)
 
 ## Reporting a Bug
 
@@ -14,11 +13,11 @@ The Cylc team take security bugs seriously. Thank you for improving the
 security of Cylc. We appreciate your efforts and responsible disclosure and
 will make every effort to acknowledge your contributions.
 
-Report security bugs by sending an email to the [Cylc
-Forum](mailto:cylc@googlegroups.com) or by posting a [Cylc repository
-Issue](https://github.com/cylc/cylc-flow/issues). Project maintainers will
-endeavor to respond within 48 hours. Progress toward a fix will be recorded on
-the Issue page, and resulting new releases will be announced on the mail forum. 
+Please report security bugs by sending an email to the lead Cylc maintainers,
+[Hilary Oliver](mailto:hilary.oliver@niwa.co.nz) and [Matt
+Shin](matthew.shin@metoffice.gov.uk). If a fix is needed, progress will be
+recorded on Cylc repository Issue page on GitHub, and resulting new releases
+will be announced on the Cylc [mail forum](mailto:cylc@googlegroups.com). 
 
 Report security bugs in third-party modules to the person or team maintaining
 the module.
@@ -37,7 +36,3 @@ handler. This person will coordinate the fix and release process as follows:
 
 If you have suggestions on how this process could be improved please submit a
 pull request.
-
-## Current Alerts
-
-(None)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the Cylc
+project.
+
+  * [Reporting a Bug](#reporting-a-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+  * [Current Alerts](#current-alerts)
+
+## Reporting a Bug
+
+The Cylc team take security bugs seriously. Thank you for improving the
+security of Cylc. We appreciate your efforts and responsible disclosure and
+will make every effort to acknowledge your contributions.
+
+Report security bugs by sending an email to the [Cylc
+Forum](mailto:cylc@googlegroups.com) or by posting a [Cylc repository
+Issue](https://github.com/cylc/cylc-flow/issues). Project maintainers will
+endeavor to respond within 48 hours. Progress toward a fix will be recorded on
+the Issue page, and resulting new releases will be announced on the mail forum. 
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.
+
+## Disclosure Policy
+
+When the team receives a security bug report, they will assign it to a primary
+handler. This person will coordinate the fix and release process as follows:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.
+
+## Current Alerts
+
+(None)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ project.
 
 ## Reporting a Bug
 
-The Cylc team take security bugs seriously. Thank you for improving the
+The Cylc maintainers take security bugs seriously. Thank you for improving the
 security of Cylc. We appreciate your efforts and responsible disclosure and
 will make every effort to acknowledge your contributions.
 
@@ -24,8 +24,9 @@ the module.
 
 ## Disclosure Policy
 
-When the team receives a security bug report, they will assign it to a primary
-handler. This person will coordinate the fix and release process as follows:
+When the Cylc maintainers receive a security bug report, they will assign it to
+a primary handler. This person will coordinate the fix and release process as
+follows:
 
   * Confirm the problem and determine the affected versions.
   * Audit code to find any potential similar problems.


### PR DESCRIPTION
Master companion of #3128 - same, but without the Jinja2 CVE note.