### PR TITLE
Compare string with equal sign

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -399,7 +399,7 @@ class SuiteConfig(object):
                 )
 
         if (self.cfg['scheduling']['final cycle point'] is not None and
-                self.cfg['scheduling']['final cycle point'].strip() is ""):
+                not self.cfg['scheduling']['final cycle point'].strip()):
             self.cfg['scheduling']['final cycle point'] = None
         fcp_str = getattr(self.options, 'fcp', None)
         if fcp_str is None:


### PR DESCRIPTION
Minuscule change, just to replace the `is` by `==` for strings. Harmless, but raises a warning when you run `cylc run --no-detach five` when Python is compiled with the pydebug flag.

<!-- Complete this Pull Request template and delete all "COMMENT:" lines. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
<!-- choose one: -->
- [x] These changes are already covered by existing tests.
<!-- choose one: -->
- [x] No change log entry required (e.g. change is small or internal only).
<!-- choose one: -->
- [x] No documentation required.
