### PR TITLE
tests/modes/02: remove time constraint

### DIFF
--- a/tests/modes/dummy-message-outputs/suite.rc
+++ b/tests/modes/dummy-message-outputs/suite.rc
@@ -2,14 +2,17 @@
     title = A suite that should only succeed in dummy mode.
 [cylc]
     [[events]]
-        abort on timeout = true
+        abort on stalled = True
     [[reference test]]
         required run mode = dummy
-        dummy mode suite timeout = PT30S
 [scheduling]
     [[dependencies]]
         graph = foo:x => bar
 [runtime]
+    [[root]]
+        [[[simulation]]]
+            default run length = PT0S
+            time limit buffer = PT1M
     [[bar]]
     [[foo]]
         script = false


### PR DESCRIPTION
Test would previously fail randomly with the dummy task job being terminated with XCPU signal or the suite timing out prematurely. This change reduces the task job run length, but removes the time constraint on the suite. Hopefully, these changes should be sufficient to prevent flakiness seen previously.

These changes partially address #2894.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
