### PR TITLE
run/restart: re-add cut off user notice line

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -19,6 +19,7 @@
 
 from collections import deque
 from errno import ENOENT
+from itertools import zip_longest
 import logging
 import os
 from shlex import quote
@@ -328,15 +329,15 @@ This program comes with ABSOLUTELY NO WARRANTY.
 It is free software, you are welcome to
 redistribute it under certain conditions;
 see `COPYING' in the Cylc source distribution.
-
   """ % CYLC_VERSION
 
         logo_lines = logo.splitlines()
         license_lines = cylc_license.splitlines()
         lmax = max(len(line) for line in license_lines)
         print(('\n'.join((
-            ('{0} {1: ^%s}' % lmax).format(*x)
-            for x in zip(logo_lines, license_lines)))))
+            ('{0} {1: ^%s}' % lmax).format(*x) for x in zip_longest(
+                logo_lines, license_lines, fillvalue=' ' * (
+                    len(logo_lines[-1]) + 1))))))
 
     def _setup_suite_logger(self):
         """Set up logger for suite."""


### PR DESCRIPTION
The copyright notice printed to STDOUT for ``cylc run`` & ``cylc restart`` recently had its ending cut off.

Upon investigation, this started at v. ``7.8.0`` & was due to the addition of a new line ("& British Crown...") to the notice & the [behaviour of ``zip()`` function](https://docs.python.org/3.3/library/functions.html#zip) which aggregates elements from *uneven-length* inputs up to the length of the *shortest* input. (The copyright text had one more line then the logo, so the final line was lost in the ``zip()``.) See the 'Outputs' section below for a breakdown by illustrative version.

I could have just padded out the logo line, but it seemed more maintainable to convert the ``zip()`` to an equivalent function ``itertools.zip_longest()`` which will pad out the shorter input as necessary & combine to produce an output with length of the longest input.

### Outputs 

#### 7.7.2 (no such issue)
```console
$ cylc run <...>
            ._.                                                       
            | |                 The Cylc Suite Engine [7.7.2]         
._____._. ._| |_____.           Copyright (C) 2008-2018 NIWA          
| .___| | | | | .___|  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
| !___| !_! | | !___.  This program comes with ABSOLUTELY NO WARRANTY;
!_____!___. |_!_____!  see `cylc warranty`.  It is free software, you 
      .___! |           are welcome to redistribute it under certain  
      !_____!                conditions; see `cylc conditions`.       

*** listening on vld456.cmpd1.metoffice.gov.uk:43082 ***

To view suite server program contact information:
```

#### 7.8.x (issue emerges from new fourth line)
```console
$ cylc run <...>
            ._.                                                       
            | |                 The Cylc Suite Engine [7.8.2]         
._____._. ._| |_____.           Copyright (C) 2008-2019 NIWA          
| .___| | | | | .___|   & British Crown (Met Office) & Contributors.  
| !___| !_! | | !___.  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
!_____!___. |_!_____!  This program comes with ABSOLUTELY NO WARRANTY;
      .___! |          see `cylc warranty`.  It is free software, you 
      !_____!           are welcome to redistribute it under certain  

*** listening on https://vld456.cmpd1.metoffice.gov.uk:43107/ ***

To view suite server program contact information:
```

#### 8.0a0 (issue still there, though notice content has changed somewhat)
```console
$ cylc run <...>
            ._.                                                       
            | |                 The Cylc Suite Engine [8.0a0]         
._____._. ._| |_____.           Copyright (C) 2008-2019 NIWA          
| .___| | | | | .___|   & British Crown (Met Office) & Contributors.  
| !___| !_! | | !___.  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
!_____!___. |_!_____!  This program comes with ABSOLUTELY NO WARRANTY.
      .___! |              It is free software, you are welcome to    
      !_____!             redistribute it under certain conditions;   

*** listening on tcp://vld456.cmpd1.metoffice.gov.uk:43051/ ***

To view suite server program contact information:
```

*****

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [X] No change log entry required (e.g. change is small or internal only).
- [X] No documentation update required for this change.
