### PR TITLE
setup.cfg: remove py2 compat for wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,6 @@ classifiers =
 python_requires = >=3.7
 setup_requires=pytest-runner==4.4
 
-[bdist_wheel]
-universal = 1
-
 [bdist_rpm]
 requires =
     python3-colorama


### PR DESCRIPTION
`python3 setup.py bdist_wheel` was giving us `dist/cylc-8.0a0-py2-py3-none-any.whl`. It now gives `dist/cylc-8.0a0-py3-none-any.whl`