### PR TITLE
jobscript: add lib/python to PYTHONPATH

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -118,8 +118,11 @@ cylc__job__main() {
     # Send task started message
     cylc message -- "${CYLC_SUITE_NAME}" "${CYLC_TASK_JOB}" 'started' &
     CYLC_TASK_MESSAGE_STARTED_PID=$!
-    # Access to the suite bin directory (installed run-dir first).
+    # System paths:
+    # * suite directory (installed run-dir first).
     export PATH="${CYLC_SUITE_RUN_DIR}/bin:${CYLC_SUITE_DEF_PATH}/bin:${PATH}"
+    export
+    PYTHONPATH="${CYLC_SUITE_RUN_DIR}/lib/python:${CYLC_SUITE_DEF_PATH}/lib/python:${PYTHONPATH:-}"
     # Create share and work directories
     mkdir -p "${CYLC_SUITE_SHARE_DIR}" || true
     mkdir -p "$(dirname "${CYLC_TASK_WORK_DIR}")" || true

--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -38,9 +38,11 @@ A cylc *suite configuration directory* contains:
 
 - **A** ``lib/python/`` **sub-directory** (optional)
 
-  - For custom job submission modules
+  - Python libraries for use by suite tasks.
+  - Automatically added to `$PYTHONPATH`` in task execution environments.
+  - Custom job submission modules
     (see :ref:`CustomJobSubmissionMethods`)
-    and local Python modules imported by custom Jinja2 filters,
+  - Python libraries for use by Jinja2 in custom filters,
     tests and globals (see :ref:`CustomJinja2Filters`).
 
 - **Any other sub-directories and files** - documentation,

--- a/tests/rnd/02-lib-python-in-job.t
+++ b/tests/rnd/02-lib-python-in-job.t
@@ -1,0 +1,31 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test ${CYLC_SUITE_DIR} in task PYTHONPATH.
+. $(dirname $0)/test_header
+set_test_number 2
+#-------------------------------------------------------------------------------
+CHOSEN_SUITE="$(basename "$0" | sed 's/\..*//')"
+install_suite "$TEST_NAME_BASE" "$CHOSEN_SUITE"
+#-------------------------------------------------------------------------------
+TEST_NAME="$TEST_NAME_BASE-validate"
+run_ok "$TEST_NAME" cylc validate "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+TEST_NAME="$TEST_NAME_BASE-run"
+suite_run_ok "$TEST_NAME" cylc run --no-detach "$SUITE_NAME"
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/rnd/02-lib-python-in-job/lib/python/pub/beer.py
+++ b/tests/rnd/02-lib-python-in-job/lib/python/pub/beer.py
@@ -1,0 +1,6 @@
+BOTTLES = [99]
+
+
+def drink():
+    BOTTLES[0] -= 1
+    return f'{BOTTLES[0]} bottles of beer on the wall.'

--- a/tests/rnd/02-lib-python-in-job/suite.rc
+++ b/tests/rnd/02-lib-python-in-job/suite.rc
@@ -1,0 +1,21 @@
+[cylc]
+    abort if any task fails = True
+
+[scheduling]
+    [[dependencies]]
+        graph = foo
+
+[runtime]
+    [[foo]]
+        script = """
+            # check PYTHONPATH is set correctly
+            grep -q "${CYLC_SUITE_RUN_DIR}/lib/python" <<< "${PYTHONPATH}"
+
+            # run a toy example
+            python -c '
+            from pub import beer
+            assert beer.drink() == "98 bottles of beer on the wall."
+            assert beer.drink() == "97 bottles of beer on the wall."
+            assert beer.drink() == "96 bottles of beer on the wall."
+            '
+        """


### PR DESCRIPTION
#### PR Template

This is a small change with no associated Issue.

Requirements check-list:
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] My commits have logically grouped changes (use interactive rebase
      to tidy your branch history if necessary).
- [x] I have not included off-topic changes (use other PRs for these).
- [x] I have included tests with adequate coverage.
- [x] I have added an entry in `CHANGES.md` for next release.

#### The Change

Small change to add `<suitedir>/lib/python` into PYTHONPATH in the task execution environment.

The motive here is to make it easier for users to link the task scripts in the suite bin directory to suite-specific Python libraries. Currently the user is responsible for doing the PYTHONPATH melding.

#### Potential Caveats

1. Users could do something stupid like create the file `<suitedir>/lib/python/os.py`
2. We are now mixing lots of different libraries into the same `lib/python` dir.
3. The `CYLC_SUITE_RUN_DIR` / `CYLC_SUITE_DEF_PATH` arrangement is horrible, this will get resolved with this with the migration of `rose suite-run` functionality?