### PR TITLE
Record all broadcast values in xtrigger return [backport]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,9 @@ to align with the new multi-component cylc-8 architecture).
 User Guide custom batch system handler example (`BATCH_SYSTEM_HANDLER` should
 be `BATCH_SYS_HANDLER`). 
 
+[#xxxx](https://github.com/cylc/cylc-flow/pull/xxxx) - Fix log & DB recording
+of broadcasts from xtriggers so they register all settings, not just one.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.3 (2019-06-12)__
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ to align with the new multi-component cylc-8 architecture).
 User Guide custom batch system handler example (`BATCH_SYSTEM_HANDLER` should
 be `BATCH_SYS_HANDLER`). 
 
-[#xxxx](https://github.com/cylc/cylc-flow/pull/xxxx) - Fix log & DB recording
+[#3280](https://github.com/cylc/cylc-flow/pull/3280) - Fix log & DB recording
 of broadcasts from xtriggers so they register all settings, not just one.
 
 -------------------------------------------------------------------------------

--- a/lib/cylc/xtrigger_mgr.py
+++ b/lib/cylc/xtrigger_mgr.py
@@ -243,10 +243,12 @@ class XtriggerManager(object):
                     for key, val in self.sat_xtrig[sig].items():
                         res["%s_%s" % (label, key)] = val
                     if res:
+                        xtrigger_env = [{'environment': {key: val}} for
+                                        key, val in res.items()]
                         self.broadcast_mgr.put_broadcast(
                             [str(ctx.point)],
                             [itask.tdef.name],
-                            [{'environment': res}],
+                            xtrigger_env
                         )
                 continue
             if sig in self.active:


### PR DESCRIPTION
These changes close (for ``7.8.x``) #3275.

This PR is a direct equivalent to #3276, to backport it to ``7.8.x``. For reviewing, note the only difference to the counterpart PR is that ``xtriggers/01-suite_state.t`` still sits under ``tests/`` here, rather than under ``flakytests/``.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.