### PR TITLE
Fix version file creation for new repo name.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,20 @@ pages**.
 - cylc-8 (master branch, written in Python 3) does not bundle Jinja2, and uses the fixed version 2.10.1.
 
 -------------------------------------------------------------------------------
+## __cylc-7.8.4 (2019-??-??)__
+
+Minor maintenance release.
+
+Selected user-facing changes:
+
+### Fixes
+
+[#3205](https://github.com/cylc/cylc-flow/pull/3205) - fix output from `cylc
+version`, which should return the numerical version string "7.8.4" not
+"flow-7.8.4". (Broken since the source repository was renamed to cylc-flow
+to align with the new multi-component cylc-8 architecture).
+
+-------------------------------------------------------------------------------
 ## __cylc-7.8.3 (2019-06-12)__
 
 Minor maintenance release.

--- a/etc/dev-bin/create-version-file
+++ b/etc/dev-bin/create-version-file
@@ -8,7 +8,7 @@ cd "${THIS_DIR}/../.."
 if [[ -d .git || -f .git ]]; then
   echo "(a cylc VERSION file is not needed in a cylc git repo)" >&2
 else    
-  VN=${PWD#*cylc-}
+  VN=${PWD#*cylc-flow-}
   echo "Setting VERSION from parent directory name: $VN" >&2
   echo $VN > VERSION
 fi

--- a/etc/dev-bin/create-version-file
+++ b/etc/dev-bin/create-version-file
@@ -8,7 +8,8 @@ cd "${THIS_DIR}/../.."
 if [[ -d .git || -f .git ]]; then
   echo "(a cylc VERSION file is not needed in a cylc git repo)" >&2
 else    
-  VN=${PWD#*cylc-flow-}
+  VN=${PWD#*cylc-}
+  VN=${VN#*flow-}
   echo "Setting VERSION from parent directory name: $VN" >&2
   echo $VN > VERSION
 fi


### PR DESCRIPTION
For compat with new repository name (cylc -> cylc-flow).

Following standard installation instructions, typing `make` in the unpacked release directory puts "flow-7.8.3" (e.g.) in the VERSION file, instead of just "7.8.3".

Which means, `cylc --version` will return `flow-7.8.3`!

No need for forward port: Cylc-8 version is determined differently.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- (This change cannot really be tested - it affects unpacked releases only).  
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.
- [x] No documentation update required for this change.
