### PR TITLE
docs: format of xtrigger results dictionary (Cylc-7)

### DIFF
--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -274,9 +274,15 @@ Function return values should be as follows:
 
   - return ``(True, results)``
 
-where ``results`` is an arbitrary dictionary of information to be
-passed to dependent tasks. How this looks to these tasks is described above
-in :ref:`Built-in Suite State Triggers`.
+where ``results`` is an arbitrary dictionary of information to be passed to
+dependent tasks, which in terms of format must:
+
+- be *flat* (non-nested);
+- contain *only* keys which are
+  `valid <http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html>`_ as environment variable names.
+
+See :ref:`Built-in Suite State Triggers` for an example of one such
+``results`` dictionary and how it gets processed by the suite.
 
 The suite server program manages trigger functions as follows:
 


### PR DESCRIPTION
A requested back-port of cylc/cylc-doc#41, which will close cylc/cylc-doc#69 (for Cylc-7).

Trivial enough, & already reviewed for Cylc-8, hence one reviewer sufficient.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (*reason*: documentation content only, conceptual hence untestable).
- [x] No change log entry required (*reason*: small & non-functional).
- [x] (7.8.x branch) I have updated the documentation in this PR branch. (*NB*: change regards just the documentation)