### PR TITLE
7.8.x: restore compat for Python 2.6

### DIFF
--- a/lib/isodatetime/data.py
+++ b/lib/isodatetime/data.py
@@ -1438,7 +1438,8 @@ class TimePoint(object):
 
         """
         if check_changes:
-            before = {key: getattr(self, key) for key in self.DATA_ATTRIBUTES}
+            before = dict(
+                (key, getattr(self, key)) for key in self.DATA_ATTRIBUTES)
         if (self.hour_of_day is not None and
                 self.minute_of_hour is not None):
             hours_remainder = self.hour_of_day - int(self.hour_of_day)
@@ -1504,11 +1505,10 @@ class TimePoint(object):
                 self.month_of_year -= CALENDAR.MONTHS_IN_YEAR
                 self.year += 1
         if check_changes:
-            return {
-                key: (value, getattr(self, key))
-                for key, value in before.items()
-                if getattr(self, key) != value
-            }
+            return dict(
+                (key, (value, getattr(self, key)))
+                for key, value in before.items() if getattr(self, key) != value
+            )
 
     def _tick_over_day_of_month(self):
         if self.day_of_month < 1:


### PR DESCRIPTION
This syntax does not work in Python 2.6:

```python
mydict = {key: value for item in items}
```

So we need to change the syntax to:

```python
mydict = dict((key, value) for item in items)
```

Unfortunately, we still have to support various platforms that will stay on Python 2.6 for some time.