### PR TITLE
7.8.x cylc review fix pager

### DIFF
--- a/lib/cylc/cylc-review/template/pager.html
+++ b/lib/cylc/cylc-review/template/pager.html
@@ -26,7 +26,7 @@
               <input type="hidden" name="no_fuzzy_time" value="{{no_fuzzy_time}}" />
             {% endif -%}
             {% if suite -%}
-              <input type="hidden" name="suite" value="{{suite|urlencode|replace("/", "%2F")}}" />
+              <input type="hidden" name="suite" value="{{suite}}" />
             {% endif -%}
             {% if cycles -%}
               <input type="hidden" name="cycles" value="{{cycles}}" />


### PR DESCRIPTION
Close #3145

Looks like I added one urlencode too many.

This one was causing URL's to be encoded twice. So I assume JQuery when posting the form was automatically encoding it again.

Tested manually after applying the change. Steps to reproduce:

- create and register suite `%63ylc`
- with the content:

```
[scheduling]
    [[dependencies]]
        graph = """
    mytask_T+030 =>
    my_task =>
    my_task-ski-bop =>
    my_task-DOO_WAP =>
    my_task+100 =>
    my_task@my_suite =>
    t@a@s@k@y@m@c@g@e@e =>
    4_my_task =>
    _OLDTASKYLAD =>
    3000  =>
    __ =>
    le_cyl%63
    C++ =>
    20130808T00 =>
    __init__ =>
    now =>
    cylc =>
    help
    #a_very_long_task_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah
    #[runtime [[bad]] ]] ]]
        """

[runtime]
    [[my_task]]
    [[my_task-ski-bop]]
    [[my_task-DOO_WAP]]
    [[my_task+100]]
    [[my_task@my_suite]]
    [[t@a@s@k@y@m@c@g@e@e]]
    [[4_my_task]]
    [[_OLDTASKYLAD]]
    [[3000]]
    [[__]]
    [[C++]]
    [[20130808T00]]
    [[__init__]]
    [[now]]
    [[cylc]]
    [[help]]
[[a_very_long_task_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah]]
    #[ [[runtime [[bad]] ]] ]]
```

- Run the suite, and then browse its 1 cycle in Cylc Review
- Wait until the list of tasks has been populated, then the pagination should have the _next_ link
- Click on it and if on `7.8.x` it should be broken. Then switch to this branch, and hopefully issue is gone :crossed_fingers: 