### PR TITLE
Fix cmp_ok arg order in a test.

### DIFF
--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -57,7 +57,7 @@ sqlite3 "${DB_FILE}" \
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
 LOCALHOST="$(hostname -f)"
-cmp_ok - "${NAME}" <<__SELECT__
+cmp_ok "${NAME}" - <<__SELECT__
 1|bar|1|1|0|0|${LOCALHOST}|background
 1|baz|1|1|0|0|${LOCALHOST}|background
 1|foo|1|1|0|0|${LOCALHOST}|background


### PR DESCRIPTION
This is a small change with no associated Issue.

7.8.x companion of #3289 - see there for documentation there.

