### PR TITLE
cylc.gcapture: don't split command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,8 +29,10 @@ Selected user-facing changes:
 
 ### Fixes
 
-[#3183] (https://github.com/cylc/cylc-flow/pull/3183) - Fix for suites failing
-to start when initiated by the GUI
+[#3186] (https://github.com/cylc/cylc-flow/pull/3186),
+[#3183] (https://github.com/cylc/cylc-flow/pull/3183) - Fix invocations of
+various commands from GUI, e.g. `cylc run` and `cylc trigger-edit`, which were
+broken at 7.8.2.
 
 [#3147] (https://github.com/cylc/cylc-flow/pull/3147) - Fix restart
 correctness when the suite has a hold point, stop point, a stop task, a stop

--- a/lib/cylc/gui/gcapture.py
+++ b/lib/cylc/gui/gcapture.py
@@ -132,7 +132,7 @@ class Gcapture(object):
     def run(self):
         proc = procopen(self.command, stdin=open(os.devnull),
                         stdout=self.stdoutfile, stderrout=True,
-                        usesh=True, splitcmd=True)
+                        usesh=True)
         # calls to open a shell are aggregated in cylc_subproc.procopen()
         self.proc = proc
         gobject.timeout_add(40, self.pulse_proc_progress)


### PR DESCRIPTION
Address issue similar to the #3183 PR, but on commands such as `cylc trigger --edit` via the GUI.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] ***GTK logic currently has no automated test.***
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.

Reported by @steoxley.