### PR TITLE
Fix duplicate test name test_strip_and_unquote_list

### DIFF
--- a/cylc/flow/tests/parsec/test_validate.py
+++ b/cylc/flow/tests/parsec/test_validate.py
@@ -465,7 +465,8 @@ class TestValidate(unittest.TestCase):
         with self.assertRaises(IllegalValueError):
             ParsecValidator.strip_and_unquote(['a'], '"""')
 
-    def test_strip_and_unquote_list(self):
+    def test_strip_and_unquote_list_parsec(self):
+        """Test strip_and_unquote_list using ParsecValidator."""
         for value, results in [
             ('"a"\n"b"', ['a', 'b']),
             ('"a", "b"', ['a', 'b']),
@@ -484,6 +485,15 @@ class TestValidate(unittest.TestCase):
         ]:
             self.assertEqual(results, ParsecValidator.strip_and_unquote_list(
                 ['a'], value))
+
+    def test_strip_and_unquote_list_cylc(self):
+        """Test strip_and_unquote_list using CylcConfigValidator."""
+        validator = VDR()
+        for values in get_test_strip_and_unquote_list():
+            value = values[0]
+            expected = values[1]
+            output = validator.strip_and_unquote_list(keys=[], value=value)
+            self.assertEqual(expected, output)
 
     def test_strip_and_unquote_list_multiparam(self):
         with self.assertRaises(ListValueError):
@@ -617,15 +627,6 @@ class TestValidate(unittest.TestCase):
             self.assertRaises(
                 IllegalValueError,
                 validator.coerce_xtrigger, value, ['whatever'])
-
-    def test_strip_and_unquote_list(self):
-        """Test strip_and_unquote_list"""
-        validator = VDR()
-        for values in get_test_strip_and_unquote_list():
-            value = values[0]
-            expected = values[1]
-            output = validator.strip_and_unquote_list(keys=[], value=value)
-            self.assertEqual(expected, output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a small change with no associated Issue.

While fixing a previous issue in Exeter regarding quotes with `shlex`, I wrote this unit test and ran it a few times in my IDE, so it passed. And it also worked on Travis, but as I named the function the same as a previous function, I am not sure which method was actually executed.

Luckily as I ran with the IDE too, so the code was actually tested. With the change in this PR, `pytest` is passing OK and both tests are working fine :relieved: 

```
cylc/flow/tests/parsec/test_validate.py::TestValidate::test_strip_and_unquote PASSED                                                                                    [ 93%]
cylc/flow/tests/parsec/test_validate.py::TestValidate::test_strip_and_unquote_list_cylc PASSED                                                                          [ 94%]
cylc/flow/tests/parsec/test_validate.py::TestValidate::test_strip_and_unquote_list_multiparam PASSED                                                                    [ 94%]
cylc/flow/tests/parsec/test_validate.py::TestValidate::test_strip_and_unquote_list_parsec PASSED                                                                        [ 94%]

```
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
