### PR TITLE
Fix schema error & in turn per-suite UI data provision

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -223,7 +223,7 @@ async def get_nodes_all(root, info, **args):
         args['ids'] = [args.get('id')]
     if field_ids:
         args['ids'] = field_ids
-    elif not field_ids:
+    elif field_ids == []:
         return []
     try:
         obj_type = str(info.return_type.of_type).replace('!', '')
@@ -250,7 +250,7 @@ async def get_nodes_by_id(root, info, **args):
         if isinstance(field_ids, str):
             field_ids = [field_ids]
         args['native_ids'] = field_ids
-    elif not field_ids:
+    elif field_ids == []:
         return []
     try:
         obj_type = str(info.return_type.of_type).replace('!', '')
@@ -298,7 +298,7 @@ async def get_edges_by_id(root, info, **args):
     field_ids = getattr(root, field_name, None)
     if field_ids:
         args['native_ids'] = list(field_ids)
-    elif not field_ids:
+    elif field_ids == []:
         return []
     resolvers = info.context.get('resolvers')
     return await resolvers.get_edges_by_id(args)


### PR DESCRIPTION
These changes partially address #3216 (the table that is not rendered returns, populated with the suite's data, but the GraphQL error on 'state' is still there & needs further investigation).

This PR essentially reverts #3211 (bar one line), because whilst ``not X`` to test for a sequence being non-empty in a conditional is the Pythonic way advocated by PEP8, in this context the logic on ``field_ids`` needs to distinguish between an empty list & ``None`` (which that form does not do, as both are "falsy").

This is because ``field_ids = getattr(root, field_name, None)`` returns ``None`` as the default, & seems to be doing so for all the suites I have tried out to test this (as observed by adding in a ``print()`` function to check), whereas the query field argument default is an empty list (e.g. [as here](https://github.com/kinow/cylc-flow/blob/67199ccc5c7abaa4f162f221e796adf5c5c83bc2/cylc/flow/network/schema.py#L156)).

However, for the remaining line from the one commit of that PR, it is safe to use a ``not X`` construct for ``workflows`` as ``X`` because ``if workflows is None:`` is explicitly tested in the previous statement, which itself cannot return a ``None`` value:

https://github.com/kinow/cylc-flow/blob/67199ccc5c7abaa4f162f221e796adf5c5c83bc2/cylc/flow/network/schema.py#L699-L706

hence that line is safe & good.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] **Off-template:** Integration testing is important :grimacing:!**
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
