### PR TITLE
Fix doc typo.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@ version`, which should return the numerical version string "7.8.4" not
 "flow-7.8.4". (Broken since the source repository was renamed to cylc-flow
 to align with the new multi-component cylc-8 architecture).
 
+[#3218](https://github.com/cylc/cylc-flow/pull/3218) - fixed typo in the
+User Guide custom batch system handler example (`BATCH_SYSTEM_HANDLER` should
+be `BATCH_SYS_HANDLER`). 
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.3 (2019-06-12)__
 

--- a/doc/src/task-job-submission.rst
+++ b/doc/src/task-job-submission.rst
@@ -560,7 +560,7 @@ batch system handler to change the directive prefix from ``#PBS`` to
    class QSUBHandler(PBSHandler):
        DIRECTIVE_PREFIX = "#QSUB "
 
-   BATCH_SYSTEM_HANDLER = QSUBHandler()
+   BATCH_SYS_HANDLER = QSUBHandler()
 
 If this is in the Python search path (see
 :ref:`Where To Put Batch System Handler Modules` below) you can use it by


### PR DESCRIPTION
This is a small change with no associated Issue (doc typo fix only).

7.8.x companion of https://github.com/cylc/cylc-doc/pull/35

One review will do.