### PR TITLE
Log exception when a decrypt error occurs

### DIFF
--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -168,9 +168,7 @@ class ZMQServer(object):
             except Exception as exc:  # purposefully catch generic exception
                 # failed to decode message, possibly resulting from failed
                 # authentication
-                import traceback
-                return {'error': {
-                    'message': str(exc), 'traceback': traceback.format_exc()}}
+                LOG.exception(f'failed to decode message: {str(exc)}')
             else:
                 # success case - serve the request
                 res = self._receiver(message)


### PR DESCRIPTION
This is a small change with no associated Issue.

Was poking around the code today, and noticed that the server thread's loop returns a value when an error occurs decoding the message the value will be returned, the job error log will contain some error, but the suite output won't contain anything.

So maybe instead we could raise a `CylcError` (or would it be better a `ValueError`? or just log it? anyhoo). This way at least we get the exception + traceback in the logs.

Cheers
Bruno

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? writing a test is doable, but I suspect it will be different when moving to asyncio, and the test won't even be re-used
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.


