### PR TITLE
Avoid %% escape in xtrigger func args (master).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -156,6 +156,9 @@ have the same value as `CYLC_TASK_CYCLE_POINT`.
 
 ### Fixes
 
+[#3258](https://github.com/cylc/cylc-flow/pull/3258) - leave '%'-escaped string
+templates alone in xtrigger arguments.
+
 [#3010](https://github.com/cylc/cylc-flow/pull/3010) - fixes except KeyError
 in task_job_mgr.
 

--- a/cylc/flow/tests/test_xtrigger_mgr.py
+++ b/cylc/flow/tests/test_xtrigger_mgr.py
@@ -22,7 +22,7 @@ from cylc.flow.subprocctx import SubFuncContext
 from cylc.flow.subprocpool import SubProcPool
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.taskdef import TaskDef
-from cylc.flow.xtrigger_mgr import XtriggerManager
+from cylc.flow.xtrigger_mgr import XtriggerManager, RE_STR_TMPL
 
 
 def test_constructor():
@@ -32,6 +32,17 @@ def test_constructor():
     assert not xtrigger_mgr.clockx_map
     # the dict with normal xtriggers starts empty
     assert not xtrigger_mgr.functx_map
+
+
+def test_extract_templates():
+    """Test escaped templates in xtrigger arg string.
+
+    They should be left alone and passed into the function as string
+    literals, not identified as template args.
+    """
+    assert (
+        RE_STR_TMPL.findall('%(cat)s, %(dog)s, %%(fish)s') == ['cat', 'dog']
+    )
 
 
 def test_add_clock_xtrigger():

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -45,8 +45,9 @@ ARG_VAL_TEMPLATES = [
     TMPL_TASK_CYCLE_POINT, TMPL_TASK_IDENT, TMPL_TASK_NAME, TMPL_SUITE_RUN_DIR,
     TMPL_SUITE_SHARE_DIR, TMPL_USER_NAME, TMPL_SUITE_NAME, TMPL_DEBUG_MODE]
 
-# Extract all 'foo' from string templates '%(foo)s'.
-RE_STR_TMPL = re.compile(r'%\(([\w]+)\)s')
+# Extract 'foo' from string templates '%(foo)s', avoiding '%%' escaping
+# ('%%(foo)s` is not a string template).
+RE_STR_TMPL = re.compile(r'(?<!%)%\(([\w]+)\)s')
 
 
 class XtriggerManager(object):


### PR DESCRIPTION
This is the master branch (cylc-8) companion of #3257 - see documentation there.

<!-- Complete this Pull Request template and delete all "COMMENT:" lines. -->
<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3256 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Includes an appropriate entry in the release change log `CHANGES.md`.
<!-- choose one: -->
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/50

