### PR TITLE
Fix PR markdown links of 7.8.3 changelog entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,15 +29,15 @@ Selected user-facing changes:
 
 ### Fixes
 
-[#3159] (https://github.com/cylc/cylc-flow/pull/3159) - restore compatibility
+[#3159](https://github.com/cylc/cylc-flow/pull/3159) - restore compatibility
 with Python 2.6 (for those stuck on older systems).
 
-[#3186] (https://github.com/cylc/cylc-flow/pull/3186),
-[#3183] (https://github.com/cylc/cylc-flow/pull/3183) - Fix subprocess
+[#3186](https://github.com/cylc/cylc-flow/pull/3186),
+[#3183](https://github.com/cylc/cylc-flow/pull/3183) - Fix subprocess
 invocation of commands from GUI, e.g. `cylc run` and `cylc trigger-edit`, which
 were broken at 7.8.2.
 
-[#3147] (https://github.com/cylc/cylc-flow/pull/3147) - Fix restart
+[#3147](https://github.com/cylc/cylc-flow/pull/3147) - Fix restart
 correctness when the suite has a hold point, stop point, a stop task, a stop
 clock time and/or an auto stop option. These settings are now stored in the
 suite run SQLite file and are retrieved on suite restart. In addition, the


### PR DESCRIPTION
There is an extra space for all links (probably from some script adding the link format framework at once) to PRs in the new changelog entry, so they are not recognised as markdown links when rendered.

Trivial, hence one reviewer sufficient.

********

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
/
- [ ] Appropriate tests are included (unit and/or functional).
- [x] These changes are already covered by existing tests.
/
- [ ] Includes an appropriate entry in the release change log `CHANGES.md`.
- [x] No change log entry required (e.g. change is small or internal only).
