### PR TITLE
Replace O(N) lookup with O(1) for task outputs (7.8.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,14 @@ Bug fix release.
 
 Selected user-facing changes:
 
+### Enhancements
+
+[#3259](https://github.com/cylc/cylc-flow/pull/3259) - sped up suite validation
+(which also affects responsiveness of suite controllers during suite startup,
+restarts, and reloads).  Impact of the speedup is most noticeable when dealing
+with suite configurations that contain tasks with many task outputs.
+
+
 ### Fixes
 
 [#3204](https://github.com/cylc/cylc-flow/pull/3204) - fix restart on

--- a/etc/dev-suites/outputs/suite.rc
+++ b/etc/dev-suites/outputs/suite.rc
@@ -1,0 +1,20 @@
+#!Jinja2
+
+{% if not N is defined %}
+    {% set N = 1000 %}
+{% else %}
+    {% set N = N | int %}
+{% endif %}
+
+[scheduling]
+    [[dependencies]]
+        graph = """
+            foo => bar
+        """
+
+[runtime]
+    [[foo]]
+        [[[outputs]]]
+{% for i in range(N) %}
+            output_{{ i }} = 123{{ i }}
+{% endfor %}

--- a/etc/profile-experiments/outputs.json
+++ b/etc/profile-experiments/outputs.json
@@ -1,0 +1,38 @@
+{
+    "runs": [
+        {
+            "name": "1",
+            "suite dir": "etc/dev-suites/outputs",
+            "options": ["N=1"],
+            "repeats": 5
+        },
+        {
+            "name": "10",
+            "suite dir": "etc/dev-suites/outputs",
+            "options": ["N=10"],
+            "repeats": 5
+        },
+        {
+            "name": "100",
+            "suite dir": "etc/dev-suites/outputs",
+            "options": ["N=100"],
+            "repeats": 5
+        },
+        {
+            "name": "1000",
+            "suite dir": "etc/dev-suites/outputs",
+            "options": ["N=1000"],
+            "repeats": 3
+        },
+        {
+            "name": "10000",
+            "suite dir": "etc/dev-suites/outputs",
+            "options": ["N=10000"],
+            "repeats": 2
+        }
+    ],
+    "profile modes": ["time"],
+    "analysis": "scale",
+    "mode": "validate",
+    "x-axis": "outputs"
+}

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -1649,7 +1649,7 @@ class SuiteConfig(object):
             # Record custom message outputs.
             for item in self.cfg['runtime'][name]['outputs'].items():
                 if item not in taskdef.outputs:
-                    taskdef.outputs.append(item)
+                    taskdef.outputs.add(item)
                     # Check for obsolete task message offsets.
                     if BCOMPAT_MSG_RE_C6.match(item[1]):
                         raise SuiteConfigError(

--- a/lib/cylc/taskdef.py
+++ b/lib/cylc/taskdef.py
@@ -75,7 +75,7 @@ class TaskDef(object):
         self.expiration_offset = None
         self.namespace_hierarchy = []
         self.dependencies = {}
-        self.outputs = []
+        self.outputs = set()
         self.param_var = {}
         self.external_triggers = []
         self.xtrig_labels = set()


### PR DESCRIPTION
This speeds up suite validation significantly for tasks with
large numbers of outputs.  The list used required an O(N)
check for membership which, when combined with being run for
each output resulted in O(N**2) complexity.

Using the builtin set should bypass any deprecated libraries in
Python 2.

These changes closes #3255

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] These changes are already covered by existing tests.
<!-- choose one: -->
- [x] No change log entry required (e.g. change is small or internal only).
<!-- choose one: -->
- [x] No documentation update required for this change.
