### PR TITLE
Update how CYLC_DIR is used in Cylc

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -22,7 +22,12 @@ CATEGORIES=('control' 'con' 'information' 'info' 'all' 'task' 'license' \
 HELP_OPTS=('help' '--help' '-h' 'h' '?')
 
 print_version() {
-    python3 -c "from cylc.flow import __version__; print(__version__)"
+    if [[ "$#" -eq 0 ]]; then
+        python3 -c "from cylc.flow import __version__; print(__version__)"
+    fi
+    if [[ "$*" == 'long' || "$*" == '--long' ]]; then
+        python3 -c """import cylc.flow;import os;print(f'{cylc.flow.__version__} ({os.path.dirname(os.path.realpath(cylc.flow.__file__))})')"""
+    fi
 }
 
 init_cylc() {

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -64,8 +64,6 @@ def main():
 
     if options.run_dir:
         print(glbl_cfg().get_host_item('run directory'))
-    elif options.site_dir:
-        print(glbl_cfg().SITE_CONF_DIR)
     else:
         glbl_cfg().idump(
             options.item, sparse=options.sparse, pnative=options.pnative)

--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -18,7 +18,6 @@
 """Set up the cylc environment."""
 
 import os
-import sys
 import logging
 
 
@@ -28,14 +27,8 @@ LOG.addHandler(logging.NullHandler())  # Start with a null handler
 
 def environ_init():
     """Initialise cylc environment."""
-    cylc_dir_lib = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    environ_path_add([cylc_dir_lib], 'PYTHONPATH')
-    # Ensure cylc library is at the front of "sys.path".
-    if sys.path[0:1] != [cylc_dir_lib]:
-        if cylc_dir_lib in sys.path:
-            sys.path.remove(cylc_dir_lib)
-        sys.path.insert(0, cylc_dir_lib)
-    os.environ['CYLC_DIR'] = os.path.dirname(cylc_dir_lib)
+    cylc_dir_lib = os.path.dirname(os.path.realpath(__file__))
+    os.environ['CYLC_DIR'] = cylc_dir_lib
     if os.getenv('CYLC_SUITE_DEF_PATH', ''):
         environ_path_add([os.getenv('CYLC_SUITE_DEF_PATH')])
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -274,9 +274,10 @@ class GlobalConfig(ParsecConfig):
     _DEFAULT = None
     _HOME = os.getenv('HOME') or get_user_home()
     CONF_BASE = "global.rc"
+    # TODO: do we need new values for these variables?
     # Site global.rc loc preference: if not in etc/ look in old conf/.
-    SITE_CONF_DIR = os.path.join(os.environ["CYLC_DIR"], "etc")
-    SITE_CONF_DIR_OLD = os.path.join(os.environ["CYLC_DIR"], "conf")
+    # SITE_CONF_DIR = os.path.join(os.environ["CYLC_DIR"], "etc")
+    # SITE_CONF_DIR_OLD = os.path.join(os.environ["CYLC_DIR"], "conf")
     # User global.rc loc preference: if not in .cylc/x.y.z/ look in .cylc/.
     USER_CONF_DIR_1 = os.path.join(_HOME, '.cylc', CYLC_VERSION)
     USER_CONF_DIR_2 = os.path.join(_HOME, '.cylc')
@@ -310,8 +311,6 @@ class GlobalConfig(ParsecConfig):
         if conf_path_str is None:
             # CYLC_CONF_PATH not defined, use default locations.
             for conf_dir_1, conf_dir_2, conf_type in [
-                    (self.SITE_CONF_DIR, self.SITE_CONF_DIR_OLD,
-                     upgrader.SITE_CONFIG),
                     (self.USER_CONF_DIR_1, self.USER_CONF_DIR_2,
                      upgrader.USER_CONFIG)]:
                 fname1 = os.path.join(conf_dir_1, self.CONF_BASE)

--- a/cylc/flow/job.sh
+++ b/cylc/flow/job.sh
@@ -36,26 +36,15 @@ cylc__job__main() {
         set -x
     fi
     # Prelude
-    typeset file_name=
+    typeset JOB_INIT_ENV=
     # conf/job-init-env.sh for back-compat pre 7.7.0.
-    for file_name in \
-        "${HOME}/.cylc/job-init-env.sh" \
-        "${CYLC_DIR}/etc/job-init-env.sh" \
-        "${CYLC_DIR}/conf/job-init-env.sh"
-    do
-        if [[ -f "${file_name}" ]]; then
-            if "${CYLC_DEBUG:-false}"; then
-                . "${file_name}"
-            else
-                . "${file_name}" 1>'/dev/null' 2>&1
-            fi
-            break
+    JOB_INIT_ENV="${HOME}/.cylc/job-init-env.sh"
+    if [[ -f "${JOB_INIT_ENV}" ]]; then
+        if "${CYLC_DEBUG:-false}"; then
+            . "${JOB_INIT_ENV}"
+        else
+            . "${JOB_INIT_ENV}" 1>'/dev/null' 2>&1
         fi
-    done
-    # Ensure that the "cylc" command is in PATH. It may not be set up correctly
-    # in Prelude above, and also not inherited from the job submit environment.
-    if ! command -v cylc 1>'/dev/null' 2>&1; then
-        PATH="${CYLC_DIR}/bin:${PATH}"
     fi
     # Init-Script
     cylc__job__run_inst_func 'global_init_script'

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -322,6 +322,6 @@ class JobFileWriter(object):
     @staticmethod
     def _write_epilogue(handle, job_conf):
         """Write epilogue."""
-        handle.write('\n\n. "${CYLC_DIR}/cylc/flow/job.sh"\ncylc__job__main')
+        handle.write('\n\n. "${CYLC_DIR}/job.sh"\ncylc__job__main')
         handle.write("\n\n%s%s\n" % (
             BatchSysManager.LINE_PREFIX_EOF, job_conf['job_d']))

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -28,6 +28,8 @@ import jose.exceptions
 import zmq
 import zmq.asyncio
 
+from shutil import which
+
 import cylc.flow.flags
 from cylc.flow import LOG
 from cylc.flow.exceptions import ClientError, ClientTimeout
@@ -256,11 +258,18 @@ class SuiteRuntimeClient(ZMQClient):
             dict: dictionary with the header information, such as
                 program and hostname.
         """
-        CYLC_EXE = os.path.join(os.environ['CYLC_DIR'], 'bin', '')
         cmd = sys.argv[0]
 
-        if cmd.startswith(CYLC_EXE):
-            cmd = cmd.replace(CYLC_EXE, '')
+        cylc_executable_location = which("cylc")
+        if cylc_executable_location:
+            cylc_bin_dir = os.path.abspath(
+                os.path.join(cylc_executable_location, os.pardir)
+            )
+            if not cylc_bin_dir.endswith("/"):
+                cylc_bin_dir = f"{cylc_bin_dir}/"
+
+            if cmd.startswith(cylc_bin_dir):
+                cmd = cmd.replace(cylc_bin_dir, '')
 
         return {
             'meta': {

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -942,7 +942,6 @@ see `COPYING' in the Cylc source distribution.
         mgr = self.suite_srv_files_mgr
         contact_data = {
             mgr.KEY_API: str(self.server.API),
-            mgr.KEY_DIR_ON_SUITE_HOST: os.environ['CYLC_DIR'],
             mgr.KEY_HOST: self.host,
             mgr.KEY_NAME: self.suite,
             mgr.KEY_OWNER: self.owner,

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -44,7 +44,6 @@ class SuiteSrvFilesManager(object):
     FILE_BASE_SUITE_RC = "suite.rc"
     KEY_API = "CYLC_API"
     KEY_COMMS_PROTOCOL_2 = "CYLC_COMMS_PROTOCOL_2"  # indirect comms
-    KEY_DIR_ON_SUITE_HOST = "CYLC_DIR_ON_SUITE_HOST"
     KEY_HOST = "CYLC_SUITE_HOST"
     KEY_NAME = "CYLC_SUITE_NAME"
     KEY_OWNER = "CYLC_SUITE_OWNER"

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -46,7 +46,7 @@ cmp_ok "${DIFF_LOG}" - <<'__END__'
 +/bin/true
  }
  
- . "${CYLC_DIR}/cylc/flow/job.sh"
+ . "${CYLC_DIR}/job.sh"
 __END__
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-diff2"
@@ -64,7 +64,7 @@ cmp_ok "${DIFF_LOG}" - <<'__END__'
 +/bin/true
  }
  
- . "${CYLC_DIR}/cylc/flow/job.sh"
+ . "${CYLC_DIR}/job.sh"
 __END__
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"

--- a/tests/cylc-trigger/08-edit-run-host-select.t
+++ b/tests/cylc-trigger/08-edit-run-host-select.t
@@ -46,7 +46,7 @@ cmp_ok "${DIFF_LOG}" - <<'__END__'
 +/bin/true
  }
  
- . "${CYLC_DIR}/cylc/flow/job.sh"
+ . "${CYLC_DIR}/job.sh"
 __END__
 #-------------------------------------------------------------------------------
 purge_suite "${SUITE_NAME}"

--- a/tests/events/47-long-output.t
+++ b/tests/events/47-long-output.t
@@ -29,7 +29,7 @@ process pool timeout = PT10S" ""
 
 # Long STDOUT output
 
-init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+init_suite "${TEST_NAME_BASE}" <<__SUITERC__
 [cylc]
 [scheduling]
     [[dependencies]]
@@ -62,7 +62,7 @@ purge_suite "${SUITE_NAME}"
 
 # REPEAT: Long STDERR output
 
-init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+init_suite "${TEST_NAME_BASE}" <<__SUITERC__
 [cylc]
 [scheduling]
     [[dependencies]]

--- a/tests/jobscript/00-torture/foo.ref-jobfile
+++ b/tests/jobscript/00-torture/foo.ref-jobfile
@@ -101,7 +101,7 @@ echo VAR_CS is $VAR_CS
 export VAR_PostCS=postcs
 }
 
-. "${CYLC_DIR}/cylc/flow/job.sh"
+. "${CYLC_DIR}/job.sh"
 cylc__job__main
 
 #EOF: 1/foo/01


### PR DESCRIPTION
#3133 (not sure if this is enough to close the issue).

This pull request removes some places where `CYLC_DIR` was used. For the test-battery, we used a temporary fix pre-setup.py, where the TRAVIS home is being set to CYLC_DIR.