### PR TITLE
extract-pkg-resources: update docstring w/ rename

### DIFF
--- a/bin/cylc-extract-pkg-resources
+++ b/bin/cylc-extract-pkg-resources
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""cylc [info] get-pkg-resources [OPTIONS] DIR [RESOURCES]
+"""cylc [info] extract-pkg-resources [OPTIONS] DIR [RESOURCES]
 
 Extract resources from the cylc.flow package and write them to DIR.
 


### PR DESCRIPTION
The ``cylc extract-pkg-resources`` command was originally called ``get-pkg-resources`` & it seems the docstring was missed when it was renamed, so this is a small PR to update the docstring accordingly.

This change is not immaterial, since the docs (for now) generate the Command Reference section from the command module doctrings, meaning the docs will record this command under the old name until this update is made. So the docs currently describe a command which doesn't exist, & are missing the one that does.

I have ``grep``-ped through the codebase & there are no other uses of the old command name; this is the only one.

Trivial, hence one reviewer sufficient.

<!-- Complete this Pull Request template and delete all "COMMENT:" lines. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.