### PR TITLE
docs: Python versions required for xtriggers (Cylc-7)

### DIFF
--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -225,11 +225,19 @@ Custom Trigger Functions
 Trigger functions are just normal Python functions, with a few special
 properties:
 
-- they must be defined in a module with the same name as the function
+- they must:
+
+  - be defined in a module with the same name as the function;
+  - be compatible with the same Python version that runs the Cylc workflow
+    server program (see :ref:`Requirements` for the latest version
+    specification).
+
 - they can be located in:
-  - ``<cylc-dir>/lib/cylc/xtriggers/``
-  - ``<suite-dir>/lib/python/``
-  - (or anywhere in your Python library path)
+
+  - ``<cylc-dir>/lib/cylc/xtriggers/``;
+  - ``<suite-dir>/lib/python/``;
+  - or anywhere in your Python library path.
+
 - they can take arbitrary positional and keyword arguments
 - suite and task identity, and cycle point, can be passed to trigger
   functions by using string templates in function arguments (see below)


### PR DESCRIPTION
A requested back-port of cylc/cylc-doc#68, which will close cylc/cylc-doc#66 (for Cylc-7).

Trivial enough, & already reviewed for Cylc-8, hence one reviewer sufficient.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (*reason*: documentation content only, conceptual hence untestable).
- [x] No change log entry required (*reason*: small & non-functional).
- [x] (7.8.x branch) I have updated the documentation in this PR branch. (*NB*: change regards just the documentation)