### PR TITLE
Remove unnecessary variable stopping

### DIFF
--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -150,11 +150,13 @@ class SubProcPool(object):
         return self.queuings or self.runnings
 
     def _is_stopping(self):
-        """Return True if .stopping is True."""
-        stopping = False
+        """Return whether .stopping is True or not.
+
+        Returns:
+            bool: Whether the pool is stopping or not.
+        """
         with self.stopping_lock:
-            stopping = self.stopping
-        return stopping
+            return self.stopping
 
     def _proc_exit(self, proc, err_xtra, ctx, callback, callback_args):
         """Get ret_code, out, err of exited command, and call its callback."""


### PR DESCRIPTION
We do not require the `stopping` variable in the function scope, being able to simply return the `self.stopping` value.

This is a small change with no associated Issue. Also updates the docstrings.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
<!-- choose one: -->
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [x] No documentation update required.
