### PR TITLE
insert: globbing capability docstring correction (Cylc-8)

### DIFF
--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -22,7 +22,7 @@ Insert task proxies into a running suite. Uses of insertion include:
  1) insert a task that was excluded by the suite definition at start-up.
  2) reinstate a task that was previously removed from a running suite.
  3) re-run an old task that cannot be retriggered because its task proxy
- is no longer live in the a suite.
+    is no longer live in the a suite.
 
 Be aware that inserted cycling tasks keep on cycling as normal, even if
 another instance of the same task exists at a later cycle (instances of
@@ -49,7 +49,7 @@ from cylc.flow.terminal import prompt, cli_function
 
 def get_option_parser():
     parser = COP(
-        __doc__, comms=True, multitask=True,
+        __doc__, comms=True, multitask_nocycles=True,
         argdoc=[
             ("REG", "Suite name"),
             ('TASKID [...]', 'Task identifier')])


### PR DESCRIPTION
These changes close #3284 (for ``master``/Cylc-8). Note I am applying a different approach for the equivalent PR to 7 & 8, adding the necessary text directly into the ``insert`` docstring for 7 since the version is soon to be dormant, but creating an alternative option-parser-level pattern matching text section here for 8 where something reusable & more maintainable could well be useful for CLI or functionality changes that may come in future.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (reason: *unable to test applicability of notional help text*).
- [x] No change log entry required (reason: *small change*).
- [x] No documentation update required (reason: *documentation auto-updated via command reference ``--help`` text extraction script*).