### PR TITLE
Adjust codecov thresholds (85 general, 95 patch)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,13 +19,13 @@ coverage:
     project:
       default:
         # commits below this threshold will be marked as failed
-        target: '58%'
+        target: '85%'
         # how much we allow the coverage to drop
-        threshold: '5%'
+        threshold: '2%'
     patch:
       default:
         # basic
-        target: '58%'
+        target: '95%'
         threshold: '5%'
         base: auto
         # advanced


### PR DESCRIPTION
This is a small change with no associated Issue.

Sets code coverage minimum acceptable before failure at 85%, and patch at 95% (how much of the code changed in a PR needs to be covered).

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? changing coverage setting).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
