### PR TITLE
Fix cmp_ok arg order in a test (master).

### DIFF
--- a/flakytests/database/00-simple.t
+++ b/flakytests/database/00-simple.t
@@ -59,7 +59,7 @@ sqlite3 "${DB_FILE}" \
 LOCALHOST="$(hostname -f)"
 # FIXME: recent Travis CI failure
 sed -i "s/localhost/${LOCALHOST}/" "${NAME}"
-cmp_ok - "${NAME}" <<__SELECT__
+cmp_ok "${NAME}" - <<__SELECT__
 1|bar|1|1|0|0|${LOCALHOST}|background
 1|baz|1|1|0|0|${LOCALHOST}|background
 1|foo|1|1|0|0|${LOCALHOST}|background


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

The test `tests/database/00-simple.t` has been failing on Travis for 7.8.x (is under `flakytests` on master):
```
cat: unrecognized option '--cmp-ok.stderr'
Try 'cat --help' for more information.
cp: unrecognized option '--cmp-ok.stderr'
Try 'cp --help' for more information.
    stdout and stderr stored in: /tmp/travis/cylctb-20190813T121051Z/database/00-simple
./tests/database/00-simple.t ................................. Failed 1/21 subtests 
```

This passes locally, but something (maybe bash version?) has changed on T-CI recently to cause the `cat` and `cp` errors above.  

A closer look shows that `cmp_ok` in the test script has its args in the wrong order (`-` for stdin should be the second arg, as documented in the file header) and even when the test passes, the test name is being identified erroneously as `-`).

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue. @kinow and @dwsutherland - can you possibly do a quick review so I can get this in (it's only a one-line change)?

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (is a test script mod).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
