### PR TITLE
Update graphene version range in setup.py

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -32,6 +32,9 @@ if grep 'unit-tests' <<< "${args[@]}"; then
     sudo apt-get install shellcheck
 fi
 
+# TODO: remove when Travis env comes with a version of six >=1.12 (graphene)
+pip install "six>=1.12"
+
 pip install -e ."[all]"
 
 # configure local SSH for Cylc jobs

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ def find_version(*file_paths):
 install_requires = [
     'ansimarkup>=1.0.0',
     'colorama==0.4.*',
-    'graphene==2.1.6',
+    'graphene>=2.1,<3',
     'metomi-isodatetime==1!2.0.*',
     'jinja2>=2.10.1, <2.11.0',
     'markupsafe==1.1.*',


### PR DESCRIPTION
This is a small change with no associated Issue.

Changes the version range of `graphene` to match the version requirement of `graphene-tornado`. Without this change, users installing `cylc-uiserver` face either a warning or a possible error. This happens because `cylc-uiserver` installs `graphene-tornado`, which is bringing `graphene==2.1.7`.

But `cylc-flow` had a hard-requirement on `==2.1.6`, due to an error on Travis.

The error on Travis was due to the Travis environment coming with `six <1.12`, while `graphql-relay` requires `>=1.12`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
