### PR TITLE
message: fix pclient undefined error

### DIFF
--- a/bin/cylc-message
+++ b/bin/cylc-message
@@ -135,7 +135,7 @@ def main():
             messages.append([options.severity, message_str.strip()])
         else:
             messages.append([getLevelName(INFO), message_str.strip()])
-    return record_messages(suite, task_job, messages)
+    record_messages(suite, task_job, messages)
 
 
 if __name__ == '__main__':

--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -81,10 +81,12 @@ def record_messages(suite, task_job, messages):
         if cylc.flow.flags.debug:
             import traceback
             traceback.print_exc()
-    pclient(
-        'put_messages',
-        {'task_job': task_job, 'event_time': event_time, 'messages': messages}
-    )
+    else:
+        pclient(
+            'put_messages',
+            {'task_job': task_job, 'event_time': event_time,
+             'messages': messages}
+        )
 
 
 def _append_job_status_file(suite, task_job, event_time, messages):


### PR DESCRIPTION
At present `cylc message` can return nasty traceback about an undefined python variable.

This PR fixes this going back to the old, fail silently unless in debug mode approach. Whether this is the correct approach or not ...