### PR TITLE
Extract job.sh at suite start-up.

### DIFF
--- a/cylc/flow/resources.py
+++ b/cylc/flow/resources.py
@@ -23,6 +23,7 @@ Uses the pkg_resources API in case the package is a compressed archive.
 
 from pathlib import Path
 import pkg_resources as pr
+from cylc.flow import LOG
 
 
 resource_names = [
@@ -60,7 +61,7 @@ def extract_resources(target_dir, resources=None):
         if resource not in resource_names:
             raise ValueError(f"Invalid resource name {resource}")
         path = Path(target_dir, resource)
-        print(f"Extracting {resource} to {path}")
+        LOG.debug(f"Extracting {resource} to {path}")
         pdir = path.parent
         if not pdir.exists():
             pdir.mkdir(parents=True)

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -30,6 +30,7 @@ from cylc.flow.remote import remrun, remote_cylc_cmd
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.suite_srv_files_mgr import (
     SuiteSrvFilesManager, SuiteServiceFileError)
+from cylc.flow.resources import extract_resources
 from cylc.flow.terminal import cli_function
 
 RUN_DOC = r"""cylc [control] run|start [OPTIONS] [ARGS]
@@ -226,14 +227,20 @@ def _auto_register():
 
 def scheduler_cli(parser, options, args, is_restart=False):
     """CLI main."""
+    reg = args[0]
     # Check suite is not already running before start of host selection.
     try:
-        SuiteSrvFilesManager().detect_old_contact_file(args[0])
+        SuiteSrvFilesManager().detect_old_contact_file(reg)
     except SuiteServiceFileError as exc:
         sys.exit(exc)
 
     # Create auth files if needed.
-    SuiteSrvFilesManager().create_auth_files(args[0])
+    SuiteSrvFilesManager().create_auth_files(reg)
+
+    # Extract job.sh from library, for use in job scripts.
+    extract_resources(
+        SuiteSrvFilesManager().get_suite_srv_dir(reg),
+        ['etc/job.sh'])
 
     # Check whether a run host is explicitly specified, else select one.
     if not options.host:

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -27,7 +27,6 @@ from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.pathutil import get_remote_suite_run_dir, get_suite_run_dir
-from cylc.flow.resources import extract_resources
 import cylc.flow.flags
 from cylc.flow.hostuserutil import (
     get_host, get_user, is_remote, is_remote_host, is_remote_user)
@@ -462,8 +461,6 @@ To start a new run, stop the old one first with one or more of these:
                 source_str = source
             os.symlink(source_str, target)
 
-        # Extract job.sh from library, for use in job scripts.
-        extract_resources(srv_d, ['etc/job.sh'])
         print('REGISTERED %s -> %s' % (reg, source))
         return reg
 

--- a/cylc/flow/tests/test_suite_srv_files_mgr.py
+++ b/cylc/flow/tests/test_suite_srv_files_mgr.py
@@ -175,8 +175,7 @@ class TestSuiteSrvFilesManager(unittest.TestCase):
         self.suite_srv_files_mgr = SuiteSrvFilesManager()
 
     @mock.patch('cylc.flow.suite_srv_files_mgr.os')
-    @mock.patch('cylc.flow.suite_srv_files_mgr.extract_resources')
-    def test_register(self, mocked_extract_resources, mocked_os):
+    def test_register(self, mocked_os):
         """Test the SuiteSrvFilesManager register function."""
         def mkdirs_standin(_, exist_ok=False):
             return True
@@ -208,7 +207,6 @@ class TestSuiteSrvFilesManager(unittest.TestCase):
             if e_expected is None:
                 reg = self.suite_srv_files_mgr.register(reg, source, redirect)
                 self.assertEqual(expected, reg)
-                assert mocked_extract_resources.called
                 if mocked_os.symlink.call_count > 0:
                     # first argument, of the first call
                     arg0 = mocked_os.symlink.call_args[0][0]


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3250

Extract `job.sh` to the suite service directory at start-up, not registration time.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (can't really start cylc-7 in cylc-8 test-battery; plus all test suite jobs will fail if this extraction does not succeed - so it's effectively covered by existing tests).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
