### PR TITLE
Upgrade isodatetime to metomi isodatetime

### DIFF
--- a/bin/cylc-cycle-point
+++ b/bin/cylc-cycle-point
@@ -59,9 +59,9 @@ import cylc.flow.cycling.iso8601
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
 
-import isodatetime.data
-import isodatetime.dumpers
-import isodatetime.parsers
+import metomi.isodatetime.data
+import metomi.isodatetime.dumpers
+import metomi.isodatetime.parsers
 
 
 def get_option_parser():
@@ -193,10 +193,10 @@ def main(parser, options, *args):
         num_expanded_year_digits=options.num_expanded_year_digits,
         time_zone=options.time_zone
     )
-    iso_point_parser = isodatetime.parsers.TimePointParser(
+    iso_point_parser = metomi.isodatetime.parsers.TimePointParser(
         num_expanded_year_digits=options.num_expanded_year_digits
     )
-    iso_point_dumper = isodatetime.dumpers.TimePointDumper(
+    iso_point_dumper = metomi.isodatetime.dumpers.TimePointDumper(
         num_expanded_year_digits=options.num_expanded_year_digits
     )
     try:
@@ -242,7 +242,7 @@ def main(parser, options, *args):
         except ValueError:
             parser.error('ERROR: offset must be integer')
 
-    offset = isodatetime.data.Duration(**offset_props)
+    offset = metomi.isodatetime.data.Duration(**offset_props)
 
     if options.offset:
         opt_offset = options.offset
@@ -251,7 +251,7 @@ def main(parser, options, *args):
             opt_offset = options.offset[1:]
             sign_factor = -1
         try:
-            offset += isodatetime.parsers.DurationParser().parse(
+            offset += metomi.isodatetime.parsers.DurationParser().parse(
                 opt_offset) * sign_factor
         except ValueError as exc:
             parser.error('ERROR: offset not valid: %s' % exc)

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -65,7 +65,7 @@ from cylc.flow.task_state import TASK_STATUSES_ORDERED
 from cylc.flow.terminal import cli_function
 from cylc.flow.cycling.util import add_offset
 
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 
 
 class SuitePoller(Poller):

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Define all legal items and values for cylc suite definition files."""
 
-from isodatetime.data import Calendar
+from metomi.isodatetime.data import Calendar
 
 from cylc.flow.network import Priv
 from cylc.flow.parsec.config import ParsecConfig

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -35,8 +35,8 @@ import os
 import re
 import traceback
 
-from isodatetime.data import Calendar
-from isodatetime.parsers import DurationParser
+from metomi.isodatetime.data import Calendar
+from metomi.isodatetime.parsers import DurationParser
 from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.util import replicate
 

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -20,9 +20,9 @@
 
 import re
 
-from isodatetime.data import Calendar, Duration
-from isodatetime.dumpers import TimePointDumper
-from isodatetime.timezone import (
+from metomi.isodatetime.data import Calendar, Duration
+from metomi.isodatetime.dumpers import TimePointDumper
+from metomi.isodatetime.timezone import (
     get_local_time_zone, get_local_time_zone_format, TimeZoneFormatMode)
 from cylc.flow.time_parser import CylcTimeParser
 from cylc.flow.cycling import (

--- a/cylc/flow/cycling/loader.py
+++ b/cylc/flow/cycling/loader.py
@@ -23,7 +23,7 @@ Each task may have multiple sequences, e.g. 12-hourly and 6-hourly.
 
 from . import integer
 from . import iso8601
-from isodatetime.data import Calendar
+from metomi.isodatetime.data import Calendar
 
 
 ISO8601_CYCLING_TYPE = 'iso8601'

--- a/cylc/flow/cycling/util.py
+++ b/cylc/flow/cycling/util.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Cycling utility functions."""
 
-from isodatetime.parsers import TimePointParser, DurationParser
+from metomi.isodatetime.parsers import TimePointParser, DurationParser
 
 
 def add_offset(cycle_point, offset):

--- a/cylc/flow/jinja/filters/duration_as.py
+++ b/cylc/flow/jinja/filters/duration_as.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Provides a Jinja2 filter for formatting ISO8601 duration strings."""
 
-from isodatetime.parsers import DurationParser
+from metomi.isodatetime.parsers import DurationParser
 
 SECONDS_PER_MINUTE = 60.0
 MINUTES_PER_HOUR = 60.0
@@ -59,8 +59,8 @@ def duration_as(iso8601_duration, units):
         >>> # Exceptions.
         >>> duration_as('invalid', 's')  # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
-        isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601 duration \
-        representation: invalid
+        metomi.isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601\
+        duration representation: invalid
     """
     for converter_names in CONVERSIONS:
         if units.lower() in converter_names:

--- a/cylc/flow/jinja/filters/strftime.py
+++ b/cylc/flow/jinja/filters/strftime.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Provides a Jinja2 filter for formatting ISO8601 datetime strings."""
 
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 
 
 def strftime(iso8601_datetime, strftime_str, strptime_str=None):
@@ -58,17 +58,17 @@ def strftime(iso8601_datetime, strftime_str, strptime_str=None):
         >>> # Exceptions.
         >>> strftime('invalid', '%H')  # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
-        <class 'isodatetime.parsers.ISO8601SyntaxError'>
-        isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601 date \
+        <class 'metomi.isodatetime.parsers.ISO8601SyntaxError'>
+        metomi.isodatetime.parsers.ISO8601SyntaxError: Invalid ISO 8601 date \
         representation: invalid
         >>> strftime('2000', '%invalid')  # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
-        isodatetime.parser_spec.StrftimeSyntaxError: Invalid \
+        metomi.isodatetime.parser_spec.StrftimeSyntaxError: Invalid \
         strftime/strptime representation: %i
         >>> strftime('2000', '%Y', '%invalid')
         ... # doctest: +NORMALIZE_WHITESPACE
         Traceback (most recent call last):
-        isodatetime.parser_spec.StrftimeSyntaxError: Invalid \
+        metomi.isodatetime.parser_spec.StrftimeSyntaxError: Invalid \
         strftime/strptime representation: %i
     """
     if not strptime_str:

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -29,9 +29,9 @@ import shlex
 from collections import deque
 from textwrap import dedent
 
-from isodatetime.data import Duration, TimePoint, Calendar
-from isodatetime.dumpers import TimePointDumper
-from isodatetime.parsers import TimePointParser, DurationParser
+from metomi.isodatetime.data import Duration, TimePoint, Calendar
+from metomi.isodatetime.dumpers import TimePointDumper
+from metomi.isodatetime.parsers import TimePointParser, DurationParser
 
 from cylc.flow.parsec.exceptions import (
     ListValueError, IllegalValueError, IllegalItemError)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -31,7 +31,7 @@ from time import sleep, time
 import traceback
 from uuid import uuid4
 
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 from cylc.flow.parsec.util import printcfg
 
 from cylc.flow import LOG

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -18,7 +18,7 @@
 
 """Provide a class to represent a task proxy in a running suite."""
 
-from isodatetime.timezone import get_local_time_zone
+from metomi.isodatetime.timezone import get_local_time_zone
 
 import cylc.flow.cycling.iso8601
 from cylc.flow.exceptions import TaskProxySequenceBoundsError

--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -33,8 +33,8 @@ time for inter-cycle task references such as "foo[-P6Y] => foo".
 
 import re
 
-import isodatetime.data
-import isodatetime.parsers
+import metomi.isodatetime.data
+import metomi.isodatetime.parsers
 
 from cylc.flow.cycling import parse_exclusion
 from cylc.flow.exceptions import (
@@ -53,7 +53,7 @@ class CylcTimeParser(object):
     context_start_point describes the beginning date/time used for
     extrapolating incomplete date/time syntax (usually initial
     cycle point). It is either a date/time string in full ISO 8601
-    syntax or an isodatetime.data.TimePoint object.
+    syntax or a metomi.isodatetime.data.TimePoint object.
     context_end_point is the same as context_start_point, but describes
     a final time - e.g. the final cycle point.
 
@@ -129,10 +129,12 @@ class CylcTimeParser(object):
 
         Returns:
             tuple: (timepoint_parser, duration_parser, time_recurrence_parser)
-                - timepoint_parser - isodatetime.parsers.TimePointParser obj.
-                - duration_parser - isodatetime.parsers.DurationParser obj.
+                - timepoint_parser - metomi.isodatetime.parsers.TimePointParser
+                  obj.
+                - duration_parser - metomi.isodatetime.parsers.DurationParser
+                  obj.
                 - time_recurrence_parser -
-                  isodatetime.parsers.TimeRecurrenceParser obj
+                  metomi.isodatetime.parsers.TimeRecurrenceParser obj
         """
 
         if dump_format is None:
@@ -141,7 +143,7 @@ class CylcTimeParser(object):
             else:
                 dump_format = "CCYYMMDDThhmmZ"
 
-        timepoint_parser = isodatetime.parsers.TimePointParser(
+        timepoint_parser = metomi.isodatetime.parsers.TimePointParser(
             allow_only_basic=False,
             allow_truncated=True,
             num_expanded_year_digits=num_expanded_year_digits,
@@ -150,8 +152,8 @@ class CylcTimeParser(object):
         )
 
         return (timepoint_parser,
-                isodatetime.parsers.DurationParser(),
-                isodatetime.parsers.TimeRecurrenceParser()
+                metomi.isodatetime.parsers.DurationParser(),
+                metomi.isodatetime.parsers.TimeRecurrenceParser()
                 )
 
     def parse_interval(self, expr):
@@ -163,7 +165,7 @@ class CylcTimeParser(object):
 
         expression should be a string such as 20010205T00Z, or a
         truncated/abbreviated format string such as T06 or -P2Y.
-        context_point should be an isodatetime.data.TimePoint object
+        context_point should be a metomi.isodatetime.data.TimePoint object
         that supplies the missing information for truncated
         expressions. For example, context_point should be the task
         cycle point for inter-cycle dependency expressions. If
@@ -277,7 +279,7 @@ class CylcTimeParser(object):
                     repetitions += 1
                 end_point = None
 
-            return isodatetime.data.TimeRecurrence(
+            return metomi.isodatetime.data.TimeRecurrence(
                 repetitions=repetitions,
                 start_point=start_point,
                 duration=interval,
@@ -310,7 +312,7 @@ class CylcTimeParser(object):
                 kwargs = {"minutes": 1}
             if not kwargs:
                 return None
-            return isodatetime.data.Duration(**kwargs)
+            return metomi.isodatetime.data.Duration(**kwargs)
         return self.duration_parser.parse(expr)
 
     def _get_min_from_expression(self, expr, context):

--- a/cylc/flow/wallclock.py
+++ b/cylc/flow/wallclock.py
@@ -20,7 +20,7 @@
 from calendar import timegm
 from datetime import datetime, timedelta
 
-from isodatetime.timezone import (
+from metomi.isodatetime.timezone import (
     get_local_time_zone_format, get_local_time_zone, TimeZoneFormatMode)
 
 
@@ -238,7 +238,7 @@ def get_unix_time_from_time_string(datetime_string):
     except ValueError:
         global PARSER
         if PARSER is None:
-            from isodatetime.parsers import TimePointParser
+            from metomi.isodatetime.parsers import TimePointParser
             PARSER = TimePointParser()
         time_zone_info = PARSER.get_info(datetime_string)[1]
         time_zone_hour = int(time_zone_info["time_zone_hour"])
@@ -256,5 +256,5 @@ def get_unix_time_from_time_string(datetime_string):
 
 def get_seconds_as_interval_string(seconds):
     """Convert a number of seconds into an ISO 8601 duration string."""
-    from isodatetime.data import Duration
+    from metomi.isodatetime.data import Duration
     return str(Duration(seconds=seconds, standardize=True))

--- a/cylc/flow/xtriggers/suite_state.py
+++ b/cylc/flow/xtriggers/suite_state.py
@@ -25,7 +25,7 @@ import sqlite3
 from cylc.flow.cycling.util import add_offset
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.dbstatecheck import CylcSuiteDBChecker
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 
 
 def suite_state(suite, task, point, offset=None, status='succeeded',

--- a/flakytests/cylc-poll/16-execution-time-limit.t
+++ b/flakytests/cylc-poll/16-execution-time-limit.t
@@ -38,7 +38,7 @@ cmp_times () {
     # Test if the times $1 and $2 are within $3 seconds of each other.
     python3 -u - "$@" <<'__PYTHON__'
 import sys
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 parser = TimePointParser()
 time_1 = parser.parse(sys.argv[1])
 time_2 = parser.parse(sys.argv[2])
@@ -50,7 +50,7 @@ time_offset () {
     # Add an ISO8601 duration to an ISO8601 date-time.
     python3 -u - "$@" <<'__PYTHON__'
 import sys
-from isodatetime.parsers import TimePointParser, DurationParser
+from metomi.isodatetime.parsers import TimePointParser, DurationParser
 print(
     TimePointParser().parse(sys.argv[1]) + DurationParser().parse(sys.argv[2]))
 __PYTHON__

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'ansimarkup>=1.0.0',
     'colorama==0.4.*',
     'graphene==2.1.6',
-    'isodatetime==1!2.0.*',
+    'metomi-isodatetime==1!2.0.*',
     'jinja2>=2.10.1, <2.11.0',
     'markupsafe==1.1.*',
     'protobuf==3.7.*',

--- a/tests/cylc.wallclock/00-single.t
+++ b/tests/cylc.wallclock/00-single.t
@@ -26,7 +26,7 @@ function test_get_unix_time_from_time_string () {
 from cylc.flow.wallclock import get_unix_time_from_time_string
 
 if $4:
-    from isodatetime.data import CALENDAR
+    from metomi.isodatetime.data import CALENDAR
     CALENDAR.set_mode(CALENDAR.MODE_360)
 assert(get_unix_time_from_time_string('$2') == $3)
 __PYTHON__

--- a/tests/restart/37-auto-restart-delay.t
+++ b/tests/restart/37-auto-restart-delay.t
@@ -27,7 +27,7 @@ set_test_number 6
 time_gt () {
     python3 -c "
 import sys
-from isodatetime.parsers import TimePointParser
+from metomi.isodatetime.parsers import TimePointParser
 parser = TimePointParser()
 sys.exit(not parser.parse('$1') > parser.parse('$2'))
 "


### PR DESCRIPTION
## Change dependency in cylc from isodatetime to metomi.isodatetime
The isodatetime module was recently renamed metomi.isodatetime ([PR 132](https://github.com/metomi/isodatetime/pull/132)). 

This PR changes the namespaces in cylc to reflect this.

- [x] Grepping for `isodatime` without `metomi` produces reasonable results.
- [x] All existing tests pass
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
