### PR TITLE
Remove zmq message logging

### DIFF
--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -173,13 +173,11 @@ class ZMQServer(object):
                     'message': str(exc), 'traceback': traceback.format_exc()}}
             else:
                 # success case - serve the request
-                LOG.debug('zmq:recv %s', message)
                 res = self._receiver(message)
                 if message['command'] in PB_METHOD_MAP:
                     response = res['data']
                 else:
                     response = self.encode(res, self.secret()).encode()
-                LOG.debug('zmq:send %s', res)
                 # send back the string to bytes response
                 self.socket.send(response)
 


### PR DESCRIPTION
After showing cylc-ui + uiserver to @hjoliver today I left a workflow running, and then had a quick look at the logs to confirm there was nothing wrong after some time. And then saw all the logs again that were taking most of the space in my console buffer :disappointed: .

This PR simply removes the two lines that were logging it. Tested locally, but better wait for Travis to make sure there are no tests expecting some line with `zmq:send`, etc

These changes close #3300 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? removed logging that should not break other tests or features).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
