### PR TITLE
Use contextlib for suppressing IOError and closing socket

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -49,6 +49,7 @@ returning the IP address associated with this socket.
 import os
 import pwd
 import socket
+from contextlib import suppress
 from time import time
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
@@ -99,13 +100,10 @@ class HostUtil(object):
         """
 
         ipaddr = ""
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.connect((target, 8000))
-            ipaddr = sock.getsockname()[0]
-            sock.close()
-        except IOError:
-            pass
+        with suppress(IOError):
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect((target, 8000))
+                ipaddr = sock.getsockname()[0]
         return ipaddr
 
     @staticmethod


### PR DESCRIPTION
This PR uses `contextlib` to suppress `IOError`, and also to close the socket (`socket` implements context manager since [Python 3.2](https://docs.python.org/3/library/socket.html#socket-objects)). Found while investigating an issue in `cylc-uiserver` regarding file leaks in sockets earlier this week. Even though the leak was not here, I thought it was still worth updating it - and then wrote a post-it to remind me later :grimacing:

`suppress` is available since [Python 3.4](https://docs.python.org/3/library/contextlib.html#contextlib.suppress), so I think it should be fine to use it.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
