### PR TITLE
Unit test PBS directives formatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -178,6 +178,11 @@ Changed the `suite.rc` schema:
 restarts, and reloads).  Impact of the speedup is most noticeable when dealing
 with suite configurations that contain tasks with many task outputs.
 
+[#3356](https://github.com/cylc/cylc-flow/pull/3356) - default job name length
+maximum for PBS is now 236 characters (i.e. assuming PBS 13 or newer). If you
+are still using PBS 12 or older, you should add a site configuration to
+restrict it to 15 characters.
+
 ### Fixes
 
 [#3308](https://github.com/cylc/cylc-flow/pull/3308) - fix a long-standing bug

--- a/cylc/flow/batch_sys_handlers/pbs.py
+++ b/cylc/flow/batch_sys_handlers/pbs.py
@@ -32,9 +32,9 @@ class PBSHandler(object):
     #     [[the-name-of-my-pbs-host]]
     #         [[[batch systems]]]
     #             [[[[pbs]]]]
-    #                # E.g.: PBS 13
-    #                job name length maximum = 236
-    JOB_NAME_LEN_MAX = 15
+    #                # E.g.: PBS 11
+    #                job name length maximum = 15
+    JOB_NAME_LEN_MAX = 236
     KILL_CMD_TMPL = "qdel '%(job_id)s'"
     # N.B. The "qstat JOB_ID" command returns 1 if JOB_ID is no longer in the
     # system, so there is no need to filter its output.

--- a/cylc/flow/tests/batch_sys_handlers/test_pbs.py
+++ b/cylc/flow/tests/batch_sys_handlers/test_pbs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from cylc.flow.batch_sys_handlers.pbs import BATCH_SYS_HANDLER
+
+
+@pytest.mark.parametrize(
+    'job_conf,lines',
+    [
+        (  # basic
+            {
+                'batch_system_conf': {},
+                'directives': {},
+                'execution_time_limit': 180,
+                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'suite_name': 'chop',
+                'task_id': 'axe.1',
+            },
+            [
+                '#PBS -N axe.1.chop',
+                '#PBS -o cylc-run/chop/log/job/1/axe/01/job.out',
+                '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
+                '#PBS -l walltime=180',
+            ],
+        ),
+        (  # super short job name length maximum
+            {
+                'batch_system_conf': {'job name length maximum': 6},
+                'directives': {},
+                'execution_time_limit': 180,
+                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'suite_name': 'chop',
+                'task_id': 'axe.1',
+            },
+            [
+                '#PBS -N axe.1.',
+                '#PBS -o cylc-run/chop/log/job/1/axe/01/job.out',
+                '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
+                '#PBS -l walltime=180',
+            ],
+        ),
+        (  # some useful directives
+            {
+                'batch_system_conf': {},
+                'directives': {
+                    '-q': 'forever',
+                    '-V': '',
+                    '-l mem': '256gb',
+                },
+                'execution_time_limit': 180,
+                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'suite_name': 'chop',
+                'task_id': 'axe.1',
+            },
+            [
+                '#PBS -N axe.1.chop',
+                '#PBS -o cylc-run/chop/log/job/1/axe/01/job.out',
+                '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
+                '#PBS -l walltime=180',
+                '#PBS -q forever',
+                '#PBS -V',
+                '#PBS -l mem=256gb',
+            ],
+        ),
+    ],
+)
+def test_format_directives(job_conf: dict, lines: list):
+    assert BATCH_SYS_HANDLER.format_directives(job_conf) == lines


### PR DESCRIPTION
Add unit test for the directives formatter function for PBS handler.

Also upgrade default PBS job name line length from 15 to 236, i.e. assuming PBS version >=13.

This is a small change with no associated Issue. The purpose is to observe the test coverage of a source file that is currently untested on Travis CI.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/79.