### PR TITLE
Remove possibility for very slow cylc print

### DIFF
--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -90,8 +90,13 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, regfilter=None):
-    allsuites = list(get_scan_items_from_fs(
-        reg_pattern=regfilter, compile_reg=True, active_only=False))
+    if regfilter:
+        try:
+            regfilter = re.compile(regfilter)
+        except re.error as exc:
+            raise ValueError("%s: %s" % (regfilter, exc))
+    allsuites = list(
+        get_scan_items_from_fs(reg_pattern=regfilter, active_only=False))
     if options.fail and not allsuites:
         raise SystemExit('ERROR: no suites matched.')
     if not options.tree:

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -35,9 +35,10 @@ if remrun():
 import os
 import re
 
+from cylc.flow.network.scan import get_scan_items_from_fs
 from cylc.flow.option_parsers import CylcOptionParser as COP
-from cylc.flow.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.flow.print_tree import print_tree
+from cylc.flow.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.flow.terminal import cli_function
 
 
@@ -89,8 +90,8 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, regfilter=None):
-    suite_src_files_mgr = SuiteSrvFilesManager()
-    allsuites = suite_src_files_mgr.list_suites(regfilter)
+    allsuites = list(get_scan_items_from_fs(
+        reg_pattern=regfilter, compile_reg=True, active_only=False))
     if options.fail and not allsuites:
         raise SystemExit('ERROR: no suites matched.')
     if not options.tree:

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -197,8 +197,7 @@ def re_compile_filters(patterns_owner=None, patterns_name=None):
 
 
 def get_scan_items_from_fs(
-        owner_pattern=None, reg_pattern=None, compile_reg=False,
-        active_only=True):
+        owner_pattern=None, reg_pattern=None, active_only=True):
     """Scrape list of suites from the filesystem.
 
     Walk users' "~/cylc-run/" to get (host, port) from ".service/contact" for
@@ -241,14 +240,8 @@ def get_scan_items_from_fs(
 
             # Filter suites by name
             reg = os.path.relpath(dirpath, run_d)
-            if reg_pattern:
-                if compile_reg:
-                    try:
-                        reg_pattern = re.compile(reg_pattern)
-                    except re.error as exc:
-                        raise ValueError("%s: %s" % (reg_pattern, exc))
-                if not reg_pattern.match(reg):
-                    continue
+            if reg_pattern and not reg_pattern.match(reg):
+                continue
 
             # Choose only suites with .service and matching filter
             if active_only:

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -349,36 +349,6 @@ To start a new run, stop the old one first with one or more of these:
             run_d = get_suite_run_dir(reg)
         return os.path.join(run_d, self.DIR_BASE_SRV)
 
-    def list_suites(self, regfilter=None):
-        """Return a filtered list of valid suite registrations."""
-        rec_regfilter = None
-        if regfilter:
-            try:
-                rec_regfilter = re.compile(regfilter)
-            except re.error as exc:
-                raise ValueError("%s: %s" % (regfilter, exc))
-        run_d = glbl_cfg().get_host_item('run directory')
-        results = []
-        for dirpath, dnames, _ in os.walk(run_d, followlinks=True):
-            # Always descend for top directory, but
-            # don't descend further if it has a .service/ dir
-            if dirpath != run_d and self.DIR_BASE_SRV in dnames:
-                dnames[:] = []
-            # Choose only suites with .service and matching filter
-            reg = os.path.relpath(dirpath, run_d)
-            path = os.path.join(dirpath, self.DIR_BASE_SRV)
-            if (not self._locate_item(self.FILE_BASE_SOURCE, path) or
-                    rec_regfilter and not rec_regfilter.search(reg)):
-                continue
-            try:
-                results.append([
-                    reg,
-                    self.get_suite_source_dir(reg),
-                    self.get_suite_title(reg)])
-            except (IOError, SuiteServiceFileError) as exc:
-                LOG.error('%s: %s', reg, exc)
-        return results
-
     def load_contact_file(self, reg, owner=None, host=None, file_base=None):
         """Load contact file. Return data as key=value dict."""
         if not file_base:


### PR DESCRIPTION
These changes close #3227, by excluding ``log`` sub-directories within run directory levels from being traversed by the ``os.walk``, so that suites under multiple directory levels from the root Cylc run directory & hierarchically-named suites can still be detected, but without needlessly trawling through highly-nested & easily numerous core Cylc directories.

Update: this is done by removing the original ``SuiteSrvFilesManager.list_suites()`` method used in ``bin/cylc-print``, & replacing it with a slight modification on ``get_scan_items_from_fs()``, which was largely duplicating it, including excluding ``log`` directories from being traversed already.

This approach does assume that suites won't be created in levels within directories named with those keywords, e.g. a suite named ``one/log/two`` with a ``.service/source`` located under an equivalent path relative to the run directory, but I suspect that may not be allowed anyway? Or at least, it should be discouraged? Could we add a constraint to prevent a (rare) case that users might try to register a suite with ``log`` higher up in its path?

Timings are **much improved** (for context, I have a couple of suites that were infinitely cycling & trivial, leading to them having generated ~20,000 cycle points, which I will naturally go in to housekeep later after using them for testing this on):

#### Before

```console
$ time cylc print
test-review-chars | No title provided | ~/cylc-run/test-review-chars
...
...
...
simple-sleepsies | No title provided | ~/cylc-run/simple-sleepsies

real	6m36.338s
user	0m31.140s
sys	1m0.304s
```

#### After

```console
$ time cylc print
test-review-chars | No title provided | ~/cylc-run/test-review-chars
...
...
...
simple-sleepsies | No title provided | ~/cylc-run/simple-sleepsies

real	0m1.727s
user	0m0.752s
sys	0m0.283s
```

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [X] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.