### PR TITLE
Update copyright notices for setup (& other) files

### DIFF
--- a/cylc/flow/cylc_subproc.py
+++ b/cylc/flow/cylc_subproc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cylc/flow/tests/test_cylc_subproc.py
+++ b/cylc/flow/tests/test_cylc_subproc.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2018 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

Whilst looking at the ``cylc-xtriggers`` repo I noticed the setup script had a copyright notice that did not include this year (cylc/cylc-xtriggers#5). Since the likelihood is that one template for these scripts was copied across repos & amended accordingly, I thought I would check that similar files in other repos were up-to-date.

In this case, it was not, & there were also three other instances remaining of outdated notices from a ``git grep "\-2018"`` (& the equivalent with a few other preceding years).

Trivial change, hence one reviewer sufficient.
<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests (reason: non-functional).
<!-- choose one: -->
- [x] No change log entry required (reason: invisible to users).
<!-- choose one: -->
- [x] No documentation update required.