### PR TITLE
WIP: fix re-packaged docs build ModuleNotFoundError

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -16,13 +16,14 @@
 
 import sys
 import os
-from cylc.flow import __version__ as CYLC_VERSION
 
 
 # -- General configuration ------------------------------------------------
 
+# Note: Cylc version & release info passed through via the setup.py.
+
 # minimal Sphinx version required.
-needs_sphinx = '1.5.3'
+needs_sphinx = '2.0.0'
 
 # Sphinx extension module names.
 sys.path.append(os.path.abspath('custom'))  # path to custom extensions.
@@ -46,10 +47,6 @@ master_doc = 'index'
 # General information about the project.
 project = 'The Cylc Suite Engine'
 copyright = '2008-2019 NIWA & British Crown (Met Office) & Contributors'
-
-# Versioning information. Sphinx advises version strictly meaning X.Y.
-version = '.'.join(CYLC_VERSION.split('.')[:2])  # The short X.Y version.
-release = CYLC_VERSION  # The full version, including alpha/beta/rc tags.
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/src/running-suites.rst
+++ b/doc/src/running-suites.rst
@@ -207,8 +207,7 @@ updated automatically according to the poll results.
 
 Existing instances of tasks removed from the suite configuration before restart
 are not removed from the task pool automatically, but they will not spawn new
-instances. They can be removed manually if necessary,
-with~``cylc remove``.
+instances. They can be removed manually if necessary, with ``cylc remove``.
 
 Similarly, instances of new tasks added to the suite configuration before
 restart are not inserted into the task pool automatically, because it is

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,7 +64,7 @@ if SPHINX_AVAILABLE:
         commands help information, in the appendices.
 
         Then, instead of calling one builder, this class will call the
-        builder fot he single HTML, and also the builder for the multiple
+        builder for the single HTML, and also the builder for the multiple
         HTML documentation.
 
         Finally, one more tweak in this class is to move the doctrees
@@ -127,8 +127,10 @@ extra_requires['all'] += extra_requires['empy']
 extra_requires['all'] += extra_requires['docs']
 extra_requires['all'] += tests_require
 
+cylc_version = find_version("cylc", "flow", "__init__.py")
+
 setup(
-    version=find_version("cylc", "flow", "__init__.py"),
+    version=cylc_version,
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     scripts=glob(join('bin', '*')),
@@ -147,5 +149,11 @@ setup(
         "Documentation": "https://cylc.github.io/documentation.html",
         "Source": "https://github.com/cylc/cylc-flow",
         "Tracker": "https://github.com/cylc/cylc-flow/issues"
-    }
+    },
+    # Passed to Sphinx conf.py, avoiding the need to access cylc.flow there:
+    command_options={
+        'build_sphinx': {
+            'project': ('setup.py', 'cylc-flow'),
+            'version': ('setup.py', '.'.join(cylc_version.split('.')[:2])),
+            'release': ('setup.py', cylc_version)}},
 )


### PR DESCRIPTION
You know how it goes; I went to fix a very small, trivial aspect (a typo causing a minor format error in the docs - see ``0a77301 ``), & ended up down a rabbit hole (regarding the ``setuptools`` & Sphinx config - see ``7315fd4``)...

****************

### Main corresponding issue :eight_pointed_black_star: 

The ``python setup.py build_sphinx`` command seems to have been set-up incorrectly (via the ``setup.py`` etc.) in that it fails on the a dependency on ``cylc.flow`` itself, which is required in at least (more may appear as I fix these the logic encounters initially) the aspects itemised below. *Note:* I have definitely activated my standard ``cylc``(``-flow``) inclusive environment (using ``conda``, if that is relevant) so that the ``cylc-flow`` system & commands work as they should in general, & the docs build seems to be treated in a self-contained way via the ``setuptools``, so I am fairly confident this isn't just due to me doing something silly!

- [x] To set ``CYLC_VERSION`` for the docs via the ``conf.py``;

  ```
  Running Sphinx v2.0.1
  
  Configuration error:
  There is a programmable error in your configuration file:
  
  Traceback (most recent call last):
    File "/home/h06/sbarth/miniconda3/envs/py3env/lib/python3.7/site-packages/sphinx/config.py", line 361, in eval_config_file
      execfile_(filename, namespace)
    File "/home/h06/sbarth/miniconda3/envs/py3env/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 86, in execfile_
      exec(code, _globals)
    File "/net/home/h06/sbarth/cylc.git/doc/src/conf.py", line 19, in <module>
      from cylc.flow import __version__ as CYLC_VERSION
  ModuleNotFoundError: No module named 'cylc.flow'
  ```

- [ ] For the ``cylc help`` command, used to auto-generate the Command Reference section (14.4.):

  ```
  ./doc/src/custom/make-commands.sh
  Traceback (most recent call last):
    File "/net/home/h06/sbarth/cylc.git/bin/cylc-help", line 20, in <module>
      from cylc.flow import __version__ as CYLC_VERSION
  ModuleNotFoundError: No module named 'cylc.flow'
  ```

- [ ] For ``autodoc``, as seen for warnings in the Sphinx build itself:

  ```
  WARNING: autodoc: failed to import class 'flow.network.server.SuiteRuntimeServer' from module 'cylc'; the following exception was raised:
  No module named 'cylc.flow'
  ```

#### In this PR:

* **Begin/attempt to (INPUT REQUIRED, hence a WIP)** fix the docs build issue (:eight_pointed_black_star: ), I have solved the first item as above RE the Sphinx  ``conf.py``. but I am not sure how to approach the others. Any ideas how to handle the dependency on those? Possibly they can all be solved at once in a better way, in which case I can revert my implementation to solve bullet number 1?
* Make some subsidiary minor amendments:
  * Fix one formatting error in the docs, as shown in this screenshot:
![format-err-scr](https://user-images.githubusercontent.com/30274190/58189398-54c91d00-7cb2-11e9-818f-a2d1ab388b8a.png)
  * update some outdated copyright notices;
  * make the Sphinx ``conf.py`` version requirement consistent with [that outlined](https://github.com/sadielbartholomew/cylc-flow/blob/7315fd4cdd24af64bbc7b1fb0387d6d249596a30/setup.py#L123) in the ``setup.py``;
  * fixed a typo in a docstring.

### Current PR state

``python setup.py build_sphinx`` now runs & builds, but not cleanly, & notably due to item 2 in :eight_pointed_black_star: the Command Reference page does not get populated as is content is generated from the ``cylc help`` command which fails from a ``ModuleNotFoundError: No module named 'cylc.flow'``:
![docs-packaging-issue](https://user-images.githubusercontent.com/30274190/58191784-36195500-7cb7-11e9-9d70-576010d77501.png)

**********

This is a small change with no associated Issue.

Requirements check-list:
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] My commits have logically grouped changes (use interactive rebase
      to tidy your branch history if necessary).
- [*I have, but to avoid lots of tiny trivial PRs*] I have not included off-topic changes (use other PRs for these).
- [n/a] I have included tests with adequate coverage.
- [ ] I have added an entry in `CHANGES.md` for next release.