### PR TITLE
Make new test more robust.

### DIFF
--- a/tests/reload/22-remove-task-cycling.t
+++ b/tests/reload/22-remove-task-cycling.t
@@ -48,10 +48,18 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 if (( CYLC_TASK_CYCLE_POINT == CYLC_SUITE_INITIAL_CYCLE_POINT )); then
    sed -i 's/^.*remove*$//g' $CYLC_SUITE_DEF_PATH/suite.rc
    cylc reload $CYLC_SUITE_NAME
+   poll "! grep 'Reload complete' $CYLC_SUITE_RUN_DIR/log/suite/log"
+   # kill the long-running orphaned bar task.
+   kill $(cat $CYLC_SUITE_RUN_DIR/work/1/bar/pid)
 fi
 """
    [[bar]]
-      script = sleep 10
+      script = """
+# Long sleep to ensure that bar does not finish before the reload.
+# Store long sleep PID to enable kill after the reload.
+sleep 1000 &
+echo $! > pid
+wait"""
 __SUITE_RC__
 
 TEST_NAME="${TEST_NAME_BASE}-validate"

--- a/tests/reload/22-remove-task-cycling.t
+++ b/tests/reload/22-remove-task-cycling.t
@@ -44,6 +44,24 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 [runtime]
    [[foo]]
       script = """
+# Use poll function from test_header.
+poll() {
+    local TIMEOUT="$(($(date +%s) + 60))" # wait 1 minute
+    local TIMED_OUT=true
+    while (($(date +%s) < TIMEOUT)); do
+        if eval "$@"; then
+            sleep 1
+        else
+            TIMED_OUT=false
+            break
+        fi
+    done
+    if $TIMED_OUT; then
+        >&2 echo "ERROR: poll timed out: $*"
+        exit 1
+    fi
+}
+
 # Remove bar and tell the server to reload.
 if (( CYLC_TASK_CYCLE_POINT == CYLC_SUITE_INITIAL_CYCLE_POINT )); then
    sed -i 's/^.*remove*$//g' $CYLC_SUITE_DEF_PATH/suite.rc


### PR DESCRIPTION
This is a small change with no associated Issue.

Ensure that a new test is not flaky under load on Travis-CI.  Failed here because task `bar` (sleep 10) completed before the reload: https://github.com/cylc/cylc-flow/pull/3317#issuecomment-525050475

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (is a test).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
