### PR TITLE
Avoid %% escape in xtrigger func args (7.8.x).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ Selected user-facing changes:
 
 ### Fixes
 
+[#3257](https://github.com/cylc/cylc-flow/pull/3257) - leave '%'-escaped string
+templates alone in xtrigger arguments.
+
 [#3204](https://github.com/cylc/cylc-flow/pull/3204) - fix restart on
 `cylc run --icp=now SUITE` and related, which was broken at 7.8.3.
 

--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -260,6 +260,10 @@ and less commonly needed:
 - ``%(suite_run_dir)s`` - suite run directory
 - ``%(suite_share_dir)s`` - suite share directory
 
+If you need to pass a string template into an xtrigger function as a string
+literal - i.e. to be used as a template inside the function - escape it with
+``%`` to avoid detection by the Cylc xtrigger parser: ``%%(cat)s``.
+
 Function return values should be as follows:
 
 - if the trigger condition is *not satisfied*:

--- a/lib/cylc/tests/test_xtrigger_mgr.py
+++ b/lib/cylc/tests/test_xtrigger_mgr.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import unittest
+
+from cylc.xtrigger_mgr import RE_STR_TMPL
+
+
+class TestXtriggerManager(unittest.TestCase):
+
+    def test_extract_templates(self):
+        """Test escaped templates in xtrigger arg string.
+        
+        They should be left alone and passed into the function as string
+        literals, not identified as template args.
+        """
+        self.assertEqual(
+            RE_STR_TMPL.findall('%(cat)s, %(dog)s, %%(fish)s'),
+            ['cat', 'dog']
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/cylc/tests/test_xtrigger_mgr.py
+++ b/lib/cylc/tests/test_xtrigger_mgr.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import unittest
 
 from cylc.xtrigger_mgr import RE_STR_TMPL
@@ -26,7 +25,7 @@ class TestXtriggerManager(unittest.TestCase):
 
     def test_extract_templates(self):
         """Test escaped templates in xtrigger arg string.
-        
+
         They should be left alone and passed into the function as string
         literals, not identified as template args.
         """

--- a/lib/cylc/xtrigger_mgr.py
+++ b/lib/cylc/xtrigger_mgr.py
@@ -40,8 +40,9 @@ ARG_VAL_TEMPLATES = [
     TMPL_TASK_CYCLE_POINT, TMPL_TASK_IDENT, TMPL_TASK_NAME, TMPL_SUITE_RUN_DIR,
     TMPL_SUITE_SHARE_DIR, TMPL_USER_NAME, TMPL_SUITE_NAME, TMPL_DEBUG_MODE]
 
-# Extract all 'foo' from string templates '%(foo)s'.
-RE_STR_TMPL = re.compile(r'%\(([\w]+)\)s')
+# Extract 'foo' from string templates '%(foo)s', avoiding '%%' escaping
+# ('%%(foo)s` is not a string template).
+RE_STR_TMPL = re.compile(r'(?<!%)%\(([\w]+)\)s')
 
 
 class XtriggerManager(object):


### PR DESCRIPTION
<!-- Complete this Pull Request template  -->
<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3256

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.
<!-- choose one: -->
- [x] (7.8.x branch) I have updated the documentation in this PR branch.
