### PR TITLE
Fix cylc-flow rename in README badges, setup.py, and a few more places

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 # Test results get posted back to Github. By default Travis will run tests on any
 # pull requests, adding a comment on the pull request page to say if the tests
 # pass or fail, it will also test any new commits, showing the test results on
-# the branch page, e.g. https://github.com/cylc/cylc/branches.
+# the branch page, e.g. https://github.com/cylc/cylc-flow/branches.
 # 
 # Connecting a Cylc branch
 # ------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,21 +3,22 @@
 ## Report Bugs
 
 Report bugs by opening an issue at [Cylc Issues on 
-Github](https://github.com/cylc/cylc/issues). Give the Cylc version affected
-by the bug (you should test the latest release if possible) and a recipe to
-reproduce the problem.
+Github](https://github.com/cylc/cylc-flow/issues). Give the Cylc version
+affected by the bug (you should test the latest release if possible) and a
+recipe to reproduce the problem.
 
 ## Request Enhancements
 
 Request enhancements by opening an issue at [Cylc Issues @
-Github](https://github.com/cylc/cylc/issues). Describe your use case in detail.
+Github](https://github.com/cylc/cylc-flow/issues). Describe your use case in
+detail.
 
 ## Contribute Code
 
 All contributions to Cylc are made via Pull Requests against the *master*
-branch of [cylc/cylc](https://github.com/cylc/cylc). Non-trivial
+branch of [cylc/cylc-flow](https://github.com/cylc/cylc-flow). Non-trivial
 developments must be discussed and agreed in advance in a [Cylc
-Issue](https://github.com/cylc/cylc/issues) as the team may not be able to
+Issue](https://github.com/cylc/cylc-flow/issues) as the team may not be able to
 consider large changes that appear out of the blue. New contributors should
 add their details to the [Code Contributors](#code-contributors) section of
 this file as part of their first Pull Request, and reviewers are responsible

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Cylc Workflow Engine
 
-[![Build Status](https://travis-ci.org/cylc/cylc.svg?branch=master)](https://travis-ci.org/cylc/cylc)
+[![Build Status](https://travis-ci.org/cylc/cylc-flow.svg?branch=master)](https://travis-ci.org/cylc/cylc-flow)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1d6a97bf05114066ae30b63dcb0cdcf9)](https://www.codacy.com/app/Cylc/cylc?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cylc/cylc&amp;utm_campaign=Badge_Grade)
-[![codecov](https://codecov.io/gh/cylc/cylc/branch/master/graph/badge.svg)](https://codecov.io/gh/cylc/cylc)
+[![codecov](https://codecov.io/gh/cylc/cylc-flow/branch/master/graph/badge.svg)](https://codecov.io/gh/cylc/cylc-flow)
 [![DOI](https://zenodo.org/badge/1836229.svg)](https://zenodo.org/badge/latestdoi/1836229)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00737/status.svg)](https://doi.org/10.21105/joss.00737)
 

--- a/doc/src/appendices/known-issues.rst
+++ b/doc/src/appendices/known-issues.rst
@@ -10,7 +10,7 @@ Current Known Issues
 --------------------
 
 The best place to find current known issues is on
-`GitHub <https://github.com/cylc/cylc/issues>`_.
+`GitHub <https://github.com/cylc/cylc-flow/issues>`_.
 
 
 .. _NotableKnownIssues:

--- a/doc/src/suite-design-guide/roadmap.rst
+++ b/doc/src/suite-design-guide/roadmap.rst
@@ -29,7 +29,7 @@ suite, which breaks the otherwise clean separation into core and site files.
 
 .. note::
 
-   In the future we `plan to <https://github.com/cylc/cylc/issues/1363>`_
+   In the future we `plan to <https://github.com/cylc/cylc-flow/issues/1363>`_
    support add, subtract, unset, and override semantics for all items.
 
 

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1382,7 +1382,7 @@ see `COPYING' in the Cylc source distribution.
             ('stop_clock_time', self.stop_clock_time),
             ('stop_point', (self.stop_point and
                             self.stop_point != self.final_point)),
-            # ^ https://github.com/cylc/cylc/issues/2799#issuecomment-436720805
+            # ^ cylc/cylc-flow/issues/2799#issuecomment-436720805
             ('stop_task', self.stop_task)
         ] if value]
 

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
     extras_require=extra_requires,
     project_urls={
         "Documentation": "https://cylc.github.io/documentation.html",
-        "Source": "https://github.com/cylc/cylc",
-        "Tracker": "https://github.com/cylc/cylc/issues"
+        "Source": "https://github.com/cylc/cylc-flow",
+        "Tracker": "https://github.com/cylc/cylc-flow/issues"
     }
 )

--- a/tests/authentication/11-suite2-stop-suite1.t
+++ b/tests/authentication/11-suite2-stop-suite1.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test calling "cylc shutdown suite1" from suite2.
-# See https://github.com/cylc/cylc/issues/1843
+# See https://github.com/cylc/cylc-flow/issues/1843
 . "$(dirname "$0")/test_header"
 
 set_test_number 1

--- a/tests/broadcast/08-space.t
+++ b/tests/broadcast/08-space.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test broadcast -s '[foo]  bar=baz' syntax. cylc/cylc#1680
+# Test broadcast -s '[foo]  bar=baz' syntax. cylc/cylc-flow#1680
 . "$(dirname "$0")/test_header"
 set_test_number 2
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/cylc-get-site-config/04-homeless.t
+++ b/tests/cylc-get-site-config/04-homeless.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Test on absence HOME (cylc/cylc#2895)
+# Test on absence HOME (cylc/cylc-flow#2895)
 
 . "$(dirname "$0")/test_header"
 set_test_number 3

--- a/tests/cylc-trigger/06-reset-ready.t
+++ b/tests/cylc-trigger/06-reset-ready.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "cylc trigger" a task should reset its output to incomplete.
-# https://github.com/cylc/cylc/issues/1852
+# https://github.com/cylc/cylc-flow/issues/1852
 . "$(dirname "$0")/test_header"
 
 set_test_number 2

--- a/tests/events/45-task-event-handler-multi-warning.t
+++ b/tests/events/45-task-event-handler-multi-warning.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Test that simultaneous warnings from a task job are all handled by the
 # warning event handler.
-# https://github.com/cylc/cylc/issues/2806
+# https://github.com/cylc/cylc-flow/issues/2806
 
 . "$(dirname "$0")/test_header"
 

--- a/tests/hold-release/20-reset-waiting-output.t
+++ b/tests/hold-release/20-reset-waiting-output.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test reset succeeded task to waiting will reset its outputs.
-# https://github.com/cylc/cylc/issues/2115
+# https://github.com/cylc/cylc-flow/issues/2115
 . "$(dirname "$0")/test_header"
 set_test_number 2
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/intercycle/02-integer-abs.t
+++ b/tests/intercycle/02-integer-abs.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dependency on absolute integer point
-# https://github.com/cylc/cylc/issues/1394
+# https://github.com/cylc/cylc-flow/issues/1394
 . "$(dirname "$0")/test_header"
 
 set_test_number 2

--- a/tests/intercycle/03-datetime-abs.t
+++ b/tests/intercycle/03-datetime-abs.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dependency on absolute datetime point
-# https://github.com/cylc/cylc/issues/1951
+# https://github.com/cylc/cylc-flow/issues/1951
 . "$(dirname "$0")/test_header"
 
 set_test_number 2

--- a/tests/intercycle/04-datetime-abs-2.t
+++ b/tests/intercycle/04-datetime-abs-2.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dependency on absolute datetime point
-# https://github.com/cylc/cylc/issues/1951
+# https://github.com/cylc/cylc-flow/issues/1951
 . "$(dirname "$0")/test_header"
 
 set_test_number 2

--- a/tests/intercycle/05-datetime-abs-3.t
+++ b/tests/intercycle/05-datetime-abs-3.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test dependency on absolute datetime point
-# https://github.com/cylc/cylc/issues/1951
+# https://github.com/cylc/cylc-flow/issues/1951
 . "$(dirname "$0")/test_header"
 
 set_test_number 2

--- a/tests/job-file-trap/00-sigusr1.t
+++ b/tests/job-file-trap/00-sigusr1.t
@@ -89,7 +89,7 @@ run_tests() {
 
 # Programs running in some environment is unable to trap SIGUSR1. E.g.:
 # An environment documented in this comment:
-# https://github.com/cylc/cylc/pull/1648#issuecomment-149348410
+# https://github.com/cylc/cylc-flow/pull/1648#issuecomment-149348410
 trap 'run_tests' 'SIGUSR1'
 kill -s 'SIGUSR1' "$$"
 sleep 1

--- a/tests/job-file-trap/02-pipefail.t
+++ b/tests/job-file-trap/02-pipefail.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test pipefail cylc/cylc#1783
+# Test pipefail cylc/cylc-flow#1783
 . "$(dirname "$0")/test_header"
 
 set_test_number 4

--- a/tests/reload/14-waiting.t
+++ b/tests/reload/14-waiting.t
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test reload a waiting task does not cause DB integrity error. cylc/cylc#1221
+# Test reload a waiting task does not cause DB integrity error.
+# cylc/cylc-flow#1221
 . $(dirname $0)/test_header
 set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/reload/15-state-summary.t
+++ b/tests/reload/15-state-summary.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that the state summary updates immediately when a reload finishes.
-# See https://github.com/cylc/cylc/pull/1756
+# See https://github.com/cylc/cylc-flow/pull/1756
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/reload/21-submit-fail.t
+++ b/tests/reload/21-submit-fail.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test task submit failed + reload
-# https://github.com/cylc/cylc/issues/2964
+# https://github.com/cylc/cylc-flow/issues/2964
 . "$(dirname "$0")/test_header"
 
 set_test_number 4

--- a/tests/restart/13-bad-job-host.t
+++ b/tests/restart/13-bad-job-host.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test restarting a suite when the host of a submitted or running job is not
-# available. https://github.com/cylc/cylc/issues/1327
+# available. https://github.com/cylc/cylc-flow/issues/1327
 CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 set_test_remote_host

--- a/tests/restart/32-reload-runahead-no-stop-point.t
+++ b/tests/restart/32-reload-runahead-no-stop-point.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc/cylc#2722
+# Test cylc/cylc-flow#2722
 . "$(dirname "$0")/test_header"
 
 set_test_number 3

--- a/tests/restart/33-simulation.t
+++ b/tests/restart/33-simulation.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc/cylc#2788
+# Test cylc/cylc-flow#2788
 . "$(dirname "$0")/test_header"
 
 set_test_number 3

--- a/tests/restart/42-auto-restart-ping-pong.t
+++ b/tests/restart/42-auto-restart-ping-pong.t
@@ -41,7 +41,7 @@ TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME_BASE}" <<< '
     abort if any task fails = True
 [scheduling]
     initial cycle point = 2000
-    final cycle point = 9999  # test https://github.com/cylc/cylc/issues/2799
+    final cycle point = 9999  # test cylc/cylc-flow/issues/2799
     [[dependencies]]
         [[[P1Y]]]
             graph = foo[-P1Y] => foo

--- a/tests/special/08-clock-triggered-0.t
+++ b/tests/special/08-clock-triggered-0.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test clock triggering is working, with no offset argument
-# https://github.com/cylc/cylc/issues/1417
+# https://github.com/cylc/cylc-flow/issues/1417
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 4

--- a/tests/startup/00-state-summary.t
+++ b/tests/startup/00-state-summary.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that the state summary updates immediately on start-up.
-# See https://github.com/cylc/cylc/pull/1756
+# See https://github.com/cylc/cylc-flow/pull/1756
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/triggering/19-and-suicide.t
+++ b/tests/triggering/19-and-suicide.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test "and" outputs from 2 tasks triggering suicide.
-# https://github.com/cylc/cylc/issues/2655
+# https://github.com/cylc/cylc-flow/issues/2655
 . "$(dirname "$0")/test_header"
 set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/triggering/19-and-suicide/suite.rc
+++ b/tests/triggering/19-and-suicide/suite.rc
@@ -12,7 +12,7 @@
         """
 [runtime]
     [[t0]]
-        # https://github.com/cylc/cylc/issues/2655
+        # https://github.com/cylc/cylc-flow/issues/2655
         # "t2.1" should not suicide on "t1.1:failed"
         script = sleep 10
     [[t1]]

--- a/tests/validate/50-hyphen-fam.t
+++ b/tests/validate/50-hyphen-fam.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation of task name with a XXX-FAM pattern.
-# See issue cylc/cylc#1778 where validation of the following valid suite failed.
+# See issue cylc/cylc-flow#1778 where validation of the following valid suite failed.
 . "$(dirname "$0")/test_header"
 set_test_number 2
 

--- a/tests/validate/51-zero-interval.t
+++ b/tests/validate/51-zero-interval.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test validation error message on zero-width date-time interval.
-# See issue cylc/cylc#1800.
+# See issue cylc/cylc-flow#1800.
 . "$(dirname "$0")/test_header"
 set_test_number 2
 

--- a/tests/validate/55-hyphen-finish.t
+++ b/tests/validate/55-hyphen-finish.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Test hyphen in task name + ":finish". See cylc/cylc#1949.
+# Test hyphen in task name + ":finish". See cylc/cylc-flow#1949.
 
 . "$(dirname "$0")/test_header"
 


### PR DESCRIPTION
While working on #3132 I was waiting for Codecov to update the coverage, then noticed that the travis badge was set to unknown, and I was expecting Codecov to appear as 89%, but clicking  on the badge it took me to the wrong place there.

Turns out we forgot to update the badge links. Also fixed the links in `setup.py`. This is the first commit in this change.

Then searched for `cylc/cylc-[^-flow]` on PyCharm and replaced by `cylc/cylc-flow`. Happy to revert this second commit if considered unnecessary :+1: 