### PR TITLE
prevented parsec.upgrader.obselete acting as parsec.upgrade.deprecate

### DIFF
--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -52,6 +52,20 @@ class upgrader(object):
         self.upgrades = OrderedDict()
 
     def deprecate(self, vn, oldkeys, newkeys=None, cvtr=None, silent=False):
+        """Replace a deprecated key from a config
+        Args:
+            vn (str):
+                Version at which this deprecation occurs.
+            oldkeys (list):
+                Path within config to be changed.
+            newkeys (list):
+                New location in the config for the item in "oldkeys".
+            cvtr (cylc.flow.parsec.upgrade.Converter):
+                Converter object containing a conversion function and a
+                description of that function.
+            silent:
+                Set silent mode for this upgrade.
+        """
         if vn not in self.upgrades:
             self.upgrades[vn] = []
         if cvtr is None:
@@ -59,12 +73,21 @@ class upgrader(object):
         self.upgrades[vn].append(
             {'old': oldkeys, 'new': newkeys, 'cvt': cvtr, 'silent': silent})
 
-    def obsolete(self, vn, oldkeys, newkeys=None, silent=False):
+    def obsolete(self, vn, oldkeys, silent=False):
+        """Remove an obsolete key from a config
+        Args:
+            vn (str):
+                Version at which this obsoletion occurs.
+            oldkeys (list):
+                Path within config to be removed.
+            silent:
+                Set silent mode for this upgrade.
+        """
         if vn not in self.upgrades:
             self.upgrades[vn] = []
         cvtr = converter(lambda x: x, "DELETED (OBSOLETE)")  # identity
         self.upgrades[vn].append(
-            {'old': oldkeys, 'new': newkeys, 'cvt': cvtr, 'silent': silent})
+            {'old': oldkeys, 'new': None, 'cvt': cvtr, 'silent': silent})
 
     def get_item(self, keys):
         item = self.cfg

--- a/cylc/flow/tests/parsec/test_upgrade.py
+++ b/cylc/flow/tests/parsec/test_upgrade.py
@@ -78,7 +78,6 @@ class TestUpgrade(unittest.TestCase):
         self.u.obsolete(
             vn='entry',
             oldkeys=['section', 'b'],
-            newkeys=['section', 'c'],
             silent=False)
         self.assertEqual(True, self.u.upgrades['entry'][0]['silent'])
         self.assertEqual(False, self.u.upgrades['entry'][1]['silent'])


### PR DESCRIPTION
Whist working on the new config I noticed that at times the method `cylc.flow.parsec.upgrader.obsolete` appeared to work in the same manner as `cylc.flow.parsec.upgrader.deprecate` taking the kwarg `newkeys` which it then does nothing with. I have suggested that this argument be removed.