### PR TITLE
isHeld API addition

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -104,6 +104,8 @@ def node_filter(node, args):
         (args.get('ghosts') or n_atts[5] != '') and
         (not args.get('states') or n_atts[5] in args['states']) and
         not (args.get('exstates') and n_atts[5] in args['exstates']) and
+        (args.get('isHeld') is None
+         or (node.is_held or not args['isHeld'])) and
         (args.get('mindepth', -1) < 0 or node.depth >= args['mindepth']) and
         (args.get('maxdepth', -1) < 0 or node.depth <= args['maxdepth']) and
         # Now filter node against id arg lists

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -104,8 +104,8 @@ def node_filter(node, args):
         (args.get('ghosts') or n_atts[5] != '') and
         (not args.get('states') or n_atts[5] in args['states']) and
         not (args.get('exstates') and n_atts[5] in args['exstates']) and
-        (args.get('isHeld') is None
-         or (node.is_held or not args['isHeld'])) and
+        (args.get('is_held') is None
+         or (node.is_held == args['is_held'])) and
         (args.get('mindepth', -1) < 0 or node.depth >= args['mindepth']) and
         (args.get('maxdepth', -1) < 0 or node.depth <= args['maxdepth']) and
         # Now filter node against id arg lists

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -270,7 +270,6 @@ async def get_nodes_all(root, info, **args):
 
 async def get_nodes_by_ids(root, info, **args):
     """Resolver for returning job, task, family node"""
-    print(args)
     field_name = to_snake_case(info.field_name)
     field_ids = getattr(root, field_name, None)
     if hasattr(args, 'id'):

--- a/cylc/flow/ws_data_mgr.py
+++ b/cylc/flow/ws_data_mgr.py
@@ -46,7 +46,6 @@ Packaging methods are included for dissemination of protobuf messages.
 """
 
 from collections import Counter
-from copy import copy
 from time import time
 
 from cylc.flow.cycling.loader import get_point
@@ -748,16 +747,13 @@ class WsDataMgr(object):
         workflow.stamp = f'{self.workflow_id}@{update_time}'
         workflow.last_updated = update_time
 
-        all_states = [
+        counter = Counter([
             t.state
             for t in self.task_proxies.values()
-            if t.state != ''
-        ]
-
-        workflow.states[:] = set(all_states)
-
+            if t.state])
+        workflow.states[:] = counter.keys()
         workflow.ClearField('state_totals')
-        for state, state_cnt in Counter(all_states).items():
+        for state, state_cnt in counter.items():
             workflow.state_totals[state] = state_cnt
 
         workflow.is_held_total = len([

--- a/cylc/flow/ws_messages.proto
+++ b/cylc/flow/ws_messages.proto
@@ -49,22 +49,6 @@ message PbTimeZone {
     string string_extended = 4;
 }
 
-message PbStateTotals {
-    int32 runahead = 1;
-    int32 waiting = 2;
-    int32 held = 3;
-    int32 queued = 4;
-    int32 expired = 5;
-    int32 ready = 6;
-    int32 submit_failed = 7;
-    int32 submit_retrying = 8;
-    int32 submitted = 9;
-    int32 retrying = 10;
-    int32 running = 11;
-    int32 failed = 12;
-    int32 succeeded = 13;
-}
-
 message PbWorkflow {
     string stamp = 1;
     string id = 2;
@@ -86,7 +70,7 @@ message PbWorkflow {
     bool reloading = 18;
     string run_mode = 19;
     string cycling_mode = 20;
-    PbStateTotals state_totals = 21;
+    map<string, int32> state_totals = 21;
     string workflow_log_dir = 22;
     PbTimeZone time_zone_info = 23;
     int32 tree_depth = 24;
@@ -96,6 +80,7 @@ message PbWorkflow {
     repeated string task_proxies = 28;
     repeated string family_proxies = 29;
     string status_msg = 30;
+    int32 is_held_total = 31;
 }
 
 message PbJob {
@@ -128,9 +113,8 @@ message PbJob {
     repeated string param_env_tmpl = 27;
     repeated string param_var = 28;
     repeated string extra_logs = 29;
-    /* For filtering speed */
-    string name = 30;
-    string cycle_point = 31;
+    string name = 30; /* filter item */
+    string cycle_point = 31; /* filter item */
 }
 
 message PbTask {
@@ -184,8 +168,8 @@ message PbTaskProxy {
     repeated string jobs = 14;
     repeated string parents = 15;
     string first_parent = 16;
-    /* For filtering speed */
-    string name = 17;
+    string name = 17; /* filter item */
+    bool is_held = 18;
 }
 
 message PbFamily {
@@ -204,7 +188,7 @@ message PbFamilyProxy {
     string stamp = 1;
     string id = 2;
     string cycle_point = 3;
-    string name = 4;
+    string name = 4; /* filter item */
     string family = 5;
     string state = 6;
     int32 depth = 7;
@@ -212,6 +196,7 @@ message PbFamilyProxy {
     repeated string parents = 9;
     repeated string child_tasks = 10;
     repeated string child_families = 11;
+    bool is_held = 12;
 }
 
 message PbEdge {

--- a/cylc/flow/ws_messages_pb2.py
+++ b/cylc/flow/ws_messages_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\x11ws_messages.proto\"O\n\x06PbMeta\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0b\n\x03URL\x18\x03 \x01(\t\x12\x14\n\x0cuser_defined\x18\x04 \x03(\t\"[\n\nPbTimeZone\x12\r\n\x05hours\x18\x01 \x01(\x05\x12\x0f\n\x07minutes\x18\x02 \x01(\x05\x12\x14\n\x0cstring_basic\x18\x03 \x01(\t\x12\x17\n\x0fstring_extended\x18\x04 \x01(\t\"\xf9\x01\n\rPbStateTotals\x12\x10\n\x08runahead\x18\x01 \x01(\x05\x12\x0f\n\x07waiting\x18\x02 \x01(\x05\x12\x0c\n\x04held\x18\x03 \x01(\x05\x12\x0e\n\x06queued\x18\x04 \x01(\x05\x12\x0f\n\x07\x65xpired\x18\x05 \x01(\x05\x12\r\n\x05ready\x18\x06 \x01(\x05\x12\x15\n\rsubmit_failed\x18\x07 \x01(\x05\x12\x17\n\x0fsubmit_retrying\x18\x08 \x01(\x05\x12\x11\n\tsubmitted\x18\t \x01(\x05\x12\x10\n\x08retrying\x18\n \x01(\x05\x12\x0f\n\x07running\x18\x0b \x01(\x05\x12\x0e\n\x06\x66\x61iled\x18\x0c \x01(\x05\x12\x11\n\tsucceeded\x18\r \x01(\x05\"\x93\x05\n\nPbWorkflow\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x0c\n\x04host\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\x05\x12\r\n\x05owner\x18\x07 \x01(\t\x12\r\n\x05tasks\x18\x08 \x03(\t\x12\x10\n\x08\x66\x61milies\x18\t \x03(\t\x12\x17\n\x05\x65\x64ges\x18\n \x01(\x0b\x32\x08.PbEdges\x12\x13\n\x0b\x61pi_version\x18\x0b \x01(\x05\x12\x14\n\x0c\x63ylc_version\x18\x0c \x01(\t\x12\x14\n\x0clast_updated\x18\r \x01(\x01\x12\x15\n\x04meta\x18\x0e \x01(\x0b\x32\x07.PbMeta\x12#\n\x1bnewest_runahead_cycle_point\x18\x0f \x01(\t\x12\x1a\n\x12newest_cycle_point\x18\x10 \x01(\t\x12\x1a\n\x12oldest_cycle_point\x18\x11 \x01(\t\x12\x11\n\treloading\x18\x12 \x01(\x08\x12\x10\n\x08run_mode\x18\x13 \x01(\t\x12\x14\n\x0c\x63ycling_mode\x18\x14 \x01(\t\x12$\n\x0cstate_totals\x18\x15 \x01(\x0b\x32\x0e.PbStateTotals\x12\x18\n\x10workflow_log_dir\x18\x16 \x01(\t\x12#\n\x0etime_zone_info\x18\x17 \x01(\x0b\x32\x0b.PbTimeZone\x12\x12\n\ntree_depth\x18\x18 \x01(\x05\x12\x15\n\rjob_log_names\x18\x19 \x03(\t\x12\x15\n\rns_defn_order\x18\x1a \x03(\t\x12\x0e\n\x06states\x18\x1b \x03(\t\x12\x14\n\x0ctask_proxies\x18\x1c \x03(\t\x12\x16\n\x0e\x66\x61mily_proxies\x18\x1d \x03(\t\x12\x12\n\nstatus_msg\x18\x1e \x01(\t\"\xf3\x04\n\x05PbJob\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x12\n\nsubmit_num\x18\x03 \x01(\x05\x12\r\n\x05state\x18\x04 \x01(\t\x12\x12\n\ntask_proxy\x18\x05 \x01(\t\x12\x16\n\x0esubmitted_time\x18\x06 \x01(\t\x12\x14\n\x0cstarted_time\x18\x07 \x01(\t\x12\x15\n\rfinished_time\x18\x08 \x01(\t\x12\x18\n\x10\x62\x61tch_sys_job_id\x18\t \x01(\t\x12\x16\n\x0e\x62\x61tch_sys_name\x18\n \x01(\t\x12\x12\n\nenv_script\x18\x0b \x01(\t\x12\x12\n\nerr_script\x18\x0c \x01(\t\x12\x13\n\x0b\x65xit_script\x18\r \x01(\t\x12\x1c\n\x14\x65xecution_time_limit\x18\x0e \x01(\x02\x12\x0c\n\x04host\x18\x0f \x01(\t\x12\x13\n\x0binit_script\x18\x10 \x01(\t\x12\x13\n\x0bjob_log_dir\x18\x11 \x01(\t\x12\r\n\x05owner\x18\x12 \x01(\t\x12\x13\n\x0bpost_script\x18\x13 \x01(\t\x12\x12\n\npre_script\x18\x14 \x01(\t\x12\x0e\n\x06script\x18\x15 \x01(\t\x12\r\n\x05shell\x18\x16 \x01(\t\x12\x14\n\x0cwork_sub_dir\x18\x17 \x01(\t\x12\x16\n\x0e\x62\x61tch_sys_conf\x18\x18 \x03(\t\x12\x13\n\x0b\x65nvironment\x18\x19 \x03(\t\x12\x12\n\ndirectives\x18\x1a \x03(\t\x12\x16\n\x0eparam_env_tmpl\x18\x1b \x03(\t\x12\x11\n\tparam_var\x18\x1c \x03(\t\x12\x12\n\nextra_logs\x18\x1d \x03(\t\x12\x0c\n\x04name\x18\x1e \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x1f \x01(\t\"\x96\x01\n\x06PbTask\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x15\n\x04meta\x18\x04 \x01(\x0b\x32\x07.PbMeta\x12\x19\n\x11mean_elapsed_time\x18\x05 \x01(\x02\x12\r\n\x05\x64\x65pth\x18\x06 \x01(\x05\x12\x0f\n\x07proxies\x18\x07 \x03(\t\x12\x11\n\tnamespace\x18\x08 \x03(\t\"r\n\nPbPollTask\x12\x13\n\x0blocal_proxy\x18\x01 \x01(\t\x12\x10\n\x08workflow\x18\x02 \x01(\t\x12\x14\n\x0cremote_proxy\x18\x03 \x01(\t\x12\x11\n\treq_state\x18\x04 \x01(\t\x12\x14\n\x0cgraph_string\x18\x05 \x01(\t\"l\n\x0bPbCondition\x12\x12\n\ntask_proxy\x18\x01 \x01(\t\x12\x12\n\nexpr_alias\x18\x02 \x01(\t\x12\x11\n\treq_state\x18\x03 \x01(\t\x12\x11\n\tsatisfied\x18\x04 \x01(\x08\x12\x0f\n\x07message\x18\x05 \x01(\t\"o\n\x0ePbPrerequisite\x12\x12\n\nexpression\x18\x01 \x01(\t\x12 \n\nconditions\x18\x02 \x03(\x0b\x32\x0c.PbCondition\x12\x14\n\x0c\x63ycle_points\x18\x03 \x03(\t\x12\x11\n\tsatisfied\x18\x04 \x01(\x08\"\xca\x02\n\x0bPbTaskProxy\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04task\x18\x03 \x01(\t\x12\r\n\x05state\x18\x04 \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x05 \x01(\t\x12\x0f\n\x07spawned\x18\x06 \x01(\x08\x12\r\n\x05\x64\x65pth\x18\x07 \x01(\x05\x12\x13\n\x0bjob_submits\x18\x08 \x01(\x05\x12\x16\n\x0elatest_message\x18\t \x01(\t\x12\x0f\n\x07outputs\x18\n \x03(\t\x12\x12\n\nbroadcasts\x18\x0b \x03(\t\x12\x11\n\tnamespace\x18\x0c \x03(\t\x12&\n\rprerequisites\x18\r \x03(\x0b\x32\x0f.PbPrerequisite\x12\x0c\n\x04jobs\x18\x0e \x03(\t\x12\x0f\n\x07parents\x18\x0f \x03(\t\x12\x14\n\x0c\x66irst_parent\x18\x10 \x01(\t\x12\x0c\n\x04name\x18\x11 \x01(\t\"\xa8\x01\n\x08PbFamily\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x15\n\x04meta\x18\x04 \x01(\x0b\x32\x07.PbMeta\x12\r\n\x05\x64\x65pth\x18\x05 \x01(\x05\x12\x0f\n\x07proxies\x18\x06 \x03(\t\x12\x0f\n\x07parents\x18\x07 \x03(\t\x12\x13\n\x0b\x63hild_tasks\x18\x08 \x03(\t\x12\x16\n\x0e\x63hild_families\x18\t \x03(\t\"\xcf\x01\n\rPbFamilyProxy\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x0e\n\x06\x66\x61mily\x18\x05 \x01(\t\x12\r\n\x05state\x18\x06 \x01(\t\x12\r\n\x05\x64\x65pth\x18\x07 \x01(\x05\x12\x14\n\x0c\x66irst_parent\x18\x08 \x01(\t\x12\x0f\n\x07parents\x18\t \x03(\t\x12\x13\n\x0b\x63hild_tasks\x18\n \x03(\t\x12\x16\n\x0e\x63hild_families\x18\x0b \x03(\t\"b\n\x06PbEdge\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\t\x12\x0f\n\x07suicide\x18\x05 \x01(\x08\x12\x0c\n\x04\x63ond\x18\x06 \x01(\x08\"o\n\x07PbEdges\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05\x65\x64ges\x18\x02 \x03(\t\x12+\n\x16workflow_polling_tasks\x18\x03 \x03(\x0b\x32\x0b.PbPollTask\x12\x0e\n\x06leaves\x18\x04 \x03(\t\x12\x0c\n\x04\x66\x65\x65t\x18\x05 \x03(\t\"\xe0\x01\n\x10PbEntireWorkflow\x12\x1d\n\x08workflow\x18\x01 \x01(\x0b\x32\x0b.PbWorkflow\x12\x16\n\x05tasks\x18\x02 \x03(\x0b\x32\x07.PbTask\x12\"\n\x0ctask_proxies\x18\x03 \x03(\x0b\x32\x0c.PbTaskProxy\x12\x14\n\x04jobs\x18\x04 \x03(\x0b\x32\x06.PbJob\x12\x1b\n\x08\x66\x61milies\x18\x05 \x03(\x0b\x32\t.PbFamily\x12&\n\x0e\x66\x61mily_proxies\x18\x06 \x03(\x0b\x32\x0e.PbFamilyProxy\x12\x16\n\x05\x65\x64ges\x18\x07 \x03(\x0b\x32\x07.PbEdgeb\x06proto3')
+  serialized_pb=_b('\n\x11ws_messages.proto\"O\n\x06PbMeta\x12\r\n\x05title\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x0b\n\x03URL\x18\x03 \x01(\t\x12\x14\n\x0cuser_defined\x18\x04 \x03(\t\"[\n\nPbTimeZone\x12\r\n\x05hours\x18\x01 \x01(\x05\x12\x0f\n\x07minutes\x18\x02 \x01(\x05\x12\x14\n\x0cstring_basic\x18\x03 \x01(\t\x12\x17\n\x0fstring_extended\x18\x04 \x01(\t\"\xec\x05\n\nPbWorkflow\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x0c\n\x04host\x18\x05 \x01(\t\x12\x0c\n\x04port\x18\x06 \x01(\x05\x12\r\n\x05owner\x18\x07 \x01(\t\x12\r\n\x05tasks\x18\x08 \x03(\t\x12\x10\n\x08\x66\x61milies\x18\t \x03(\t\x12\x17\n\x05\x65\x64ges\x18\n \x01(\x0b\x32\x08.PbEdges\x12\x13\n\x0b\x61pi_version\x18\x0b \x01(\x05\x12\x14\n\x0c\x63ylc_version\x18\x0c \x01(\t\x12\x14\n\x0clast_updated\x18\r \x01(\x01\x12\x15\n\x04meta\x18\x0e \x01(\x0b\x32\x07.PbMeta\x12#\n\x1bnewest_runahead_cycle_point\x18\x0f \x01(\t\x12\x1a\n\x12newest_cycle_point\x18\x10 \x01(\t\x12\x1a\n\x12oldest_cycle_point\x18\x11 \x01(\t\x12\x11\n\treloading\x18\x12 \x01(\x08\x12\x10\n\x08run_mode\x18\x13 \x01(\t\x12\x14\n\x0c\x63ycling_mode\x18\x14 \x01(\t\x12\x32\n\x0cstate_totals\x18\x15 \x03(\x0b\x32\x1c.PbWorkflow.StateTotalsEntry\x12\x18\n\x10workflow_log_dir\x18\x16 \x01(\t\x12#\n\x0etime_zone_info\x18\x17 \x01(\x0b\x32\x0b.PbTimeZone\x12\x12\n\ntree_depth\x18\x18 \x01(\x05\x12\x15\n\rjob_log_names\x18\x19 \x03(\t\x12\x15\n\rns_defn_order\x18\x1a \x03(\t\x12\x0e\n\x06states\x18\x1b \x03(\t\x12\x14\n\x0ctask_proxies\x18\x1c \x03(\t\x12\x16\n\x0e\x66\x61mily_proxies\x18\x1d \x03(\t\x12\x12\n\nstatus_msg\x18\x1e \x01(\t\x12\x15\n\ris_held_total\x18\x1f \x01(\x05\x1a\x32\n\x10StateTotalsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x05:\x02\x38\x01\"\xf3\x04\n\x05PbJob\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x12\n\nsubmit_num\x18\x03 \x01(\x05\x12\r\n\x05state\x18\x04 \x01(\t\x12\x12\n\ntask_proxy\x18\x05 \x01(\t\x12\x16\n\x0esubmitted_time\x18\x06 \x01(\t\x12\x14\n\x0cstarted_time\x18\x07 \x01(\t\x12\x15\n\rfinished_time\x18\x08 \x01(\t\x12\x18\n\x10\x62\x61tch_sys_job_id\x18\t \x01(\t\x12\x16\n\x0e\x62\x61tch_sys_name\x18\n \x01(\t\x12\x12\n\nenv_script\x18\x0b \x01(\t\x12\x12\n\nerr_script\x18\x0c \x01(\t\x12\x13\n\x0b\x65xit_script\x18\r \x01(\t\x12\x1c\n\x14\x65xecution_time_limit\x18\x0e \x01(\x02\x12\x0c\n\x04host\x18\x0f \x01(\t\x12\x13\n\x0binit_script\x18\x10 \x01(\t\x12\x13\n\x0bjob_log_dir\x18\x11 \x01(\t\x12\r\n\x05owner\x18\x12 \x01(\t\x12\x13\n\x0bpost_script\x18\x13 \x01(\t\x12\x12\n\npre_script\x18\x14 \x01(\t\x12\x0e\n\x06script\x18\x15 \x01(\t\x12\r\n\x05shell\x18\x16 \x01(\t\x12\x14\n\x0cwork_sub_dir\x18\x17 \x01(\t\x12\x16\n\x0e\x62\x61tch_sys_conf\x18\x18 \x03(\t\x12\x13\n\x0b\x65nvironment\x18\x19 \x03(\t\x12\x12\n\ndirectives\x18\x1a \x03(\t\x12\x16\n\x0eparam_env_tmpl\x18\x1b \x03(\t\x12\x11\n\tparam_var\x18\x1c \x03(\t\x12\x12\n\nextra_logs\x18\x1d \x03(\t\x12\x0c\n\x04name\x18\x1e \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x1f \x01(\t\"\x96\x01\n\x06PbTask\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x15\n\x04meta\x18\x04 \x01(\x0b\x32\x07.PbMeta\x12\x19\n\x11mean_elapsed_time\x18\x05 \x01(\x02\x12\r\n\x05\x64\x65pth\x18\x06 \x01(\x05\x12\x0f\n\x07proxies\x18\x07 \x03(\t\x12\x11\n\tnamespace\x18\x08 \x03(\t\"r\n\nPbPollTask\x12\x13\n\x0blocal_proxy\x18\x01 \x01(\t\x12\x10\n\x08workflow\x18\x02 \x01(\t\x12\x14\n\x0cremote_proxy\x18\x03 \x01(\t\x12\x11\n\treq_state\x18\x04 \x01(\t\x12\x14\n\x0cgraph_string\x18\x05 \x01(\t\"l\n\x0bPbCondition\x12\x12\n\ntask_proxy\x18\x01 \x01(\t\x12\x12\n\nexpr_alias\x18\x02 \x01(\t\x12\x11\n\treq_state\x18\x03 \x01(\t\x12\x11\n\tsatisfied\x18\x04 \x01(\x08\x12\x0f\n\x07message\x18\x05 \x01(\t\"o\n\x0ePbPrerequisite\x12\x12\n\nexpression\x18\x01 \x01(\t\x12 \n\nconditions\x18\x02 \x03(\x0b\x32\x0c.PbCondition\x12\x14\n\x0c\x63ycle_points\x18\x03 \x03(\t\x12\x11\n\tsatisfied\x18\x04 \x01(\x08\"\xdb\x02\n\x0bPbTaskProxy\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04task\x18\x03 \x01(\t\x12\r\n\x05state\x18\x04 \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x05 \x01(\t\x12\x0f\n\x07spawned\x18\x06 \x01(\x08\x12\r\n\x05\x64\x65pth\x18\x07 \x01(\x05\x12\x13\n\x0bjob_submits\x18\x08 \x01(\x05\x12\x16\n\x0elatest_message\x18\t \x01(\t\x12\x0f\n\x07outputs\x18\n \x03(\t\x12\x12\n\nbroadcasts\x18\x0b \x03(\t\x12\x11\n\tnamespace\x18\x0c \x03(\t\x12&\n\rprerequisites\x18\r \x03(\x0b\x32\x0f.PbPrerequisite\x12\x0c\n\x04jobs\x18\x0e \x03(\t\x12\x0f\n\x07parents\x18\x0f \x03(\t\x12\x14\n\x0c\x66irst_parent\x18\x10 \x01(\t\x12\x0c\n\x04name\x18\x11 \x01(\t\x12\x0f\n\x07is_held\x18\x12 \x01(\x08\"\xa8\x01\n\x08PbFamily\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\x15\n\x04meta\x18\x04 \x01(\x0b\x32\x07.PbMeta\x12\r\n\x05\x64\x65pth\x18\x05 \x01(\x05\x12\x0f\n\x07proxies\x18\x06 \x03(\t\x12\x0f\n\x07parents\x18\x07 \x03(\t\x12\x13\n\x0b\x63hild_tasks\x18\x08 \x03(\t\x12\x16\n\x0e\x63hild_families\x18\t \x03(\t\"\xe0\x01\n\rPbFamilyProxy\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x13\n\x0b\x63ycle_point\x18\x03 \x01(\t\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x0e\n\x06\x66\x61mily\x18\x05 \x01(\t\x12\r\n\x05state\x18\x06 \x01(\t\x12\r\n\x05\x64\x65pth\x18\x07 \x01(\x05\x12\x14\n\x0c\x66irst_parent\x18\x08 \x01(\t\x12\x0f\n\x07parents\x18\t \x03(\t\x12\x13\n\x0b\x63hild_tasks\x18\n \x03(\t\x12\x16\n\x0e\x63hild_families\x18\x0b \x03(\t\x12\x0f\n\x07is_held\x18\x0c \x01(\x08\"b\n\x06PbEdge\x12\r\n\x05stamp\x18\x01 \x01(\t\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\t\x12\x0e\n\x06target\x18\x04 \x01(\t\x12\x0f\n\x07suicide\x18\x05 \x01(\x08\x12\x0c\n\x04\x63ond\x18\x06 \x01(\x08\"o\n\x07PbEdges\x12\n\n\x02id\x18\x01 \x01(\t\x12\r\n\x05\x65\x64ges\x18\x02 \x03(\t\x12+\n\x16workflow_polling_tasks\x18\x03 \x03(\x0b\x32\x0b.PbPollTask\x12\x0e\n\x06leaves\x18\x04 \x03(\t\x12\x0c\n\x04\x66\x65\x65t\x18\x05 \x03(\t\"\xe0\x01\n\x10PbEntireWorkflow\x12\x1d\n\x08workflow\x18\x01 \x01(\x0b\x32\x0b.PbWorkflow\x12\x16\n\x05tasks\x18\x02 \x03(\x0b\x32\x07.PbTask\x12\"\n\x0ctask_proxies\x18\x03 \x03(\x0b\x32\x0c.PbTaskProxy\x12\x14\n\x04jobs\x18\x04 \x03(\x0b\x32\x06.PbJob\x12\x1b\n\x08\x66\x61milies\x18\x05 \x03(\x0b\x32\t.PbFamily\x12&\n\x0e\x66\x61mily_proxies\x18\x06 \x03(\x0b\x32\x0e.PbFamilyProxy\x12\x16\n\x05\x65\x64ges\x18\x07 \x03(\x0b\x32\x07.PbEdgeb\x06proto3')
 )
 
 
@@ -130,100 +130,23 @@ _PBTIMEZONE = _descriptor.Descriptor(
 )
 
 
-_PBSTATETOTALS = _descriptor.Descriptor(
-  name='PbStateTotals',
-  full_name='PbStateTotals',
+_PBWORKFLOW_STATETOTALSENTRY = _descriptor.Descriptor(
+  name='StateTotalsEntry',
+  full_name='PbWorkflow.StateTotalsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='runahead', full_name='PbStateTotals.runahead', index=0,
-      number=1, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
+      name='key', full_name='PbWorkflow.StateTotalsEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='waiting', full_name='PbStateTotals.waiting', index=1,
+      name='value', full_name='PbWorkflow.StateTotalsEntry.value', index=1,
       number=2, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='held', full_name='PbStateTotals.held', index=2,
-      number=3, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='queued', full_name='PbStateTotals.queued', index=3,
-      number=4, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='expired', full_name='PbStateTotals.expired', index=4,
-      number=5, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='ready', full_name='PbStateTotals.ready', index=5,
-      number=6, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='submit_failed', full_name='PbStateTotals.submit_failed', index=6,
-      number=7, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='submit_retrying', full_name='PbStateTotals.submit_retrying', index=7,
-      number=8, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='submitted', full_name='PbStateTotals.submitted', index=8,
-      number=9, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='retrying', full_name='PbStateTotals.retrying', index=9,
-      number=10, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='running', full_name='PbStateTotals.running', index=10,
-      number=11, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='failed', full_name='PbStateTotals.failed', index=11,
-      number=12, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='succeeded', full_name='PbStateTotals.succeeded', index=12,
-      number=13, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -234,16 +157,15 @@ _PBSTATETOTALS = _descriptor.Descriptor(
   nested_types=[],
   enum_types=[
   ],
-  serialized_options=None,
+  serialized_options=_b('8\001'),
   is_extendable=False,
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=196,
-  serialized_end=445,
+  serialized_start=894,
+  serialized_end=944,
 )
-
 
 _PBWORKFLOW = _descriptor.Descriptor(
   name='PbWorkflow',
@@ -394,8 +316,8 @@ _PBWORKFLOW = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='state_totals', full_name='PbWorkflow.state_totals', index=20,
-      number=21, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      number=21, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -462,10 +384,17 @@ _PBWORKFLOW = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='is_held_total', full_name='PbWorkflow.is_held_total', index=30,
+      number=31, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
-  nested_types=[],
+  nested_types=[_PBWORKFLOW_STATETOTALSENTRY, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -474,8 +403,8 @@ _PBWORKFLOW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=448,
-  serialized_end=1107,
+  serialized_start=196,
+  serialized_end=944,
 )
 
 
@@ -715,8 +644,8 @@ _PBJOB = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1110,
-  serialized_end=1737,
+  serialized_start=947,
+  serialized_end=1574,
 )
 
 
@@ -795,8 +724,8 @@ _PBTASK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1740,
-  serialized_end=1890,
+  serialized_start=1577,
+  serialized_end=1727,
 )
 
 
@@ -854,8 +783,8 @@ _PBPOLLTASK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1892,
-  serialized_end=2006,
+  serialized_start=1729,
+  serialized_end=1843,
 )
 
 
@@ -913,8 +842,8 @@ _PBCONDITION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2008,
-  serialized_end=2116,
+  serialized_start=1845,
+  serialized_end=1953,
 )
 
 
@@ -965,8 +894,8 @@ _PBPREREQUISITE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2118,
-  serialized_end=2229,
+  serialized_start=1955,
+  serialized_end=2066,
 )
 
 
@@ -1096,6 +1025,13 @@ _PBTASKPROXY = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='is_held', full_name='PbTaskProxy.is_held', index=17,
+      number=18, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -1108,8 +1044,8 @@ _PBTASKPROXY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2232,
-  serialized_end=2562,
+  serialized_start=2069,
+  serialized_end=2416,
 )
 
 
@@ -1195,8 +1131,8 @@ _PBFAMILY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2565,
-  serialized_end=2733,
+  serialized_start=2419,
+  serialized_end=2587,
 )
 
 
@@ -1284,6 +1220,13 @@ _PBFAMILYPROXY = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='is_held', full_name='PbFamilyProxy.is_held', index=11,
+      number=12, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -1296,8 +1239,8 @@ _PBFAMILYPROXY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2736,
-  serialized_end=2943,
+  serialized_start=2590,
+  serialized_end=2814,
 )
 
 
@@ -1362,8 +1305,8 @@ _PBEDGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2945,
-  serialized_end=3043,
+  serialized_start=2816,
+  serialized_end=2914,
 )
 
 
@@ -1421,8 +1364,8 @@ _PBEDGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3045,
-  serialized_end=3156,
+  serialized_start=2916,
+  serialized_end=3027,
 )
 
 
@@ -1494,13 +1437,14 @@ _PBENTIREWORKFLOW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3159,
-  serialized_end=3383,
+  serialized_start=3030,
+  serialized_end=3254,
 )
 
+_PBWORKFLOW_STATETOTALSENTRY.containing_type = _PBWORKFLOW
 _PBWORKFLOW.fields_by_name['edges'].message_type = _PBEDGES
 _PBWORKFLOW.fields_by_name['meta'].message_type = _PBMETA
-_PBWORKFLOW.fields_by_name['state_totals'].message_type = _PBSTATETOTALS
+_PBWORKFLOW.fields_by_name['state_totals'].message_type = _PBWORKFLOW_STATETOTALSENTRY
 _PBWORKFLOW.fields_by_name['time_zone_info'].message_type = _PBTIMEZONE
 _PBTASK.fields_by_name['meta'].message_type = _PBMETA
 _PBPREREQUISITE.fields_by_name['conditions'].message_type = _PBCONDITION
@@ -1516,7 +1460,6 @@ _PBENTIREWORKFLOW.fields_by_name['family_proxies'].message_type = _PBFAMILYPROXY
 _PBENTIREWORKFLOW.fields_by_name['edges'].message_type = _PBEDGE
 DESCRIPTOR.message_types_by_name['PbMeta'] = _PBMETA
 DESCRIPTOR.message_types_by_name['PbTimeZone'] = _PBTIMEZONE
-DESCRIPTOR.message_types_by_name['PbStateTotals'] = _PBSTATETOTALS
 DESCRIPTOR.message_types_by_name['PbWorkflow'] = _PBWORKFLOW
 DESCRIPTOR.message_types_by_name['PbJob'] = _PBJOB
 DESCRIPTOR.message_types_by_name['PbTask'] = _PBTASK
@@ -1545,19 +1488,20 @@ PbTimeZone = _reflection.GeneratedProtocolMessageType('PbTimeZone', (_message.Me
   })
 _sym_db.RegisterMessage(PbTimeZone)
 
-PbStateTotals = _reflection.GeneratedProtocolMessageType('PbStateTotals', (_message.Message,), {
-  'DESCRIPTOR' : _PBSTATETOTALS,
-  '__module__' : 'ws_messages_pb2'
-  # @@protoc_insertion_point(class_scope:PbStateTotals)
-  })
-_sym_db.RegisterMessage(PbStateTotals)
-
 PbWorkflow = _reflection.GeneratedProtocolMessageType('PbWorkflow', (_message.Message,), {
+
+  'StateTotalsEntry' : _reflection.GeneratedProtocolMessageType('StateTotalsEntry', (_message.Message,), {
+    'DESCRIPTOR' : _PBWORKFLOW_STATETOTALSENTRY,
+    '__module__' : 'ws_messages_pb2'
+    # @@protoc_insertion_point(class_scope:PbWorkflow.StateTotalsEntry)
+    })
+  ,
   'DESCRIPTOR' : _PBWORKFLOW,
   '__module__' : 'ws_messages_pb2'
   # @@protoc_insertion_point(class_scope:PbWorkflow)
   })
 _sym_db.RegisterMessage(PbWorkflow)
+_sym_db.RegisterMessage(PbWorkflow.StateTotalsEntry)
 
 PbJob = _reflection.GeneratedProtocolMessageType('PbJob', (_message.Message,), {
   'DESCRIPTOR' : _PBJOB,
@@ -1637,4 +1581,5 @@ PbEntireWorkflow = _reflection.GeneratedProtocolMessageType('PbEntireWorkflow', 
 _sym_db.RegisterMessage(PbEntireWorkflow)
 
 
+_PBWORKFLOW_STATETOTALSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/tests/graphql/01-workflow.t
+++ b/tests/graphql/01-workflow.t
@@ -27,40 +27,41 @@ run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
 
 # query suite
 TEST_NAME="${TEST_NAME_BASE}-workflows"
-run_graphql_ok "${TEST_NAME}" "${SUITE_NAME}" '
+read -r -d '' workflowQuery <<_args_
 {
-    "request_string": "
-        query {
-            workflows {
-                name
-                status
-                statusMsg
-                host
-                port
-                owner
-                cylcVersion
-                meta {
-                    title
-                    description
-                }
-                newestRunaheadCyclePoint
-                newestCyclePoint
-                oldestCyclePoint
-                reloading
-                runMode
-                stateTotals
-                workflowLogDir
-                timeZoneInfo {
-                    hours
-                    minutes
-                }
-                nsDefnOrder
-                states
-            }
-        }
-    "
+  "request_string": "
+query {
+  workflows {
+    name
+    status
+    statusMsg
+    host
+    port
+    owner
+    cylcVersion
+    meta {
+      title
+      description
+    }
+    newestRunaheadCyclePoint
+    newestCyclePoint
+    oldestCyclePoint
+    reloading
+    runMode
+    stateTotals
+    workflowLogDir
+    timeZoneInfo {
+      hours
+      minutes
+    }
+    nsDefnOrder
+    states
+  }
+}",
+  "variables": null
 }
-'
+_args_
+run_graphql_ok "${TEST_NAME}" "${SUITE_NAME}" "${workflowQuery}"
 
 # scrape suite info from contact file
 TEST_NAME="${TEST_NAME_BASE}-contact"

--- a/tests/graphql/01-workflow.t
+++ b/tests/graphql/01-workflow.t
@@ -95,7 +95,18 @@ cat > expected << __HERE__
             "reloading": false,
             "runMode": "live",
             "stateTotals": {
-                "ready": 1
+                "runahead": 0,
+                "waiting": 0,
+                "queued": 0,
+                "expired": 0,
+                "ready": 1,
+                "submit-failed": 0,
+                "submit-retrying": 0,
+                "submitted": 0,
+                "retrying": 0,
+                "running": 0,
+                "failed": 0,
+                "succeeded": 0
             },
             "workflowLogDir": "${SUITE_LOG_DIR}",
             "timeZoneInfo": {

--- a/tests/graphql/01-workflow.t
+++ b/tests/graphql/01-workflow.t
@@ -48,11 +48,7 @@ run_graphql_ok "${TEST_NAME}" "${SUITE_NAME}" '
                 oldestCyclePoint
                 reloading
                 runMode
-                stateTotals {
-                    waiting
-                    held
-                    running
-                }
+                stateTotals
                 workflowLogDir
                 timeZoneInfo {
                     hours
@@ -99,9 +95,7 @@ cat > expected << __HERE__
             "reloading": false,
             "runMode": "live",
             "stateTotals": {
-                "waiting": 0,
-                "held": 0,
-                "running": 0
+                "ready": 1
             },
             "workflowLogDir": "${SUITE_LOG_DIR}",
             "timeZoneInfo": {
@@ -112,7 +106,9 @@ cat > expected << __HERE__
                 "foo",
                 "root"
             ],
-            "states": []
+            "states": [
+                "ready"
+            ]
         }
     ]
 }

--- a/tests/graphql/02-root-queries.t
+++ b/tests/graphql/02-root-queries.t
@@ -69,7 +69,7 @@ query {
     id
   }
 }",
-"variables": null
+  "variables": null
 }
 _args_
 run_graphql_ok "${TEST_NAME}" "${SUITE_NAME}" "${rootQueries}"

--- a/tests/graphql/02-root-queries.t
+++ b/tests/graphql/02-root-queries.t
@@ -50,7 +50,7 @@ query {
   taskProxy(id: \"${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}20190101T00${ID_DELIM}foo\") {
     id
   }
-  taskProxies(workflows: [\"*${ID_DELIM}*\"], ids: [\"*${ID_DELIM}*\"], sort: {keys: [\"id\"], reverse: false}) {
+  taskProxies(workflows: [\"*${ID_DELIM}*\"], ids: [\"*${ID_DELIM}*\"], isHeld: false, sort: {keys: [\"id\"], reverse: false}) {
     id
   }
   family(id: \"${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}FAM\") {

--- a/tests/graphql/03-is-held-arg.t
+++ b/tests/graphql/03-is-held-arg.t
@@ -1,0 +1,83 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test suite graphql interface
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 4
+#-------------------------------------------------------------------------------
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+# run suite
+run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
+cylc hold "${SUITE_NAME}"
+sleep 1
+
+# query suite
+TEST_NAME="${TEST_NAME_BASE}-is-held-arg"
+ID_DELIM='|'
+read -r -d '' isHeld <<_args_
+{
+  "request_string": "
+query {
+  workflows {
+    name
+    isHeldTotal
+    taskProxies(isHeld: false) {
+      id
+    }
+    familyProxies(exids: [\"root\"], isHeld: true) {
+      id
+    }
+  }
+}",
+  "variables": null
+}
+_args_
+run_graphql_ok "${TEST_NAME}" "${SUITE_NAME}" "${isHeld}"
+
+# scrape suite info from contact file
+TEST_NAME="${TEST_NAME_BASE}-contact"
+run_ok "${TEST_NAME_BASE}-contact" cylc get-contact "${SUITE_NAME}"
+
+# stop suite
+cylc stop --max-polls=10 --interval=2 --kill "${SUITE_NAME}"
+
+# compare to expectation
+cat > expected << __HERE__
+{
+    "workflows": [
+        {
+            "name": "${SUITE_NAME}",
+            "isHeldTotal": 1,
+            "taskProxies": [],
+            "familyProxies": [
+                {
+                    "id": "${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}1${ID_DELIM}BAZ"
+                }
+            ]
+        }
+    ]
+}
+__HERE__
+cmp_json "${TEST_NAME}-out" \
+    "${TEST_NAME_BASE}-is-held-arg.stdout" \
+    "$(cat expected)"
+
+purge_suite "${SUITE_NAME}"
+
+exit

--- a/tests/graphql/03-is-held-arg/suite.rc
+++ b/tests/graphql/03-is-held-arg/suite.rc
@@ -1,0 +1,16 @@
+[meta]
+    title = foo
+    description = bar
+
+[cylc]
+    UTC mode = True
+
+[scheduling]
+    [[graph]]
+        R1 = foo
+
+[runtime]
+    [[BAZ]]
+    [[foo]]
+        inherit = BAZ
+        script = sleep 60

--- a/tests/job-submission/01-job-nn-localhost/db.sqlite3
+++ b/tests/job-submission/01-job-nn-localhost/db.sqlite3
@@ -19,9 +19,9 @@ CREATE TABLE task_events(name TEXT, cycle TEXT, time TEXT, submit_num INTEGER, e
 CREATE TABLE task_jobs(cycle TEXT, name TEXT, submit_num INTEGER, is_manual_submit INTEGER, try_num INTEGER, time_submit TEXT, time_submit_exit TEXT, submit_status INTEGER, time_run TEXT, time_run_exit TEXT, run_signal TEXT, run_status INTEGER, user_at_host TEXT, batch_sys_name TEXT, batch_sys_job_id TEXT, PRIMARY KEY(cycle, name, submit_num));
 CREATE TABLE task_late_flags(cycle TEXT, name TEXT, value INTEGER, PRIMARY KEY(cycle, name));
 CREATE TABLE task_outputs(cycle TEXT, name TEXT, outputs TEXT, PRIMARY KEY(cycle, name));
-CREATE TABLE task_pool(cycle TEXT, name TEXT, spawned INTEGER, status TEXT, is_held TEXT, PRIMARY KEY(cycle, name));
-INSERT INTO task_pool VALUES('1','foo',1,'retrying',NULL);
-CREATE TABLE task_pool_checkpoints(id INTEGER, cycle TEXT, name TEXT, spawned INTEGER, status TEXT, is_held TEXT, PRIMARY KEY(id, cycle, name));
+CREATE TABLE task_pool(cycle TEXT, name TEXT, spawned INTEGER, status TEXT, is_held INTEGER, PRIMARY KEY(cycle, name));
+INSERT INTO task_pool VALUES('1','foo',1,'retrying',0);
+CREATE TABLE task_pool_checkpoints(id INTEGER, cycle TEXT, name TEXT, spawned INTEGER, status TEXT, is_held INTEGER, PRIMARY KEY(id, cycle, name));
 CREATE TABLE task_states(name TEXT, cycle TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, PRIMARY KEY(name, cycle));
 INSERT INTO task_states VALUES('foo','1','2019-06-14T11:30:16+01:00','2019-06-14T11:40:24+01:00',99,'retrying');
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));


### PR DESCRIPTION
These changes close #3278

This change:
- Removes `held` from state totals.
- Adds `isHeldTotal` to workflow query.
- Makes state totals agnostic to internal suite state names.
- Adds `is_held`/`isHeld` field to the data-store and GraphQL Schema
- stateTotals is resolved at the GraphQL side, states names imported from cylc.flow.
- Query field stateTotals returns all states (no need to specify sub-fields)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Covered by new test.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
