### PR TITLE
Fix security email link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ will make every effort to acknowledge your contributions.
 
 Please report security bugs by sending an email to the lead Cylc maintainers,
 [Hilary Oliver](mailto:hilary.oliver@niwa.co.nz) and [Matt
-Shin](matthew.shin@metoffice.gov.uk). If a fix is needed, progress will be
+Shin](mailto:matthew.shin@metoffice.gov.uk). If a fix is needed, progress will be
 recorded on Cylc repository Issue page on GitHub, and resulting new releases
 will be announced on the Cylc [mail forum](mailto:cylc@googlegroups.com). 
 


### PR DESCRIPTION
The link to one of the e-mails was missing the `mailto`. Found via IDE analysis, then confirmed that in the GitHub UI it points to a 404 location.

This is a small change with no associated Issue.

Requirements check-list:
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] My commits have logically grouped changes (use interactive rebase
      to tidy your branch history if necessary).
- [x] I have not included off-topic changes (use other PRs for these).
- [ ] I have included tests with adequate coverage.
- [ ] I have added an entry in `CHANGES.md` for next release.
