### PR TITLE
Comment comments in issue and PR templates?

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,22 +9,22 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of the bug.
+<!-- A clear and concise description of the bug. -->
 
 **Release version(s) and/or repository branch(es) affected?**
-Have you checked that the bug is not already fixed in newer versions?
+<!-- Have you checked that the bug is not already fixed in newer versions? -->
 
 **Steps to reproduce the bug**
-Give sufficient details so that others can quickly verify the problem.
+<!-- Give sufficient details so that others can quickly verify the problem. -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add other useful information here.
+<!-- Add other useful information here. -->
 
 **Pull requests welcome!**
 This is an Open Source project - please consider contributing a bug fix

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -9,12 +9,12 @@ assignees: ''
 ---
 
 **Describe exactly what you would like to see in an upcoming release**
-Give a clear and concise description of the new feature or behaviour, and
-reasons why you think it would be useful.
+<!-- Give a clear and concise description of the new feature or behaviour, and
+reasons why you think it would be useful. -->
 
 **Additional context**
-Add other useful information here.
+<!-- Add other useful information here. -->
 
 **Pull requests welcome!**
-This is an Open Source project - please consider contributing code yourself
-(please read `CONTRIBUTING.md` before starting any work though).
+<!-- This is an Open Source project - please consider contributing code yourself
+(please read `CONTRIBUTING.md` before starting any work though). -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,25 @@
-COMMENT: Complete this Pull Request template and delete all "COMMENT:" lines.
+<!-- Complete this Pull Request template and delete all "COMMENT:" lines. -->
 
-COMMENT: Significant PRs should address an existing Issue. Choose one:
+<!-- Significant PRs should address an existing Issue. Choose one: -->
+
 These changes partially address #xxxx
 These changes close #xxxx
 This is a small change with no associated Issue.
 
-COMMENT: The following requirements must be satisfied (with "[x]").
-COMMENT: Mark the PR as a Draft if all requirements are not yet satisfied.
+<!-- The following requirements must be satisfied (with "[x]"). -->
+<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->
+
 **Requirements check-list**
 - [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
 - [ ] Contains logically grouped changes (else tidy your branch by rebase).
 - [ ] Does not contain off-topic changes (use other PRs for other changes).
-COMMENT: choose one:
+<!-- choose one: -->
 - [ ] Appropriate tests are included (unit and/or functional).
 - [ ] These changes are already covered by existing tests.
-COMMENT: choose one:
+<!-- choose one: -->
 - [ ] Includes an appropriate entry in the release change log `CHANGES.md`.
 - [ ] No change log entry required (e.g. change is small or internal only).
-COMMENT: choose one:
+<!-- choose one: -->
 - [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc#XXXX.
 - [ ] (7.8.x branch) I have updated the documentation in this PR branch.
 - [ ] No documentation update required for this change.


### PR DESCRIPTION
Just wondering if others prefer to have the comments in the templates as comments? It just helps not having to remember to delete the comments, but if others think this could confuse users (especially the parts they have to choose only one option?), then I think it's fine the way it is :+1: 

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
