### PR TITLE
async_map: fix bug

### DIFF
--- a/lib/cylc/network/scan.py
+++ b/lib/cylc/network/scan.py
@@ -82,6 +82,8 @@ def async_map(coroutine, iterator):
                 yield completed_tasks.pop(index)
                 changed = True
                 index += 1
+            else:
+                break
 
 
 def async_unordered_map(coroutine, iterator):


### PR DESCRIPTION
Fix a really embarrassing bug in the `async_map` function (which is used for the `--ordered` option to `cylc scan`) :cry: .