### PR TITLE
Fix some doc heading levels

### DIFF
--- a/doc/src/custom/make-commands.sh
+++ b/doc/src/custom/make-commands.sh
@@ -46,10 +46,10 @@ END
 for CAT in $($CYLC categories); do
 	$(cat >> "$COMMAND_REF_FILE" <<END
 
+.. _command-cat-${CAT}:
+
 ${CAT}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _command-cat-${CAT}:
 
 .. code-block:: none
 
@@ -71,10 +71,10 @@ END
 for COM in $($CYLC commands); do
 	$(cat >> "$COMMAND_REF_FILE" <<END
 
+.. _command-${COM}:
+
 ${COM}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. _command-${COM}:
 
 .. code-block:: none
 

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -267,7 +267,7 @@ debug problems.
 .. _RTAST:
 
 Automated Tests
-^^^^^^^^^^^^^^^
+---------------
 
 The cylc test battery is primarily intended for developers to check that
 changes to the source code don't break existing functionality.

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -2581,7 +2581,7 @@ task families in the *namespaces* example suite.
 .. _Parameterized Tasks Label:
 
 Parameterized Tasks
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Cylc can automatically generate tasks and dependencies by expanding
 parameterized task names over lists of parameter values. Uses for this
@@ -3717,7 +3717,7 @@ For better clarity and disambiguation Python modules can be prefixed with
 .. _EmPylabel:
 
 EmPy
-^^^^
+----
 
 In addition to Jinja2, Cylc supports EmPy template processor in suite
 configurations. Similarly to Jinja2, EmPy provides variables, mathematical
@@ -3772,7 +3772,7 @@ reasons:
 
 
 Omitting Tasks At Runtime
-^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
 It is sometimes convenient to omit certain tasks from the suite at
 runtime without actually deleting their definitions from the suite.


### PR DESCRIPTION
(I can see how this happened, with the crazy way sphinx determines heading level ... you can't determine the level locally, have to compare the heading "adornment" with that of other headings!)

@sadielbartholomew - are you able to do a quick sanity check?  (Otherwise I might merge this unilaterally as a hot fix in order to put the release out ... it doesn't affect the code, and is fairly obviously correct - I compared heading levels in the table of contents with those in the old LaTeX-generated PDF at 7.8.0).

Also switches order of labels and headings in the auto-generated command reference, which was generating an error message (at least for my version of Sphinx).

I'll do the same for master once I've made the 7.8.x release...