### PR TITLE
Add cylc-flow egg info to gitignore after module rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build
 dist
 MANIFEST
 cylc.egg-info
+cylc_flow.egg-info
 .eggs
 
 # virtualenv


### PR DESCRIPTION
We need now to include the egg info file with the new module name to the gitignore. One review should do I think?

Cheers
Bruno