### PR TITLE
Turn colour off in jobscript generation command.

### DIFF
--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -22,18 +22,17 @@ usage() {
     cat <<__END__
 Usage: cylc [prep] jobscript [OPTIONS] REG TASK
 
-Generate a task job script and print it to stdout.
-
-This command wraps 'cylc [control] submit --dry-run'.
-Other options (e.g. for workflow host and owner) are passed
-through to the submit command.
+Generate a task job script and print it to stdout. Note you must give a valid
+task ID including the cycle point. "cylc list --points" can be used to see
+valid task IDs for a specific workflow cycle point range.
 
 Options:
   -h, --help   Print this usage message.
   -e --edit    Open the jobscript in a CLI text editor.
   -g --gedit   Open the jobscript in a GUI text editor.
   --plain      Don't print the "Task Job Script Generated message."
- (see also 'cylc submit --help')
+Any additional options will be passed through to the wrapped submit
+command; see "cylc submit --help".
 
 Arguments:
   REG          Registered workflow name.

--- a/bin/cylc-jobscript
+++ b/bin/cylc-jobscript
@@ -24,13 +24,8 @@ Usage: cylc [prep] jobscript [OPTIONS] REG TASK
 
 Generate a task job script and print it to stdout.
 
-Here's how to capture the script in the vim editor:
-  % cylc jobscript REG TASK | vim -
-Emacs unfortunately cannot read from stdin:
-  % cylc jobscript REG TASK > tmp.sh; emacs tmp.sh
-
 This command wraps 'cylc [control] submit --dry-run'.
-Other options (e.g. for suite host and owner) are passed
+Other options (e.g. for workflow host and owner) are passed
 through to the submit command.
 
 Options:
@@ -41,7 +36,7 @@ Options:
  (see also 'cylc submit --help')
 
 Arguments:
-  REG          Registered suite name.
+  REG          Registered workflow name.
   TASK         Task ID (NAME.CYCLE_POINT)
 __END__
 }
@@ -75,7 +70,7 @@ for arg in "${@}"; do
 done
 
 # shellcheck disable=2086
-if CYLC_SUBMIT_OUT="$(cylc submit --dry-run ${SUBMIT_ARGS})"; then
+if CYLC_SUBMIT_OUT="$(cylc submit --color=never --dry-run ${SUBMIT_ARGS})"; then
     JOBSCRIPT="$(sed -n 's/^JOB SCRIPT=//p' <<<"${CYLC_SUBMIT_OUT}")"
     if ! "${PLAIN}"; then
         echo "Task Job Script Generated: ${JOBSCRIPT}" >&2


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->
- fix `cylc jobscript` command - it's not printing the generated jobscript as advertised
- and  update its command help

On current master the command generates a jobscript then claims that it doesn't exist (so printing it fails):
```
(venv) [oliverh@drugs-and-money cylc-flow]$ cylc jobscript foo bar_m09_n07.20000101T0000+12                                                                                      
Task Job Script Generated: /home/oliverh/cylc-run/foo/log/job/20000101T0000+12/bar_m09_n07/01/job
/home/oliverh/cylc-run/foo/log/job/20000101T0000+12/bar_m09_n07/01/job: No such file or directory
```

Using the "open in editor" option instead, with vim, reveals the problem is a control code added to the filename by colorama:
```
"~/cylc-run/foo/log/job/20000101T0000+12/bar_m09_n07/01/job^[[0m"
```

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests (why?).
     - `cylc jobscript` is already tested in functional tests; I think this particular problem can't really be tested because colorama switches off if an interactive terminal is not detected?
<!-- choose one: -->
- [x] No change log entry required (why? e.g. invisible to users).
    - (the bug won't have been visible to users as this is a new feature in cylc 8)
<!-- choose one: -->
- [x] No documentation update required.
