### PR TITLE
Fix minor bug in cat-log command.

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -32,11 +32,21 @@ If remote job logs are retrieved to the suite host on completion (global config
 '[JOB-HOST]retrieve job logs = True') and the job is not currently running, the
 local (retrieved) log will be accessed unless '-o/--force-remote' is used.
 
-Custom job logs (written to $CYLC_TASK_LOG_DIR on the job host) can be 
+Custom job logs (written to $CYLC_TASK_LOG_DIR on the job host) can be
 listed in 'extra log files' in the suite definition. The file
-name must be given here, but can be discovered with '--mode=l' (list-dir).
+name must be given, but can be discovered with '--mode=l' (list-dir).
 
-The correct cycle point format of the suite must be for task job logs.
+The correct cycle poin t format of the suite must be used for task job logs,
+but can be discovered with '--mode=d' (print-dir).
+
+Basic examples, for a task "bar.2020" in suite "foo":
+  Print suite log:
+    cylc cat-log foo
+  Print task stdout:
+    cylc cat-log foo bar.2020
+    cylc cat-log -f o foo bar.2020
+  Print task stderr:
+    cylc cat-log -f e foo bar.2020
 
 Note the --host/user options are not needed to view remote job logs. They are
 the general command reinvocation options for sites using ssh-based task
@@ -199,8 +209,8 @@ def get_option_parser():
         "-m", "--mode",
         help="Mode: %s. Default c(cat)." % (
             ', '.join(['%s(%s)' % (i, j) for i, j in MODES.items()])),
-        action="store", choices=list(MODES.keys()) + list(MODES.values()), default='c',
-        dest="mode")
+        action="store", choices=list(MODES.keys()) + list(MODES.values()),
+        default='c', dest="mode")
 
     parser.add_option(
         "-r", "--rotation",
@@ -318,6 +328,10 @@ def main():
 
     if len(args) == 1:
         # Cat suite logs, local only.
+        if options.filename is not None:
+            raise UserInputError("The '-f' option is for job logs only.")
+        tail_tmpl = str(glbl_cfg().get_host_item("tail command template"))
+
         logpath = get_suite_run_log_name(suite_name)
         if options.rotation_num:
             logs = glob('%s.*' % logpath)

--- a/tests/cylc-cat-log/00-local.t
+++ b/tests/cylc-cat-log/00-local.t
@@ -18,13 +18,13 @@
 # Test "cylc cat-log" on the suite host.
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-set_test_number 27
+set_test_number 29
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate $SUITE_NAME
 #-------------------------------------------------------------------------------
-# Run detached so we get suite out and err logs.
+# Run detached.
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
 sleep 5
 # Wait for the suite to finish.
@@ -33,6 +33,12 @@ cylc stop --max-polls=10 --interval=2 $SUITE_NAME 2>'/dev/null'
 TEST_NAME=${TEST_NAME_BASE}-suite-log-log
 run_ok $TEST_NAME cylc cat-log $SUITE_NAME
 contains_ok "${TEST_NAME}.stdout" "${SUITE_RUN_DIR}/log/suite/log"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-suite-log-fail
+run_fail $TEST_NAME cylc cat-log -f e $SUITE_NAME
+contains_ok "${TEST_NAME}.stderr" - << __END__
+UserInputError: The '-f' option is for job logs only.
+__END__
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-task-out
 run_ok $TEST_NAME cylc cat-log -f o $SUITE_NAME a-task.1
@@ -48,7 +54,7 @@ echo "the quick brown fox"
 echo "jumped over the lazy dog" >&2
 # Write to a custom log file
 echo "drugs and money" > \${CYLC_TASK_LOG_ROOT}.custom-log
-# Generate a message in the suite err log.
+# Generate a warning message in the suite log.
 cylc task message -p WARNING 'marmite and squashed bananas'
 __END__
 #-------------------------------------------------------------------------------

--- a/tests/cylc-cat-log/00-local/suite.rc
+++ b/tests/cylc-cat-log/00-local/suite.rc
@@ -14,6 +14,6 @@ echo "the quick brown fox"
 echo "jumped over the lazy dog" >&2
 # Write to a custom log file
 echo "drugs and money" > ${CYLC_TASK_LOG_ROOT}.custom-log
-# Generate a message in the suite err log.
+# Generate a warning message in the suite log.
 cylc task message -p WARNING 'marmite and squashed bananas'
 """

--- a/tests/cylc-cat-log/03-bad-suite.t
+++ b/tests/cylc-cat-log/03-bad-suite.t
@@ -24,7 +24,7 @@ BAD_NAME="$(basename "$(mktemp -u "${CYLC_RUN_DIR}/XXXXXXXX")")"
 
 run_fail "${TEST_NAME_BASE}-suite" cylc cat-log -f l "${BAD_NAME}"
 cmp_ok "${TEST_NAME_BASE}-suite.stderr" <<__ERR__
-file not found: ${CYLC_RUN_DIR}/${BAD_NAME}/log/suite/log
+UserInputError: The '-f' option is for job logs only.
 __ERR__
 
 run_fail "${TEST_NAME_BASE}-suite" cylc cat-log -f j "${BAD_NAME}" "garbage.1"


### PR DESCRIPTION
Abort if "-f" option used with suite log.

These changes close #3194 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
