### PR TITLE
job.sh: export ISODATETIMECALENDAR ISODATETIMEREF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,6 +149,11 @@ Can now be written as:
         P1D = task1 => task2
 ```
 
+[#3249](https://github.com/cylc/cylc-flow/pull/3249) - export the environment
+variable `ISODATETIMEREF` (reference time for the `isodatetime` command from
+[metomi-isodatetime](https://github.com/metomi/isodatetime/)) in task jobs to
+have the same value as `CYLC_TASK_CYCLE_POINT`.
+
 ### Fixes
 
 [#3010](https://github.com/cylc/cylc-flow/pull/3010) - fixes except KeyError

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -85,7 +85,12 @@ cylc__job__main() {
     export CYLC_SUITE_WORK_DIR="${CYLC_SUITE_WORK_DIR_ROOT}/work"
     CYLC_TASK_CYCLE_POINT="$(cut -d '/' -f 1 <<<"${CYLC_TASK_JOB}")"
     CYLC_TASK_NAME="$(cut -d '/' -f 2 <<<"${CYLC_TASK_JOB}")"
-    export CYLC_TASK_NAME CYLC_TASK_CYCLE_POINT
+    export CYLC_TASK_NAME CYLC_TASK_CYCLE_POINT ISODATETIMEREF
+    if [[ "${CYLC_CYCLING_MODE}" != "integer" ]]; then  # i.e. date-time cycling
+        ISODATETIMECALENDAR="${CYLC_CYCLING_MODE}"
+        ISODATETIMEREF="${CYLC_TASK_CYCLE_POINT}"
+        export ISODATETIMECALENDAR ISODATETIMEREF
+    fi
     # The "10#" part ensures that the submit number is interpreted in base 10.
     # Otherwise, a zero padded number will be interpreted as an octal.
     export CYLC_TASK_SUBMIT_NUMBER=$((10#$(cut -d '/' -f 3 <<<"${CYLC_TASK_JOB}")))

--- a/tests/jobscript/20-isodatetime-envs.t
+++ b/tests/jobscript/20-isodatetime-envs.t
@@ -1,0 +1,62 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test for ISODATETIMEREF and ISODATETIMECALENDAR.
+. "$(dirname "${0}")/test_header"
+set_test_number 2
+
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    initial cycle point = 20200202T2020Z
+    [[dependencies]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = """
+test "${ISODATETIMECALENDAR}" = "${CYLC_CYCLING_MODE}"
+test "${ISODATETIMECALENDAR}" = 'gregorian'
+test "${ISODATETIMEREF}" = "${CYLC_TASK_CYCLE_POINT}"
+test "${ISODATETIMEREF}" = '20200202T2020Z'
+"""
+__SUITE_RC__
+
+suite_run_ok "${TEST_NAME_BASE}" cylc run --no-detach "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    UTC mode = True
+    [[events]]
+        abort on stalled = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+[runtime]
+    [[foo]]
+        script = """
+test -z "${ISODATETIMECALENDAR:-}"
+test -z "${ISODATETIMEREF:-}"
+"""
+__SUITE_RC__
+suite_run_ok "${TEST_NAME_BASE}" cylc run --no-detach "${SUITE_NAME}"
+
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
Set calendar mode and reference time for the `isodatetime` command (for date-time cycling suites).

<!-- Complete this Pull Request template and delete all "COMMENT:" lines. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc#42.