### PR TITLE
Fix exception when set-severity receives invalid logging level

### DIFF
--- a/bin/cylc-set-verbosity
+++ b/bin/cylc-set-verbosity
@@ -62,7 +62,7 @@ def main(parser, options, suite, severity_str):
     try:
         severity = LOGGING_LVL_OF[severity_str]
     except KeyError:
-        parser.error("Illegal logging level, %s" % severity)
+        parser.error("Illegal logging level, %s" % severity_str)
 
     prompt("Set logging level to %s in %s" % (severity_str, suite),
            options.force)

--- a/tests/cli/03-set-verbosity.t
+++ b/tests/cli/03-set-verbosity.t
@@ -1,0 +1,25 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc set-verbosity" with a bad verbosity level.
+. "$(dirname "$0")/test_header"
+set_test_number 2
+run_fail "${TEST_NAME_BASE}" cylc set-verbosity duck quack
+contains_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
+cylc-set-verbosity: error: Illegal logging level, quack
+__ERR__
+exit


### PR DESCRIPTION
This is a small change with no associated Issue.

Executing something like `cylc set-verbosity five ubirajara`, you will get:

```bash
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc-flow/bin/cylc-set-verbosity", line 63, in main
    severity = LOGGING_LVL_OF[severity_str]
KeyError: 'ubirajara'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc-flow/venv/bin/cylc-set-verbosity", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/kinow/Development/python/workspace/cylc-flow/bin/cylc-set-verbosity", line 77, in <module>
    main()
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/terminal.py", line 137, in wrapper
    wrapped_function(*wrapped_args, **wrapped_kwargs)
  File "/home/kinow/Development/python/workspace/cylc-flow/bin/cylc-set-verbosity", line 65, in main
    parser.error("Illegal logging level, %s" % severity)
UnboundLocalError: local variable 'severity' referenced before assignment
```

I believe that is because we are trying to log the `severity` value, while the invalid logging level provided by the user was actually in `severity_str`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? this part of the code is not really tested for now, except for functional tests. I think we don't need one for this small change.).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
