### PR TITLE
Remove unnecessary duplicate variable declaration

### DIFF
--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -737,7 +737,6 @@ def ingest_time(value, my_now=None):
                     timepoints[i_time] -
                     duration_parser.parse(go_back[next_unit]))
 
-        my_diff = []
         my_diff = [abs(my_time - my_now) for my_time in timepoints]
 
         my_cp = timepoints[my_diff.index(min(my_diff))]


### PR DESCRIPTION
One variable being declared twice. First to an empty array, just to be initialized right after that. Probably one review is enough?

This is a small change with no associated Issue.

Requirements check-list:
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] My commits have logically grouped changes (use interactive rebase
      to tidy your branch history if necessary).
- [x] I have not included off-topic changes (use other PRs for these).
- [ ] I have included tests with adequate coverage.
- [ ] I have added an entry in `CHANGES.md` for next release.
