### PR TITLE
Fix insert family submit-num increment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -216,6 +216,9 @@ The `cylc run` and `cylc restart` commands can now accept the new
 configuration to force auto shutdown to be enabled. Previously, it is only
 possible to disable auto shutdown on the command line.
 
+[#3236](https://github.com/cylc/cylc-flow/pull/3236) - Fix submit number
+increment logic on insert of family with tasks that were previously submitted.
+
 ### Documentation
 
 [#3181](https://github.com/cylc/cylc-flow/pull/3181) - moved documentation to

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -663,19 +663,16 @@ class CylcSuiteDAO(object):
         task_ids should be specified as [(name-glob, cycle), ...]
 
         """
-        stmt = r"SELECT name,cycle,submit_num FROM %(name)s" % {
-            "name": self.TABLE_TASK_STATES}
-        stmt_args = []
-        if task_ids:
-            stmt += (
-                " WHERE (" +
-                ") OR (".join(["name GLOB ? AND cycle==?"] * len(task_ids)) +
-                ")")
-            for name, cycle in task_ids:
-                stmt_args += [name, cycle]
+        stmt = (
+            r"SELECT name,cycle,submit_num FROM %(name)s"
+            r" WHERE name==? AND CYCLE==?"
+        ) % {"name": self.TABLE_TASK_STATES}
         ret = {}
-        for name, cycle, submit_num in self.connect().execute(stmt, stmt_args):
-            ret[(name, cycle)] = submit_num
+        for name, cycle in task_ids:
+            for name, cycle, submit_num in self.connect().execute(
+                stmt, (name, cycle,)
+            ):
+                ret[(name, cycle)] = submit_num
         return ret
 
     def select_xtriggers_for_restart(self, callback):

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -663,7 +663,10 @@ class CylcSuiteDAO(object):
         task_ids should be specified as [(name-glob, cycle), ...]
 
         """
-        stmt = (
+        # Ignore bandit false positive: B608: hardcoded_sql_expressions
+        # Not an injection, simply putting the table name in the SQL query
+        # expression as a string constant local to this module.
+        stmt = (  # nosec
             r"SELECT name,cycle,submit_num FROM %(name)s"
             r" WHERE name==? AND CYCLE==?"
         ) % {"name": self.TABLE_TASK_STATES}

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -668,7 +668,7 @@ class CylcSuiteDAO(object):
         # expression as a string constant local to this module.
         stmt = (  # nosec
             r"SELECT name,cycle,submit_num FROM %(name)s"
-            r" WHERE name==? AND CYCLE==?"
+            r" WHERE name==? AND cycle==?"
         ) % {"name": self.TABLE_TASK_STATES}
         ret = {}
         for name, cycle in task_ids:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -134,7 +134,7 @@ class TaskPool(object):
                 continue
             for taskdef in taskdefs:
                 task_items[(taskdef.name, point_str)] = taskdef
-            select_args.append((name_str, point_str))
+                select_args.append((taskdef.name, point_str))
         if stopcp is None:
             stop_point = None
         else:
@@ -161,11 +161,11 @@ class TaskPool(object):
                         key[1]))
                     continue
 
-            submit_num = submit_nums.get(key)
+            submit_num = submit_nums.get(key, 0)
             itask = self.add_to_runahead_pool(TaskProxy(
                 taskdef, point, stop_point=stop_point, submit_num=submit_num))
             if itask:
-                LOG.info("[%s] -inserted", itask)
+                LOG.info("[%s] -submit-num=%02d, inserted", itask, submit_num)
         return n_warnings
 
     def add_to_runahead_pool(self, itask, is_new=True):

--- a/tests/cylc-insert/13-family-submit-num.t
+++ b/tests/cylc-insert/13-family-submit-num.t
@@ -15,26 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test cylc insert command, with wildcard in a task name string
+# Test "cylc insert" family where a task in the family have previous jobs.
+# The submit number of the task should increment.
 . "$(dirname "$0")/test_header"
-set_test_number 4
+set_test_number 3
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
-run_ok "${TEST_NAME_BASE}" cylc run --hold "${SUITE_NAME}"
-LOG="${SUITE_RUN_DIR}/log/suite/log"
-poll "! grep -q -F 'Held on start-up' '${LOG}' 2>'/dev/null'"
-run_ok "${TEST_NAME_BASE}-insert" cylc insert "${SUITE_NAME}" '2008/*'
-poll "! grep -q -F 'Command succeeded: insert_tasks' '${LOG}' 2>'/dev/null'"
-cylc stop --max-polls=10 --interval=6 "${SUITE_NAME}" 2>'/dev/null'
-cut -d' ' -f 2- "${LOG}" >'trimmed-log'
-{
-    for I in {001..500}; do
-        echo "INFO - [v_i${I}.2008] -submit-num=00, inserted"
-    done
-    echo "INFO - Command succeeded: insert_tasks(['2008/*'], stop_point_string=None, no_check=False)"
-} >'expected-log'
-contains_ok 'trimmed-log' 'expected-log'
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run "${SUITE_NAME}" --no-detach --debug --reference-test
+run_ok "${TEST_NAME_BASE}-bar-02" test -d "${SUITE_RUN_DIR}/log/job/1/bar/02"
 
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/cylc-insert/13-family-submit-num/reference.log
+++ b/tests/cylc-insert/13-family-submit-num/reference.log
@@ -1,0 +1,6 @@
+2019-07-24T12:28:47+01:00 INFO - Run mode: live
+2019-07-24T12:28:47+01:00 INFO - Initial point: 1
+2019-07-24T12:28:47+01:00 INFO - Final point: 1
+2019-07-24T12:28:47+01:00 INFO - [bar.1] -triggered off []
+2019-07-24T12:28:51+01:00 INFO - [foo.1] -triggered off ['bar.1']
+2019-07-24T12:28:55+01:00 INFO - [bar.1] -triggered off []

--- a/tests/cylc-insert/13-family-submit-num/suite.rc
+++ b/tests/cylc-insert/13-family-submit-num/suite.rc
@@ -1,0 +1,18 @@
+[cylc]
+    abort if any task fails = True
+    [[events]]
+        abort on stalled = True
+        abort on inactivity = True
+        inactivity = PT2M
+[scheduling]
+    [[dependencies]]
+        graph = bar => foo
+[runtime]
+    [[foo]]
+        script = """
+            cylc remove "${CYLC_SUITE_NAME}" 'bar.1'
+            cylc insert "${CYLC_SUITE_NAME}" 'BAR.1'
+        """
+    [[BAR]]
+    [[bar]]
+        inherit = BAR


### PR DESCRIPTION
On insert of a family with tasks that had submitted jobs before, the submit
numbers of the tasks were not incremented. This changes fixes the issue.

These changes close #3210.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.
- [x] No documentation update required for this change.
