### PR TITLE
Test header: poll abort on timeout.

### DIFF
--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -86,7 +86,7 @@
 #         Tidy up test directories for SUITE_NAME.
 #     poll COMMAND
 #         Run COMMAND in 1 second intervals for a minute until COMMAND returns
-#         a non-zero value.
+#         a non-zero value, or exit 1 (abort test) with a timeout message.
 #     skip N SKIP_REASON
 #         echo "ok $((++T)) # skip SKIP_REASON" N times.
 #     skip_all SKIP_REASON
@@ -485,10 +485,20 @@ purge_suite() {
 }
 
 poll() {
-    local TIMEOUT="$(($(date +%s) + 60))" # wait 1 minute
-    while (($(date +%s) < TIMEOUT)) && eval "$@"; do
-        sleep 1
+    local TIMEOUT="$(($(date +%s) + 10))" # wait 1 minute
+    local TIMED_OUT=true
+    while (($(date +%s) < TIMEOUT)); do
+        if eval "$@"; then
+            sleep 1
+        else
+            TIMED_OUT=false
+            break
+        fi
     done
+    if $TIMED_OUT; then
+        >&2 echo "ERROR: poll timed out: $@"
+        exit 1
+    fi
 }
 
 skip() {

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -485,7 +485,7 @@ purge_suite() {
 }
 
 poll() {
-    local TIMEOUT="$(($(date +%s) + 10))" # wait 1 minute
+    local TIMEOUT="$(($(date +%s) + 60))" # wait 1 minute
     local TIMED_OUT=true
     while (($(date +%s) < TIMEOUT)); do
         if eval "$@"; then


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

We use a `poll` function in a bunch of tests, to repeatedly run a command until we get the desired result - for one minute.  However, the test scripts just continue as normal if one minute is reached without getting the desired result.  This seems like a potential source of test flakiness under high load conditions (if not an actual source, because one minute is quite long).

This PR causes the `poll` function to abort the test with a sensible message, on timeout.

@matthewrmshin (original author of `poll` according to git!) - if you agree with this, I'll copy it to master as well.

<!-- Significant PRs should address an existing Issue. Choose one: -->


This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests (obviously).
<!-- choose one: -->
- [x] No change log entry required (invisible to users).
<!-- choose one: -->
- [x] No documentation update required.
