### PR TITLE
Fix a cylc ZMQ unit test.

### DIFF
--- a/cylc/flow/tests/test_zmq.py
+++ b/cylc/flow/tests/test_zmq.py
@@ -29,8 +29,7 @@ def test_single_port():
     serv1.start(*PORT_RANGE)
     port = serv1.port
 
-    with pytest.raises(CylcError) as exc:
+    with pytest.raises(CylcError, match=r"Address already in use") as exc:
         serv2.start(port, port)
-    assert 'Address already in use' in str(exc)
 
     serv1.stop()


### PR DESCRIPTION
This is a small change with no associated Issue.

`cylc/flow/tests/test_zmq.py:test_single_port` passes on Travis CI (Python 3.7.1, pytest 4.4.2) but fails in my local environment (Python 3.7.3, pytest 5.1.1):
```
cylc-flow]$ pytest cylc/flow/tests/test_zmq.py 
============================================================ test session starts ===========================================================================
platform linux -- Python 3.7.3, pytest-5.1.1, py-1.8.0, pluggy-0.12.0 -- /home/oliverh/cylc/cylc-flow/venv/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/oliverh/cylc/cylc-flow, inifile: pytest.ini
collected 1 item                                                                                                                                                                                                  

cylc/flow/tests/test_zmq.py::test_single_port FAILED                                                                                                                                                        [100%]

============================================================ FAILURES ======================================================================
____________________________________________________________ test_single_port _________________________________________________________________________

    def test_single_port():
        """Test server on a single port and port in use exception."""
        serv1 = ZMQServer(encrypt, decrypt, get_secret)
        serv2 = ZMQServer(encrypt, decrypt, get_secret)
    
        serv1.start(*PORT_RANGE)
        port = serv1.port
    
        with pytest.raises(CylcError) as exc:
            serv2.start(port, port)
>       assert 'Address already in use' in str(exc)
E       AssertionError: assert 'Address already in use' in '<ExceptionInfo CylcError tblen=2>'
E        +  where '<ExceptionInfo CylcError tblen=2>' = str(<ExceptionInfo CylcError tblen=2>)

cylc/flow/tests/test_zmq.py:34: AssertionError
```
and then hangs until Ctrl-C:
```
^CException ignored in: <module 'threading' from '/usr/local/lib/python3.7/threading.py'>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/threading.py", line 1281, in _shutdown
    t.join()
  File "/usr/local/lib/python3.7/threading.py", line 1032, in join
    self._wait_for_tstate_lock()
  File "/usr/local/lib/python3.7/threading.py", line 1048, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
KeyboardInterrupt
```

This change fixes the test in my environment.

Pinging @oliver-sanders as the original test writer, because I'm not entirely sure why the original doesn't work.  It doesn't seem to be a simple scoping error, because (e.g.) this works fine with Python 3.7.3:
```
#!/usr/bin/env python3
from contextlib import contextmanager

@contextmanager
def foo():
    yield "drugs and money"

with foo() as f:
    print('in:  ' + f)
print('out: ' + f)
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests (is a test).
<!-- choose one: -->
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [x] No documentation update required.
