### PR TITLE
Unify global and local configs.

### DIFF
--- a/cylc/flow/client_schema.py
+++ b/cylc/flow/client_schema.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Define all legal items and values for cylc local client definitions.
+
+from cylc.flow.parsec.validate import DurationFloat as VDR
+
+
+SPEC = {
+    'disable interactive command prompts': [VDR.V_BOOLEAN, True],
+    'editors': {
+        'terminal': [VDR.V_STRING, 'vim'],
+        'gui': [VDR.V_STRING, 'gvim -f'],
+    },
+    'monitor': {
+        'sort order': [VDR.V_STRING, 'definition', 'alphanumeric'],
+    },
+}

--- a/cylc/flow/client_schema.py
+++ b/cylc/flow/client_schema.py
@@ -18,8 +18,8 @@
 
 # Define all legal items and values for cylc local client definitions.
 
-from cylc.flow.parsec.validate import DurationFloat as VDR
-
+from cylc.flow.parsec.validate import (
+    DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
 
 SPEC = {
     'disable interactive command prompts': [VDR.V_BOOLEAN, True],

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Define all legal items and values for cylc suite definition files."""
+
+from metomi.isodatetime.data import Calendar
+
+from cylc.flow import LOG
+from cylc.flow.network.authorisation import Priv
+from cylc.flow.parsec.config import ParsecConfig
+from cylc.flow.parsec.upgrade import upgrader
+from cylc.flow.parsec.validate import (
+    DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
+
+# Nested dict of spec items.
+# Spec value is [value_type, default, allowed_2, allowed_3, ...]
+# where:
+# - value_type: value type (compulsory).
+# - default: the default value (optional).
+# - allowed_2, ...: the only other allowed values of this setting (optional).
+SPEC = {
+    'meta': {
+        'description': [VDR.V_STRING, ''],
+        'group': [VDR.V_STRING, ''],
+        'title': [VDR.V_STRING, ''],
+        'URL': [VDR.V_STRING, ''],
+        '__MANY__': [VDR.V_STRING, ''],
+    },
+    'cylc': {
+        'UTC mode': [VDR.V_BOOLEAN, False],
+        'cycle point format': [VDR.V_CYCLE_POINT_FORMAT],
+        'cycle point num expanded year digits': [VDR.V_INTEGER, 0],
+        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE],
+        'required run mode': [
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
+        'force run mode': [
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
+        'health check interval': [VDR.V_INTERVAL],
+        'task event mail interval': [VDR.V_INTERVAL],
+        'disable automatic shutdown': [VDR.V_BOOLEAN],
+        'simulation': {
+            'disable suite event handlers': [VDR.V_BOOLEAN, True],
+        },
+        'environment': {
+            '__MANY__': [VDR.V_STRING],
+        },
+        'parameters': {
+            '__MANY__': [VDR.V_PARAMETER_LIST],
+        },
+        'parameter templates': {
+            '__MANY__': [VDR.V_STRING],
+        },
+        'events': {
+            'handlers': [VDR.V_STRING_LIST, None],
+            'handler events': [VDR.V_STRING_LIST, None],
+            'startup handler': [VDR.V_STRING_LIST, None],
+            'timeout handler': [VDR.V_STRING_LIST, None],
+            'inactivity handler': [VDR.V_STRING_LIST, None],
+            'shutdown handler': [VDR.V_STRING_LIST, None],
+            'aborted handler': [VDR.V_STRING_LIST, None],
+            'stalled handler': [VDR.V_STRING_LIST, None],
+            'timeout': [VDR.V_INTERVAL],
+            'inactivity': [VDR.V_INTERVAL],
+            'abort if startup handler fails': [VDR.V_BOOLEAN],
+            'abort if shutdown handler fails': [VDR.V_BOOLEAN],
+            'abort if timeout handler fails': [VDR.V_BOOLEAN],
+            'abort if inactivity handler fails': [VDR.V_BOOLEAN],
+            'abort if stalled handler fails': [VDR.V_BOOLEAN],
+            'abort if any task fails': [VDR.V_BOOLEAN],
+            'abort on stalled': [VDR.V_BOOLEAN],
+            'abort on timeout': [VDR.V_BOOLEAN],
+            'abort on inactivity': [VDR.V_BOOLEAN],
+            'mail events': [VDR.V_STRING_LIST, None],
+            'mail from': [VDR.V_STRING],
+            'mail smtp': [VDR.V_STRING],
+            'mail to': [VDR.V_STRING],
+            'mail footer': [VDR.V_STRING],
+        },
+        'reference test': {
+            'expected task failures': [VDR.V_STRING_LIST],
+        },
+        'authentication': {
+            # Allow owners to grant public shutdown rights at the most, not
+            # full control.
+            'public': (
+                [VDR.V_STRING, '']
+                + [level.name.lower().replace('_', '-') for level in [
+                    Priv.IDENTITY, Priv.DESCRIPTION, Priv.STATE_TOTALS,
+                    Priv.READ, Priv.SHUTDOWN]])
+        },
+    },
+    'scheduling': {
+        'initial cycle point': [VDR.V_CYCLE_POINT],
+        'final cycle point': [VDR.V_STRING],
+        'initial cycle point constraints': [VDR.V_STRING_LIST],
+        'final cycle point constraints': [VDR.V_STRING_LIST],
+        'hold after point': [VDR.V_CYCLE_POINT],
+        'cycling mode': (
+            [VDR.V_STRING, Calendar.MODE_GREGORIAN] +
+            list(Calendar.MODES) + ["integer"]),
+        'runahead limit': [VDR.V_STRING],
+        'max active cycle points': [VDR.V_INTEGER, 3],
+        'spawn to max active cycle points': [VDR.V_BOOLEAN],
+        'queues': {
+            'default': {
+                'limit': [VDR.V_INTEGER, 0],
+                'members': [VDR.V_STRING_LIST],
+            },
+            '__MANY__': {
+                'limit': [VDR.V_INTEGER, 0],
+                'members': [VDR.V_STRING_LIST],
+            },
+        },
+        'special tasks': {
+            'clock-trigger': [VDR.V_STRING_LIST],
+            'external-trigger': [VDR.V_STRING_LIST],
+            'clock-expire': [VDR.V_STRING_LIST],
+            'sequential': [VDR.V_STRING_LIST],
+            'exclude at start-up': [VDR.V_STRING_LIST],
+            'include at start-up': [VDR.V_STRING_LIST],
+        },
+        'xtriggers': {
+            '__MANY__': [VDR.V_XTRIGGER],
+        },
+        'graph': {
+            '__MANY__': [VDR.V_STRING],
+        },
+    },
+    'runtime': {
+        '__MANY__': {
+            'inherit': [VDR.V_STRING_LIST],
+            'init-script': [VDR.V_STRING],
+            'env-script': [VDR.V_STRING],
+            'err-script': [VDR.V_STRING],
+            'exit-script': [VDR.V_STRING],
+            'pre-script': [VDR.V_STRING],
+            'script': [VDR.V_STRING],
+            'post-script': [VDR.V_STRING],
+            'extra log files': [VDR.V_STRING_LIST],
+            'work sub-directory': [VDR.V_STRING],
+            'meta': {
+                'title': [VDR.V_STRING, ''],
+                'description': [VDR.V_STRING, ''],
+                'URL': [VDR.V_STRING, ''],
+                '__MANY__': [VDR.V_STRING, ''],
+            },
+            'simulation': {
+                'default run length': [VDR.V_INTERVAL, DurationFloat(10)],
+                'speedup factor': [VDR.V_FLOAT],
+                'time limit buffer': [VDR.V_INTERVAL, DurationFloat(30)],
+                'fail cycle points': [VDR.V_STRING_LIST],
+                'fail try 1 only': [VDR.V_BOOLEAN, True],
+                'disable task event handlers': [VDR.V_BOOLEAN, True],
+            },
+            'environment filter': {
+                'include': [VDR.V_STRING_LIST],
+                'exclude': [VDR.V_STRING_LIST],
+            },
+            'job': {
+                'batch system': [VDR.V_STRING, 'background'],
+                'batch submit command template': [VDR.V_STRING],
+                'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
+                'execution retry delays': [VDR.V_INTERVAL_LIST, None],
+                'execution time limit': [VDR.V_INTERVAL],
+                'submission polling intervals': [VDR.V_INTERVAL_LIST, None],
+                'submission retry delays': [VDR.V_INTERVAL_LIST, None],
+            },
+            'remote': {
+                'host': [VDR.V_STRING],
+                'owner': [VDR.V_STRING],
+                'suite definition directory': [VDR.V_STRING],
+                'retrieve job logs': [VDR.V_BOOLEAN],
+                'retrieve job logs max size': [VDR.V_STRING],
+                'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST, None],
+            },
+            'events': {
+                'execution timeout': [VDR.V_INTERVAL],
+                'handlers': [VDR.V_STRING_LIST, None],
+                'handler events': [VDR.V_STRING_LIST, None],
+                'handler retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail events': [VDR.V_STRING_LIST, None],
+                'mail from': [VDR.V_STRING],
+                'mail retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail smtp': [VDR.V_STRING],
+                'mail to': [VDR.V_STRING],
+                'submission timeout': [VDR.V_INTERVAL],
+
+                'expired handler': [VDR.V_STRING_LIST, None],
+                'late offset': [VDR.V_INTERVAL, None],
+                'late handler': [VDR.V_STRING_LIST, None],
+                'submitted handler': [VDR.V_STRING_LIST, None],
+                'started handler': [VDR.V_STRING_LIST, None],
+                'succeeded handler': [VDR.V_STRING_LIST, None],
+                'failed handler': [VDR.V_STRING_LIST, None],
+                'submission failed handler': [VDR.V_STRING_LIST, None],
+                'warning handler': [VDR.V_STRING_LIST, None],
+                'critical handler': [VDR.V_STRING_LIST, None],
+                'retry handler': [VDR.V_STRING_LIST, None],
+                'submission retry handler': [VDR.V_STRING_LIST, None],
+                'execution timeout handler': [VDR.V_STRING_LIST, None],
+                'submission timeout handler': [VDR.V_STRING_LIST, None],
+                'custom handler': [VDR.V_STRING_LIST, None],
+            },
+            'suite state polling': {
+                'user': [VDR.V_STRING],
+                'host': [VDR.V_STRING],
+                'interval': [VDR.V_INTERVAL],
+                'max-polls': [VDR.V_INTEGER],
+                'message': [VDR.V_STRING],
+                'run-dir': [VDR.V_STRING],
+                'verbose mode': [VDR.V_BOOLEAN],
+            },
+            'environment': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'directives': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'outputs': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'parameter environment templates': {
+                '__MANY__': [VDR.V_STRING],
+            },
+        },
+    },
+    'visualization': {
+        'initial cycle point': [VDR.V_CYCLE_POINT],
+        'final cycle point': [VDR.V_STRING],
+        'number of cycle points': [VDR.V_INTEGER, 3],
+        'collapsed families': [VDR.V_STRING_LIST],
+        'use node color for edges': [VDR.V_BOOLEAN],
+        'use node fillcolor for edges': [VDR.V_BOOLEAN],
+        'use node color for labels': [VDR.V_BOOLEAN],
+        'node penwidth': [VDR.V_INTEGER, 2],
+        'edge penwidth': [VDR.V_INTEGER, 2],
+        'default node attributes': [
+            VDR.V_STRING_LIST, ['style=unfilled', 'shape=ellipse']],
+        'default edge attributes': [VDR.V_STRING_LIST],
+        'node groups': {
+            '__MANY__': [VDR.V_STRING_LIST],
+        },
+        'node attributes': {
+            '__MANY__': [VDR.V_STRING_LIST],
+        },
+    },
+}
+
+
+def upg(cfg, descr):
+    """Upgrade old suite configuration."""
+    u = upgrader(cfg, descr)
+    u.obsolete('6.1.3', ['visualization', 'enable live graph movie'])
+    u.obsolete('7.2.2', ['cylc', 'dummy mode'])
+    u.obsolete('7.2.2', ['cylc', 'simulation mode'])
+    u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
+    u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
+    u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
+    u.obsolete(
+        '7.8.0',
+        ['runtime', '__MANY__', 'suite state polling', 'template'])
+    u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
+    u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
+    u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
+    u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'dummy mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'dummy-local mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'simulation mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'required run mode'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'suite shutdown event handler'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'abort if any task fails'],
+        ['cylc', 'events', 'abort if any task fails'])
+    u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.upgrade()
+
+    # Upgrader cannot do this type of move.
+    try:
+        keys = set()
+        cfg['scheduling'].setdefault('graph', {})
+        cfg['scheduling']['graph'].update(
+            cfg['scheduling'].pop('dependencies'))
+        graphdict = cfg['scheduling']['graph']
+        for key, value in graphdict.copy().items():
+            if isinstance(value, dict) and 'graph' in value:
+                graphdict[key] = value['graph']
+                keys.add(key)
+        if keys:
+            LOG.warning(
+                "deprecated graph items were automatically upgraded in '%s':",
+                descr)
+            LOG.warning(
+                ' * (8.0.0) %s -> %s - for X in:\n%s',
+                u.show_keys(['scheduling', 'dependencies', 'X', 'graph']),
+                u.show_keys(['scheduling', 'graph', 'X']),
+                '\n'.join(sorted(keys)),
+            )
+    except KeyError:
+        pass
+
+
+class RawSuiteConfig(ParsecConfig):
+    """Raw suite configuration."""
+
+    def __init__(self, fpath, output_fname, tvars):
+        """Return the default instance."""
+        ParsecConfig.__init__(
+            self, SPEC, upg, output_fname, tvars, cylc_config_validate)
+        self.loadcfg(fpath, "suite definition")

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -45,7 +45,7 @@ SPEC = {
         'URL': [VDR.V_STRING, ''],
         '__MANY__': [VDR.V_STRING, ''],
     },
-    'general': {
+    'misc': {
         'UTC mode': [VDR.V_BOOLEAN, False],
         'cycle point format': [VDR.V_CYCLE_POINT_FORMAT],
         'cycle point num expanded year digits': [VDR.V_INTEGER, 0],
@@ -275,7 +275,7 @@ SPEC = {
             'outputs': {
                 '__MANY__': [VDR.V_STRING],
             },
-            'parameter environment templates': {
+            'task parameter environment templates': {
                 '__MANY__': [VDR.V_STRING],
             },
         },
@@ -440,6 +440,11 @@ def upg(cfg, descr):
     )
     u.deprecate(
         '8.0.0',
+        ['runtime', '__MANY__', 'parameter environment templates'],
+        ['runtime', '__MANY__', 'task parameter environment templates']
+    )
+    u.deprecate(
+        '8.0.0',
         ['scheduling', 'hold after point'],
         ['scheduling', 'hold after cycle point']
     )
@@ -458,7 +463,7 @@ def upg(cfg, descr):
         ['task events'],
         ['runtime', 'root', 'events']
     )
-    u.deprecate('8.0.0', ['cylc'], ['general'])
+    u.deprecate('8.0.0', ['cylc'], ['misc'])
     u.upgrade()
 
     # Upgrader cannot do this type of move.

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -355,31 +355,26 @@ def upg(cfg, descr):
         ['documentation', 'files', 'multi-page html user guide'],
         ['documentation', 'local']
     )
+    # Cylc 8 Obseletions
     u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
     u.obsolete('8.0.0', ['cylc', 'required run mode'])
     u.obsolete('8.0.0', ['cylc', 'force run mode'])
     u.obsolete('8.0.0', ['cylc', 'disable automatic shutdown'])
-    u.deprecate(
-        '8.0.0',
-        ['runtime', '__MANY__', 'environment'],
-        ['runtime', '__MANY__', 'job environment']
-    )
-    u.deprecate(
-        '8.0.0',
-        ['runtime', '__MANY__', 'directives'],
-        ['runtime', '__MANY__', 'batch system directives']
-    )
-    u.deprecate(
-        '8.0.0',
-        ['cylc', 'task event mail interval'],
-        ['mail', 'task event interval']
-    )
-    u.deprecate('8.0.0', ['cylc', 'parameters'], ['task parameters'])
-    u.deprecate(
-        '8.0.0',
-        ['cylc', 'parameter templates'],
-        ['task parameter templates']
-    )
+    u.obsolete('8.0.0', ['enable run directory housekeeping'])
+    u.obsolete('8.0.0', ['cylc', 'reference test'])
+    u.obsolete('8.0.0', ['suite definition directory'])
+    u.obsolete('8.0.0', ['communication'])
+    u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
+    u.obsolete('8.0.0', ['suite servers', 'scan ports'])
+    u.obsolete('8.0.0', ['temporary directory'])
+    u.obsolete('8.0.0', ['test battery'])
+    u.obsolete('8.0.0', ['task host select command timeout'])
+    u.obsolete('8.0.0', ['xtrigger function timeout'])
+    u.obsolete('8.0.0', ['visualization'])
+    u.obsolete('8.0.0', ['documentation'])
+    # Cylc 8 Deprecations
+    # All mail ____ items moved from [cylc][events] to [email]
     for key in [
         'mail from', 'mail events', 'mail footer', 'mail smtp', 'mail to'
     ]:
@@ -388,35 +383,51 @@ def upg(cfg, descr):
             ['cylc', 'events', key],
             ['mail', key.replace('mail ', '')]
         )
-    u.deprecate('8.0.0', ['cylc', 'events'], ['server events'])
-    u.obsolete('8.0.0', ['cylc', 'reference test'])
     u.deprecate(
         '8.0.0',
         ['cylc', 'abort if any task fails'],
-        ['cylc', 'events', 'abort if any task fails'])
-    # All mail ____ items moved from [cylc][events] to [email]
-
-
-    u.deprecate('8.0.0',
-                ['documentation', 'files', 'html index'],
-                ['documentation', 'local']
-                )
+        ['cylc', 'events', 'abort if any task fails']
+    )
     u.deprecate(
         '8.0.0',
-        ['documentation', 'urls', 'internet homepage'],
-        ['documentation', 'cylc homepage']
+        ['cylc', 'authentication'],
+        ['cylc', 'authorization']
     )
-    u.obsolete('8.0.0', ['suite definition directory'])
-    u.obsolete('8.0.0', ['communication'])
-    u.deprecate('8.0.0', ['cylc', 'authentication'], ['cylc', 'authorization'])
     u.deprecate(
         '8.0.0',
-        ['general', 'authentication'],
-        ['general', 'authorization']
+        ['cylc', 'events'],
+        ['server events']
     )
-    u.obsolete('8.0.0', ['enable run directory housekeeping'])
-
-    u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'parameters'],
+        ['task parameters']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'parameter templates'],
+        ['task parameter templates']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'task event mail interval'],
+        ['mail', 'task event interval']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'directives'],
+        ['runtime', '__MANY__', 'batch system directives']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'environment'],
+        ['runtime', '__MANY__', 'job environment']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'events'],
+        ['runtime', '__MANY__', 'task events']
+    )
     u.deprecate(
         '8.0.0',
         ['runtime', '__MANY__', 'job', 'execution retry delays'],
@@ -429,30 +440,25 @@ def upg(cfg, descr):
     )
     u.deprecate(
         '8.0.0',
+        ['scheduling', 'hold after point'],
+        ['scheduling', 'hold after cycle point']
+    )
+    u.deprecate(
+        '8.0.0',
         ['suite host self-identification'],
         ['workflow server platforms', 'suite host self-identification']
     )
     u.deprecate(
         '8.0.0',
-        ['runtime', '__MANY__', 'events'],
-        ['runtime', '__MANY__', 'task events']
+        ['suite servers'],
+        ['workflow server platforms']
     )
-    u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
-    u.obsolete('8.0.0', ['suite servers', 'scan ports'])
-    u.deprecate('8.0.0', ['suite servers'], ['workflow server platforms'])
     u.deprecate(
         '8.0.0',
-        ['scheduling', 'hold after point'],
-        ['scheduling', 'hold after cycle point']
+        ['task events'],
+        ['runtime', 'root', 'events']
     )
-    u.deprecate('8.0.0', ['task events'], ['runtime', 'root', 'events'])
-    u.obsolete('8.0.0', ['temporary directory'])
-    u.obsolete('8.0.0', ['test battery'])
-    u.obsolete('8.0.0', ['task host select command timeout'])
-    u.obsolete('8.0.0', ['xtrigger function timeout'])
     u.deprecate('8.0.0', ['cylc'], ['general'])
-    u.obsolete('8.0.0', ['visualization'])
-    u.deprecate('8.0.0', ['general', 'events'], ['server events'])
     u.upgrade()
 
     # Upgrader cannot do this type of move.

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -356,12 +356,19 @@ def upg(cfg, descr):
         ['documentation', 'local']
     )
     u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'dummy mode suite timeout'])
     u.obsolete('8.0.0', ['cylc', 'required run mode'])
     u.obsolete('8.0.0', ['cylc', 'force run mode'])
     u.obsolete('8.0.0', ['cylc', 'disable automatic shutdown'])
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'environment'],
+        ['runtime', '__MANY__', 'job environment']
+    )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'directives'],
+        ['runtime', '__MANY__', 'batch system directives']
+    )
     u.deprecate(
         '8.0.0',
         ['cylc', 'task event mail interval'],
@@ -373,16 +380,6 @@ def upg(cfg, descr):
         ['cylc', 'parameter templates'],
         ['task parameter templates']
     )
-    u.deprecate('8.0.0', ['cylc', 'events'], ['server events'])
-    u.obsolete('8.0.0', ['cylc', 'reference test'])
-    u.obsolete(
-        '8.0.0',
-        ['cylc', 'reference test', 'suite shutdown event handler'])
-    u.deprecate(
-        '8.0.0',
-        ['cylc', 'abort if any task fails'],
-        ['cylc', 'events', 'abort if any task fails'])
-    # All mail ____ items moved from [cylc][events] to [email]
     for key in [
         'mail from', 'mail events', 'mail footer', 'mail smtp', 'mail to'
     ]:
@@ -391,6 +388,14 @@ def upg(cfg, descr):
             ['cylc', 'events', key],
             ['mail', key.replace('mail ', '')]
         )
+    u.deprecate('8.0.0', ['cylc', 'events'], ['server events'])
+    u.obsolete('8.0.0', ['cylc', 'reference test'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'abort if any task fails'],
+        ['cylc', 'events', 'abort if any task fails'])
+    # All mail ____ items moved from [cylc][events] to [email]
+
 
     u.deprecate('8.0.0',
                 ['documentation', 'files', 'html index'],
@@ -425,7 +430,7 @@ def upg(cfg, descr):
     u.deprecate(
         '8.0.0',
         ['suite host self-identification'],
-        ['suite run platforms', 'suite host self-identification']
+        ['workflow server platforms', 'suite host self-identification']
     )
     u.deprecate(
         '8.0.0',
@@ -434,7 +439,7 @@ def upg(cfg, descr):
     )
     u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
     u.obsolete('8.0.0', ['suite servers', 'scan ports'])
-    u.deprecate('8.0.0', ['suite servers'], ['suite run platforms'])
+    u.deprecate('8.0.0', ['suite servers'], ['workflow server platforms'])
     u.deprecate(
         '8.0.0',
         ['scheduling', 'hold after point'],
@@ -446,7 +451,8 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['task host select command timeout'])
     u.obsolete('8.0.0', ['xtrigger function timeout'])
     u.deprecate('8.0.0', ['cylc'], ['general'])
-    u.obsolete('8.0.0', ['vizualization'])
+    u.obsolete('8.0.0', ['visualization'])
+    u.deprecate('8.0.0', ['general', 'events'], ['server events'])
     u.upgrade()
 
     # Upgrader cannot do this type of move.

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -39,23 +39,25 @@ from cylc.flow.hostuserutil import get_user_home, is_remote_user
 # - allowed_2, ...: the only other allowed values of this setting (optional).
 SPEC = {
     'meta': {
-        'description': [VDR.V_STRING, ''],
-        'group': [VDR.V_STRING, ''],
-        'title': [VDR.V_STRING, ''],
-        'URL': [VDR.V_STRING, ''],
-        '__MANY__': [VDR.V_STRING, ''],
+        'description': [VDR.V_STRING],
+        'group': [VDR.V_STRING],
+        'title': [VDR.V_STRING],
+        'URL': [VDR.V_STRING],
+        '__MANY__': [VDR.V_STRING],
     },
     'misc': {
         'UTC mode': [VDR.V_BOOLEAN, False],
         'cycle point format': [VDR.V_CYCLE_POINT_FORMAT],
         'cycle point num expanded year digits': [VDR.V_INTEGER, 0],
-        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE, 'Z'],
-        'maximum size in bytes': [VDR.V_INTEGER, 1000000],
+        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE],
+        'suite logging': {
+            'maximum size in bytes': [VDR.V_INTEGER, 1000000], # suite logging
+            'rolling archive length': [VDR.V_INTEGER, 5],  # suite logging
+        },
+        'run directory rolling archive length': [VDR.V_INTEGER, -1],  # suite logging
         'process pool size': [VDR.V_INTEGER, 4],
         'process pool timeout': [VDR.V_INTERVAL, DurationFloat(600)],
-        'rolling archive length': [VDR.V_INTEGER, 5],
-        'run directory rolling archive length': [VDR.V_INTEGER, -1],
-        'health check interval': [VDR.V_INTERVAL],
+        'health check interval': [VDR.V_INTERVAL, DurationFloat(600)],
         'simulation': {
             'disable suite event handlers': [VDR.V_BOOLEAN, True],
         },
@@ -66,7 +68,7 @@ SPEC = {
             # Allow owners to grant public shutdown rights at the most, not
             # full control.
             'public': (
-                [VDR.V_STRING, '']
+                [VDR.V_STRING]
                 + [level.name.lower().replace('_', '-') for level in [
                     Priv.IDENTITY, Priv.DESCRIPTION, Priv.STATE_TOTALS,
                     Priv.READ, Priv.SHUTDOWN]])
@@ -80,7 +82,6 @@ SPEC = {
                 VDR.V_STRING, 'zmq', 'ssh+zmq', 'poll'],
             'submission polling intervals': [VDR.V_INTERVAL_LIST],
             'submission retry delays': [VDR.V_INTERVAL_LIST, None],
-            'execution polling intervals': [VDR.V_INTERVAL_LIST],
             'scp command': [
                 VDR.V_STRING, 'scp -oBatchMode=yes -oConnectTimeout=10'],
             'ssh command': [
@@ -89,6 +90,7 @@ SPEC = {
             'login hosts': [VDR.V_INTERVAL_LIST],
             'cylc executable': [VDR.V_STRING, 'cylc'],
             'global init-script': [VDR.V_STRING],
+            'copyable environment variables': [VDR.V_STRING],
             'retrieve job logs': [VDR.V_BOOLEAN],
             'retrieve job logs command': [VDR.V_STRING, 'rsync -a'],
             'retrieve job logs max size': [VDR.V_STRING],
@@ -97,6 +99,7 @@ SPEC = {
             'tail command template': [
                 VDR.V_STRING, 'tail -n +1 -F %(filename)s'],
             'owner': [VDR.V_STRING_LIST],
+            'mail smtp': [VDR.V_STRING],
             'batch system': {
                 'name': [VDR.V_STRING, None],
                 'err tailer': [VDR.V_STRING],
@@ -104,8 +107,8 @@ SPEC = {
                 'err viewer': [VDR.V_STRING],
                 'out viewer': [VDR.V_STRING],
                 'job name length maximum': [VDR.V_INTEGER],
-                'execution time limit': [VDR.V_INTERVAL_LIST],
                 'execution polling intervals': [VDR.V_INTERVAL_LIST],
+                'execution time limit polling interval': [VDR.V_INTERVAL_LIST],
                 'execution retry delays': [VDR.V_INTERVAL_LIST],
                 'batch submit command template': [VDR.V_STRING]
             },
@@ -114,34 +117,35 @@ SPEC = {
             },
         },
         '__MANY__': {
-            'run directory': [VDR.V_STRING, ''],
-            'work directory': [VDR.V_STRING, ''],
-            'task communication method': [VDR.V_STRING, ''],
-            'submission polling intervals': [VDR.V_STRING, ''],
+            'run directory': [VDR.V_STRING],
+            'work directory': [VDR.V_STRING],
+            'task communication method': [VDR.V_STRING],
+            'submission polling intervals': [VDR.V_STRING],
             'submission retry delays': [VDR.V_INTERVAL_LIST, None],
-            'execution polling intervals': [VDR.V_STRING, ''],
-            'scp command': [VDR.V_STRING, ''],
-            'ssh command': [VDR.V_STRING, ''],
-            'use login shell': [VDR.V_STRING, ''],
-            'login hosts': [VDR.V_STRING, ''],
-            'batch system': [VDR.V_STRING, ''],
-            'cylc executable': [VDR.V_STRING, ''],
-            'global init-script': [VDR.V_STRING, ''],
-            'copyable environment variables': [VDR.V_STRING, ''],
-            'retrieve job logs': [VDR.V_STRING, ''],
-            'retrieve job logs command': [VDR.V_STRING, ''],
-            'retrieve job logs max size': [VDR.V_STRING, ''],
-            'retrieve job logs retry delays': [VDR.V_STRING, ''],
-            'task event handler retry delays': [VDR.V_STRING, ''],
-            'tail command template': [VDR.V_STRING, ''],
+            'scp command': [VDR.V_STRING],
+            'ssh command': [VDR.V_STRING],
+            'use login shell': [VDR.V_STRING],
+            'login hosts': [VDR.V_STRING],
+            'batch system': [VDR.V_STRING],
+            'cylc executable': [VDR.V_STRING],
+            'global init-script': [VDR.V_STRING],
+            'copyable environment variables': [VDR.V_STRING],
+            'retrieve job logs': [VDR.V_STRING],
+            'retrieve job logs command': [VDR.V_STRING],
+            'retrieve job logs max size': [VDR.V_STRING],
+            'retrieve job logs retry delays': [VDR.V_STRING],
+            'task event handler retry delays': [VDR.V_STRING],
+            'tail command template': [VDR.V_STRING],
             'owner': [VDR.V_STRING_LIST],
+            'mail smtp': [VDR.V_STRING],
             'batch systems': {
-                'err tailer': [VDR.V_STRING, ''],
-                'out tailer': [VDR.V_STRING, ''],
-                'err viewer': [VDR.V_STRING, ''],
-                'out viewer': [VDR.V_STRING, ''],
-                'job name length maximum': [VDR.V_STRING, ''],
-                'execution time limit': [VDR.V_INTERVAL_LIST],
+                'name': [VDR.V_STRING],
+                'err tailer': [VDR.V_STRING],
+                'out tailer': [VDR.V_STRING],
+                'err viewer': [VDR.V_STRING],
+                'out viewer': [VDR.V_STRING],
+                'job name length maximum': [VDR.V_STRING],
+                'execution time limit polling interval': [VDR.V_INTERVAL_LIST],
                 'execution polling intervals': [VDR.V_INTERVAL_LIST],
                 'execution retry delays': [VDR.V_INTERVAL_LIST],
                 'batch submit command template': [VDR.V_STRING]
@@ -157,7 +161,7 @@ SPEC = {
         'smtp': [VDR.V_STRING],
         'to': [VDR.V_STRING],
         'footer': [VDR.V_STRING],
-        'task event interval': [VDR.V_INTERVAL],
+        'task event interval': [VDR.V_INTERVAL, DurationFloat(300)],
     },
     'scheduling': {
         'initial cycle point': [VDR.V_CYCLE_POINT],
@@ -211,10 +215,10 @@ SPEC = {
             'extra log files': [VDR.V_STRING_LIST],
             'work sub-directory': [VDR.V_STRING],
             'meta': {
-                'title': [VDR.V_STRING, ''],
-                'description': [VDR.V_STRING, ''],
-                'URL': [VDR.V_STRING, ''],
-                '__MANY__': [VDR.V_STRING, ''],
+                'title': [VDR.V_STRING],
+                'description': [VDR.V_STRING],
+                'URL': [VDR.V_STRING],
+                '__MANY__': [VDR.V_STRING],
             },
             'simulation': {
                 'default run length': [VDR.V_INTERVAL, DurationFloat(10)],
@@ -237,10 +241,8 @@ SPEC = {
                 'mail events': [VDR.V_STRING_LIST, None],
                 'mail from': [VDR.V_STRING],
                 'mail retry delays': [VDR.V_INTERVAL_LIST, None],
-                'mail smtp': [VDR.V_STRING],
                 'mail to': [VDR.V_STRING],
                 'submission timeout': [VDR.V_INTERVAL],
-
                 'expired handler': [VDR.V_STRING_LIST, None],
                 'late offset': [VDR.V_INTERVAL, None],
                 'late handler': [VDR.V_STRING_LIST, None],
@@ -280,8 +282,9 @@ SPEC = {
             },
         },
     },
-    'server events': {
-        'expected task failures': [VDR.V_STRING_LIST],
+    'workflow server events': {
+        # add obsoletion event
+        'ref test expected task failures': [VDR.V_STRING_LIST],
         'handlers': [VDR.V_STRING_LIST, None],
         'handler events': [VDR.V_STRING_LIST, None],
         'startup handler': [VDR.V_STRING_LIST, None],
@@ -329,10 +332,9 @@ SPEC = {
 
 def upg(cfg, descr):
     # Upgrade older suite configurations.
+    # Reviews shgould consider whether deprecations are tested.
     u = upgrader(cfg, descr)
     u.obsolete('6.1.3', ['visualization', 'enable live graph movie'])
-    u.obsolete('6.4.1', ['test battery', 'directives'])
-    u.obsolete('6.11.0', ['state dump rolling archive length'])
     u.obsolete('7.2.2', ['cylc', 'dummy mode'])
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
@@ -340,21 +342,9 @@ def upg(cfg, descr):
     u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
     u.obsolete('7.8.0', ['runtime', '__MANY__', 'suite state polling',
                          'template'])
-    u.obsolete('7.8.0', ['suite logging', 'roll over at start-up'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
     u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
-    u.obsolete('7.8.1', ['documentation', 'local index'])
-    u.obsolete('7.8.1', ['documentation', 'files', 'pdf user guide'])
-    u.obsolete(
-        '7.8.1',
-        ['documentation', 'files', 'single-page html user guide']
-    )
-    u.deprecate(
-        '7.8.1',
-        ['documentation', 'files', 'multi-page html user guide'],
-        ['documentation', 'local']
-    )
     # Cylc 8 Obseletions
     u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
     u.obsolete('8.0.0', ['cylc', 'required run mode'])
@@ -365,8 +355,6 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['suite definition directory'])
     u.obsolete('8.0.0', ['communication'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
-    u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
-    u.obsolete('8.0.0', ['suite servers', 'scan ports'])
     u.obsolete('8.0.0', ['temporary directory'])
     u.obsolete('8.0.0', ['test battery'])
     u.obsolete('8.0.0', ['task host select command timeout'])
@@ -374,24 +362,24 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['visualization'])
     u.obsolete('8.0.0', ['documentation'])
     # Cylc 8 Deprecations
-    # All mail ____ items moved from [cylc][events] to [email]
+    # All mail ____ items moved from [cylc][events] to [mail]
     for key in [
         'mail from', 'mail events', 'mail footer', 'mail smtp', 'mail to'
     ]:
         u.deprecate(
             '8.0.0',
             ['cylc', 'events', key],
-            ['mail', key.replace('mail ', '')]
+            ['mail', key.replace('mail ')]
         )
     u.deprecate(
         '8.0.0',
         ['cylc', 'abort if any task fails'],
-        ['cylc', 'events', 'abort if any task fails']
+        ['server events', 'abort if any task fails']
     )
     u.deprecate(
         '8.0.0',
         ['cylc', 'authentication'],
-        ['cylc', 'authorization']
+        ['misc', 'authorization']
     )
     u.deprecate(
         '8.0.0',
@@ -451,17 +439,7 @@ def upg(cfg, descr):
     u.deprecate(
         '8.0.0',
         ['suite host self-identification'],
-        ['workflow server platforms', 'suite host self-identification']
-    )
-    u.deprecate(
-        '8.0.0',
-        ['suite servers'],
-        ['workflow server platforms']
-    )
-    u.deprecate(
-        '8.0.0',
-        ['task events'],
-        ['runtime', 'root', 'events']
+        ['workflow server platforms', 'host self-identification']
     )
     u.deprecate('8.0.0', ['cylc'], ['misc'])
     u.upgrade()


### PR DESCRIPTION
As part of the rose-suite-run conversion to cylc-??? the config schema for site, local and suite configs should be merged as described by [this cylc-admin proposal document](https://github.com/cylc/cylc-admin/blob/master/docs/rose-suite-run-proposal/cylc-flow-rc.md). 

As a first step I have created a combined schema. This is not yet hooked into any functionality, although it has been checked by changing files that call it and using it to validate a test `suite.rc` file.

The first commit does nothing except move the file `cfgspc/suite.py` to `config_schema`. Changes to the schema are made in the second PR. Reviewers may therefore find it even more than usually useful to review individual commits.