### PR TITLE
restrict suite name character set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@ Cylc CLI.
 [#2963](https://github.com/cylc/cylc-flow/pull/2963) - make suite context
 available before config parsing.
 
-[#3274](https://github.com/cylc/cylc-flow/pull/3274) - dissallow the use of
+[#3274](https://github.com/cylc/cylc-flow/pull/3274) - disallow the use of
 special characters in suite names.
 
 [#3001](https://github.com/cylc/cylc-flow/pull/3001) - simplify cylc version,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@ Cylc CLI.
 [#2963](https://github.com/cylc/cylc-flow/pull/2963) - make suite context
 available before config parsing.
 
+[#3274](https://github.com/cylc/cylc-flow/pull/3274) - dissallow the use of
+special characters in suite names.
+
 [#3001](https://github.com/cylc/cylc-flow/pull/3001) - simplify cylc version,
 dropping VERSION file and git info.
 

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -31,6 +31,7 @@ from cylc.flow.resources import extract_resources
 import cylc.flow.flags
 from cylc.flow.hostuserutil import (
     get_host, get_user, is_remote, is_remote_host, is_remote_user)
+from cylc.flow.unicode_rules import SuiteNameValidator
 
 
 class SuiteSrvFilesManager(object):
@@ -396,7 +397,7 @@ To start a new run, stop the old one first with one or more of these:
             redirect (bool): allow reuse of existing name and run directory.
 
         Return:
-            The registered suite name (which may be computed here).
+            str: The registered suite name (which may be computed here).
 
         Raise:
             SuiteServiceFileError:
@@ -406,6 +407,12 @@ To start a new run, stop the old one first with one or more of these:
         """
         if reg is None:
             reg = os.path.basename(os.getcwd())
+
+        is_valid, message = SuiteNameValidator.validate(reg)
+        if not is_valid:
+            raise SuiteServiceFileError(
+                f'invalid suite name - {message}'
+            )
 
         if os.path.isabs(reg):
             raise SuiteServiceFileError(

--- a/cylc/flow/tests/test_suite_srv_files_mgr.py
+++ b/cylc/flow/tests/test_suite_srv_files_mgr.py
@@ -165,6 +165,20 @@ def get_register_test_cases():
          None,  # expected return value
          SuiteServiceFileError,  # expected exception
          "cannot be an absolute path"  # expected part of exception message
+         ),
+        # 10 invalid suite name
+        ("-foo",  # reg
+         None,  # source
+         False,  # redirect,
+         None,  # cwd
+         True,  # isabs
+         True,  # isfile
+         None,  # suite_srv_dir
+         None,  # readlink
+         None,  # expected symlink
+         None,  # expected return value
+         SuiteServiceFileError,  # expected exception
+         "can not start with: ., -"  # expected part of exception message
          )
     ]
 

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -1,0 +1,128 @@
+"""Module for unicode restrictions"""
+
+import re
+
+
+ENGLISH_REGEX_MAP = {
+    r'\w': 'alphanumeric',
+    r'\-': '-',
+    r'\.': '.',
+    r'\/': '/'
+}
+
+
+def regex_chars_to_text(chars):
+    r"""Return a string representing a regex component.
+
+    Examples:
+        >>> regex_chars_to_text(['a', 'b', 'c'])
+        ['a', 'b', 'c']
+        >>> regex_chars_to_text([r'\-', r'\.', r'\/'])
+        ['-', '.', '/']
+        >>> regex_chars_to_text([r'\w'])
+        ['alphanumeric']
+
+    """
+    return [
+        ENGLISH_REGEX_MAP.get(char, char)
+        for char in chars
+    ]
+
+
+def length(minimum, maximum):
+    """Restrict character length.
+
+    Example:
+        >>> regex, message = length(0, 5)
+        >>> message
+        'must be between 0 and 5 characters long'
+        >>> bool(regex.match('abcde'))
+        True
+        >>> bool(regex.match('abcdef'))
+        False
+
+    """
+    return (
+        re.compile(r'^.{%d,%d}$' % (minimum, maximum)),
+        f'must be between {minimum} and {maximum} characters long'
+    )
+
+
+def allowed_characters(*chars):
+    """Restrict permitted characters.
+
+    Example:
+        >>> regex, message = allowed_characters('a', 'b', 'c')
+        >>> message
+        'can only contain: a, b, c'
+        >>> bool(regex.match('abc'))
+        True
+        >>> bool(regex.match('def'))
+        False
+
+    """
+    return (
+        re.compile(r'^[%s]+$' % ''.join(chars)),
+        f'can only contain: {", ".join(regex_chars_to_text(chars))}'
+    )
+
+
+def not_starts_with(*chars):
+    """Restrict first character.
+
+    Example:
+        >>> regex, message = not_starts_with('a', 'b', 'c')
+        >>> message
+        'can not start with: a, b, c'
+        >>> bool(regex.match('def'))
+        True
+        >>> bool(regex.match('adef'))
+        False
+
+    """
+    return (
+        re.compile(r'^[^%s]' % ''.join(chars)),
+        f'can not start with: {", ".join(regex_chars_to_text(chars))}'
+    )
+
+
+class UnicodeRuleChecker():
+
+    RULES = []
+
+    @classmethod
+    def __init_subclass__(cls):
+        cls.__doc__ = cls.__doc__ + '\n' if cls.__doc__ else ''
+        cls.__doc__ += '\n' + '\n'.join([
+            f'* {message}'
+            for regex, message in cls.RULES
+        ])
+
+    @classmethod
+    def validate(cls, string):
+        """Run this collection of rules against the given string.
+
+        Args:
+            string (str):
+                String to validate.
+
+        Returns:
+            tuple - (outcome, message)
+            outcome (bool) - True if all patterns match.
+            message (str) - User-friendly error message.
+
+        """
+        for rule, message in cls.RULES:
+            if not rule.match(string):
+                return (False, message)
+        return (True, None)
+
+
+class SuiteNameValidator(UnicodeRuleChecker):
+    """The rules for valid suite names:"""
+
+    RULES = [
+        length(1, 254),
+        not_starts_with(r'\.', r'\-'),
+        allowed_characters(r'\w', r'\/', '_', '+', r'\-', r'\.', '@')
+    ]


### PR DESCRIPTION
**For Discussion**

address "suite registration" point of #2979 

Create a `unicode_rules` module:
* Centralise unicode restrictions (e.g. suite / task names) for consistency.
* Provide user with an informative error explaining which rule an invalid name has broken.
* Allow us to auto-document text restrictions.

**Questions**

* [x] Permit `=` character? **No**
* [x] Permit `%` character? **No**
* [x] Limit number of characters? **Yes - 255**
* [x] Prohibit `-` and `.` as the first character (as implemented)? **Yes**
* [x] Any other changes? **No**

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/52