### PR TITLE
Remove obsolete command category "hook".

### DIFF
--- a/bin/cylc
+++ b/bin/cylc
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 CATEGORIES=('control' 'con' 'information' 'info' 'all' 'task' 'license' \
-            'GPL' 'admin' 'prep' 'preparation' 'hook' 'discovery' 'utility' \
+            'GPL' 'admin' 'prep' 'preparation' 'discovery' 'utility' \
             'util')
                 
 HELP_OPTS=('help' '--help' '-h' 'h' '?')
@@ -181,7 +181,7 @@ fi
 # Check for help or version options.
 case "${UTIL}" in
 # Deal with categories
-control|information|all|task|license|GPL|admin|preparation|hook|discovery\
+control|information|all|task|license|GPL|admin|preparation|discovery\
         |utility|util|prep|con|info)
     if (( $# == 0 )); then
         help_util "${UTIL}"

--- a/bin/cylc-help
+++ b/bin/cylc-help
@@ -206,7 +206,6 @@ categories['discovery'] = ['discovery']
 categories['control'] = ['control']
 categories['utility'] = ['utility']
 categories['task'] = ['task']
-categories['hook'] = ['hook']
 categories['admin'] = ['admin']
 
 information_commands = {}
@@ -312,7 +311,6 @@ catsum['preparation'] = "Suite editing, validation, visualization, etc."
 catsum['discovery'] = "Detect running suites."
 catsum['control'] = "Suite start up, monitoring, and control."
 catsum['task'] = "The task messaging interface."
-catsum['hook'] = "Suite and task event hook scripts."
 catsum['utility'] = "Cycle arithmetic and templating, etc."
 
 # Some commands and categories are aliased and


### PR DESCRIPTION
Follow-up #3286, which removed the last remaining "hook" command, but forgot to remove the associated command category (noticed when I tried to build the docs).  @kinow - one review will do.