### PR TITLE
rename pkg_resources module to avoid namespace conflict

### DIFF
--- a/bin/cylc-extract-resources
+++ b/bin/cylc-extract-resources
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""cylc [info] extract-pkg-resources [OPTIONS] DIR [RESOURCES]
+"""cylc [info] extract-resources [OPTIONS] DIR [RESOURCES]
 
 Extract resources from the cylc.flow package and write them to DIR.
 
@@ -15,7 +15,7 @@ import os
 import sys
 
 from cylc.flow.exceptions import UserInputError
-from cylc.flow.pkg_resources import extract_pkg_resources, list_pkg_resources
+from cylc.flow.resources import extract_resources, list_resources
 from cylc.flow.terminal import cli_function
 
 
@@ -36,7 +36,7 @@ class ArgParser:
                 f"see '{os.path.basename(sys.argv[0])} --help'."
             )
         elif '--list' in sys.argv:
-            print('\n'.join(list_pkg_resources()))
+            print('\n'.join(list_resources()))
         else:
             return (None, sys.argv[1:])
         sys.exit()
@@ -44,7 +44,7 @@ class ArgParser:
 
 @cli_function(ArgParser.parser)
 def main(parser, _, target_dir, *resources):
-    extract_pkg_resources(target_dir, resources or None)
+    extract_resources(target_dir, resources or None)
 
 
 if __name__ == '__main__':

--- a/bin/cylc-help
+++ b/bin/cylc-help
@@ -216,7 +216,7 @@ information_commands['list'] = ['list', 'ls']
 information_commands['dump'] = ['dump']
 information_commands['show'] = ['show']
 information_commands['cat-log'] = ['cat-log', 'log']
-information_commands['extract-pkg-resources'] = ['extract-pkg-resources']
+information_commands['extract-resources'] = ['extract-resources']
 information_commands['get-suite-contact'] = [
     'get-suite-contact', 'get-contact']
 information_commands['get-suite-version'] = [
@@ -343,7 +343,7 @@ comsum['list'] = 'List suite tasks and family namespaces'
 comsum['dump'] = 'Print the state of tasks in a running suite'
 comsum['show'] = 'Print task state (prerequisites and outputs etc.)'
 comsum['cat-log'] = 'Print various suite and task log files'
-comsum['extract-pkg-resources'] = 'Extract cylc.flow library package resources'
+comsum['extract-resources'] = 'Extract cylc.flow library package resources'
 comsum['documentation'] = 'Display cylc documentation (User Guide etc.)'
 comsum['monitor'] = 'An in-terminal suite monitor'
 comsum['get-suite-config'] = 'Print suite configuration items'

--- a/cylc/flow/resources.py
+++ b/cylc/flow/resources.py
@@ -38,7 +38,7 @@ resource_names = [
 ]
 
 
-def list_pkg_resources():
+def list_resources():
     """List available cylc.flow package resources.
 
     The API has a "listdir" function but no automatic recursion capability,
@@ -47,7 +47,7 @@ def list_pkg_resources():
     return resource_names
 
 
-def extract_pkg_resources(target_dir, resources=None):
+def extract_resources(target_dir, resources=None):
     """Extract cylc.flow resources and write them to a target directory.
 
     Arguments:

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -27,7 +27,7 @@ from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.pathutil import get_remote_suite_run_dir, get_suite_run_dir
-from cylc.flow.pkg_resources import extract_pkg_resources
+from cylc.flow.resources import extract_resources
 import cylc.flow.flags
 from cylc.flow.hostuserutil import (
     get_host, get_user, is_remote, is_remote_host, is_remote_user)
@@ -463,7 +463,7 @@ To start a new run, stop the old one first with one or more of these:
             os.symlink(source_str, target)
 
         # Extract job.sh from library, for use in job scripts.
-        extract_pkg_resources(srv_d, ['etc/job.sh'])
+        extract_resources(srv_d, ['etc/job.sh'])
         print('REGISTERED %s -> %s' % (reg, source))
         return reg
 

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -23,7 +23,7 @@ import tarfile
 
 import cylc.flow.flags
 from cylc.flow.suite_srv_files_mgr import SuiteSrvFilesManager
-from cylc.flow.pkg_resources import extract_pkg_resources
+from cylc.flow.resources import extract_resources
 
 
 FILE_BASE_UUID = 'uuid'
@@ -53,7 +53,7 @@ def remote_init(uuid_str, rund, indirect_comm=None):
     oldcwd = os.getcwd()
     os.chdir(rund)
     # Extract job.sh from library, for use in job scripts.
-    extract_pkg_resources(SuiteSrvFilesManager.DIR_BASE_SRV, ['etc/job.sh'])
+    extract_resources(SuiteSrvFilesManager.DIR_BASE_SRV, ['etc/job.sh'])
     try:
         tarhandle = tarfile.open(fileobj=sys.stdin.buffer, mode='r|')
         tarhandle.extractall()

--- a/cylc/flow/tests/test_resources.py
+++ b/cylc/flow/tests/test_resources.py
@@ -21,29 +21,29 @@ import unittest
 import tempfile
 import shutil
 
-from cylc.flow.pkg_resources import (
-    resource_names, list_pkg_resources, extract_pkg_resources)
+from cylc.flow.resources import (
+    resource_names, list_resources, extract_resources)
 
 
 class TestPkgResources(unittest.TestCase):
 
-    def test_list_pkg_resources(self):
-        """Test pkg_resources.list_pkg_resources."""
-        self.assertEqual(list_pkg_resources(), resource_names)
+    def test_list_resources(self):
+        """Test resources.list_resources."""
+        self.assertEqual(list_resources(), resource_names)
 
-    def test_extract_pkg_resources_one(self):
+    def test_extract_resources_one(self):
         """Test extraction of a specific resource.
 
         Just check that a file of the right name gets extracted, but not its
         content - which may change in the future.
         """
         tmpdir = tempfile.gettempdir()
-        extract_pkg_resources(tmpdir, resources=['etc/job.sh'])
+        extract_resources(tmpdir, resources=['etc/job.sh'])
         extracted = os.path.join(tmpdir, 'etc', 'job.sh')
         self.assertTrue(os.path.isfile(extracted))
         shutil.rmtree(os.path.dirname(extracted), ignore_errors=True)
 
-    def test_extract_pkg_resources_all(self):
+    def test_extract_resources_all(self):
         """Test extraction of all resources under 'etc'.
 
         Just check that file of the right names gets extracted, but not their
@@ -51,7 +51,7 @@ class TestPkgResources(unittest.TestCase):
 
         """
         tmpdir = tempfile.gettempdir()
-        extract_pkg_resources(tmpdir, None)
+        extract_resources(tmpdir, None)
         for resource in resource_names:
             extracted = os.path.join(tmpdir, resource)
             self.assertTrue(os.path.isfile(extracted))

--- a/cylc/flow/tests/test_suite_srv_files_mgr.py
+++ b/cylc/flow/tests/test_suite_srv_files_mgr.py
@@ -175,8 +175,8 @@ class TestSuiteSrvFilesManager(unittest.TestCase):
         self.suite_srv_files_mgr = SuiteSrvFilesManager()
 
     @mock.patch('cylc.flow.suite_srv_files_mgr.os')
-    @mock.patch('cylc.flow.suite_srv_files_mgr.extract_pkg_resources')
-    def test_register(self, mocked_extract_pkg_resources, mocked_os):
+    @mock.patch('cylc.flow.suite_srv_files_mgr.extract_resources')
+    def test_register(self, mocked_extract_resources, mocked_os):
         """Test the SuiteSrvFilesManager register function."""
         def mkdirs_standin(_, exist_ok=False):
             return True
@@ -208,7 +208,7 @@ class TestSuiteSrvFilesManager(unittest.TestCase):
             if e_expected is None:
                 reg = self.suite_srv_files_mgr.register(reg, source, redirect)
                 self.assertEqual(expected, reg)
-                assert mocked_extract_pkg_resources.called
+                assert mocked_extract_resources.called
                 if mocked_os.symlink.call_count > 0:
                     # first argument, of the first call
                     arg0 = mocked_os.symlink.call_args[0][0]


### PR DESCRIPTION
Running Cylc commands from within the `cylc/flow` directory can cause traceback due to a namespace conflict with the Python `pkg_resources` module.

Rename `pkg_resources` to `resources` which doesn't have a stdlib counterpart:

```console
$ cd cylc.git/cylc/flow
$ cylc validate generic
Traceback (most recent call last):
  File "....cylc/bin/cylc-validate", line 4, in <module>
    __import__('pkg_resources').require('cylc-flow==8.0a0')
AttributeError: module 'pkg_resources' has no attribute 'require'
$ cd ../
$ cylc validate generic
Valid for cylc-8.0a0
```

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] These changes are already covered by existing tests.
- [x] No change log entry required (e.g. change is small or internal only).
- [x] No documentation update required for this change.
