### PR TITLE
[WIP] Plug new `config_schema.py` into the workings of cylc validate.

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -66,7 +66,7 @@ from stat import S_IRUSR
 from tempfile import NamedTemporaryFile
 from subprocess import Popen, PIPE
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import UserInputError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote

--- a/bin/cylc-documentation
+++ b/bin/cylc-documentation
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""cylc [info] documentation|browse [OPTIONS] ARGS
+
+View documentation in the browser, as per Cylc global config.
+
+% cylc doc [--local] [OPTIONS]
+    Open the Cylc documentation.
+% cylc doc [-t TASK] SUITE
+    View suite or task documentation, if URLs are specified in the suite. This
+    parses the suite definition to extract the requested URL."""
+
+import sys
+
+for arg in sys.argv[1:]:
+    if arg.startswith('--host=') or arg.startswith('--user='):
+        from cylc.flow.remote import remrun
+        if remrun(forward_x11=True):
+            sys.exit(0)
+
+import os
+from subprocess import check_call, CalledProcessError
+
+from cylc.flow.glbl_cfg import glbl_cfg
+from cylc.flow.exceptions import UserInputError
+from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.run_get_stdout import run_get_stdout
+from cylc.flow.terminal import cli_function
+
+
+def get_option_parser():
+    parser = COP(
+        __doc__, argdoc=[('[TARGET]', 'File or suite name')])
+
+    parser.add_option(
+        "--local",
+        help="Open the local documentation (if it has been built).",
+        action="store_true", default=False, dest="local")
+
+    parser.add_option(
+        "-t", "--task", help="Browse task documentation URLs.",
+        metavar="TASK_NAME", action="store", default=None, dest="task_name")
+
+    parser.add_option(
+        "-s", "--stdout", help="Just print the URL to stdout.",
+        action="store_true", default=False, dest="stdout")
+
+    parser.add_option(
+        "--user",
+        help="Other user account name. This results in "
+             "command reinvocation on the remote account.",
+        metavar="USER", action="store", dest="owner")
+
+    parser.add_option(
+        "--host",
+        help="Other host name. This results in "
+             "command reinvocation on the remote account.",
+        metavar="HOST", action="store", dest="host")
+
+    parser.add_option(
+        "--debug",
+        help="Print exception traceback on error.",
+        action="store_true", default=False, dest="debug")
+
+    return parser
+
+
+@cli_function(get_option_parser, remove_opts=['--host', '--user'])
+def main(parser, options, *args):
+    viewer = glbl_cfg().get(['document viewers', 'html'])
+    if len(args) == 0:
+        # Cylc documentation.
+        if options.local:
+            target = glbl_cfg().get(['documentation', 'local'])
+        else:
+            target = glbl_cfg().get(['documentation', 'online'])
+        if target is None:
+            raise UserInputError(
+                "no url defined, see the [documentation][%s'] "
+                "global configuration" % (
+                    'local' if options.local else 'online'))
+
+    elif len(args) == 1:
+        # Suite or task documentation.
+        suite = args[0]
+        if options.task_name:
+            # Task documentation.
+            res, stdout = run_get_stdout(
+                "cylc get-suite-config -i [runtime][%s][meta]URL %s" % (
+                    options.task_name, suite))
+        else:
+            # Suite documentation.
+            res, stdout = run_get_stdout(
+                "cylc get-suite-config -i [meta]URL %s" % suite)
+        if not res:
+            # (Illegal config item)
+            raise UserInputError(stdout)
+        elif len(stdout) == 0:
+            if options.task_name is not None:
+                raise UserInputError("No URL defined for %s in %s." % (
+                    options.task_name, suite))
+            else:
+                raise UserInputError("No URL defined for %s." % suite)
+        target = stdout[0]
+    else:
+        parser.error("Too many arguments.")
+
+    if options.stdout:
+        print(target)
+        sys.exit(0)
+
+    # viewer may have spaces (e.g. 'firefox --no-remote'):
+    command = ('%s %s' % (viewer, target)).split(' ')
+    try:
+        check_call(command, stdin=open(os.devnull))
+    except CalledProcessError:
+        print('failed to execute: %s' % command, file=sys.stderr)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/cylc-edit
+++ b/bin/cylc-edit
@@ -72,7 +72,7 @@ from cylc.flow.parsec.include import inline, \
     split_file, backup, backups, newfiles, cleanup, modtimes
 
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.suite_srv_files_mgr import SuiteSrvFilesManager
 from cylc.flow.terminal import cli_function

--- a/bin/cylc-get-site-config
+++ b/bin/cylc-get-site-config
@@ -26,7 +26,7 @@ use -i/--item and wrap parent sections in square brackets:
 Multiple items can be specified at once."""
 
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
 

--- a/bin/cylc-monitor
+++ b/bin/cylc-monitor
@@ -37,7 +37,7 @@ from cylc.flow.parsec.OrderedDict import OrderedDict
 from cylc.flow.exceptions import ClientError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.task_state import (
     TASK_STATUS_RUNAHEAD, TASK_STATUSES_ORDERED,
     TASK_STATUSES_RESTRICTED)

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -59,7 +59,7 @@ from cylc.flow.exceptions import CylcError, UserInputError
 import cylc.flow.flags
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.dbstatecheck import CylcSuiteDBChecker
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.command_polling import Poller
 from cylc.flow.task_state import TASK_STATUSES_ORDERED
 from cylc.flow.terminal import cli_function

--- a/bin/cylc-trigger
+++ b/bin/cylc-trigger
@@ -54,7 +54,7 @@ from subprocess import call
 from cylc.flow.exceptions import CylcError, UserInputError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.task_job_logs import JOB_LOG_DIFF
 from cylc.flow.terminal import prompt, cli_function
 

--- a/bin/cylc-view
+++ b/bin/cylc-view
@@ -40,7 +40,7 @@ from tempfile import NamedTemporaryFile
 import shlex
 from subprocess import call
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.parsec.fileparse import read_and_proc

--- a/cylc/flow/client_schema.py
+++ b/cylc/flow/client_schema.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Define all legal items and values for cylc local client definitions.
+
+SPEC = {
+    'disable interactive command prompts': [VDR.V_BOOLEAN, True],
+    'editors': {
+        'terminal': [VDR.V_STRING, 'vim'],
+        'gui': [VDR.V_STRING, 'gvim -f'],
+    },
+}

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -45,7 +45,7 @@ from cylc.flow.exceptions import (
     CylcError, SuiteConfigError, IntervalParsingError, TaskDefError)
 from cylc.flow.graph_parser import GraphParser
 from cylc.flow.param_expand import NameExpander
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.cfgspec.suite import RawSuiteConfig
 from cylc.flow.cycling.loader import (
     get_point, get_point_relative, get_interval, get_interval_cls,

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -46,7 +46,7 @@ from cylc.flow.exceptions import (
 from cylc.flow.graph_parser import GraphParser
 from cylc.flow.param_expand import NameExpander
 from cylc.flow.config_schema import glbl_cfg
-from cylc.flow.config_schema.suite import RawSuiteConfig
+from cylc.flow.config_schema import RawSuiteConfig
 from cylc.flow.cycling.loader import (
     get_point, get_point_relative, get_interval, get_interval_cls,
     get_sequence, get_sequence_cls, init_cyclers, INTEGER_CYCLING_TYPE,

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1268,8 +1268,8 @@ class SuiteConfig(object):
 
             if tdef.run_mode == 'dummy-local':
                 # Run all dummy tasks on the suite host.
-                rtc['remote']['host'] = None
-                rtc['remote']['owner'] = None
+                rtc['job']['host'] = None
+                rtc['job']['owner'] = None
 
             # Simulation mode tasks should fail in which cycle points?
             f_pts = []

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -46,7 +46,7 @@ from cylc.flow.exceptions import (
 from cylc.flow.graph_parser import GraphParser
 from cylc.flow.param_expand import NameExpander
 from cylc.flow.config_schema import glbl_cfg
-from cylc.flow.cfgspec.suite import RawSuiteConfig
+from cylc.flow.config_schema.suite import RawSuiteConfig
 from cylc.flow.cycling.loader import (
     get_point, get_point_relative, get_interval, get_interval_cls,
     get_sequence, get_sequence_cls, init_cyclers, INTEGER_CYCLING_TYPE,

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -45,7 +45,7 @@ from cylc.flow.exceptions import (
     CylcError, SuiteConfigError, IntervalParsingError, TaskDefError)
 from cylc.flow.graph_parser import GraphParser
 from cylc.flow.param_expand import NameExpander
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.config_schema import RawSuiteConfig
 from cylc.flow.cycling.loader import (
     get_point, get_point_relative, get_interval, get_interval_cls,

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -234,12 +234,12 @@ class SuiteConfig(object):
             self.cfg['runtime']['root'] = OrderedDictWithDefaults()
 
         try:
-            parameter_values = self.cfg['cylc']['parameters']
+            parameter_values = self.cfg['general']['parameters']
         except KeyError:
             # (Suite config defaults not put in yet.)
             parameter_values = {}
         try:
-            parameter_templates = self.cfg['cylc']['parameter templates']
+            parameter_templates = self.cfg['general']['parameter templates']
         except KeyError:
             parameter_templates = {}
         # parameter values and templates are normally needed together.
@@ -312,10 +312,10 @@ class SuiteConfig(object):
         init_cyclers(self.cfg)
 
         # Running in UTC time? (else just use the system clock)
-        if self.cfg['cylc']['UTC mode'] is None:
-            set_utc_mode(glbl_cfg().get(['cylc', 'UTC mode']))
+        if self.cfg['general']['UTC mode'] is None:
+            set_utc_mode(glbl_cfg().get(['general', 'UTC mode']))
         else:
-            set_utc_mode(self.cfg['cylc']['UTC mode'])
+            set_utc_mode(self.cfg['general']['UTC mode'])
 
         # Initial point from suite definition (or CLI override above).
         orig_icp = self.cfg['scheduling']['initial cycle point']
@@ -1406,7 +1406,7 @@ class SuiteConfig(object):
         os.environ['CYLC_CYCLING_MODE'] = self.cfg['scheduling'][
             'cycling mode']
         #     (global config auto expands environment variables in local paths)
-        cenv = self.cfg['cylc']['environment'].copy()
+        cenv = self.cfg['general']['environment'].copy()
         for var, val in cenv.items():
             cenv[var] = os.path.expandvars(val)
         #     path to suite bin directory for suite and event handlers
@@ -1425,7 +1425,7 @@ class SuiteConfig(object):
         """
         mode = getattr(self.options, 'run_mode', None)
         if not mode:
-            mode = self.cfg['cylc']['force run mode']
+            mode = self.cfg['general']['force run mode']
         if not mode:
             mode = 'live'
         if reqmodes:
@@ -2238,8 +2238,8 @@ class SuiteConfig(object):
         - None if there is no expectation either way.
         """
         if self.options.reftest:
-            return self.cfg['cylc']['reference test']['expected task failures']
-        elif self.cfg['cylc']['events']['abort if any task fails']:
+            return self.cfg['general']['reference test']['expected task failures']
+        elif self.cfg['general']['events']['abort if any task fails']:
             return []
         else:
             return None

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2238,7 +2238,8 @@ class SuiteConfig(object):
         - None if there is no expectation either way.
         """
         if self.options.reftest:
-            return self.cfg['general']['reference test']['expected task failures']
+            return self.cfg[
+                'general']['reference test']['expected task failures']
         elif self.cfg['general']['events']['abort if any task fails']:
             return []
         else:

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Define all legal items and values for cylc suite definition files."""
+
+from metomi.isodatetime.data import Calendar
+
+from cylc.flow import LOG
+from cylc.flow.network.authorisation import Priv
+from cylc.flow.parsec.config import ParsecConfig
+from cylc.flow.parsec.upgrade import upgrader
+from cylc.flow.parsec.validate import (
+    DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
+
+# Nested dict of spec items.
+# Spec value is [value_type, default, allowed_2, allowed_3, ...]
+# where:
+# - value_type: value type (compulsory).
+# - default: the default value (optional).
+# - allowed_2, ...: the only other allowed values of this setting (optional).
+SPEC = {
+    'meta': {
+        'description': [VDR.V_STRING, ''],
+        'group': [VDR.V_STRING, ''],
+        'title': [VDR.V_STRING, ''],
+        'URL': [VDR.V_STRING, ''],
+        '__MANY__': [VDR.V_STRING, ''],
+    },
+    'cylc': {
+        'UTC mode': [VDR.V_BOOLEAN, False],
+        'cycle point format': [VDR.V_CYCLE_POINT_FORMAT],
+        'cycle point num expanded year digits': [VDR.V_INTEGER, 0],
+        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE],
+        'required run mode': [
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
+        'force run mode': [
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
+        'health check interval': [VDR.V_INTERVAL],
+        'task event mail interval': [VDR.V_INTERVAL],
+        'disable automatic shutdown': [VDR.V_BOOLEAN],
+        'simulation': {
+            'disable suite event handlers': [VDR.V_BOOLEAN, True],
+        },
+        'environment': {
+            '__MANY__': [VDR.V_STRING],
+        },
+        'parameters': {
+            '__MANY__': [VDR.V_PARAMETER_LIST],
+        },
+        'parameter templates': {
+            '__MANY__': [VDR.V_STRING],
+        },
+        'events': {
+            'handlers': [VDR.V_STRING_LIST, None],
+            'handler events': [VDR.V_STRING_LIST, None],
+            'startup handler': [VDR.V_STRING_LIST, None],
+            'timeout handler': [VDR.V_STRING_LIST, None],
+            'inactivity handler': [VDR.V_STRING_LIST, None],
+            'shutdown handler': [VDR.V_STRING_LIST, None],
+            'aborted handler': [VDR.V_STRING_LIST, None],
+            'stalled handler': [VDR.V_STRING_LIST, None],
+            'timeout': [VDR.V_INTERVAL],
+            'inactivity': [VDR.V_INTERVAL],
+            'abort if startup handler fails': [VDR.V_BOOLEAN],
+            'abort if shutdown handler fails': [VDR.V_BOOLEAN],
+            'abort if timeout handler fails': [VDR.V_BOOLEAN],
+            'abort if inactivity handler fails': [VDR.V_BOOLEAN],
+            'abort if stalled handler fails': [VDR.V_BOOLEAN],
+            'abort if any task fails': [VDR.V_BOOLEAN],
+            'abort on stalled': [VDR.V_BOOLEAN],
+            'abort on timeout': [VDR.V_BOOLEAN],
+            'abort on inactivity': [VDR.V_BOOLEAN],
+            'mail events': [VDR.V_STRING_LIST, None],
+            'mail from': [VDR.V_STRING],
+            'mail smtp': [VDR.V_STRING],
+            'mail to': [VDR.V_STRING],
+            'mail footer': [VDR.V_STRING],
+        },
+        'reference test': {
+            'expected task failures': [VDR.V_STRING_LIST],
+        },
+        'authentication': {
+            # Allow owners to grant public shutdown rights at the most, not
+            # full control.
+            'public': (
+                [VDR.V_STRING, '']
+                + [level.name.lower().replace('_', '-') for level in [
+                    Priv.IDENTITY, Priv.DESCRIPTION, Priv.STATE_TOTALS,
+                    Priv.READ, Priv.SHUTDOWN]])
+        },
+    },
+    'scheduling': {
+        'initial cycle point': [VDR.V_CYCLE_POINT],
+        'final cycle point': [VDR.V_STRING],
+        'initial cycle point constraints': [VDR.V_STRING_LIST],
+        'final cycle point constraints': [VDR.V_STRING_LIST],
+        'hold after point': [VDR.V_CYCLE_POINT],
+        'cycling mode': (
+            [VDR.V_STRING, Calendar.MODE_GREGORIAN] +
+            list(Calendar.MODES) + ["integer"]),
+        'runahead limit': [VDR.V_STRING],
+        'max active cycle points': [VDR.V_INTEGER, 3],
+        'spawn to max active cycle points': [VDR.V_BOOLEAN],
+        'queues': {
+            'default': {
+                'limit': [VDR.V_INTEGER, 0],
+                'members': [VDR.V_STRING_LIST],
+            },
+            '__MANY__': {
+                'limit': [VDR.V_INTEGER, 0],
+                'members': [VDR.V_STRING_LIST],
+            },
+        },
+        'special tasks': {
+            'clock-trigger': [VDR.V_STRING_LIST],
+            'external-trigger': [VDR.V_STRING_LIST],
+            'clock-expire': [VDR.V_STRING_LIST],
+            'sequential': [VDR.V_STRING_LIST],
+            'exclude at start-up': [VDR.V_STRING_LIST],
+            'include at start-up': [VDR.V_STRING_LIST],
+        },
+        'xtriggers': {
+            '__MANY__': [VDR.V_XTRIGGER],
+        },
+        'graph': {
+            '__MANY__': [VDR.V_STRING],
+        },
+    },
+    'runtime': {
+        '__MANY__': {
+            'inherit': [VDR.V_STRING_LIST],
+            'init-script': [VDR.V_STRING],
+            'env-script': [VDR.V_STRING],
+            'err-script': [VDR.V_STRING],
+            'exit-script': [VDR.V_STRING],
+            'pre-script': [VDR.V_STRING],
+            'script': [VDR.V_STRING],
+            'post-script': [VDR.V_STRING],
+            'extra log files': [VDR.V_STRING_LIST],
+            'work sub-directory': [VDR.V_STRING],
+            'meta': {
+                'title': [VDR.V_STRING, ''],
+                'description': [VDR.V_STRING, ''],
+                'URL': [VDR.V_STRING, ''],
+                '__MANY__': [VDR.V_STRING, ''],
+            },
+            'simulation': {
+                'default run length': [VDR.V_INTERVAL, DurationFloat(10)],
+                'speedup factor': [VDR.V_FLOAT],
+                'time limit buffer': [VDR.V_INTERVAL, DurationFloat(30)],
+                'fail cycle points': [VDR.V_STRING_LIST],
+                'fail try 1 only': [VDR.V_BOOLEAN, True],
+                'disable task event handlers': [VDR.V_BOOLEAN, True],
+            },
+            'environment filter': {
+                'include': [VDR.V_STRING_LIST],
+                'exclude': [VDR.V_STRING_LIST],
+            },
+            'job': {
+                'batch system': [VDR.V_STRING, 'background'],
+                'batch submit command template': [VDR.V_STRING],
+                'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
+                'execution retry delays': [VDR.V_INTERVAL_LIST, None],
+                'execution time limit': [VDR.V_INTERVAL],
+                'submission polling intervals': [VDR.V_INTERVAL_LIST, None],
+                'submission retry delays': [VDR.V_INTERVAL_LIST, None],
+            },
+            'remote': {
+                'host': [VDR.V_STRING],
+                'owner': [VDR.V_STRING],
+                'suite definition directory': [VDR.V_STRING],
+                'retrieve job logs': [VDR.V_BOOLEAN],
+                'retrieve job logs max size': [VDR.V_STRING],
+                'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST, None],
+            },
+            'events': {
+                'execution timeout': [VDR.V_INTERVAL],
+                'handlers': [VDR.V_STRING_LIST, None],
+                'handler events': [VDR.V_STRING_LIST, None],
+                'handler retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail events': [VDR.V_STRING_LIST, None],
+                'mail from': [VDR.V_STRING],
+                'mail retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail smtp': [VDR.V_STRING],
+                'mail to': [VDR.V_STRING],
+                'submission timeout': [VDR.V_INTERVAL],
+
+                'expired handler': [VDR.V_STRING_LIST, None],
+                'late offset': [VDR.V_INTERVAL, None],
+                'late handler': [VDR.V_STRING_LIST, None],
+                'submitted handler': [VDR.V_STRING_LIST, None],
+                'started handler': [VDR.V_STRING_LIST, None],
+                'succeeded handler': [VDR.V_STRING_LIST, None],
+                'failed handler': [VDR.V_STRING_LIST, None],
+                'submission failed handler': [VDR.V_STRING_LIST, None],
+                'warning handler': [VDR.V_STRING_LIST, None],
+                'critical handler': [VDR.V_STRING_LIST, None],
+                'retry handler': [VDR.V_STRING_LIST, None],
+                'submission retry handler': [VDR.V_STRING_LIST, None],
+                'execution timeout handler': [VDR.V_STRING_LIST, None],
+                'submission timeout handler': [VDR.V_STRING_LIST, None],
+                'custom handler': [VDR.V_STRING_LIST, None],
+            },
+            'suite state polling': {
+                'user': [VDR.V_STRING],
+                'host': [VDR.V_STRING],
+                'interval': [VDR.V_INTERVAL],
+                'max-polls': [VDR.V_INTEGER],
+                'message': [VDR.V_STRING],
+                'run-dir': [VDR.V_STRING],
+                'verbose mode': [VDR.V_BOOLEAN],
+            },
+            'environment': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'directives': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'outputs': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'parameter environment templates': {
+                '__MANY__': [VDR.V_STRING],
+            },
+        },
+    },
+    'visualization': {
+        'initial cycle point': [VDR.V_CYCLE_POINT],
+        'final cycle point': [VDR.V_STRING],
+        'number of cycle points': [VDR.V_INTEGER, 3],
+        'collapsed families': [VDR.V_STRING_LIST],
+        'use node color for edges': [VDR.V_BOOLEAN],
+        'use node fillcolor for edges': [VDR.V_BOOLEAN],
+        'use node color for labels': [VDR.V_BOOLEAN],
+        'node penwidth': [VDR.V_INTEGER, 2],
+        'edge penwidth': [VDR.V_INTEGER, 2],
+        'default node attributes': [
+            VDR.V_STRING_LIST, ['style=unfilled', 'shape=ellipse']],
+        'default edge attributes': [VDR.V_STRING_LIST],
+        'node groups': {
+            '__MANY__': [VDR.V_STRING_LIST],
+        },
+        'node attributes': {
+            '__MANY__': [VDR.V_STRING_LIST],
+        },
+    },
+}
+
+
+def upg(cfg, descr):
+    """Upgrade old suite configuration."""
+    u = upgrader(cfg, descr)
+    u.obsolete('6.1.3', ['visualization', 'enable live graph movie'])
+    u.obsolete('7.2.2', ['cylc', 'dummy mode'])
+    u.obsolete('7.2.2', ['cylc', 'simulation mode'])
+    u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
+    u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
+    u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
+    u.obsolete(
+        '7.8.0',
+        ['runtime', '__MANY__', 'suite state polling', 'template'])
+    u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
+    u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
+    u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
+    u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'dummy mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'dummy-local mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'simulation mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'required run mode'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'suite shutdown event handler'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'abort if any task fails'],
+        ['cylc', 'events', 'abort if any task fails'])
+    u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.upgrade()
+
+    # Upgrader cannot do this type of move.
+    try:
+        keys = set()
+        cfg['scheduling'].setdefault('graph', {})
+        cfg['scheduling']['graph'].update(
+            cfg['scheduling'].pop('dependencies'))
+        graphdict = cfg['scheduling']['graph']
+        for key, value in graphdict.copy().items():
+            if isinstance(value, dict) and 'graph' in value:
+                graphdict[key] = value['graph']
+                keys.add(key)
+        if keys:
+            LOG.warning(
+                "deprecated graph items were automatically upgraded in '%s':",
+                descr)
+            LOG.warning(
+                ' * (8.0.0) %s -> %s - for X in:\n%s',
+                u.show_keys(['scheduling', 'dependencies', 'X', 'graph']),
+                u.show_keys(['scheduling', 'graph', 'X']),
+                '\n'.join(sorted(keys)),
+            )
+    except KeyError:
+        pass
+
+
+class RawSuiteConfig(ParsecConfig):
+    """Raw suite configuration."""
+
+    def __init__(self, fpath, output_fname, tvars):
+        """Return the default instance."""
+        ParsecConfig.__init__(
+            self, SPEC, upg, output_fname, tvars, cylc_config_validate)
+        self.loadcfg(fpath, "suite definition")

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -485,6 +485,30 @@ def upg(cfg, descr):
         ['documentation', 'files', 'multi-page html user guide'],
         ['documentation', 'local']
     )
+    u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'dummy mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'dummy-local mode suite timeout'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'simulation mode suite timeout'])
+    u.obsolete('8.0.0', ['cylc', 'reference test', 'required run mode'])
+    u.obsolete(
+        '8.0.0',
+        ['cylc', 'reference test', 'suite shutdown event handler'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'abort if any task fails'],
+        ['cylc', 'events', 'abort if any task fails'])
+    # All mail ____ items moved from [cylc][events] to [email]
+    for key in [
+        'mail from', 'mail events', 'mail footer', 'mail smtp', 'mail to'
+    ]:
+        u.deprecate('8.0.0', ['cylc', 'events', key], ['email', key])
+
     u.deprecate('8.0.0',
                 ['documentation', 'files', 'html index'],
                 ['documentation', 'local']
@@ -695,8 +719,6 @@ class GlobalConfig(ParsecConfig):
         # Expand environment variables and ~user in LOCAL file paths.
         if 'HOME' not in os.environ:
             os.environ['HOME'] = self._HOME
-        cfg['documentation']['local'] = os.path.expandvars(
-            cfg['documentation']['local'])
         for key, val in cfg['job platforms']['default platform'].items():
             if val and 'directory' in key:
                 cfg['job platforms']['default platform'][key] =\

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -602,8 +602,3 @@ class GlobalConfig(ParsecConfig):
             if val and 'directory' in key:
                 cfg['job platforms']['default platform'][key] =\
                     os.path.expandvars(val)
-
-
-def glbl_cfg(cached=True):
-    """Load and return the global configuration singleton instance."""
-    return GlobalConfig.get_inst(cached=cached)

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -225,6 +225,105 @@ SPEC = {
         },
     },
     'runtime': {
+        # This section should probably be removed before go live
+        # forcing site admins to add it to the site.rc
+        'root': {
+            'inherit': [VDR.V_STRING_LIST],
+            'init-script': [VDR.V_STRING],
+            'env-script': [VDR.V_STRING],
+            'err-script': [VDR.V_STRING],
+            'exit-script': [VDR.V_STRING],
+            'pre-script': [VDR.V_STRING],
+            'script': [VDR.V_STRING],
+            'post-script': [VDR.V_STRING],
+            'extra log files': [VDR.V_STRING_LIST],
+            'work sub-directory': [VDR.V_STRING],
+            'meta': {
+                'title': [VDR.V_STRING, ''],
+                'description': [VDR.V_STRING, ''],
+                'URL': [VDR.V_STRING, ''],
+                '__MANY__': [VDR.V_STRING, ''],
+            },
+            'simulation': {
+                'default run length': [VDR.V_INTERVAL, DurationFloat(10)],
+                'speedup factor': [VDR.V_FLOAT],
+                'time limit buffer': [VDR.V_INTERVAL, DurationFloat(30)],
+                'fail cycle points': [VDR.V_STRING_LIST],
+                'fail try 1 only': [VDR.V_BOOLEAN, True],
+                'disable task event handlers': [VDR.V_BOOLEAN, True],
+            },
+            'environment filter': {
+                'include': [VDR.V_STRING_LIST],
+                'exclude': [VDR.V_STRING_LIST],
+            },
+            'job': {
+                'batch system': [VDR.V_STRING, 'background'],
+                'batch submit command template': [VDR.V_STRING],
+                'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
+                'execution retry delays': [VDR.V_INTERVAL_LIST, None],
+                'execution time limit': [VDR.V_INTERVAL],
+                'submission polling intervals': [
+                    VDR.V_INTERVAL_LIST, None
+                ],
+                'submission retry delays': [VDR.V_INTERVAL_LIST, None],
+                'host': [VDR.V_STRING],
+                'owner': [VDR.V_STRING],
+                'platform': [VDR.V_STRING],
+                'suite definition directory': [VDR.V_STRING],
+                'retrieve job logs': [VDR.V_BOOLEAN],
+                'retrieve job logs max size': [VDR.V_STRING],
+                'retrieve job logs retry delays': [
+                    VDR.V_INTERVAL_LIST, None],
+            },
+            'events': {
+                'execution timeout': [VDR.V_INTERVAL],
+                'handlers': [VDR.V_STRING_LIST, None],
+                'handler events': [VDR.V_STRING_LIST, None],
+                'handler retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail events': [VDR.V_STRING_LIST, None],
+                'mail from': [VDR.V_STRING],
+                'mail retry delays': [VDR.V_INTERVAL_LIST, None],
+                'mail smtp': [VDR.V_STRING],
+                'mail to': [VDR.V_STRING],
+                'submission timeout': [VDR.V_INTERVAL],
+                'expired handler': [VDR.V_STRING_LIST, None],
+                'late offset': [VDR.V_INTERVAL, None],
+                'late handler': [VDR.V_STRING_LIST, None],
+                'submitted handler': [VDR.V_STRING_LIST, None],
+                'started handler': [VDR.V_STRING_LIST, None],
+                'succeeded handler': [VDR.V_STRING_LIST, None],
+                'failed handler': [VDR.V_STRING_LIST, None],
+                'submission failed handler': [VDR.V_STRING_LIST, None],
+                'warning handler': [VDR.V_STRING_LIST, None],
+                'critical handler': [VDR.V_STRING_LIST, None],
+                'retry handler': [VDR.V_STRING_LIST, None],
+                'submission retry handler': [VDR.V_STRING_LIST, None],
+                'execution timeout handler': [VDR.V_STRING_LIST, None],
+                'submission timeout handler': [VDR.V_STRING_LIST, None],
+                'custom handler': [VDR.V_STRING_LIST, None],
+            },
+            'suite state polling': {
+                'user': [VDR.V_STRING],
+                'host': [VDR.V_STRING],
+                'interval': [VDR.V_INTERVAL],
+                'max-polls': [VDR.V_INTEGER],
+                'message': [VDR.V_STRING],
+                'run-dir': [VDR.V_STRING],
+                'verbose mode': [VDR.V_BOOLEAN],
+            },
+            'environment': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'directives': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'outputs': {
+                '__MANY__': [VDR.V_STRING],
+            },
+            'parameter environment templates': {
+                '__MANY__': [VDR.V_STRING],
+            },
+        },
         '__MANY__': {
             'inherit': [VDR.V_STRING_LIST],
             'init-script': [VDR.V_STRING],
@@ -398,7 +497,11 @@ def upg(cfg, descr):
     u.deprecate('8.0.0', ['suite definition directory'])
     u.obsolete('8.0.0', ['communication'])
     u.deprecate('8.0.0', ['cylc', 'authentication'], ['cylc', 'authorization'])
-    u.deprecate('8.0.0', ['cylc'], ['general'])
+    u.deprecate(
+        '8.0.0',
+        ['general', 'authentication'],
+        ['general', 'authorization']
+    )
     u.obsolete('8.0.0', ['enable run directory housekeeping'])
 
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
@@ -415,11 +518,7 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['test battery'])
     u.obsolete('8.0.0', ['task host select command timeout'])
     u.obsolete('8.0.0', ['xtrigger function timeout'])
-    u.deprecate(
-        '8.0.0',
-        ['general', 'authentication'],
-        ['general', 'authorization']
-    )
+    u.deprecate('8.0.0', ['cylc'], ['general'])
     u.upgrade()
 
     # Upgrader cannot do this type of move.

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -75,6 +75,7 @@ SPEC = {
             '__MANY__': [VDR.V_STRING],
         },
         'events': {
+            'abort if any task fails': [VDR.V_BOOLEAN, False],
             'handlers': [VDR.V_STRING_LIST, None],
             'handler events': [VDR.V_STRING_LIST, None],
             'startup handler': [VDR.V_STRING_LIST, None],

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -17,21 +17,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Define all legal items and values for cylc suite definition files."""
 
+import os
+import re
+
 from metomi.isodatetime.data import Calendar
 
 from cylc.flow import LOG
+from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.network.authorisation import Priv
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.parsec.upgrade import upgrader
 from cylc.flow.parsec.validate import (
     DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
+from cylc.flow.hostuserutil import get_user_home, is_remote_user
 
 # Nested dict of spec items.
 # Spec value is [value_type, default, allowed_2, allowed_3, ...]
-# where:
-# - value_type: value type (compulsory).
-# - default: the default value (optional).
-# - allowed_2, ...: the only other allowed values of this setting (optional).
 SPEC = {
     'meta': {
         'description': [VDR.V_STRING, ''],
@@ -40,17 +41,26 @@ SPEC = {
         'URL': [VDR.V_STRING, ''],
         '__MANY__': [VDR.V_STRING, ''],
     },
-    'cylc': {
+    'general': {
         'UTC mode': [VDR.V_BOOLEAN, False],
         'cycle point format': [VDR.V_CYCLE_POINT_FORMAT],
         'cycle point num expanded year digits': [VDR.V_INTEGER, 0],
-        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE],
+        'cycle point time zone': [VDR.V_CYCLE_POINT_TIME_ZONE, 'Z'],
+        'maximum size in bytes': [VDR.V_INTEGER, 1000000],
+        'process pool size': [VDR.V_INTEGER, 4],
+        'process pool timeout': [VDR.V_INTERVAL, DurationFloat(600)],
         'required run mode': [
-            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local',
+            'simulation'
+        ],
+        'rolling archive length': [VDR.V_INTEGER, 5],
+        'run directory rolling archive length': [VDR.V_INTEGER, -1],
         'force run mode': [
-            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local', 'simulation'],
-        'health check interval': [VDR.V_INTERVAL],
-        'task event mail interval': [VDR.V_INTERVAL],
+            VDR.V_STRING, '', 'live', 'dummy', 'dummy-local',
+            'simulation'
+        ],
+        'health check interval': [VDR.V_INTERVAL, 1500],
+        'task event mail interval': [VDR.V_INTERVAL, 300],
         'disable automatic shutdown': [VDR.V_BOOLEAN],
         'simulation': {
             'disable suite event handlers': [VDR.V_BOOLEAN, True],
@@ -75,25 +85,20 @@ SPEC = {
             'stalled handler': [VDR.V_STRING_LIST, None],
             'timeout': [VDR.V_INTERVAL],
             'inactivity': [VDR.V_INTERVAL],
+            'abort if any task fails': [VDR.V_BOOLEAN, False],
             'abort if startup handler fails': [VDR.V_BOOLEAN],
             'abort if shutdown handler fails': [VDR.V_BOOLEAN],
             'abort if timeout handler fails': [VDR.V_BOOLEAN],
             'abort if inactivity handler fails': [VDR.V_BOOLEAN],
             'abort if stalled handler fails': [VDR.V_BOOLEAN],
-            'abort if any task fails': [VDR.V_BOOLEAN],
             'abort on stalled': [VDR.V_BOOLEAN],
             'abort on timeout': [VDR.V_BOOLEAN],
             'abort on inactivity': [VDR.V_BOOLEAN],
-            'mail events': [VDR.V_STRING_LIST, None],
-            'mail from': [VDR.V_STRING],
-            'mail smtp': [VDR.V_STRING],
-            'mail to': [VDR.V_STRING],
-            'mail footer': [VDR.V_STRING],
         },
         'reference test': {
             'expected task failures': [VDR.V_STRING_LIST],
         },
-        'authentication': {
+        'authorization': {
             # Allow owners to grant public shutdown rights at the most, not
             # full control.
             'public': (
@@ -101,6 +106,84 @@ SPEC = {
                 + [level.name.lower().replace('_', '-') for level in [
                     Priv.IDENTITY, Priv.DESCRIPTION, Priv.STATE_TOTALS,
                     Priv.READ, Priv.SHUTDOWN]])
+        },
+    },
+    'job platforms': {
+        'default platform': {
+            'run directory': [VDR.V_STRING, '$HOME/cylc-run'],
+            'work directory': [VDR.V_STRING, '$HOME/cylc-run'],
+            'task communication method': [
+                VDR.V_STRING, 'zmq', 'ssh+zmq', 'poll'],
+            'submission polling intervals': [VDR.V_INTERVAL_LIST],
+            'execution polling intervals': [VDR.V_INTERVAL_LIST],
+            'scp command': [
+                VDR.V_STRING, 'scp -oBatchMode=yes -oConnectTimeout=10'],
+            'ssh command': [
+                VDR.V_STRING, 'ssh -oBatchMode=yes -oConnectTimeout=10'],
+            'use login shell': [VDR.V_BOOLEAN, True],
+            'login hosts': [VDR.V_STRING, None],
+            'batch system': [VDR.V_STRING, None],
+            'cylc executable': [VDR.V_STRING, 'cylc'],
+            'global init-script': [VDR.V_STRING],
+            'retrieve job logs': [VDR.V_BOOLEAN],
+            'retrieve job logs command': [VDR.V_STRING, 'rsync -a'],
+            'retrieve job logs max size': [VDR.V_STRING],
+            'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST],
+            'task event handler retry delays': [VDR.V_INTERVAL_LIST],
+            'tail command template': [
+                VDR.V_STRING, 'tail -n +1 -F %(filename)s'],
+            'batch systems': {
+                'err tailer': [VDR.V_STRING],
+                'out tailer': [VDR.V_STRING],
+                'err viewer': [VDR.V_STRING],
+                'out viewer': [VDR.V_STRING],
+                'job name length maximum': [VDR.V_INTEGER],
+                'execution time limit polling intervals': [
+                    VDR.V_INTERVAL_LIST],
+            },
+        },
+        '__MANY__': {
+            'run directory': [VDR.V_STRING, ''],
+            'work directory': [VDR.V_STRING, ''],
+            'task communication method': [VDR.V_STRING, ''],
+            'submission polling intervals': [VDR.V_STRING, ''],
+            'execution polling intervals': [VDR.V_STRING, ''],
+            'scp command': [VDR.V_STRING, ''],
+            'ssh command': [VDR.V_STRING, ''],
+            'use login shell': [VDR.V_STRING, ''],
+            'login hosts': [VDR.V_STRING, ''],
+            'batch system': [VDR.V_STRING, ''],
+            'cylc executable': [VDR.V_STRING, ''],
+            'global init-script': [VDR.V_STRING, ''],
+            'copyable environment variables': [VDR.V_STRING, ''],
+            'retrieve job logs': [VDR.V_STRING, ''],
+            'retrieve job logs command': [VDR.V_STRING, ''],
+            'retrieve job logs max size': [VDR.V_STRING, ''],
+            'retrieve job logs retry delays': [VDR.V_STRING, ''],
+            'task event handler retry delays': [VDR.V_STRING, ''],
+            'tail command template': [VDR.V_STRING, ''],
+            'batch systems': {
+                '__MANY__': {
+                    'err tailer': [VDR.V_STRING, ''],
+                    'out tailer': [VDR.V_STRING, ''],
+                    'err viewer': [VDR.V_STRING, ''],
+                    'out viewer': [VDR.V_STRING, ''],
+                    'job name length maximum': [VDR.V_STRING, ''],
+                    'execution time limit polling intervals': [
+                        VDR.V_STRING, ''
+                    ],
+                }
+            }
+        },
+    },
+    'email': {
+        'mail events': [VDR.V_STRING_LIST, None],
+        'mail from': [VDR.V_STRING],
+        'mail smtp': [VDR.V_STRING],
+        'mail to': [VDR.V_STRING],
+        'mail footer': [VDR.V_STRING],
+        'monitor': {
+            'sort order': [VDR.V_STRING, 'definition', 'alphanumeric'],
         },
     },
     'scheduling': {
@@ -151,7 +234,6 @@ SPEC = {
             'script': [VDR.V_STRING],
             'post-script': [VDR.V_STRING],
             'extra log files': [VDR.V_STRING_LIST],
-            'work sub-directory': [VDR.V_STRING],
             'meta': {
                 'title': [VDR.V_STRING, ''],
                 'description': [VDR.V_STRING, ''],
@@ -171,21 +253,16 @@ SPEC = {
                 'exclude': [VDR.V_STRING_LIST],
             },
             'job': {
-                'batch system': [VDR.V_STRING, 'background'],
-                'batch submit command template': [VDR.V_STRING],
                 'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
                 'execution retry delays': [VDR.V_INTERVAL_LIST, None],
                 'execution time limit': [VDR.V_INTERVAL],
-                'submission polling intervals': [VDR.V_INTERVAL_LIST, None],
-                'submission retry delays': [VDR.V_INTERVAL_LIST, None],
+                'submission polling intervals': [
+                    VDR.V_INTERVAL_LIST, None
+                ],
             },
+            'platform': [VDR.V_STRING],
             'remote': {
                 'host': [VDR.V_STRING],
-                'owner': [VDR.V_STRING],
-                'suite definition directory': [VDR.V_STRING],
-                'retrieve job logs': [VDR.V_BOOLEAN],
-                'retrieve job logs max size': [VDR.V_STRING],
-                'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST, None],
             },
             'events': {
                 'execution timeout': [VDR.V_INTERVAL],
@@ -198,7 +275,6 @@ SPEC = {
                 'mail smtp': [VDR.V_STRING],
                 'mail to': [VDR.V_STRING],
                 'submission timeout': [VDR.V_INTERVAL],
-
                 'expired handler': [VDR.V_STRING_LIST, None],
                 'late offset': [VDR.V_INTERVAL, None],
                 'late handler': [VDR.V_STRING_LIST, None],
@@ -238,6 +314,22 @@ SPEC = {
             },
         },
     },
+    'suite run platforms': {
+        'run hosts': [VDR.V_SPACELESS_STRING_LIST],
+        'run ports': [VDR.V_INTEGER_LIST, list(range(43001, 43101))],
+        'condemned hosts': [VDR.V_ABSOLUTE_HOST_LIST],
+        'auto restart delay': [VDR.V_INTERVAL],
+        'run host select': {
+            'rank': [VDR.V_STRING, 'random', 'load:1', 'load:5', 'load:15',
+                     'memory', 'disk-space'],
+            'thresholds': [VDR.V_STRING],
+        },
+        'suite host self-identification': {
+            'method': [VDR.V_STRING, 'name', 'address', 'hardwired'],
+            'target': [VDR.V_STRING, 'google.com'],
+            'host': [VDR.V_STRING],
+        },
+    },
     'visualization': {
         'initial cycle point': [VDR.V_CYCLE_POINT],
         'final cycle point': [VDR.V_STRING],
@@ -259,42 +351,74 @@ SPEC = {
         },
     },
 }
+# where:
+# - value_type: value type (compulsory).
+# - default: the default value (optional).
+# - allowed_2, ...: the only other allowed values of this setting (optional).
 
 
 def upg(cfg, descr):
-    """Upgrade old suite configuration."""
+    # Upgrade older suite configurations.
     u = upgrader(cfg, descr)
     u.obsolete('6.1.3', ['visualization', 'enable live graph movie'])
+    u.obsolete('6.4.1', ['test battery', 'directives'])
+    u.obsolete('6.11.0', ['state dump rolling archive length'])
     u.obsolete('7.2.2', ['cylc', 'dummy mode'])
     u.obsolete('7.2.2', ['cylc', 'simulation mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
     u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
     u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
-    u.obsolete(
-        '7.8.0',
-        ['runtime', '__MANY__', 'suite state polling', 'template'])
+    u.obsolete('7.8.0', ['runtime', '__MANY__', 'suite state polling',
+                         'template'])
+    u.obsolete('7.8.0', ['suite logging', 'roll over at start-up'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
     u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
-    u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'dummy mode suite timeout'])
+    u.obsolete('7.8.1', ['documentation', 'local index'])
+    u.obsolete('7.8.1', ['documentation', 'files', 'pdf user guide'])
     u.obsolete(
-        '8.0.0',
-        ['cylc', 'reference test', 'dummy-local mode suite timeout'])
-    u.obsolete(
-        '8.0.0',
-        ['cylc', 'reference test', 'simulation mode suite timeout'])
-    u.obsolete('8.0.0', ['cylc', 'reference test', 'required run mode'])
-    u.obsolete(
-        '8.0.0',
-        ['cylc', 'reference test', 'suite shutdown event handler'])
+        '7.8.1',
+        ['documentation', 'files', 'single-page html user guide']
+    )
+    u.deprecate(
+        '7.8.1',
+        ['documentation', 'files', 'multi-page html user guide'],
+        ['documentation', 'local']
+    )
+    u.deprecate('8.0.0',
+                ['documentation', 'files', 'html index'],
+                ['documentation', 'local']
+                )
     u.deprecate(
         '8.0.0',
-        ['cylc', 'abort if any task fails'],
-        ['cylc', 'events', 'abort if any task fails'])
+        ['documentation', 'urls', 'internet homepage'],
+        ['documentation', 'cylc homepage']
+    )
+    u.deprecate('8.0.0', ['suite definition directory'])
+    u.obsolete('8.0.0', ['communication'])
+    u.deprecate('8.0.0', ['cylc', 'authentication'], ['cylc', 'authorization'])
+    u.deprecate('8.0.0', ['cylc'], ['general'])
+    u.obsolete('8.0.0', ['enable run directory housekeeping'])
+
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.deprecate(
+        '8.0.0',
+        ['suite host self-identification'],
+        ['suite run platforms', 'suite host self-identification']
+    )
+    u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
+    u.obsolete('8.0.0', ['suite servers', 'scan ports'])
+    u.deprecate('8.0.0', ['suite servers'], ['suite run platforms'])
+    u.deprecate('8.0.0', ['task events'], ['runtime', 'root', 'events'])
+    u.obsolete('8.0.0', ['temporary directory'])
+    u.obsolete('8.0.0', ['test battery'])
+    u.obsolete('8.0.0', ['task host select command timeout'])
+    u.obsolete('8.0.0', ['xtrigger function timeout'])
+    u.deprecate(
+        '8.0.0',
+        ['general', 'authentication'],
+        ['general', 'authorization']
+    )
     u.upgrade()
 
     # Upgrader cannot do this type of move.
@@ -330,3 +454,155 @@ class RawSuiteConfig(ParsecConfig):
         ParsecConfig.__init__(
             self, SPEC, upg, output_fname, tvars, cylc_config_validate)
         self.loadcfg(fpath, "suite definition")
+
+
+class GlobalConfig(ParsecConfig):
+    """
+    Handle global (all suites) site and user configuration for cylc.
+    User file values override site file values.
+    """
+
+    _DEFAULT = None
+    _HOME = os.getenv('HOME') or get_user_home()
+    CONF_BASENAME = "cylc-flow.rc"
+    SITE_CONF_DIR = os.path.join(os.sep, 'etc', 'cylc', 'flow', CYLC_VERSION)
+    USER_CONF_DIR = os.path.join(_HOME, '.cylc', 'flow', CYLC_VERSION)
+
+    @classmethod
+    def get_inst(cls, cached=True):
+        """Return a GlobalConfig instance.
+
+        Args:
+            cached (bool):
+                If cached create if necessary and return the singleton
+                instance, else return a new instance.
+        """
+        if not cached:
+            # Return an up-to-date global config without affecting the
+            # singleton.
+            new_instance = cls(SPEC, upg, validator=cylc_config_validate)
+            new_instance.load()
+            return new_instance
+        elif not cls._DEFAULT:
+            cls._DEFAULT = cls(SPEC, upg, validator=cylc_config_validate)
+            cls._DEFAULT.load()
+        return cls._DEFAULT
+
+    def load(self):
+        """Load or reload configuration from files."""
+        self.sparse.clear()
+        self.dense.clear()
+        LOG.debug("Loading site/user config files")
+        conf_path_str = os.getenv("CYLC_CONF_PATH")
+        if conf_path_str:
+            # Explicit config file override.
+            fname = os.path.join(conf_path_str, self.CONF_BASENAME)
+            if os.access(fname, os.F_OK | os.R_OK):
+                self.loadcfg(fname, upgrader.USER_CONFIG)
+        elif conf_path_str is None:
+            # Use default locations.
+            for conf_dir, conf_type in [
+                    (self.SITE_CONF_DIR, upgrader.SITE_CONFIG),
+                    (self.USER_CONF_DIR, upgrader.USER_CONFIG)]:
+                fname = os.path.join(conf_dir, self.CONF_BASENAME)
+                if not os.access(fname, os.F_OK | os.R_OK):
+                    continue
+                try:
+                    self.loadcfg(fname, conf_type)
+                except ParsecError as exc:
+                    if conf_type == upgrader.SITE_CONFIG:
+                        # Warn on bad site file (users can't fix it).
+                        LOG.warning(
+                            'ignoring bad %s %s:\n%s', conf_type, fname, exc)
+                    else:
+                        # Abort on bad user file (users can fix it).
+                        LOG.error('bad %s %s', conf_type, fname)
+                        raise
+        # (OK if no flow.rc is found, just use system defaults).
+        self._transform()
+
+    def get_host_item(self, item, platform=None, owner=None,
+                      replace_home=False, owner_home=None):
+        """This allows hosts with no matching entry in the config file
+        to default to appropriately modified localhost settings."""
+
+        cfg = self.get()
+
+        # (this may be called with explicit None values for localhost
+        # and owner, so we can't use proper defaults in the arg list)
+        if not platform:
+            # if no platform is given the caller is asking about localhost
+            platform = 'default platform'
+
+        # is there a matching host section?
+        platform_key = None
+        if platform in cfg['job platforms']:
+            # there's an entry for this platform
+            platform_key = platform
+        else:
+            # try for a pattern match
+            for cfg_host in cfg['job platforms']:
+                if re.match(cfg_host, platform):
+                    platform_key = cfg_host
+                    break
+        modify_dirs = False
+        if platform_key is not None:
+            # entry exists, any unset items under it have already
+            # defaulted to modified localhost values (see site cfgspec)
+            value = cfg['job platforms'][platform_key][item]
+        else:
+            # no entry so default to localhost and modify appropriately
+            value = cfg['job platforms']['default platform'][item]
+            modify_dirs = True
+        if value and 'directory' in item:
+            if replace_home or modify_dirs:
+                # Replace local home dir with $HOME for eval'n on other host.
+                value = value.replace(self._HOME, '$HOME')
+            elif is_remote_user(owner):
+                # Replace with ~owner for direct access via local filesys
+                # (works for standard cylc-run directory location).
+                if owner_home is None:
+                    owner_home = os.path.expanduser('~%s' % owner)
+                value = value.replace(self._HOME, owner_home)
+        if item == "task communication method" and value == "default":
+            # Translate "default" to client-server comms: "zmq"
+            value = 'zmq'
+        return value
+
+    def _transform(self):
+        """Transform various settings.
+
+        Host item values of None default to modified localhost values.
+        Expand environment variables and ~ notations.
+
+        Ensure os.environ['HOME'] is defined with the correct value.
+        """
+        cfg = self.get()
+        for platform in cfg['job platforms']:
+            if platform == 'default platform':
+                continue
+            for item, value in cfg['job platforms'][platform].items():
+                if value is not None:
+                    newvalue = cfg['job platforms']['default platform'][item]
+                else:
+                    newvalue = value
+                if newvalue and 'directory' in item:
+                    # replace local home dir with $HOME for evaluation on other
+                    # host
+                    newvalue = newvalue.replace(self._HOME, '$HOME')
+                cfg['job platforms'][platform][item] = newvalue
+
+        # Expand environment variables and ~user in LOCAL file paths.
+        if 'HOME' not in os.environ:
+            os.environ['HOME'] = self._HOME
+        cfg['documentation']['local'] = os.path.expandvars(
+            cfg['documentation']['local'])
+        for key, val in cfg['job platforms']['default platform'].items():
+            if val and 'directory' in key:
+                cfg['job platforms']['default platform'][key] =\
+                    os.path.expandvars(val)
+
+
+def glbl_cfg(cached=True):
+    """Load and return the global configuration singleton instance."""
+    return GlobalConfig.get_inst(cached=cached)

--- a/cylc/flow/config_schema.py
+++ b/cylc/flow/config_schema.py
@@ -122,7 +122,7 @@ SPEC = {
             'ssh command': [
                 VDR.V_STRING, 'ssh -oBatchMode=yes -oConnectTimeout=10'],
             'use login shell': [VDR.V_BOOLEAN, True],
-            'login hosts': [VDR.V_STRING, None],
+            'login hosts': [VDR.V_INTERVAL_LIST],
             'batch system': [VDR.V_STRING, None],
             'cylc executable': [VDR.V_STRING, 'cylc'],
             'global init-script': [VDR.V_STRING],
@@ -133,7 +133,7 @@ SPEC = {
             'task event handler retry delays': [VDR.V_INTERVAL_LIST],
             'tail command template': [
                 VDR.V_STRING, 'tail -n +1 -F %(filename)s'],
-            'batch systems': {
+            'batch system info': {
                 'err tailer': [VDR.V_STRING],
                 'out tailer': [VDR.V_STRING],
                 'err viewer': [VDR.V_STRING],
@@ -163,17 +163,16 @@ SPEC = {
             'retrieve job logs retry delays': [VDR.V_STRING, ''],
             'task event handler retry delays': [VDR.V_STRING, ''],
             'tail command template': [VDR.V_STRING, ''],
-            'batch systems': {
-                '__MANY__': {
-                    'err tailer': [VDR.V_STRING, ''],
-                    'out tailer': [VDR.V_STRING, ''],
-                    'err viewer': [VDR.V_STRING, ''],
-                    'out viewer': [VDR.V_STRING, ''],
-                    'job name length maximum': [VDR.V_STRING, ''],
-                    'execution time limit polling intervals': [
-                        VDR.V_STRING, ''
-                    ],
-                }
+            'batch system': {
+                'name': [VDR.V_STRING, ''],
+                'err tailer': [VDR.V_STRING, ''],
+                'out tailer': [VDR.V_STRING, ''],
+                'err viewer': [VDR.V_STRING, ''],
+                'out viewer': [VDR.V_STRING, ''],
+                'job name length maximum': [VDR.V_STRING, ''],
+                'execution time limit polling intervals': [
+                    VDR.V_STRING, ''
+                ],
             }
         },
     },

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -781,11 +781,11 @@ def ingest_time(value, my_now=None):
 
 def init_from_cfg(cfg):
     """Initialise global variables (yuk) based on the configuration."""
-    num_expanded_year_digits = cfg['cylc'][
+    num_expanded_year_digits = cfg['general'][
         'cycle point num expanded year digits']
-    time_zone = cfg['cylc']['cycle point time zone']
-    custom_dump_format = cfg['cylc']['cycle point format']
-    assume_utc = cfg['cylc']['UTC mode']
+    time_zone = cfg['general']['cycle point time zone']
+    custom_dump_format = cfg['general']['cycle point format']
+    assume_utc = cfg['general']['UTC mode']
     cycling_mode = cfg['scheduling']['cycling mode']
 
     init(
@@ -824,7 +824,7 @@ def init(num_expanded_year_digits=0, custom_dump_format=None, time_zone=None,
         if "+X" not in custom_dump_format and num_expanded_year_digits:
             raise IllegalValueError(
                 'cycle point format',
-                ('cylc', 'cycle point format'),
+                ('general', 'cycle point format'),
                 SuiteSpecifics.DUMP_FORMAT
             )
 

--- a/cylc/flow/glbl_cfg.py
+++ b/cylc/flow/glbl_cfg.py
@@ -18,5 +18,5 @@
 
 def glbl_cfg(cached=True):
     """Load and return the global configuration singleton instance."""
-    from cylc.flow.cfgspec.globalcfg import GlobalConfig
+    from cylc.flow.config_schema import GlobalConfig
     return GlobalConfig.get_inst(cached=cached)

--- a/cylc/flow/host_appointer.py
+++ b/cylc/flow/host_appointer.py
@@ -23,7 +23,7 @@ import socket
 from time import sleep
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.hostuserutil import is_remote_host, get_fqdn_by_host
 from cylc.flow.remote import remote_cylc_cmd, run_cmd

--- a/cylc/flow/host_appointer.py
+++ b/cylc/flow/host_appointer.py
@@ -23,7 +23,7 @@ import socket
 from time import sleep
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.hostuserutil import is_remote_host, get_fqdn_by_host
 from cylc.flow.remote import remote_cylc_cmd, run_cmd

--- a/cylc/flow/host_appointer.py
+++ b/cylc/flow/host_appointer.py
@@ -181,7 +181,7 @@ class HostAppointer(object):
             else:
                 # 1st instance of localhost
                 host_proc_map['localhost'] = run_cmd(
-                    ['general'] + cmd, capture_process=True)
+                    ['cylc'] + cmd, capture_process=True)
         # Collect results from commands
         while host_proc_map:
             for host, proc in list(host_proc_map.copy().items()):

--- a/cylc/flow/host_appointer.py
+++ b/cylc/flow/host_appointer.py
@@ -45,7 +45,7 @@ class EmptyHostList(CylcError):
         suite_server_cfg_items = (['run hosts'], ['run host select', 'rank'],
                                   ['run host select', 'thresholds'])
         for cfg_end_ref in suite_server_cfg_items:
-            cfg_end_ref.insert(0, 'suite servers')
+            cfg_end_ref.insert(0, 'suite run platforms')
             # Add 2-space indentation for clarity in distinction of items.
             msg = '\n  '.join([msg, ' -> '.join(cfg_end_ref) + ':',
                                '  ' + str(glbl_cfg().get(cfg_end_ref))])
@@ -74,13 +74,13 @@ class HostAppointer(object):
         # list the condemned hosts, hosts may be suffixed with `!`
         condemned_hosts = [
             get_fqdn_by_host(host.split('!')[0]) for host in
-            global_config.get(['suite servers', 'condemned hosts'])]
+            global_config.get(['suite run platforms', 'condemned hosts'])]
 
         # list configured run hosts eliminating any which cannot be contacted
         # or which are condemned
         self.hosts = []
         for host in (
-                global_config.get(['suite servers', 'run hosts']) or
+                global_config.get(['suite run platforms', 'run hosts']) or
                 ['localhost']):
             try:
                 if get_fqdn_by_host(host) not in condemned_hosts:
@@ -90,9 +90,9 @@ class HostAppointer(object):
 
         # determine the server ranking and acceptance thresholds if configured
         self.rank_method = global_config.get(
-            ['suite servers', 'run host select', 'rank'])
+            ['suite run platforms', 'run host select', 'rank'])
         self.parsed_thresholds = self.parse_thresholds(global_config.get(
-            ['suite servers', 'run host select', 'thresholds']))
+            ['suite run platforms', 'run host select', 'thresholds']))
 
     @staticmethod
     def parse_thresholds(raw_thresholds_spec):

--- a/cylc/flow/host_appointer.py
+++ b/cylc/flow/host_appointer.py
@@ -181,7 +181,7 @@ class HostAppointer(object):
             else:
                 # 1st instance of localhost
                 host_proc_map['localhost'] = run_cmd(
-                    ['cylc'] + cmd, capture_process=True)
+                    ['general'] + cmd, capture_process=True)
         # Collect results from commands
         while host_proc_map:
             for host, proc in list(host_proc_map.copy().items()):

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -50,7 +50,7 @@ import socket
 from contextlib import suppress
 from time import time
 
-from cylc.flow.config_schema import glbl_cfg
+#from cylc.flow.config_schema import glbl_cfg
 
 
 class HostUtil(object):

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -50,7 +50,7 @@ import socket
 from contextlib import suppress
 from time import time
 
-import cylc.flow.config_schema
+from cylc.flow.glbl_cfg import glbl_cfg
 
 
 class HostUtil(object):
@@ -125,7 +125,7 @@ class HostUtil(object):
     @staticmethod
     def _get_identification_cfg(key):
         """Return the [suite host self-identification]key global conf."""
-        return cylc.flow.config_schema.glbl_cfg().get(
+        return glbl_cfg().get(
             ['suite run platforms', 'suite host self-identification', key]
         )
 

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -50,7 +50,7 @@ import socket
 from contextlib import suppress
 from time import time
 
-#from cylc.flow.config_schema import glbl_cfg
+import cylc.flow.config_schema
 
 
 class HostUtil(object):
@@ -125,7 +125,9 @@ class HostUtil(object):
     @staticmethod
     def _get_identification_cfg(key):
         """Return the [suite host self-identification]key global conf."""
-        return glbl_cfg().get(['suite host self-identification', key])
+        return cylc.flow.config_schema.glbl_cfg().get(
+            ['suite host self-identification', key]
+        )
 
     def get_host(self):
         """Return the preferred identifier for the suite (or current) host.

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -126,7 +126,7 @@ class HostUtil(object):
     def _get_identification_cfg(key):
         """Return the [suite host self-identification]key global conf."""
         return cylc.flow.config_schema.glbl_cfg().get(
-            ['suite host self-identification', key]
+            ['suite run platforms', 'suite host self-identification', key]
         )
 
     def get_host(self):

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -50,7 +50,7 @@ import socket
 from contextlib import suppress
 from time import time
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 
 
 class HostUtil(object):

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE, DEVNULL
 
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.batch_sys_manager import BatchSysManager
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.pathutil import (
     get_remote_suite_run_dir,

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -22,7 +22,7 @@ from subprocess import Popen, PIPE, DEVNULL
 
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.batch_sys_manager import BatchSysManager
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.pathutil import (
     get_remote_suite_run_dir,

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -34,7 +34,7 @@ from ansimarkup import parse as cparse
 
 from cylc.flow.wallclock import (get_current_time_string,
                                  get_time_string_from_unix_time)
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.pathutil import get_suite_run_log_name
 
 

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -34,7 +34,7 @@ from ansimarkup import parse as cparse
 
 from cylc.flow.wallclock import (get_current_time_string,
                                  get_time_string_from_unix_time)
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.pathutil import get_suite_run_log_name
 
 

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -22,7 +22,7 @@ import re
 import sys
 import socket
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote_host, get_host_ip_by_name
 from cylc.flow.network.client import (

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -22,7 +22,7 @@ import re
 import sys
 import socket
 
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote_host, get_host_ip_by_name
 from cylc.flow.network.client import (

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -27,7 +27,7 @@ from graphql.execution.executors.asyncio import AsyncioExecutor
 import zmq
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.network.authorisation import Priv, authorise
 from cylc.flow.network.authentication import encrypt, decrypt, get_secret

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -27,7 +27,7 @@ from graphql.execution.executors.asyncio import AsyncioExecutor
 import zmq
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.network.authorisation import Priv, authorise
 from cylc.flow.network.authentication import encrypt, decrypt, get_secret

--- a/cylc/flow/parsec/example/test.py
+++ b/cylc/flow/parsec/example/test.py
@@ -18,7 +18,7 @@
 import os
 import sys
 
-from cylc.flow.cfgspec.globalcfg import SPEC
+from cylc.flow.config_schema import SPEC
 from cylc.flow.parsec.config import ParsecConfig
 import cylc.flow.flags
 

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -20,7 +20,7 @@ from shutil import rmtree
 
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 
 
 def get_remote_suite_run_dir(host, owner, suite, *args):

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -20,7 +20,7 @@ from shutil import rmtree
 
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 
 
 def get_remote_suite_run_dir(host, owner, suite, *args):

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -29,7 +29,7 @@ import sys
 from time import sleep
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote
 from cylc.flow import __version__ as CYLC_VERSION

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -29,7 +29,7 @@ import sys
 from time import sleep
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote
 from cylc.flow import __version__ as CYLC_VERSION

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -243,7 +243,7 @@ class Scheduler(object):
             self._setup_suite_logger()
             self.ws_data_mgr = WsDataMgr(self)
             self.server = SuiteRuntimeServer(self)
-            port_range = glbl_cfg().get(['suite servers', 'run ports'])
+            port_range = glbl_cfg().get(['suite run platforms', 'run ports'])
             self.server.start(port_range[0], port_range[-1])
             self.port = self.server.port
             self.configure()
@@ -1429,7 +1429,7 @@ see `COPYING' in the Cylc source distribution.
             # 2. check if suite host is condemned - if so auto restart.
             if self.stop_mode is None:
                 current_glbl_cfg = glbl_cfg(cached=False)
-                for host in current_glbl_cfg.get(['suite servers',
+                for host in current_glbl_cfg.get(['suite run platforms',
                                                   'condemned hosts']):
                     if host.endswith('!'):
                         # host ends in an `!` -> force shutdown mode
@@ -1459,7 +1459,7 @@ see `COPYING' in the Cylc source distribution.
                             if self.set_auto_restart(mode=mode):
                                 return  # skip remaining health checks
                         elif (self.set_auto_restart(current_glbl_cfg.get(
-                                ['suite servers', 'auto restart delay']))):
+                                ['suite run platforms', 'auto restart delay']))):
                             # server is condemned -> configure the suite to
                             # auto stop-restart if possible, else, report the
                             # issue preventing this

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -404,7 +404,7 @@ see `COPYING' in the Cylc source distribution.
 
         self.suite_db_mgr.on_suite_start(self.is_restart)
 
-        reqmode = self.config.cfg['cylc']['required run mode']
+        reqmode = self.config.cfg['general']['required run mode']
         if reqmode and not self.config.run_mode(reqmode):
             raise ValueError('this suite requires the %s run mode' % reqmode)
 
@@ -471,9 +471,9 @@ see `COPYING' in the Cylc source distribution.
         self.already_inactive = False
         key = self.EVENT_INACTIVITY_TIMEOUT
         if self.options.reftest:
-            self.config.cfg['cylc']['events'][f'abort on {key}'] = True
-            if not self.config.cfg['cylc']['events'][key]:
-                self.config.cfg['cylc']['events'][key] = DurationFloat(180)
+            self.config.cfg['general']['events'][f'abort on {key}'] = True
+            if not self.config.cfg['general']['events'][key]:
+                self.config.cfg['general']['events'][key] = DurationFloat(180)
         if self._get_events_conf(key):
             self.set_suite_inactivity_timer()
 
@@ -1111,7 +1111,7 @@ see `COPYING' in the Cylc source distribution.
         try:
             if (
                 conf.run_mode('simulation', 'dummy') and
-                conf.cfg['cylc']['simulation']['disable suite event handlers']
+                conf.cfg['general']['simulation']['disable suite event handlers']
             ):
                 return
         except KeyError:
@@ -1146,9 +1146,9 @@ see `COPYING' in the Cylc source distribution.
             self.count = 0
         if self.options.no_auto_shutdown is not None:
             self.can_auto_stop = not self.options.no_auto_shutdown
-        elif self.config.cfg['cylc']['disable automatic shutdown'] is not None:
+        elif self.config.cfg['general']['disable automatic shutdown'] is not None:
             self.can_auto_stop = (
-                not self.config.cfg['cylc']['disable automatic shutdown'])
+                not self.config.cfg['general']['disable automatic shutdown'])
 
     def process_task_pool(self):
         """Process ALL TASKS whenever something has changed that might
@@ -1293,7 +1293,7 @@ see `COPYING' in the Cylc source distribution.
 
     def suite_auto_restart(self, max_retries=3):
         """Attempt to restart the suite assuming it has already stopped."""
-        cmd = ['cylc', 'restart', quote(self.suite)]
+        cmd = ['general', 'restart', quote(self.suite)]
 
         for attempt_no in range(max_retries):
             new_host = HostAppointer(cached=False).appoint_host()
@@ -1942,7 +1942,7 @@ see `COPYING' in the Cylc source distribution.
 
     def _get_cylc_conf(self, key, default=None):
         """Return a named setting under [cylc] from suite.rc or flow.rc."""
-        for getter in [self.config.cfg['cylc'], glbl_cfg().get(['cylc'])]:
+        for getter in [self.config.cfg['general'], glbl_cfg().get(['general'])]:
             try:
                 value = getter[key]
             except TypeError:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -33,7 +33,7 @@ from metomi.isodatetime.parsers import TimePointParser
 
 from cylc.flow import LOG
 from cylc.flow.broadcast_mgr import BroadcastMgr
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.config import SuiteConfig
 from cylc.flow.cycling.loader import get_point, standardise_point_string
 from cylc.flow.daemonize import daemonize

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1111,7 +1111,8 @@ see `COPYING' in the Cylc source distribution.
         try:
             if (
                 conf.run_mode('simulation', 'dummy') and
-                conf.cfg['general']['simulation']['disable suite event handlers']
+                conf.cfg[
+                    'general']['simulation']['disable suite event handlers']
             ):
                 return
         except KeyError:
@@ -1146,7 +1147,10 @@ see `COPYING' in the Cylc source distribution.
             self.count = 0
         if self.options.no_auto_shutdown is not None:
             self.can_auto_stop = not self.options.no_auto_shutdown
-        elif self.config.cfg['general']['disable automatic shutdown'] is not None:
+        elif (
+            self.config.cfg['general']['disable automatic shutdown']
+            is not None
+        ):
             self.can_auto_stop = (
                 not self.config.cfg['general']['disable automatic shutdown'])
 
@@ -1459,7 +1463,8 @@ see `COPYING' in the Cylc source distribution.
                             if self.set_auto_restart(mode=mode):
                                 return  # skip remaining health checks
                         elif (self.set_auto_restart(current_glbl_cfg.get(
-                                ['suite run platforms', 'auto restart delay']))):
+                            ['suite run platforms', 'auto restart delay']))
+                        ):
                             # server is condemned -> configure the suite to
                             # auto stop-restart if possible, else, report the
                             # issue preventing this
@@ -1942,7 +1947,9 @@ see `COPYING' in the Cylc source distribution.
 
     def _get_cylc_conf(self, key, default=None):
         """Return a named setting under [cylc] from suite.rc or flow.rc."""
-        for getter in [self.config.cfg['general'], glbl_cfg().get(['general'])]:
+        for getter in (
+            [self.config.cfg['general'], glbl_cfg().get(['general'])]
+        ):
             try:
                 value = getter[key]
             except TypeError:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -33,7 +33,7 @@ from metomi.isodatetime.parsers import TimePointParser
 
 from cylc.flow import LOG
 from cylc.flow.broadcast_mgr import BroadcastMgr
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.config import SuiteConfig
 from cylc.flow.cycling.loader import get_point, standardise_point_string
 from cylc.flow.daemonize import daemonize

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -204,7 +204,7 @@ def get_option_parser(is_restart):
         help=(
             "Specify the host on which to start-up the suite. "
             "If not specified, a host will be selected using "
-            "the 'suite servers' global config."
+            "the 'suite run platforms' global config."
         ),
         metavar="HOST", action="store", dest="host")
 

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -27,7 +27,7 @@ from time import time
 from subprocess import DEVNULL  # nosec
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.cylc_subproc import procopen
 from cylc.flow.wallclock import get_current_time_string
 

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -27,7 +27,7 @@ from time import time
 from subprocess import DEVNULL  # nosec
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.cylc_subproc import procopen
 from cylc.flow.wallclock import get_current_time_string
 

--- a/cylc/flow/suite_db_mgr.py
+++ b/cylc/flow/suite_db_mgr.py
@@ -297,10 +297,10 @@ class SuiteDatabaseManager(object):
             {"key": "cylc_version", "value": CYLC_VERSION},
             {"key": "UTC_mode", "value": get_utc_mode()},
         ])
-        if schd.config.cfg['cylc']['cycle point format']:
+        if schd.config.cfg['general']['cycle point format']:
             self.db_inserts_map[self.TABLE_SUITE_PARAMS].append({
                 "key": "cycle_point_format",
-                "value": schd.config.cfg['cylc']['cycle point format']})
+                "value": schd.config.cfg['general']['cycle point format']})
         if schd.pool.is_held:
             self.db_inserts_map[self.TABLE_SUITE_PARAMS].append({
                 "key": self.KEY_HOLD, "value": 1})

--- a/cylc/flow/suite_events.py
+++ b/cylc/flow/suite_events.py
@@ -52,8 +52,8 @@ class SuiteEventHandler():
     def get_events_conf(config, key, default=None):
         """Return a named [cylc][[events]] configuration."""
         for getter in [
-                config.cfg['cylc']['events'],
-                glbl_cfg().get(['cylc', 'events'])]:
+                config.cfg['general']['events'],
+                glbl_cfg().get(['general', 'events'])]:
             try:
                 value = getter[key]
             except KeyError:

--- a/cylc/flow/suite_events.py
+++ b/cylc/flow/suite_events.py
@@ -20,7 +20,7 @@ import os
 from shlex import quote
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import SuiteEventError
 from cylc.flow.hostuserutil import get_host, get_user
 from cylc.flow.log_diagnosis import run_reftest

--- a/cylc/flow/suite_events.py
+++ b/cylc/flow/suite_events.py
@@ -20,7 +20,7 @@ import os
 from shlex import quote
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import SuiteEventError
 from cylc.flow.hostuserutil import get_host, get_user
 from cylc.flow.log_diagnosis import run_reftest

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -22,7 +22,7 @@ import re
 from string import ascii_letters, digits
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.pathutil import get_remote_suite_run_dir, get_suite_run_dir
 import cylc.flow.flags

--- a/cylc/flow/suite_srv_files_mgr.py
+++ b/cylc/flow/suite_srv_files_mgr.py
@@ -22,7 +22,7 @@ import re
 from string import ascii_letters, digits
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.pathutil import get_remote_suite_run_dir, get_suite_run_dir
 import cylc.flow.flags

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -35,7 +35,7 @@ from time import time
 from cylc.flow.parsec.config import ItemNotFoundError
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.hostuserutil import get_host, get_user
 from cylc.flow.pathutil import (
     get_remote_suite_run_job_dir,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -35,7 +35,7 @@ from time import time
 from cylc.flow.parsec.config import ItemNotFoundError
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.hostuserutil import get_host, get_user
 from cylc.flow.pathutil import (
     get_remote_suite_run_job_dir,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -593,7 +593,7 @@ class TaskEventsManager():
         for getter in [
                 self.broadcast_mgr.get_broadcast(itask.identity).get("events"),
                 itask.tdef.rtconfig["events"],
-                glbl_cfg().get()["task events"]]:
+                glbl_cfg().get(["runtime", "root", "events"])]:
             try:
                 value = getter.get(key)
             except (AttributeError, ItemNotFoundError, KeyError):

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -773,7 +773,7 @@ class TaskJobManager(object):
         # because dynamic host selection may be used.
         try:
             task_host = self.task_remote_mgr.remote_host_select(
-                rtconfig['remote']['host'])
+                rtconfig['job']['host'])
         except TaskRemoteMgmtError as exc:
             # Submit number not yet incremented
             itask.submit_num += 1
@@ -843,7 +843,7 @@ class TaskJobManager(object):
 
     def _prep_submit_task_job_impl(self, suite, itask, rtconfig):
         """Helper for self._prep_submit_task_job."""
-        itask.task_owner = rtconfig['remote']['owner']
+        itask.task_owner = rtconfig['job']['owner']
         if itask.task_owner:
             owner_at_host = itask.task_owner + "@" + itask.task_host
         else:
@@ -896,7 +896,7 @@ class TaskJobManager(object):
             'param_var': itask.tdef.param_var,
             'post-script': scripts[2],
             'pre-script': scripts[0],
-            'remote_suite_d': rtconfig['remote']['suite definition directory'],
+            'remote_suite_d': rtconfig['job']['suite definition directory'],
             'script': scripts[1],
             'submit_num': itask.submit_num,
             'suite_name': suite,

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -30,7 +30,7 @@ import tarfile
 from time import time
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import TaskRemoteMgmtError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote, is_remote_host, is_remote_user

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -30,7 +30,7 @@ import tarfile
 from time import time
 
 from cylc.flow import LOG
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import TaskRemoteMgmtError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote, is_remote_host, is_remote_user

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -30,7 +30,7 @@ import cylc.flow.flags
 
 from cylc.flow.exceptions import CylcError
 from cylc.flow.loggingutil import CylcLogFormatter
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.parsec.exceptions import ParsecError
 
 

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -30,7 +30,7 @@ import cylc.flow.flags
 
 from cylc.flow.exceptions import CylcError
 from cylc.flow.loggingutil import CylcLogFormatter
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.parsec.exceptions import ParsecError
 
 

--- a/cylc/flow/tests/test_zmq.py
+++ b/cylc/flow/tests/test_zmq.py
@@ -25,7 +25,7 @@ from cylc.flow.network.server import ZMQServer
 
 
 def get_port_range():
-    ports = glbl_cfg().get(['suite servers', 'run ports'])
+    ports = glbl_cfg().get(['suite run platforms', 'run ports'])
     return min(ports), max(ports)
 
 

--- a/cylc/flow/tests/test_zmq.py
+++ b/cylc/flow/tests/test_zmq.py
@@ -18,7 +18,7 @@
 import pytest
 import secrets
 
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.network.authentication import encrypt, decrypt
 from cylc.flow.network.server import ZMQServer

--- a/cylc/flow/tests/test_zmq.py
+++ b/cylc/flow/tests/test_zmq.py
@@ -18,7 +18,7 @@
 import pytest
 import secrets
 
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.network.authentication import encrypt, decrypt
 from cylc.flow.network.server import ZMQServer

--- a/cylc/flow/xtriggers/suite_state.py
+++ b/cylc/flow/xtriggers/suite_state.py
@@ -21,7 +21,7 @@
 import os
 import sqlite3
 from cylc.flow.cycling.util import add_offset
-from cylc.flow.config_schema import glbl_cfg
+from cylc.flow.glbl_cfg import glbl_cfg
 from cylc.flow.dbstatecheck import CylcSuiteDBChecker
 from metomi.isodatetime.parsers import TimePointParser
 

--- a/cylc/flow/xtriggers/suite_state.py
+++ b/cylc/flow/xtriggers/suite_state.py
@@ -21,7 +21,7 @@
 import os
 import sqlite3
 from cylc.flow.cycling.util import add_offset
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.config_schema import glbl_cfg
 from cylc.flow.dbstatecheck import CylcSuiteDBChecker
 from metomi.isodatetime.parsers import TimePointParser
 

--- a/flakytests/events/44-timeout/suite.rc
+++ b/flakytests/events/44-timeout/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[events]]
       abort on timeout = True
       timeout = PT20S

--- a/tests/api-suite-info/01-get-graph-raw-2/suite.rc
+++ b/tests/api-suite-info/01-get-graph-raw-2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    cycle point format = %Y
 [scheduling]
     initial cycle point = 2020

--- a/tests/api-suite-info/02-get-graph-raw-3/suite.rc
+++ b/tests/api-suite-info/02-get-graph-raw-3/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    cycle point format = %Y
 [scheduling]
     initial cycle point = 2020

--- a/tests/api-suite-info/03-get-graph-raw-4/suite.rc
+++ b/tests/api-suite-info/03-get-graph-raw-4/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20200202T0000Z

--- a/tests/authentication/08-shared-fs/suite.rc
+++ b/tests/authentication/08-shared-fs/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode=True
     [[events]]
         abort on inactivity = True

--- a/tests/authentication/09-remote-suite-same-name/suite.rc
+++ b/tests/authentication/09-remote-suite-same-name/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode=True
 [scheduling]
     initial cycle point=1970

--- a/tests/authentication/10-remote-suite-passphrase-cache/suite.rc
+++ b/tests/authentication/10-remote-suite-passphrase-cache/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode=True
     [[reference test]]
         expected task failures = t1.19700101T0000Z

--- a/tests/authentication/11-suite2-stop-suite1.t
+++ b/tests/authentication/11-suite2-stop-suite1.t
@@ -30,7 +30,7 @@ cylc register "${NAME1}" "${SUITE1_RUND}"
 SUITE2_RUND="${RUND}/${NAME2}"
 mkdir -p "${SUITE2_RUND}"
 cat >"${SUITE2_RUND}/suite.rc" <<__SUITERC__
-[cylc]
+[general]
     [[events]]
         abort if any task fails=True
 [scheduling]

--- a/tests/authentication/basic/suite.rc
+++ b/tests/authentication/basic/suite.rc
@@ -6,7 +6,7 @@
     """
     custom_metadata = something_custom
     another_metadata = 1
-[cylc]
+[general]
     [[events]]
         timeout = PT1M
         abort on timeout = True

--- a/tests/authentication/override/suite.rc
+++ b/tests/authentication/override/suite.rc
@@ -2,7 +2,7 @@
     title = Authentication test suite.
     description = """Stalls when the first task fails.
 Suite overrides global authentication settings."""
-[cylc]
+[general]
     [[events]]
         timeout = PT30S
         abort on timeout = True

--- a/tests/broadcast/00-simple/suite.rc
+++ b/tests/broadcast/00-simple/suite.rc
@@ -9,7 +9,7 @@ shutdown event handler compares the broadcast log file with a previously
 generated reference version.
               """
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/broadcast/02-inherit/suite.rc
+++ b/tests/broadcast/02-inherit/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=broadcast
     description=Test Broadcast Inheritance
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 [scheduling]
     initial cycle point = 20140101T00

--- a/tests/broadcast/03-expire/suite.rc
+++ b/tests/broadcast/03-expire/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title=broadcast expire
     description=Test broadcast expire option
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2020

--- a/tests/broadcast/05-bad-point/suite.rc
+++ b/tests/broadcast/05-bad-point/suite.rc
@@ -2,7 +2,7 @@
     title=broadcast bad point
     description=Test broadcast to an invalid cycle point fails.
 # And see github #1415 - it did cause the suite server program to abort.
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         abort on timeout = True

--- a/tests/broadcast/06-bad-namespace/suite.rc
+++ b/tests/broadcast/06-bad-namespace/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title=broadcast bad namespace
     description=Test broadcast to an undefined namespace fails.
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         abort on timeout = True

--- a/tests/broadcast/07-timeout/suite.rc
+++ b/tests/broadcast/07-timeout/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test suite for broadcast timeout functionality"
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/broadcast/08-space/suite.rc
+++ b/tests/broadcast/08-space/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title=broadcast section-space-key
     description=Test broadcast set section-space-key syntax
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort if any task fails = True

--- a/tests/broadcast/09-remote/suite.rc
+++ b/tests/broadcast/09-remote/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/broadcast/10-file-1/suite.rc
+++ b/tests/broadcast/10-file-1/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/broadcast/11-file-2/suite.rc
+++ b/tests/broadcast/11-file-2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/broadcast/12-file-stdin/suite.rc
+++ b/tests/broadcast/12-file-stdin/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/broadcast/13-file-cancel/suite.rc
+++ b/tests/broadcast/13-file-cancel/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cli/.nfs8000040804ca2e220000015c
+++ b/tests/cli/.nfs8000040804ca2e220000015c
@@ -1,0 +1,68 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc run SUITE now" and "cylc run --icp=now SUITE".
+# And "cylc run --icp=next(...) SUITE" and "cylc run --icp=previous(...) SUITE"
+# And restart.
+
+. "$(dirname "$0")/test_header"
+set_test_number 13
+init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+[cylc]
+    [[events]]
+        abort on stalled = true
+        abort on inactivity = true
+        inactivity = PT1M
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = wait; cylc stop --now --now "${CYLC_SUITE_NAME}"
+__SUITERC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate --icp='now' "${SUITE_NAME}"
+
+# Test "cylc run SUITE now"
+suite_run_ok "${TEST_NAME_BASE}-run-now" \
+    cylc run --debug --no-detach "${SUITE_NAME}" 'now'
+MY_CYCLE="$(sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT cycle FROM task_pool')"
+suite_run_ok "${TEST_NAME_BASE}-restart-now" \
+    cylc restart --debug --no-detach "${SUITE_NAME}"
+sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool' >'task_pool.out'
+cmp_ok 'task_pool.out' <<__OUT__
+${MY_CYCLE}|foo|1|succeeded|0
+__OUT__
+
+# Tests:
+# "cylc run --icp=now SUITE"
+# "cylc run --icp=next(T00) SUITE"
+# "cylc run --icp=previous(T00) SUITE"
+for ICP in 'now' 'next(T00)' 'previous(T00)'; do
+    suite_run_ok "${TEST_NAME_BASE}-run-icp-now" \
+        cylc run --debug --no-detach --icp="${ICP}" "${SUITE_NAME}"
+    MY_CYCLE="$(sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT cycle FROM task_pool')"
+    suite_run_ok "${TEST_NAME_BASE}-restart-icp-now" \
+        cylc restart --debug --no-detach "${SUITE_NAME}"
+    sqlite3 "${SUITE_RUN_DIR}/log/db" 'SELECT * FROM task_pool' >'task_pool.out'
+    cmp_ok 'task_pool.out' <<__OUT__
+${MY_CYCLE}|foo|1|succeeded|0
+__OUT__
+done
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/cli/.nfs8000040804ca2e220000015c
+++ b/tests/cli/.nfs8000040804ca2e220000015c
@@ -22,7 +22,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 13
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = true
         abort on inactivity = true

--- a/tests/cli/00-cycle-points/suite.rc
+++ b/tests/cli/00-cycle-points/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = true
     [[events]]
         abort on timeout = true

--- a/tests/cli/02-now.t
+++ b/tests/cli/02-now.t
@@ -22,7 +22,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 13
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = true
         abort on inactivity = true

--- a/tests/clock-expire/00-basic/suite.rc
+++ b/tests/clock-expire/00-basic/suite.rc
@@ -3,7 +3,7 @@
     description = """
 Skip a daily post-processing workflow if the 'copy' task has expired."""
 
-[cylc]
+[general]
     cycle point format = %Y-%m-%dT%H
     [[events]]
         abort if any task fails = True

--- a/tests/cyclers/0000_rollunder/suite.rc
+++ b/tests/cyclers/0000_rollunder/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 00000101T00

--- a/tests/cyclers/21-360_calendar/suite.rc
+++ b/tests/cyclers/21-360_calendar/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20130228T00

--- a/tests/cyclers/36-icp_fcp_notation/suite.rc
+++ b/tests/cyclers/36-icp_fcp_notation/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = true
 [scheduling]
     initial cycle point = 20160101T00Z

--- a/tests/cyclers/47-icp_fcp_notation/suite.rc
+++ b/tests/cyclers/47-icp_fcp_notation/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = true
 [scheduling]
     initial cycle point = 20160101T00Z

--- a/tests/cyclers/48-icp-cutoff.t
+++ b/tests/cyclers/48-icp-cutoff.t
@@ -20,7 +20,7 @@
 set_test_number 1
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE__'
-[cylc]
+[general]
     cycle point time zone = Z
     [[events]]
         abort on stalled = True

--- a/tests/cyclers/49-365_calendar/suite.rc
+++ b/tests/cyclers/49-365_calendar/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20120228T00

--- a/tests/cyclers/50-366_calendar/suite.rc
+++ b/tests/cyclers/50-366_calendar/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20130228T00

--- a/tests/cyclers/9999_rollover/suite.rc
+++ b/tests/cyclers/9999_rollover/suite.rc
@@ -2,7 +2,7 @@
 # [visualization]number of cycle points = 1" keeps it under the limit during
 # validation, but R3/PT1H puts it over the limit at run time.
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 99991231T2200

--- a/tests/cyclers/aeon/suite.rc
+++ b/tests/cyclers/aeon/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point num expanded year digits = 7
     UTC mode = True
 [scheduling]

--- a/tests/cyclers/daily/suite.rc
+++ b/tests/cyclers/daily/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20131231T2300

--- a/tests/cyclers/daily_final/suite.rc
+++ b/tests/cyclers/daily_final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/day_of_week/suite.rc
+++ b/tests/cyclers/day_of_week/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/cyclers/exclusions/suite.rc
+++ b/tests/cyclers/exclusions/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20000101T00Z

--- a/tests/cyclers/exclusions_advanced/suite.rc
+++ b/tests/cyclers/exclusions_advanced/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20000101T00Z

--- a/tests/cyclers/hourly/suite.rc
+++ b/tests/cyclers/hourly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20000229T2000

--- a/tests/cyclers/monthly/suite.rc
+++ b/tests/cyclers/monthly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20000131T0100Z

--- a/tests/cyclers/monthly_complex/suite.rc
+++ b/tests/cyclers/monthly_complex/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20000331T0100Z

--- a/tests/cyclers/multidaily/suite.rc
+++ b/tests/cyclers/multidaily/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = Z
 [scheduling]
     initial cycle point = 20001231T0100

--- a/tests/cyclers/multihourly/suite.rc
+++ b/tests/cyclers/multihourly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +13
 [scheduling]
     initial cycle point = 20000131T0100Z

--- a/tests/cyclers/multimonthly/suite.rc
+++ b/tests/cyclers/multimonthly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 1000

--- a/tests/cyclers/multiweekly/suite.rc
+++ b/tests/cyclers/multiweekly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 1000W011

--- a/tests/cyclers/multiyearly/suite.rc
+++ b/tests/cyclers/multiyearly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 1005

--- a/tests/cyclers/no_initial_but_final_cycle_point/suite.rc
+++ b/tests/cyclers/no_initial_but_final_cycle_point/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     final cycle point = 20140101T00

--- a/tests/cyclers/no_initial_cycle_point/suite.rc
+++ b/tests/cyclers/no_initial_cycle_point/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cyclers/offset_final/suite.rc
+++ b/tests/cyclers/offset_final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/offset_initial/suite.rc
+++ b/tests/cyclers/offset_initial/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_final/suite.rc
+++ b/tests/cyclers/r1_final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_initial/suite.rc
+++ b/tests/cyclers/r1_initial/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_initial_back_comp_standalone_line/suite.rc
+++ b/tests/cyclers/r1_initial_back_comp_standalone_line/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_initial_immortal/suite.rc
+++ b/tests/cyclers/r1_initial_immortal/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_middle/suite.rc
+++ b/tests/cyclers/r1_middle/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r1_multi_start/suite.rc
+++ b/tests/cyclers/r1_multi_start/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2014-01-01

--- a/tests/cyclers/r1_restricted/suite.rc
+++ b/tests/cyclers/r1_restricted/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20130808T00

--- a/tests/cyclers/r5_final/suite.rc
+++ b/tests/cyclers/r5_final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/r5_initial/suite.rc
+++ b/tests/cyclers/r5_initial/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101

--- a/tests/cyclers/rmany_reverse/suite.rc
+++ b/tests/cyclers/rmany_reverse/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2015-02-21T00

--- a/tests/cyclers/rnone_reverse/suite.rc
+++ b/tests/cyclers/rnone_reverse/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2015-02-21T00

--- a/tests/cyclers/subhourly/suite.rc
+++ b/tests/cyclers/subhourly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20131231T2300

--- a/tests/cyclers/weekly/suite.rc
+++ b/tests/cyclers/weekly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2005W015T12

--- a/tests/cyclers/yearly/suite.rc
+++ b/tests/cyclers/yearly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2005023T12

--- a/tests/cylc-cat-log/00-local/suite.rc
+++ b/tests/cylc-cat-log/00-local/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
        abort on inactivity = True

--- a/tests/cylc-cat-log/01-remote/suite.rc
+++ b/tests/cylc-cat-log/01-remote/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on timeout = True
        timeout = PT1M

--- a/tests/cylc-cat-log/04-local-tail/suite.rc
+++ b/tests/cylc-cat-log/04-local-tail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[events]]
        abort on timeout = True
        timeout = PT2M

--- a/tests/cylc-cat-log/05-remote-tail/suite.rc
+++ b/tests/cylc-cat-log/05-remote-tail/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on timeout = True
        timeout = PT2M

--- a/tests/cylc-cat-log/09-cat-running/suite.rc
+++ b/tests/cylc-cat-log/09-cat-running/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/cylc-cat-log/editor/suite.rc
+++ b/tests/cylc-cat-log/editor/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT30S

--- a/tests/cylc-cat-log/remote-simple/suite.rc
+++ b/tests/cylc-cat-log/remote-simple/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on timeout = True
        timeout = PT1M

--- a/tests/cylc-diff/03-icp.t
+++ b/tests/cylc-diff/03-icp.t
@@ -21,7 +21,7 @@
 set_test_number 3
 
 init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]
@@ -33,7 +33,7 @@ __SUITE_RC__
 # shellcheck disable=SC2153
 SUITE_NAME1="${SUITE_NAME}"
 init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cylc-diff/04-icp-2.t
+++ b/tests/cylc-diff/04-icp-2.t
@@ -21,7 +21,7 @@
 set_test_number 3
 
 init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]
@@ -33,7 +33,7 @@ __SUITE_RC__
 # shellcheck disable=SC2153
 SUITE_NAME1="${SUITE_NAME}"
 init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2016

--- a/tests/cylc-edit/00-basic/suite.rc
+++ b/tests/cylc-edit/00-basic/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=foo
     description=A test suite.rc with includes
-[cylc]
+[general]
 UTC mode=True # Ignore DST
 %include include/suite-scheduling.rc
 %include include/suite-runtime.rc

--- a/tests/cylc-get-config/01-no-final/suite.rc
+++ b/tests/cylc-get-config/01-no-final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/cylc-get-config/03-icp.t
+++ b/tests/cylc-get-config/03-icp.t
@@ -21,7 +21,7 @@
 set_test_number 3
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cylc-get-config/05-param-vars/suite.rc
+++ b/tests/cylc-get-config/05-param-vars/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[parameters]]
          t = 1..5
          u = right,left

--- a/tests/cylc-get-site-config/02-jinja2.t
+++ b/tests/cylc-get-site-config/02-jinja2.t
@@ -22,10 +22,10 @@ set_test_number 3
 
 create_test_globalrc '#!jinja2' '
 {% set UTC_MODE = True %}
-[cylc]
+[general]
     UTC mode = {{UTC_MODE}}'
 
-run_ok "${TEST_NAME_BASE}" cylc get-global-config --item='[cylc]UTC mode'
+run_ok "${TEST_NAME_BASE}" cylc get-global-config --item='[general]UTC mode'
 cmp_ok "${TEST_NAME_BASE}.stdout" <<<'True'
 cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
 exit

--- a/tests/cylc-get-suite-contact/00-basic.t
+++ b/tests/cylc-get-suite-contact/00-basic.t
@@ -19,7 +19,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 6
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = 2016

--- a/tests/cylc-graph-diff/00-simple-control/suite.rc
+++ b/tests/cylc-graph-diff/00-simple-control/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140808T00

--- a/tests/cylc-graph-diff/00-simple-diffs/suite.rc
+++ b/tests/cylc-graph-diff/00-simple-diffs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140808T00

--- a/tests/cylc-graph-diff/01-icp.t
+++ b/tests/cylc-graph-diff/01-icp.t
@@ -21,7 +21,7 @@
 set_test_number 3
 
 init_suite "${TEST_NAME_BASE}-1" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]
@@ -33,7 +33,7 @@ __SUITE_RC__
 # shellcheck disable=SC2153
 SUITE_NAME1="${SUITE_NAME}"
 init_suite "${TEST_NAME_BASE}-2" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cylc-insert/00-insert/suite.rc
+++ b/tests/cylc-insert/00-insert/suite.rc
@@ -6,7 +6,7 @@ three tasks are excluded at start-up but are inserted manually by the
 initial prep task. One is inserted with no stop cycle, to run for the
 duration of the suite; and the other is set to stop after two cycles."""
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/cylc-insert/01-insert-bad-cycle-point/suite.rc
+++ b/tests/cylc-insert/01-insert-bad-cycle-point/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test insertion of a task with a bad cycle point."
 
-[cylc]
+[general]
     cycle point time zone = +01
     [[events]]
         abort on stalled = True

--- a/tests/cylc-insert/02-insert-bad-stop-cycle-point/suite.rc
+++ b/tests/cylc-insert/02-insert-bad-stop-cycle-point/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test insertion of a task with a bad cycle point."
 
-[cylc]
+[general]
     cycle point time zone = +01
 
 [scheduling]

--- a/tests/cylc-insert/03-insert-old/suite.rc
+++ b/tests/cylc-insert/03-insert-old/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Test insertion of a task that has previously run"
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/cylc-insert/05-insert-compat/suite.rc
+++ b/tests/cylc-insert/05-insert-compat/suite.rc
@@ -6,7 +6,7 @@ three tasks are excluded at start-up but are inserted manually by the
 initial prep task. One is inserted with no stop cycle, to run for the
 duration of the suite; and the other is set to stop after two cycles."""
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/cylc-insert/06-insert-bad-cycle-point-compat/suite.rc
+++ b/tests/cylc-insert/06-insert-bad-cycle-point-compat/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test insertion of a task with a bad cycle point."
 
-[cylc]
+[general]
     cycle point time zone = +01
     [[events]]
         abort on stalled = True

--- a/tests/cylc-insert/07-insert-bad-stop-cycle-point/suite.rc
+++ b/tests/cylc-insert/07-insert-bad-stop-cycle-point/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test insertion of a task with a bad cycle point."
 
-[cylc]
+[general]
     cycle point time zone = +01
     [[events]]
         abort on stalled = True

--- a/tests/cylc-insert/09-insert-no-cycle-point/suite.rc
+++ b/tests/cylc-insert/09-insert-no-cycle-point/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test insertion of a task with no cycle point."
 
-[cylc]
+[general]
     cycle point time zone = +01
 
 [scheduling]

--- a/tests/cylc-insert/12-cycle-500-tasks/suite.rc
+++ b/tests/cylc-insert/12-cycle-500-tasks/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
     [[parameters]]
         i = 1..500

--- a/tests/cylc-insert/13-family-submit-num/suite.rc
+++ b/tests/cylc-insert/13-family-submit-num/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         abort on stalled = True

--- a/tests/cylc-kill/00-multi-hosts-compat/suite.rc
+++ b/tests/cylc-kill/00-multi-hosts-compat/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
     [[reference test]]
         expected task failures = local-1.1, local-2.1, local-3.1, remote-1.1, remote-2.1

--- a/tests/cylc-kill/01-multi-hosts/suite.rc
+++ b/tests/cylc-kill/01-multi-hosts/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
     [[reference test]]
         expected task failures = local-1.1, local-2.1, local-3.1, remote-1.1, remote-2.1

--- a/tests/cylc-list/01-icp.t
+++ b/tests/cylc-list/01-icp.t
@@ -21,7 +21,7 @@
 set_test_number 3
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cylc-list/suite/suite.rc
+++ b/tests/cylc-list/suite/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
    initial cycle point = 20140808T00

--- a/tests/cylc-message/00-ssh/suite.rc
+++ b/tests/cylc-message/00-ssh/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True # Ignore DST
 
 [scheduling]

--- a/tests/cylc-poll/01-task-failed/suite.rc
+++ b/tests/cylc-poll/01-task-failed/suite.rc
@@ -4,7 +4,7 @@
 unless polled. Task B then polls A to find it has failed, allowing A to
 suicide via a :fail trigger, and the suite to shut down successfully."""
 
-[cylc]
+[general]
    [[reference test]]
        expected task failures = a.1
 

--- a/tests/cylc-poll/02-task-submit-failed/suite.rc
+++ b/tests/cylc-poll/02-task-submit-failed/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
 [scheduling]

--- a/tests/cylc-poll/04-poll-multi-hosts/suite.rc
+++ b/tests/cylc-poll/04-poll-multi-hosts/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
     [[reference test]]
         expected task failures = local-fail-1.1, local-fail-2.1, remote-fail-1.1

--- a/tests/cylc-poll/05-poll-multi-messages/suite.rc
+++ b/tests/cylc-poll/05-poll-multi-messages/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/cylc-poll/12-reverse-state/suite.rc
+++ b/tests/cylc-poll/12-reverse-state/suite.rc
@@ -2,7 +2,7 @@
 # task perpetrator must complete successfully, so that perpetrator succeeds and
 # the suite shuts down cleanly.
 
-[cylc]
+[general]
     [[events]]
         timeout = PT10S
         abort on timeout = True

--- a/tests/cylc-poll/15-job-st-file-no-batch/suite.rc
+++ b/tests/cylc-poll/15-job-st-file-no-batch/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/cylc-remove/00-simple/suite.rc
+++ b/tests/cylc-remove/00-simple/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = c.1
 

--- a/tests/cylc-remove/01-simple-comat/suite.rc
+++ b/tests/cylc-remove/01-simple-comat/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = c.1
 

--- a/tests/cylc-remove/02-cycling/suite.rc
+++ b/tests/cylc-remove/02-cycling/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
 

--- a/tests/cylc-reset/00-compat/suite.rc
+++ b/tests/cylc-reset/00-compat/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = fixable.1

--- a/tests/cylc-reset/01-filter-failed/suite.rc
+++ b/tests/cylc-reset/01-filter-failed/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = fixable1.1, fixable2.1, fixable3.1

--- a/tests/cylc-search/00-basic/suite.rc
+++ b/tests/cylc-search/00-basic/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=foo
     description=A test suite.rc with includes
-[cylc]
+[general]
 UTC mode=True # Ignore DST
 %include include/suite-scheduling.rc
 %include include/suite-runtime.rc

--- a/tests/cylc-show/05-complex/suite.rc
+++ b/tests/cylc-show/05-complex/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2000

--- a/tests/cylc-show/clock-triggered-alt-tz/suite.rc
+++ b/tests/cylc-show/clock-triggered-alt-tz/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140808T09

--- a/tests/cylc-show/clock-triggered-non-utc-mode/suite.rc
+++ b/tests/cylc-show/clock-triggered-non-utc-mode/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
 [scheduling]
     initial cycle point = 20140808T09
     final cycle point = 20140808T09

--- a/tests/cylc-show/clock-triggered/suite.rc
+++ b/tests/cylc-show/clock-triggered/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141106T09

--- a/tests/cylc-submit/11-multi.t
+++ b/tests/cylc-submit/11-multi.t
@@ -22,7 +22,7 @@ export CYLC_TEST_IS_GENERIC=false
 set_test_number 4
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
 [scheduling]

--- a/tests/cylc-trigger/02-filter-failed/suite.rc
+++ b/tests/cylc-trigger/02-filter-failed/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = fixable1.1, fixable2.1, fixable3.1

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -3,7 +3,7 @@
     description = """
 A broken task will fail and cause the suite to abort on timeout, unless a
 second task fixes and retriggers it with an edit-run."""
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT20S

--- a/tests/cylc-trigger/04-filter-names/suite.rc
+++ b/tests/cylc-trigger/04-filter-names/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = fixable-1a.1, fixable-1b.1, fixable-2a.1, fixable-2b.1, fixable-3.1, loser.1

--- a/tests/cylc-trigger/05-filter-cycles/suite.rc
+++ b/tests/cylc-trigger/05-filter-cycles/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = fixable.19700101T0000Z, fixable.19900101T0000Z, fixable.20100101T0000Z

--- a/tests/cylc-trigger/06-reset-ready/suite.rc
+++ b/tests/cylc-trigger/06-reset-ready/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = t2.1
 [scheduling]

--- a/tests/cylc-trigger/07-edit-run-abort/suite.rc
+++ b/tests/cylc-trigger/07-edit-run-abort/suite.rc
@@ -1,6 +1,6 @@
 [meta]
     title = A suite to test an aborted edit run has no subsequent effect.
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT20S

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -3,7 +3,7 @@
     description = """
 A broken task will fail and cause the suite to abort on timeout, unless a
 second task fixes and retriggers it with an edit-run."""
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT20S

--- a/tests/database/03-remote/suite.rc
+++ b/tests/database/03-remote/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point=2020

--- a/tests/database/04-lock-recover/suite.rc
+++ b/tests/database/04-lock-recover/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/database/05-lock-recover-100/suite.rc
+++ b/tests/database/05-lock-recover-100/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/database/06-task-message/suite.rc
+++ b/tests/database/06-task-message/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/deprecations/00-pre-cylc8.t
+++ b/tests/deprecations/00-pre-cylc8.t
@@ -30,8 +30,8 @@ cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
  * (6.1.3) [visualization][enable live graph movie] - DELETED (OBSOLETE)
- * (7.2.2) [cylc][dummy mode] - DELETED (OBSOLETE)
- * (7.2.2) [cylc][simulation mode] - DELETED (OBSOLETE)
+ * (7.2.2) [general][dummy mode] - DELETED (OBSOLETE)
+ * (7.2.2) [general][simulation mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][dummy mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][simulation mode] - DELETED (OBSOLETE)
  * (7.6.0) [runtime][foo, cat, dog][enable resurrection] - DELETED (OBSOLETE)

--- a/tests/deprecations/00-pre-cylc8.t
+++ b/tests/deprecations/00-pre-cylc8.t
@@ -39,6 +39,7 @@ cmp_ok val.out <<__END__
  * (7.8.1) [cylc][events][reset timer] - DELETED (OBSOLETE)
  * (7.8.1) [cylc][events][reset inactivity timer] - DELETED (OBSOLETE)
  * (7.8.1) [runtime][foo, cat, dog][events][reset timer] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc] -> [general] - value unchanged
 __END__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/deprecations/00-pre-cylc8.t
+++ b/tests/deprecations/00-pre-cylc8.t
@@ -30,8 +30,8 @@ cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
  * (6.1.3) [visualization][enable live graph movie] - DELETED (OBSOLETE)
- * (7.2.2) [general][dummy mode] - DELETED (OBSOLETE)
- * (7.2.2) [general][simulation mode] - DELETED (OBSOLETE)
+ * (7.2.2) [cylc][dummy mode] - DELETED (OBSOLETE)
+ * (7.2.2) [cylc][simulation mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][dummy mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][simulation mode] - DELETED (OBSOLETE)
  * (7.6.0) [runtime][foo, cat, dog][enable resurrection] - DELETED (OBSOLETE)

--- a/tests/deprecations/00-pre-cylc8/suite.rc
+++ b/tests/deprecations/00-pre-cylc8/suite.rc
@@ -1,7 +1,7 @@
 # Test automatic deprecation and deletion of config items as specified
 # in cylc/flow/cfgspec/suite.py.
 
-[cylc]
+[general]
     [[dummy mode]]
     [[simulation mode]]
     [[events]]

--- a/tests/deprecations/00-pre-cylc8/suite.rc
+++ b/tests/deprecations/00-pre-cylc8/suite.rc
@@ -1,7 +1,7 @@
 # Test automatic deprecation and deletion of config items as specified
 # in cylc/flow/cfgspec/suite.py.
 
-[general]
+[cylc]
     [[dummy mode]]
     [[simulation mode]]
     [[events]]

--- a/tests/deprecations/01-cylc8-basic.t
+++ b/tests/deprecations/01-cylc8-basic.t
@@ -39,6 +39,7 @@ cmp_ok val.out <<__END__
  * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][abort if any task fails] -> [cylc][events][abort if any task fails] - value unchanged
  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc] -> [general] - value unchanged
 __END__
 
 purge_suite "${SUITE_NAME}"

--- a/tests/deprecations/01-cylc8-simple.t
+++ b/tests/deprecations/01-cylc8-simple.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test all current non-silent suite obsoletions and deprecations.
+# Test all suite obsoletions and deprecations related to change to cylc8
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2
@@ -29,12 +29,14 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
+ * (8.0.0) [documentation][urls][internet homepage] -> [documentation][cylc homepage] - value unchanged
  * (8.0.0) [cylc][authentication] -> [cylc][authorization] - value unchanged
  * (8.0.0) [runtime][Bob][remote] -> [runtime][Bob][job] - value unchanged
  * (8.0.0) [runtime][Charlie][remote] -> [runtime][Charlie][job] - value unchanged
  * (8.0.0) [runtime][Dai][remote] -> [runtime][Dai][job] - value unchanged
  * (8.0.0) [suite host self-identification] -> [suite run platforms][suite host self-identification] - value unchanged
  * (8.0.0) [suite servers] -> [suite run platforms] - value unchanged
+ * (8.0.0) [task events] -> [runtime][root][events] - value unchanged
  * (8.0.0) [test battery] - DELETED (OBSOLETE)
  * (8.0.0) [cylc] -> [general] - value unchanged
  * (8.0.0) [scheduling][dependencies][X][graph] -> [scheduling][graph][X] - for X in:

--- a/tests/deprecations/01-cylc8-simple.t
+++ b/tests/deprecations/01-cylc8-simple.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test all current non-silent suite obsoletions and deprecations.
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-val"
+run_ok "${TEST_NAME}" cylc validate -v "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-cmp
+cylc validate -v "${SUITE_NAME}" 2>&1 \
+    | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
+cmp_ok val.out <<__END__
+ * (8.0.0) [cylc][authentication] -> [cylc][authorization] - value unchanged
+ * (8.0.0) [runtime][Bob][remote] -> [runtime][Bob][job] - value unchanged
+ * (8.0.0) [runtime][Charlie][remote] -> [runtime][Charlie][job] - value unchanged
+ * (8.0.0) [runtime][Dai][remote] -> [runtime][Dai][job] - value unchanged
+ * (8.0.0) [suite host self-identification] -> [suite run platforms][suite host self-identification] - value unchanged
+ * (8.0.0) [suite servers] -> [suite run platforms] - value unchanged
+ * (8.0.0) [cylc] -> [general] - value unchanged
+ * (8.0.0) [scheduling][dependencies][X][graph] -> [scheduling][graph][X] - for X in:
+__END__
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"

--- a/tests/deprecations/01-cylc8-simple/suite.rc
+++ b/tests/deprecations/01-cylc8-simple/suite.rc
@@ -10,6 +10,8 @@
 
 [test battery]
 
+[task events]
+
 [scheduling]
     initial cycle point = 19831213T0600Z
     final cycle point = 19831213T1200Z

--- a/tests/deprecations/01-cylc8-simple/suite.rc
+++ b/tests/deprecations/01-cylc8-simple/suite.rc
@@ -1,0 +1,56 @@
+# Test automatic deprecation and deletion of config items as specified
+# in cylc/flow/config_schema
+[cylc]
+    UTC mode = True
+    [[authentication]]
+
+[suite host self-identification]
+
+[suite servers]
+
+[scheduling]
+    initial cycle point = 19831213T0600Z
+    final cycle point = 19831213T1200Z
+    [[dependencies]]
+        [[[PT3H]]]
+            graph="""Alice => Bob
+                  Alice => Charlie
+                  """
+[runtime]
+    [[Alice]]
+        script="""
+               sleep 5
+               echo "Alice\'s script is boring"
+               """
+
+    [[Bob]]
+        script="""
+               sleep 5
+               echo "Bob\'s script is boring"
+               """
+        [[[remote]]]
+            host=abc123
+
+
+    [[Charlie]]
+        script="""
+               sleep 5
+               echo "Charlie\'s script is boring"
+               """
+        [[[job]]]
+            batch system = slurm
+        [[[directives]]]
+            --mem=5
+            --ntasks=1
+        [[[remote]]]
+            host=abc123
+
+    [[Dai]]
+        script="""
+               sleep 5
+               echo "Dai\'s script is boring"
+               """
+        [[[remote]]]
+            host = xcel00
+
+

--- a/tests/deprecations/02-cylc8-host-set-in-task.t
+++ b/tests/deprecations/02-cylc8-host-set-in-task.t
@@ -35,7 +35,6 @@ cmp_ok val.out <<__END__
  * (8.0.0) [runtime][Dai][remote] -> [runtime][Dai][job] - value unchanged
  * (8.0.0) [suite host self-identification] -> [suite run platforms][suite host self-identification] - value unchanged
  * (8.0.0) [suite servers] -> [suite run platforms] - value unchanged
- * (8.0.0) [test battery] - DELETED (OBSOLETE)
  * (8.0.0) [cylc] -> [general] - value unchanged
  * (8.0.0) [scheduling][dependencies][X][graph] -> [scheduling][graph][X] - for X in:
 __END__

--- a/tests/deprecations/02-cylc8-host-set-in-task/suite.rc
+++ b/tests/deprecations/02-cylc8-host-set-in-task/suite.rc
@@ -8,8 +8,6 @@
 
 [suite servers]
 
-[test battery]
-
 [scheduling]
     initial cycle point = 19831213T0600Z
     final cycle point = 19831213T1200Z

--- a/tests/deprecations/02-cylc8-simple-consolidation.t
+++ b/tests/deprecations/02-cylc8-simple-consolidation.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test all current non-silent suite obsoletions and deprecations.
+# Test all suite obsoletions and deprecations related to change to cylc8
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2
@@ -29,12 +29,16 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
+ * (8.0.0) [cylc][events][mail from] -> [email][mail from] - value unchanged
+ * (8.0.0) [cylc][events][mail events] -> [email][mail events] - value unchanged
+ * (8.0.0) [cylc][events][mail footer] -> [email][mail footer] - value unchanged
+ * (8.0.0) [cylc][events][mail smtp] -> [email][mail smtp] - value unchanged
+ * (8.0.0) [cylc][events][mail to] -> [email][mail to] - value unchanged
  * (8.0.0) [cylc][authentication] -> [cylc][authorization] - value unchanged
- * (8.0.0) [runtime][Bob][remote] -> [runtime][Bob][job] - value unchanged
- * (8.0.0) [runtime][Charlie][remote] -> [runtime][Charlie][job] - value unchanged
- * (8.0.0) [runtime][Dai][remote] -> [runtime][Dai][job] - value unchanged
  * (8.0.0) [suite host self-identification] -> [suite run platforms][suite host self-identification] - value unchanged
  * (8.0.0) [suite servers] -> [suite run platforms] - value unchanged
+ * (8.0.0) [task events] -> [runtime][root][events] - value unchanged
+ * (8.0.0) [test battery] - DELETED (OBSOLETE)
  * (8.0.0) [cylc] -> [general] - value unchanged
  * (8.0.0) [scheduling][dependencies][X][graph] -> [scheduling][graph][X] - for X in:
 __END__

--- a/tests/deprecations/02-cylc8-simple-consolidation/suite.rc
+++ b/tests/deprecations/02-cylc8-simple-consolidation/suite.rc
@@ -2,11 +2,22 @@
 # in cylc/flow/config_schema
 [cylc]
     UTC mode = True
+
+    [[events]]
+        mail from =
+        mail events =
+        mail footer =
+        mail smtp =
+        mail to =
     [[authentication]]
 
 [suite host self-identification]
 
 [suite servers]
+
+[test battery]
+
+[task events]
 
 [scheduling]
     initial cycle point = 19831213T0600Z
@@ -26,31 +37,6 @@
     [[Bob]]
         script="""
                sleep 5
-               echo "Bob\'s script is boring"
+               echo "Bob\'s script is boring "
                """
         [[[remote]]]
-            host=abc123
-
-
-    [[Charlie]]
-        script="""
-               sleep 5
-               echo "Charlie\'s script is boring"
-               """
-        [[[job]]]
-            batch system = slurm
-        [[[directives]]]
-            --mem=5
-            --ntasks=1
-        [[[remote]]]
-            host=abc123
-
-    [[Dai]]
-        script="""
-               sleep 5
-               echo "Dai\'s script is boring"
-               """
-        [[[remote]]]
-            host = xcel00
-
-

--- a/tests/deprecations/03-cylc8-host-set-in-task.t
+++ b/tests/deprecations/03-cylc8-host-set-in-task.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test all suite obsoletions and deprecations related to change to cylc8
+# Test all current non-silent suite obsoletions and deprecations.
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2
@@ -29,15 +29,8 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
- * (8.0.0) [documentation][urls][internet homepage] -> [documentation][cylc homepage] - value unchanged
- * (8.0.0) [cylc][authentication] -> [cylc][authorization] - value unchanged
- * (8.0.0) [runtime][Bob][remote] -> [runtime][Bob][job] - value unchanged
- * (8.0.0) [runtime][Charlie][remote] -> [runtime][Charlie][job] - value unchanged
- * (8.0.0) [runtime][Dai][remote] -> [runtime][Dai][job] - value unchanged
  * (8.0.0) [suite host self-identification] -> [suite run platforms][suite host self-identification] - value unchanged
  * (8.0.0) [suite servers] -> [suite run platforms] - value unchanged
- * (8.0.0) [task events] -> [runtime][root][events] - value unchanged
- * (8.0.0) [test battery] - DELETED (OBSOLETE)
  * (8.0.0) [cylc] -> [general] - value unchanged
  * (8.0.0) [scheduling][dependencies][X][graph] -> [scheduling][graph][X] - for X in:
 __END__

--- a/tests/deprecations/03-cylc8-host-set-in-task/suite.rc
+++ b/tests/deprecations/03-cylc8-host-set-in-task/suite.rc
@@ -1,48 +1,76 @@
 # Test automatic deprecation and deletion of config items as specified
 # in cylc/flow/config_schema
-[cylc]
+[general]
 
-[suite host self-identification]
+[job platform]
+    [[cinnamon]]
+        login hosts = cnm001, cnm002, cnm003
+        batch system = slurm
+        suite definition directory =
+        retrieve job logs = True
+        retrieve job logs max size =
+        retrieve job logs retry delays =
 
-[suite servers]
+
 
 [scheduling]
     initial cycle point = 19831213T0600Z
     final cycle point = 19831213T1200Z
-    [[dependencies]]
+    [[graph]]
         [[[PT3H]]]
             graph="""Alice => Bob
                   Alice => Charlie
+                  Alice => Dai
+                  Dai => Emma
+                  Charlie => Emma
+                  Charlie => Fingal
                   """
 [runtime]
     [[Alice]]
+    # Test that a task parses nicely with no infomation
+    # other than "platform"
         script="""
                sleep 5
                echo "Alice\'s script is boring"
                """
+        platform = cinnamon
+
 
     [[Bob]]
+    # Test that a task parses sensibly when both [platform] and
+    # [remote][host] are provided.
+    # Unclear what desirable behaviour here is:
+    # * Have 'host' over-ride [job platforms][login hosts] completely.
+    # * Have 'host' over-ride [job platforms][login hosts] if 'host' is in
+    #   [job platforms][login hosts] else return warning.
+    # * Have 'host' ignored and return a warning explaining that the user that
+    #   they need to write their own job platform.
         script="""
                sleep 5
                echo "Bob\'s script is boring"
                """
+        platform = cinnamon
         [[[remote]]]
-            host=abc123
+            host=cnm001
 
 
     [[Charlie]]
+    # Platform is not defined but lots of deprecated items in job and remote
+    # are. Options:
+    # * Create a job platform from the infomation given
+    # * Pick a sensible job platform from host and bin everything else, leaving
+    #   a user warning.
         script="""
                sleep 5
                echo "Charlie\'s script is boring"
                """
         [[[job]]]
-            # Unclear how we want this to behave
             batch system = slurm
         [[[directives]]]
             --mem=5
             --ntasks=1
         [[[remote]]]
-            host=abc123
+            host=cnm001
             suite definition directory =
             retrieve job logs =
             retrieve job logs max size =
@@ -50,11 +78,29 @@
             owner = fprefect
 
     [[Dai]]
+    # A very simple test to upgrade host to job platform. Logic is to be:
+    # for job platform in job platforms:
+    #   if host in job platform > login hosts:
+    #       use job platform
         script="""
                sleep 5
                echo "Dai\'s script is boring"
                """
         [[[remote]]]
-            host = xcel00
+            host = abc123
+
+    [[Emma]]
+    # Run the task on the suite host platform
+        script="""
+               sleep 5
+               echo "Emma\'s script is boring"
+               """
 
 
+    [[Fingal]]
+    # Run the task on the cylc-go (?) invocation platform
+        script="""
+               sleep 5
+               echo "Fingal\'s script is boring"
+               """
+        platform = dev host

--- a/tests/deprecations/03-cylc8-host-set-in-task/suite.rc
+++ b/tests/deprecations/03-cylc8-host-set-in-task/suite.rc
@@ -1,16 +1,10 @@
 # Test automatic deprecation and deletion of config items as specified
 # in cylc/flow/config_schema
 [cylc]
-    UTC mode = True
-    [[authentication]]
 
 [suite host self-identification]
 
 [suite servers]
-
-[test battery]
-
-[task events]
 
 [scheduling]
     initial cycle point = 19831213T0600Z
@@ -42,12 +36,18 @@
                echo "Charlie\'s script is boring"
                """
         [[[job]]]
+            # Unclear how we want this to behave
             batch system = slurm
         [[[directives]]]
             --mem=5
             --ntasks=1
         [[[remote]]]
             host=abc123
+            suite definition directory =
+            retrieve job logs =
+            retrieve job logs max size =
+            retrieve job logs retry delays =
+            owner = fprefect
 
     [[Dai]]
         script="""

--- a/tests/directives/01-at/suite.rc
+++ b/tests/directives/01-at/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = rem2.1
 [scheduling]

--- a/tests/directives/loadleveler/suite.rc
+++ b/tests/directives/loadleveler/suite.rc
@@ -1,7 +1,7 @@
 #!Jinja2
 {% set HOST = environ['CYLC_TEST_BATCH_TASK_HOST'] %}
 {% set SITE_DIRECTIVES = environ['CYLC_TEST_BATCH_SITE_DIRECTIVES'] %}
-[cylc]
+[general]
    [[reference test]]
        expected task failures = rem2.1
 [scheduling]

--- a/tests/directives/pbs/suite.rc
+++ b/tests/directives/pbs/suite.rc
@@ -1,7 +1,7 @@
 #!Jinja2
 {% set HOST = environ['CYLC_TEST_BATCH_TASK_HOST'] %}
 {% set SITE_DIRECTIVES = environ['CYLC_TEST_BATCH_SITE_DIRECTIVES'] %}
-[cylc]
+[general]
    [[reference test]]
        expected task failures = rem2.1
 [scheduling]

--- a/tests/directives/slurm/suite.rc
+++ b/tests/directives/slurm/suite.rc
@@ -1,7 +1,7 @@
 #!Jinja2
 {% set HOST = environ['CYLC_TEST_BATCH_TASK_HOST'] %}
 {% set SITE_DIRECTIVES = environ['CYLC_TEST_BATCH_SITE_DIRECTIVES'] %}
-[cylc]
+[general]
    [[reference test]]
        expected task failures = rem2.1
 [scheduling]

--- a/tests/events/09-task-event-mail.t
+++ b/tests/events/09-task-event-mail.t
@@ -25,7 +25,7 @@ mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     [[events]]
         mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 [task events]

--- a/tests/events/09-task-event-mail/suite.rc
+++ b/tests/events/09-task-event-mail/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Task Event Mail
 
-[cylc]
+[general]
 {% if GLOBALCFG is not defined %}
     [[events]]
         mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/

--- a/tests/events/11-cycle-task-event-job-logs-retrieve/suite.rc
+++ b/tests/events/11-cycle-task-event-job-logs-retrieve/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Task Event Job Log Retrieve
 
-[cylc]
+[general]
     UTC mode = True
     cycle point format=%Y-%m-%dT%H:%MZ
 

--- a/tests/events/18-suite-event-mail.t
+++ b/tests/events/18-suite-event-mail.t
@@ -25,7 +25,7 @@ mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     [[events]]
         mail events = startup, shutdown
         mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/

--- a/tests/events/18-suite-event-mail/suite.rc
+++ b/tests/events/18-suite-event-mail/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Suite Event Mail
 
-[cylc]
+[general]
     [[events]]
 {% if GLOBALCFG is not defined %}
         mail events = startup, shutdown

--- a/tests/events/20-suite-event-handlers.t
+++ b/tests/events/20-suite-event-handlers.t
@@ -21,7 +21,7 @@ set_test_number 4
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     [[events]]
         handlers = echo 'Your %(suite)s suite has a %(event)s event and URL %(suite_url)s and suite-priority as %(suite-priority)s and suite-UUID as %(suite_uuid)s.'
         handler events = startup"

--- a/tests/events/20-suite-event-handlers/suite.rc
+++ b/tests/events/20-suite-event-handlers/suite.rc
@@ -4,7 +4,7 @@
     URL = http://mysuites.com/${CYLC_SUITE_NAME}.html
     suite-priority = HIGH
 
-[cylc]
+[general]
     [[events]]
 {% if GLOBALCFG is not defined %}
         handlers = echo 'Your %(suite)s suite has a %(event)s event and URL %(suite_url)s and suite-priority as %(suite-priority)s and suite-UUID as %(suite_uuid)s.'

--- a/tests/events/23-suite-stalled-handler/suite.rc
+++ b/tests/events/23-suite-stalled-handler/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True # Ignore DST
     [[events]]
         stalled handler = cylc reset %(suite)s bar -s succeeded

--- a/tests/events/24-abort-on-stalled/suite.rc
+++ b/tests/events/24-abort-on-stalled/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True # Ignore DST
     [[events]]
         abort on stalled = true

--- a/tests/events/25-held-not-stalled/suite.rc
+++ b/tests/events/25-held-not-stalled/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on inactivity = False
         abort on stalled = True

--- a/tests/events/26-suite-stalled-dump-prereq/suite.rc
+++ b/tests/events/26-suite-stalled-dump-prereq/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True # Ignore DST
     [[events]]
         abort on stalled = true

--- a/tests/events/27-suite-stalled-dump-prereq-fam/suite.rc
+++ b/tests/events/27-suite-stalled-dump-prereq-fam/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True # Ignore DST
     [[events]]
         abort on stalled = true

--- a/tests/events/28-inactivity/suite.rc
+++ b/tests/events/28-inactivity/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         inactivity = PT10S

--- a/tests/events/29-task-event-mail-1/suite.rc
+++ b/tests/events/29-task-event-mail-1/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Task Event Mail
 
-[cylc]
+[general]
     [[events]]
         mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 

--- a/tests/events/30-task-event-mail-2.t
+++ b/tests/events/30-task-event-mail-2.t
@@ -25,7 +25,7 @@ mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     [[events]]
         mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 [task events]

--- a/tests/events/30-task-event-mail-2/suite.rc
+++ b/tests/events/30-task-event-mail-2/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Task Event Mail
 
-[cylc]
+[general]
     task event mail interval = PT15S
     [[events]]
         abort on timeout = True

--- a/tests/events/33-task-event-job-logs-retrieve-3/suite.rc
+++ b/tests/events/33-task-event-job-logs-retrieve-3/suite.rc
@@ -2,7 +2,7 @@
 [meta]
     title=Task Event Job Log Retrieve 1
 
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT1M

--- a/tests/events/34-task-abort/suite.rc
+++ b/tests/events/34-task-abort/suite.rc
@@ -1,6 +1,6 @@
 [meta]
     title = "Test job abort with retries and failed handler"
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
 [scheduling]

--- a/tests/events/37-suite-event-bad-custom-template/suite.rc
+++ b/tests/events/37-suite-event-bad-custom-template/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     [[events]]
         handlers = echo %(rubbish)s
         handler events = startup

--- a/tests/events/41-late/suite.rc
+++ b/tests/events/41-late/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = now

--- a/tests/events/42-late-then-restart/suite.rc
+++ b/tests/events/42-late-then-restart/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = now

--- a/tests/events/43-late-spawn/suite.rc
+++ b/tests/events/43-late-spawn/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2015

--- a/tests/events/48-suite-aborted/suite.rc
+++ b/tests/events/48-suite-aborted/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     health check interval = PT1S
     [[events]]
         abort on inactivity = true

--- a/tests/events/49-task-event-host-select-fail.t
+++ b/tests/events/49-task-event-host-select-fail.t
@@ -20,7 +20,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 3
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/events/suite/hidden/shutdown/suite.rc
+++ b/tests/events/suite/hidden/shutdown/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         shutdown handler = "/bin/false"
         abort if shutdown handler fails = True

--- a/tests/events/suite/hidden/startup/suite.rc
+++ b/tests/events/suite/hidden/startup/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         startup handler = "/bin/false"
         abort if startup handler fails = True

--- a/tests/events/suite/hidden/timeout/suite.rc
+++ b/tests/events/suite/hidden/timeout/suite.rc
@@ -3,7 +3,7 @@
 This suite is supposed to time out and abort when the timeout handler
 deliberately fails."""
 
-[cylc]
+[general]
     [[events]]
         timeout = PT5S
         timeout handler = "/bin/false"

--- a/tests/events/timeout-ref/suite.rc
+++ b/tests/events/timeout-ref/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     description = This suite is supposed to time out
 
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT1S

--- a/tests/events/timeout/suite.rc
+++ b/tests/events/timeout/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     description = This suite is supposed to time out
 
-[cylc]
+[general]
     [[events]]
         timeout = PT6S
         abort on timeout = True

--- a/tests/ext-trigger/00-satellite/suite.rc
+++ b/tests/ext-trigger/00-satellite/suite.rc
@@ -25,7 +25,7 @@
 {% set DATA_IN_DIR = "$CYLC_SUITE_SHARE_DIR/incoming" %}
 {% set PRODUCT_DIR = "$CYLC_SUITE_SHARE_DIR/products" %}
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/ext-trigger/01-no-nudge/suite.rc
+++ b/tests/ext-trigger/01-no-nudge/suite.rc
@@ -8,7 +8,7 @@ task processing occurs foo will submit and kill bar, allowing the suite
 to shutdown.  Otherwise, foo won't submit, bar will keep running, and the suite
 will time out."""
 
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT30S

--- a/tests/ext-trigger/02-cycle-point/suite.rc
+++ b/tests/ext-trigger/02-cycle-point/suite.rc
@@ -3,7 +3,7 @@
     description = """Cycle-point specific external triggering in a date-time
 cycling suite.  The suite will time out and abort if the ext trigger fails."""
 
-[cylc]
+[general]
     cycle point format = %Y
     [[events]]
         abort on timeout = True

--- a/tests/graphing/00-boundaries/suite.rc
+++ b/tests/graphing/00-boundaries/suite.rc
@@ -1,5 +1,5 @@
 
-[cylc]
+[general]
     cycle point time zone = +12
 
 [scheduling]

--- a/tests/graphing/02-icp-task-missing/suite.rc
+++ b/tests/graphing/02-icp-task-missing/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20150304T00

--- a/tests/graphing/06-family-or.t
+++ b/tests/graphing/06-family-or.t
@@ -20,7 +20,7 @@
 set_test_number 2
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2000

--- a/tests/graphing/07-stop-at-final-point/suite.rc
+++ b/tests/graphing/07-stop-at-final-point/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     cycle point format = %Y-%m-%d
 [scheduling]
     initial cycle point = 2015-01-01

--- a/tests/graphing/09-ref-graph/suite.rc
+++ b/tests/graphing/09-ref-graph/suite.rc
@@ -1,5 +1,5 @@
 
-[cylc]
+[general]
     cycle point time zone = +12
 
 [scheduling]

--- a/tests/graphql/01-workflow/suite.rc
+++ b/tests/graphql/01-workflow/suite.rc
@@ -2,7 +2,7 @@
     title = foo
     description = bar
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/graphql/02-root-queries/suite.rc
+++ b/tests/graphql/02-root-queries/suite.rc
@@ -6,7 +6,7 @@
     importance = critical
     ranking = one
 
-[cylc]
+[general]
     cycle point format = CCYYMMDDThh
     UTC mode = True
 

--- a/tests/graphql/03-is-held-arg/suite.rc
+++ b/tests/graphql/03-is-held-arg/suite.rc
@@ -2,7 +2,7 @@
     title = foo
     description = bar
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/hold-release/00-suite/suite.rc
+++ b/tests/hold-release/00-suite/suite.rc
@@ -8,7 +8,7 @@
 
 # ref: bug-fix GitHub Pull Request #843 (5412d01)
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/hold-release/01-beyond-stop/suite.rc
+++ b/tests/hold-release/01-beyond-stop/suite.rc
@@ -7,7 +7,7 @@ beyond the suite stop point."""
 
 # ref: GitHub Pull Request #1144
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/hold-release/02-hold-on-spawn/suite.rc
+++ b/tests/hold-release/02-hold-on-spawn/suite.rc
@@ -4,7 +4,7 @@
     first cycle point of the suite. The spawned successors to those tasks should
     still be in the held state and should not run."""
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141009T00

--- a/tests/hold-release/12-hold-then-retry/suite.rc
+++ b/tests/hold-release/12-hold-then-retry/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = Test: run task - hold suite - task job retry - release suite
 
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/hold-release/17-hold-after-point/suite.rc
+++ b/tests/hold-release/17-hold-after-point/suite.rc
@@ -3,7 +3,7 @@
 
     description = """Define a hold after point in the suite.rc"""
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/hold-release/18-hold-cycle-globs/suite.rc
+++ b/tests/hold-release/18-hold-cycle-globs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 1990

--- a/tests/hold-release/19-no-reset-prereq-on-waiting/suite.rc
+++ b/tests/hold-release/19-no-reset-prereq-on-waiting/suite.rc
@@ -1,6 +1,6 @@
 [meta]
     title = Test cylc hold/release remembers satisfied dependencies
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/hold-release/21-client/suite.rc
+++ b/tests/hold-release/21-client/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/hold-release/hold-family/suite.rc
+++ b/tests/hold-release/hold-family/suite.rc
@@ -5,7 +5,7 @@
     description = """One task that selectively holds tasks in the first cycle
 point of the suite."""
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141009T00

--- a/tests/hold-release/hold-task/suite.rc
+++ b/tests/hold-release/hold-task/suite.rc
@@ -5,7 +5,7 @@
     description = """One task that selectively holds tasks in the first cycle
 point of the suite."""
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141009T00

--- a/tests/hold-release/release-family/suite.rc
+++ b/tests/hold-release/release-family/suite.rc
@@ -5,7 +5,7 @@
     description = """One task that holds then selectively releases a family in the
 first cycle point of the suite.."""
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141009T00

--- a/tests/hold-release/release-task/suite.rc
+++ b/tests/hold-release/release-task/suite.rc
@@ -5,7 +5,7 @@
     description = """One task that holds then selectively releases tasks in the
 first cycle point of the suite."""
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20141009T00

--- a/tests/hold-release/run-hold-after/suite.rc
+++ b/tests/hold-release/run-hold-after/suite.rc
@@ -3,7 +3,7 @@
 
     description = """Test running with a hold-after cycle point."""
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/host-select/01-timeout/suite.rc
+++ b/tests/host-select/01-timeout/suite.rc
@@ -1,0 +1,15 @@
+#!Jinja2
+[meta]
+    title = Test task host selection with a bad command
+
+[general]
+    [[reference test]]
+        expected task failures = foo.1
+[scheduling]
+    [[graph]]
+        R1 = "foo:submit-fail => !foo"
+[runtime]
+    [[foo]]
+        script = true
+        [[[remote]]]
+            host = $(sleep 2; echo 'localhost')

--- a/tests/intercycle/00-past/suite.rc
+++ b/tests/intercycle/00-past/suite.rc
@@ -4,7 +4,7 @@
     description = """
 Task A should only run at 0, 12 hours; Task B at 6, 18"""
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/intercycle/01-future/suite.rc
+++ b/tests/intercycle/01-future/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/intercycle/02-integer-abs/suite.rc
+++ b/tests/intercycle/02-integer-abs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/intercycle/03-datetime-abs/suite.rc
+++ b/tests/intercycle/03-datetime-abs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/intercycle/04-datetime-abs-2/suite.rc
+++ b/tests/intercycle/04-datetime-abs-2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/intercycle/05-datetime-abs-3/suite.rc
+++ b/tests/intercycle/05-datetime-abs-3/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/jinja2/09-custom-jinja2-filters/suite.rc
+++ b/tests/jinja2/09-custom-jinja2-filters/suite.rc
@@ -1,6 +1,6 @@
 #!Jinja2
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/jinja2/commandline-set/suite.rc
+++ b/tests/jinja2/commandline-set/suite.rc
@@ -5,7 +5,7 @@
 line or else this test will fail to validate: TASKNAME and STEP. Also,
 to pass the test run their values must be 'foo' and '2', respectively."""
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/job-file-trap/02-pipefail/suite.rc
+++ b/tests/job-file-trap/02-pipefail/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
    [[reference test]]

--- a/tests/job-kill/00-local/suite.rc
+++ b/tests/job-kill/00-local/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1, t2.1, t3.1, t4.1, stop2.1
 [scheduling]

--- a/tests/job-kill/01-remote/suite.rc
+++ b/tests/job-kill/01-remote/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1, t2.1
 [scheduling]

--- a/tests/job-kill/02-loadleveler/suite.rc
+++ b/tests/job-kill/02-loadleveler/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 [scheduling]

--- a/tests/job-kill/03-slurm/suite.rc
+++ b/tests/job-kill/03-slurm/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 [scheduling]

--- a/tests/job-kill/04-pbs/suite.rc
+++ b/tests/job-kill/04-pbs/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 [scheduling]

--- a/tests/job-submission/01-job-nn-localhost/suite.rc
+++ b/tests/job-submission/01-job-nn-localhost/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True # Ignore DST
 
 [scheduling]

--- a/tests/job-submission/04-submit-num/suite.rc
+++ b/tests/job-submission/04-submit-num/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT30S

--- a/tests/job-submission/06-garbage/suite.rc
+++ b/tests/job-submission/06-garbage/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 

--- a/tests/job-submission/07-multi/suite.rc
+++ b/tests/job-submission/07-multi/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/job-submission/08-activity-log-host/suite.rc
+++ b/tests/job-submission/08-activity-log-host/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/job-submission/09-activity-log-host-bad-submit/suite.rc
+++ b/tests/job-submission/09-activity-log-host-bad-submit/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
    [[reference test]]
        expected task failures = bad-submitter.19990101T0000Z

--- a/tests/job-submission/11-garbage-host-command/suite.rc
+++ b/tests/job-submission/11-garbage-host-command/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 

--- a/tests/job-submission/15-garbage-host-command-2/suite.rc
+++ b/tests/job-submission/15-garbage-host-command-2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[parameters]]
         i = 1..5
 [scheduling]

--- a/tests/job-submission/17-remote-localtime/suite.rc
+++ b/tests/job-submission/17-remote-localtime/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = False
 
 [scheduling]

--- a/tests/jobscript/06-slurm-no-directives/suite.rc
+++ b/tests/jobscript/06-slurm-no-directives/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Job script: no directives test for SLURM"
 
-[cylc]
+[general]
 
 [scheduling]
     [[graph]]

--- a/tests/jobscript/07-traps-failure/suite.rc
+++ b/tests/jobscript/07-traps-failure/suite.rc
@@ -1,7 +1,7 @@
 #!jinja2
 [meta]
     title = "Job script: test different failure traps based on batch system"
-[cylc]
+[general]
 [scheduling]
     [[graph]]
         R1 = root

--- a/tests/jobscript/08-pbs-job-name-len-max/suite.rc
+++ b/tests/jobscript/08-pbs-job-name-len-max/suite.rc
@@ -1,7 +1,7 @@
 #!jinja2
 [meta]
     title = "Job script: test PBS job name maximum length"
-[cylc]
+[general]
 [scheduling]
     [[graph]]
         R1 = abcdefghijklmnopqrstuvwxyz_0123456789

--- a/tests/jobscript/09-icp.t
+++ b/tests/jobscript/09-icp.t
@@ -20,7 +20,7 @@
 
 set_test_number 3
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/jobscript/10-bad-syntax/suite.rc
+++ b/tests/jobscript/10-bad-syntax/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
     [[events]]

--- a/tests/jobscript/12-err-script/suite.rc
+++ b/tests/jobscript/12-err-script/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
     [[events]]

--- a/tests/jobscript/13-hostname/suite.rc
+++ b/tests/jobscript/13-hostname/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/jobscript/15-semicolon/suite.rc
+++ b/tests/jobscript/15-semicolon/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
     [[events]]

--- a/tests/jobscript/16-midfail/suite.rc
+++ b/tests/jobscript/16-midfail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[reference test]]
         expected task failures = foo.1
     [[events]]

--- a/tests/jobscript/17-envfail/suite.rc
+++ b/tests/jobscript/17-envfail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
 [scheduling]

--- a/tests/jobscript/18-env-task-dependencies/suite.rc
+++ b/tests/jobscript/18-env-task-dependencies/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Job script: dependencies in environment tes"
 
-[cylc]
+[general]
 
 [scheduling]
     [[graph]]

--- a/tests/jobscript/18-no-err/suite.rc
+++ b/tests/jobscript/18-no-err/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         inactivity = PT20S
         abort on inactivity = True

--- a/tests/jobscript/19-exit-script/suite.rc
+++ b/tests/jobscript/19-exit-script/suite.rc
@@ -3,7 +3,7 @@
 {% set NSLEEP = NSLEEP | default(1) %}
 {% set EXIT = EXIT | default("false") %}
 
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/jobscript/20-isodatetime-envs.t
+++ b/tests/jobscript/20-isodatetime-envs.t
@@ -20,7 +20,7 @@
 set_test_number 2
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True
@@ -42,7 +42,7 @@ suite_run_ok "${TEST_NAME_BASE}" cylc run --no-detach "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"
 
 init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/jobscript/cycling/suite.rc
+++ b/tests/jobscript/cycling/suite.rc
@@ -3,7 +3,7 @@
 
     description = """Test the output of cycling environment variables"""
 
-[cylc]
+[general]
     cycle point time zone = +13
 
 [scheduling]

--- a/tests/logging/02-duplicates/suite.rc
+++ b/tests/logging/02-duplicates/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/logging/03-roll.t
+++ b/tests/logging/03-roll.t
@@ -20,7 +20,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 11
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/message-triggers/00-basic/suite.rc
+++ b/tests/message-triggers/00-basic/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "test suite for cylc-6 message triggers"
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/message-triggers/02-action/suite.rc
+++ b/tests/message-triggers/02-action/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         abort on inactivity = True

--- a/tests/modes/00-simulation/suite.rc
+++ b/tests/modes/00-simulation/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     force run mode = simulation
 [scheduling]
     [[graph]]

--- a/tests/modes/01-dummy/suite.rc
+++ b/tests/modes/01-dummy/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     force run mode = dummy
     [[reference test]]
         expected task failures = a.1, b.1, c.1

--- a/tests/modes/02-dummy-message-outputs.t
+++ b/tests/modes/02-dummy-message-outputs.t
@@ -22,7 +22,9 @@ set_test_number 2
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+cylc version --long >&2
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --no-detach --mode=dummy --reference-test "${SUITE_NAME}"
+    cylc run --no-detach --mode=dummy-local --reference-test "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/modes/02-dummy-message-outputs/suite.rc
+++ b/tests/modes/02-dummy-message-outputs/suite.rc
@@ -1,6 +1,6 @@
 [meta]
     title = A suite that should only succeed in dummy mode.
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/offset/00-final-simple/suite.rc
+++ b/tests/offset/00-final-simple/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/offset/01-final-next/suite.rc
+++ b/tests/offset/01-final-next/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
     [[events]]
         abort on stalled = True

--- a/tests/offset/02-final-chain/suite.rc
+++ b/tests/offset/02-final-chain/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/offset/03-final-next-chain/suite.rc
+++ b/tests/offset/03-final-next-chain/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/offset/04-cycle-offset-chain/suite.rc
+++ b/tests/offset/04-cycle-offset-chain/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/offset/05-long-final-chain/suite.rc
+++ b/tests/offset/05-long-final-chain/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/param_expand/01-basic.t
+++ b/tests/param_expand/01-basic.t
@@ -20,7 +20,7 @@
 set_test_number 39
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -44,7 +44,7 @@ cylc graph --reference 'suite.rc' >'01.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/01.graph.ref" '01.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = 25, 30..35, 1..5, 110
 [scheduling]
@@ -63,7 +63,7 @@ cylc graph --reference 'suite.rc' >'02.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/02.graph.ref" '02.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = a-t, c-g
 [scheduling]
@@ -82,7 +82,7 @@ cylc graph --reference 'suite.rc' >'03.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/03.graph.ref" '03.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = 100, hundred, one-hundred, 99+1
 [scheduling]
@@ -101,7 +101,7 @@ cylc graph --reference 'suite.rc' >'04.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/04.graph.ref" '04.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = space is dangerous
 [scheduling]
@@ -117,11 +117,11 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-05" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-05.stderr" <<'__ERR__'
-IllegalValueError: (type=parameter) [cylc][parameters]i = space is dangerous - (space is dangerous: bad value)
+IllegalValueError: (type=parameter) [general][parameters]i = space is dangerous - (space is dangerous: bad value)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = mix, 1..10
 [scheduling]
@@ -137,11 +137,11 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-06" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-06.stderr" <<'__ERR__'
-IllegalValueError: (type=parameter) [cylc][parameters]i = mix, 1..10 - (mixing int range and str)
+IllegalValueError: (type=parameter) [general][parameters]i = mix, 1..10 - (mixing int range and str)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = a, b #, c, d, e  # comment
 [scheduling]
@@ -160,7 +160,7 @@ cylc graph --reference 'suite.rc' >'07.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/07.graph.ref" '07.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = 1..2 3..4
 [scheduling]
@@ -176,11 +176,11 @@ foo<i> => bar<i>
 __SUITE__
 run_fail "${TEST_NAME_BASE}-08" cylc validate "suite.rc"
 cmp_ok "${TEST_NAME_BASE}-08.stderr" <<'__ERR__'
-IllegalValueError: (type=parameter) [cylc][parameters]i = 1..2 3..4 - (1..2 3..4: bad value)
+IllegalValueError: (type=parameter) [general][parameters]i = 1..2 3..4 - (1..2 3..4: bad value)
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i =
 [scheduling]
@@ -217,7 +217,7 @@ ParamExpandError: parameter i is not defined in <i>: foo<i>=>bar<i>
 __ERR__
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         j = +1..+5
     [[parameter templates]]
@@ -236,7 +236,7 @@ cylc graph --reference 'suite.rc' >'11.graph'
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/11.graph.ref" '11.graph'
 
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         j = 1..5
     [[parameter templates]]
@@ -256,7 +256,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/12.graph.ref" '12.graph'
 
 # Parameter with various meta characters
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         p = -minus, +plus, @at, %percent
     [[parameter templates]]
@@ -276,7 +276,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/13.graph.ref" '13.graph'
 
 # Parameter as task name
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = 0..2
         s = mercury, venus, earth, mars
@@ -299,7 +299,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/14.graph.ref" '14.graph'
 
 # Parameter in middle of family name
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         s = mercury, venus, earth, mars
 [scheduling]
@@ -317,7 +317,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/15.graph.ref" '15.graph'
 
 # -ve offset on RHS
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         m = cat, dog
 [scheduling]
@@ -334,7 +334,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/16.graph.ref" '16.graph'
 
 # +ve offset
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         m = cat, dog
 [scheduling]
@@ -351,7 +351,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/17.graph.ref" '17.graph'
 
 # Negative integers
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         m = -12..12..6
 [scheduling]
@@ -368,7 +368,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/18.graph.ref" '18.graph'
 
 # Reference by value, with -+ meta characters
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         lang = c++, fortran-2008
     [[parameter templates]]
@@ -394,7 +394,7 @@ cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/19.graph.ref" '19.graph'
 #       Inconsistence between graph/runtime parameter expansion.
 cylc get-config --sparse 'suite.rc' >'19.rc'
 cmp_ok '19.rc' <<'__SUITERC__'
-[cylc]
+[general]
     [[parameters]]
         lang = c++, fortran-2008
     [[parameter templates]]

--- a/tests/param_expand/02-param_val.t
+++ b/tests/param_expand/02-param_val.t
@@ -22,7 +22,7 @@ set_test_number 23
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -55,7 +55,7 @@ cmp_ok "${TNAME}-graph-nam" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph-nam-1.re
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -89,7 +89,7 @@ cmp_ok "${TNAME}-graph-nam" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph-nam-1.re
 #------------------------------------------------------------------------------
 # Same, with white space in the parameter syntax.
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -122,7 +122,7 @@ cmp_ok "${TNAME}-graph-nam" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph-nam-1.re
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -155,7 +155,7 @@ cmp_ok "${TNAME}-graph-nam" "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph-nam-b.re
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -179,7 +179,7 @@ run_ok "${TEST_NAME_BASE}-5" cylc validate "suite.rc"
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -201,7 +201,7 @@ cmp_ok '06.graph' "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/06.graph.ref"
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5
@@ -227,7 +227,7 @@ __ERR__
 
 #------------------------------------------------------------------------------
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     [[parameters]]
         i = cat, dog, fish
         j = 1..5

--- a/tests/param_expand/03-env-tmpl/suite.rc
+++ b/tests/param_expand/03-env-tmpl/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[parameters]]
         num = 99..101..2
         stuff = this, that

--- a/tests/periodicals/Daily/suite.rc
+++ b/tests/periodicals/Daily/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20140107

--- a/tests/periodicals/Monthly-reorder/suite.rc
+++ b/tests/periodicals/Monthly-reorder/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20130130T00

--- a/tests/periodicals/Monthly/suite.rc
+++ b/tests/periodicals/Monthly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 2010-02

--- a/tests/periodicals/Yearly/suite.rc
+++ b/tests/periodicals/Yearly/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 2011

--- a/tests/pre-initial/00-simple/suite.rc
+++ b/tests/pre-initial/00-simple/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/pre-initial/01-basic/suite.rc
+++ b/tests/pre-initial/01-basic/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/pre-initial/02-advanced/suite.rc
+++ b/tests/pre-initial/02-advanced/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/pre-initial/03-drop/suite.rc
+++ b/tests/pre-initial/03-drop/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/pre-initial/06-over-bracketed/suite.rc
+++ b/tests/pre-initial/06-over-bracketed/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20131225T1200Z

--- a/tests/pre-initial/07-simple-messaging/suite.rc
+++ b/tests/pre-initial/07-simple-messaging/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20100808T00

--- a/tests/pre-initial/08-conditional-messaging/suite.rc
+++ b/tests/pre-initial/08-conditional-messaging/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
    [[reference test]]
        expected task failures = bar.20100809T0000Z

--- a/tests/pre-initial/warm-insert-stall/suite.rc
+++ b/tests/pre-initial/warm-insert-stall/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on inactivity = True

--- a/tests/pre-initial/warm-insert/suite.rc
+++ b/tests/pre-initial/warm-insert/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = true
     [[events]]
         # Trigger the pre-start foo inserted by the inserter task.

--- a/tests/pre-initial/warm-offset/suite.rc
+++ b/tests/pre-initial/warm-offset/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20130101T00

--- a/tests/pre-initial/warm-start-iso/suite.rc
+++ b/tests/pre-initial/warm-start-iso/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20130101T00

--- a/tests/pre-initial/warm-start/suite.rc
+++ b/tests/pre-initial/warm-start/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     initial cycle point = 20130101T00

--- a/tests/queues/02-queueorder/suite.rc
+++ b/tests/queues/02-queueorder/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[parameters]]
         n = 1..7
 [scheduling]

--- a/tests/recurrence-min/00-basic/suite.rc
+++ b/tests/recurrence-min/00-basic/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
 UTC mode = true
 [scheduling]
 initial cycle point = 20100101T03

--- a/tests/recurrence-min/01-offset-initial/suite.rc
+++ b/tests/recurrence-min/01-offset-initial/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
 UTC mode = true
 [scheduling]
 initial cycle point = 20100101T03

--- a/tests/recurrence-min/02-offset-truncated/suite.rc
+++ b/tests/recurrence-min/02-offset-truncated/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
 UTC mode = true
 [scheduling]
 initial cycle point = 20100101T03

--- a/tests/recurrence-min/03-neg-offset-truncated/suite.rc
+++ b/tests/recurrence-min/03-neg-offset-truncated/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
 UTC mode = true
 [scheduling]
 initial cycle point = 20100101T03

--- a/tests/reload/01-startup/suite.rc
+++ b/tests/reload/01-startup/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = "%Y%m%dT%H"
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/reload/07-final-cycle/suite.rc
+++ b/tests/reload/07-final-cycle/suite.rc
@@ -2,7 +2,7 @@
     title = final cycle reload test
     description = """change final cycle."""
 
-[cylc]
+[general]
    UTC mode = True
 
 [scheduling]

--- a/tests/reload/08-cycle/suite.rc
+++ b/tests/reload/08-cycle/suite.rc
@@ -2,7 +2,7 @@
     title = cycling period change
     description = """change cycle points"""
 
-[cylc]
+[general]
    UTC mode = True
 
 [scheduling]

--- a/tests/reload/19-remote-kill/suite.rc
+++ b/tests/reload/19-remote-kill/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
    [[reference test]]

--- a/tests/reload/20-stop-point/suite.rc
+++ b/tests/reload/20-stop-point/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
 [scheduling]

--- a/tests/reload/21-submit-fail/suite.rc
+++ b/tests/reload/21-submit-fail/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
    [[reference test]]

--- a/tests/reload/22-remove-task-cycling.t
+++ b/tests/reload/22-remove-task-cycling.t
@@ -25,8 +25,8 @@ set_test_number 3
 # A suite designed to orphan a single copy of a task 'bar' on self-reload,
 # or stall and abort if the orphaned task triggers the #3306 bug.
 
-init_suite "${TEST_NAME_BASE}" <<__SUITE_RC__
-[cylc]
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[general]
    [[events]]
       inactivity = PT25S
       abort on inactivity = True

--- a/tests/reload/remove-add-alter-task/suite.rc
+++ b/tests/reload/remove-add-alter-task/suite.rc
@@ -1,0 +1,31 @@
+[meta]
+    title = "Test reloading of a task removed then added by a reload."
+# Don't run this suite in-place: it modifies itself.
+
+[general]
+    UTC mode = True
+
+[scheduling]
+    [[graph]]
+        R1 = reloader => remove_add_alter_me
+
+[runtime]
+   [[remove_add_alter_me]]
+      script = false
+   [[reloader]]
+      script = """
+sed -i "12s/\(graph = reloader\).*/\1/" $CYLC_SUITE_DEF_PATH/suite.rc
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+sed -i "12s/\(graph = reloader\)/\1 => remove_add_alter_me/" $CYLC_SUITE_DEF_PATH/suite.rc
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+cylc insert $CYLC_SUITE_NAME remove_add_alter_me.1
+sleep 5
+cat >>$CYLC_SUITE_DEF_PATH/suite.rc <<'__RUNTIME__'
+[[remove_add_alter_me]]
+    script = true
+__RUNTIME__
+cylc reload $CYLC_SUITE_NAME
+sleep 5
+        """

--- a/tests/reload/runahead/suite.rc
+++ b/tests/reload/runahead/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         timeout = PT0.2M

--- a/tests/repeated-items/one/suite.rc
+++ b/tests/repeated-items/one/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "override this"
     title = "the quick brown fox"
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20130101T0000Z

--- a/tests/restart/00-pre-initial/suite.rc
+++ b/tests/restart/00-pre-initial/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/restart/03-retrying.t
+++ b/tests/restart/03-retrying.t
@@ -19,7 +19,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 5
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/restart/04-running.t
+++ b/tests/restart/04-running.t
@@ -19,7 +19,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 5
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/restart/16-template-vars/suite.rc
+++ b/tests/restart/16-template-vars/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    UTC mode = True
    [[events]]
        startup handler = cylc release '%(suite)s'

--- a/tests/restart/18-template-vars-override/suite.rc
+++ b/tests/restart/18-template-vars-override/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
    UTC mode = True
     [[events]]
         startup handler = cylc release '%(suite)s'

--- a/tests/restart/20-event-retry/suite.rc
+++ b/tests/restart/20-event-retry/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    UTC mode = True
 [scheduling]
     [[graph]]

--- a/tests/restart/22-hold/suite.rc
+++ b/tests/restart/22-hold/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode=True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/23-hold-retry/suite.rc
+++ b/tests/restart/23-hold-retry/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/restart/25-hold-suite/suite.rc
+++ b/tests/restart/25-hold-suite/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode=True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/26-remote-kill/suite.rc
+++ b/tests/restart/26-remote-kill/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/27-broadcast-timeout/suite.rc
+++ b/tests/restart/27-broadcast-timeout/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
 [scheduling]

--- a/tests/restart/28-execution-timeout/suite.rc
+++ b/tests/restart/28-execution-timeout/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
 [scheduling]

--- a/tests/restart/30-outputs/suite.rc
+++ b/tests/restart/30-outputs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on inactivity = True
         abort on stalled = True

--- a/tests/restart/32-reload-runahead-no-stop-point/suite.rc
+++ b/tests/restart/32-reload-runahead-no-stop-point/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = 2018

--- a/tests/restart/33-simulation.t
+++ b/tests/restart/33-simulation.t
@@ -20,7 +20,7 @@
 
 set_test_number 3
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     cycle point format = %Y
     [[events]]
         abort if any task fails = True

--- a/tests/restart/34-auto-restart-basic.t
+++ b/tests/restart/34-auto-restart-basic.t
@@ -29,7 +29,7 @@ if ${CYLC_TEST_DEBUG:-false}; then ERR=2; else ERR=1; fi
 #-------------------------------------------------------------------------------
 # run through the shutdown - restart procedure
 BASE_GLOBALRC="
-[cylc]
+[general]
     health check interval = PT15S
     [[events]]
         abort on inactivity = True
@@ -41,7 +41,7 @@ BASE_GLOBALRC="
 
 TEST_NAME="${TEST_NAME_BASE}"
 TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME}" - <<'__SUITERC__'
-[cylc]
+[general]
     [[parameters]]
         foo = 1..25
 [scheduling]

--- a/tests/restart/35-auto-restart-recovery.t
+++ b/tests/restart/35-auto-restart-recovery.t
@@ -28,7 +28,7 @@ set_test_number 10
 #-------------------------------------------------------------------------------
 # test the failure recovery mechanism
 BASE_GLOBALRC="
-[cylc]
+[general]
     health check interval = PT15S
     [[events]]
         abort on inactivity = True

--- a/tests/restart/37-auto-restart-delay.t
+++ b/tests/restart/37-auto-restart-delay.t
@@ -34,7 +34,7 @@ sys.exit(not parser.parse('$1') > parser.parse('$2'))
 "
 }
 BASE_GLOBALRC="
-[cylc]
+[general]
     health check interval = PT5S
     [[events]]
         abort on inactivity = True
@@ -45,7 +45,7 @@ BASE_GLOBALRC="
 #-------------------------------------------------------------------------------
 # Test the delayed restart feature
 TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME_BASE}" <<< '
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2000

--- a/tests/restart/38-auto-restart-stopping.t
+++ b/tests/restart/38-auto-restart-stopping.t
@@ -29,7 +29,7 @@ if ${CYLC_TEST_DEBUG:-false}; then ERR=2; else ERR=1; fi
 #-------------------------------------------------------------------------------
 # ensure that suites don't get auto stop-restarted if they are already stopping
 BASE_GLOBALRC="
-[cylc]
+[general]
     health check interval = PT1S
     [[events]]
         abort on inactivity = True

--- a/tests/restart/41-auto-restart-local-jobs.t
+++ b/tests/restart/41-auto-restart-local-jobs.t
@@ -28,7 +28,7 @@ if ${CYLC_TEST_DEBUG:-false}; then ERR=2; else ERR=1; fi
 set_test_number 17
 
 BASE_GLOBALRC="
-[cylc]
+[general]
     health check interval = PT5S
     [[events]]
         abort on inactivity = True

--- a/tests/restart/42-auto-restart-ping-pong.t
+++ b/tests/restart/42-auto-restart-ping-pong.t
@@ -28,7 +28,7 @@ export CLOWNS
 export JOKERS="${HOSTNAME}"
 
 BASE_GLOBALRC='
-[cylc]
+[general]
     health check interval = PT5S
     [[events]]
         abort on inactivity = True
@@ -38,7 +38,7 @@ BASE_GLOBALRC='
 '
 
 TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME_BASE}" <<< '
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
 [scheduling]

--- a/tests/restart/43-auto-restart-force-override-normal.t
+++ b/tests/restart/43-auto-restart-force-override-normal.t
@@ -27,7 +27,7 @@ export CYLC_TEST_HOST_2
 export CYLC_TEST_HOST_1="${HOSTNAME}"
 
 BASE_GLOBALRC='
-[cylc]
+[general]
     health check interval = PT5S
     [[events]]
         abort on inactivity = True
@@ -37,7 +37,7 @@ BASE_GLOBALRC='
 '
 
 TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME_BASE}" <<< '
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
 [scheduling]

--- a/tests/restart/44-stop-point.t
+++ b/tests/restart/44-stop-point.t
@@ -40,7 +40,7 @@ set_test_number 16
 # Restart, should run to 2021, reset stop point before stop
 # Restart, should run to final cycle point == 2025
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     UTC mode=True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/45-stop-task.t
+++ b/tests/restart/45-stop-task.t
@@ -37,7 +37,7 @@ set_test_number 10
 # Restart
 # Suite stops normally at t8.1
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[parameters]]
         i = 1..8
     [[events]]

--- a/tests/restart/48-enable-auto-stop.t
+++ b/tests/restart/48-enable-auto-stop.t
@@ -36,7 +36,7 @@ set_test_number 8
 # Restart, should retain auto shutdown enabled option
 # Suite runs to final task and shuts down normally
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     disable automatic shutdown = True
     [[parameters]]
         i = 1..5

--- a/tests/restart/49-enable-auto-stop-2.t
+++ b/tests/restart/49-enable-auto-stop-2.t
@@ -35,7 +35,7 @@ set_test_number 8
 # Restart with auto shutdown enabled, should override original
 # Suite runs to final task and shuts down normally
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[parameters]]
         i = 1..5
     [[events]]

--- a/tests/restart/50-ignore-stop-point.t
+++ b/tests/restart/50-ignore-stop-point.t
@@ -34,7 +34,7 @@ set_test_number 7
 # Restart, ignoring stop point
 # Suite runs to final cycle point == 2020
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     UTC mode=True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/51-ignore-final-point.t
+++ b/tests/restart/51-ignore-final-point.t
@@ -38,7 +38,7 @@ set_test_number 13
 # Restart, ignore final cycle point
 # Suite runs to final cycle point == 2020
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     UTC mode=True
     cycle point format = %Y
     [[events]]

--- a/tests/restart/bad-job-host/suite.rc
+++ b/tests/restart/bad-job-host/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         timeout = PT2M

--- a/tests/restart/broadcast/suite.rc
+++ b/tests/restart/broadcast/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 {%- set TEST_DIR = environ['TEST_DIR'] %}
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort if any task fails = True

--- a/tests/restart/deleted-logs/suite.rc
+++ b/tests/restart/deleted-logs/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT20S

--- a/tests/restart/failed/suite.rc
+++ b/tests/restart/failed/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 {%- set TEST_DIR = environ['TEST_DIR'] %}
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/restart/pre-init-2/suite.rc
+++ b/tests/restart/pre-init-2/suite.rc
@@ -7,7 +7,7 @@
 # 2) the restart as reference test:
 #      cylc restart --debug --reference-test SUITE
 
-[cylc]
+[general]
     cycle point format = %Y%m%dT%H
 
 [scheduling]

--- a/tests/restart/reload/suite.rc
+++ b/tests/restart/reload/suite.rc
@@ -6,7 +6,7 @@ which should run to completion on restarting."""
 
 # The restart can be run as a reference test.
 
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20100808T00

--- a/tests/restart/submit-failed/suite.rc
+++ b/tests/restart/submit-failed/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 {%- set TEST_DIR = environ['TEST_DIR'] %}
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on timeout = True

--- a/tests/restart/succeeded/suite.rc
+++ b/tests/restart/succeeded/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 {%- set TEST_DIR = environ['TEST_DIR'] %}
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on timeout = True

--- a/tests/restart/waiting/suite.rc
+++ b/tests/restart/waiting/suite.rc
@@ -1,6 +1,6 @@
 #!jinja2
 {%- set TEST_DIR = environ['TEST_DIR'] %}
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on timeout = True

--- a/tests/retries/execution/suite.rc
+++ b/tests/retries/execution/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
        abort on inactivity = True

--- a/tests/retries/submission/suite.rc
+++ b/tests/retries/submission/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[events]]
        abort on stalled = True
        abort on inactivity = True

--- a/tests/rnd/02-lib-python-in-job/suite.rc
+++ b/tests/rnd/02-lib-python-in-job/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
 

--- a/tests/runahead/default-complex/suite.rc
+++ b/tests/runahead/default-complex/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         timeout = PT0.1M

--- a/tests/runahead/default-future/suite.rc
+++ b/tests/runahead/default-future/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         timeout = PT30S

--- a/tests/runahead/default-simple/suite.rc
+++ b/tests/runahead/default-simple/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         timeout = PT0.3M

--- a/tests/runahead/no_final/suite.rc
+++ b/tests/runahead/no_final/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = Z
     [[events]]
         abort on stalled = True

--- a/tests/runahead/release-update/suite.rc
+++ b/tests/runahead/release-update/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = now

--- a/tests/runahead/runahead/suite.rc
+++ b/tests/runahead/runahead/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point time zone = Z
     [[events]]
         timeout = PT30S

--- a/tests/shutdown/00-cycle/suite.rc
+++ b/tests/shutdown/00-cycle/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/shutdown/01-task/suite.rc
+++ b/tests/shutdown/01-task/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/shutdown/04-kill/suite.rc
+++ b/tests/shutdown/04-kill/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = t1.1
 

--- a/tests/shutdown/05-auto/suite.rc
+++ b/tests/shutdown/05-auto/suite.rc
@@ -1,6 +1,6 @@
 #!Jinja2
 
-[cylc]
+[general]
     disable automatic shutdown = {{environ['SUITE_DISABLE_AUTO_SHUTDOWN'] | default(false)}}
     [[events]]
         timeout = PT2M

--- a/tests/shutdown/06-kill-fail/suite.rc
+++ b/tests/shutdown/06-kill-fail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on timeout = True
         timeout = PT1M

--- a/tests/shutdown/07-task-fail/suite.rc
+++ b/tests/shutdown/07-task-fail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort if any task fails = True
         abort on timeout = True

--- a/tests/shutdown/08-now1/suite.rc
+++ b/tests/shutdown/08-now1/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/shutdown/09-now2/suite.rc
+++ b/tests/shutdown/09-now2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/shutdown/10-no-port-file/suite.rc
+++ b/tests/shutdown/10-no-port-file/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = False
         abort on timeout = True

--- a/tests/shutdown/11-bad-port-file/suite.rc
+++ b/tests/shutdown/11-bad-port-file/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = False
         abort on timeout = True

--- a/tests/shutdown/12-bad-port-file-check.t
+++ b/tests/shutdown/12-bad-port-file-check.t
@@ -23,7 +23,7 @@ set_test_number 3
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     health check interval = PT10S"
     OPT_SET='-s GLOBALCFG=True'
 fi

--- a/tests/shutdown/12-bad-port-file-check/suite.rc
+++ b/tests/shutdown/12-bad-port-file-check/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
 {% if GLOBALCFG is not defined %}
     health check interval = PT10S
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/shutdown/13-no-port-file-check.t
+++ b/tests/shutdown/13-no-port-file-check.t
@@ -23,7 +23,7 @@ set_test_number 3
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     health check interval = PT10S"
     OPT_SET='-s GLOBALCFG=True'
 fi

--- a/tests/shutdown/13-no-port-file-check/suite.rc
+++ b/tests/shutdown/13-no-port-file-check/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
 {% if GLOBALCFG is not defined %}
     health check interval = PT10S
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/shutdown/14-no-dir-check.t
+++ b/tests/shutdown/14-no-dir-check.t
@@ -23,7 +23,7 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_globalrc "" "
-[cylc]
+[general]
     health check interval = PT10S"
     OPT_SET='-s GLOBALCFG=True'
 fi

--- a/tests/shutdown/14-no-dir-check/suite.rc
+++ b/tests/shutdown/14-no-dir-check/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
 {% if GLOBALCFG is not defined %}
     health check interval = PT10S
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/shutdown/18-client-on-dead-suite.t
+++ b/tests/shutdown/18-client-on-dead-suite.t
@@ -20,7 +20,7 @@
 . "$(dirname "$0")/test_header"
 set_test_number 5
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/shutdown/19-log-reference.t
+++ b/tests/shutdown/19-log-reference.t
@@ -22,7 +22,7 @@
 set_test_number 3
 #-------------------------------------------------------------------------------
 init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
-[cylc]
+[general]
     [[events]]
         abort on inactivity = True
         inactivity = PT3M

--- a/tests/spawn-max/00-basic/suite.rc
+++ b/tests/spawn-max/00-basic/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
     [[reference test]]
         expected task failures = get_obs.2010

--- a/tests/special/00-sequential/suite.rc
+++ b/tests/special/00-sequential/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    cycle point format = %Y%m%dT%H
 [scheduling]
     initial cycle point = 20100101T00

--- a/tests/special/clock-360/suite.rc
+++ b/tests/special/clock-360/suite.rc
@@ -1,5 +1,5 @@
 #!Jinja2
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on timeout = True

--- a/tests/startup/01-log-suiterc.t
+++ b/tests/startup/01-log-suiterc.t
@@ -24,7 +24,7 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
 [meta]
     title = a suite that logs run, reload, and restart configs
     description = the weather is {{WEATHER | default("bad")}}
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 [scheduling]

--- a/tests/suite-state/07-message2/suite.rc
+++ b/tests/suite-state/07-message2/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = 2010

--- a/tests/suite-state/format/suite.rc
+++ b/tests/suite-state/format/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     cycle point format = CCYY-MM-DD
 

--- a/tests/suite-state/message/suite.rc
+++ b/tests/suite-state/message/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/suite-state/options/suite.rc
+++ b/tests/suite-state/options/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20100101T00Z

--- a/tests/suite-state/template/suite.rc
+++ b/tests/suite-state/template/suite.rc
@@ -1,5 +1,5 @@
 #!jinja2
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20100101T0000Z

--- a/tests/suite-state/template_ref/suite.rc
+++ b/tests/suite-state/template_ref/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     cycle point format = %Y
 

--- a/tests/task-name/00-basic/suite.rc
+++ b/tests/task-name/00-basic/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20150101

--- a/tests/task-proc-loop/00-count/suite.rc
+++ b/tests/task-proc-loop/00-count/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
         abort on inactivity = True

--- a/tests/triggering/00-recovery/suite.rc
+++ b/tests/triggering/00-recovery/suite.rc
@@ -6,7 +6,7 @@
         Model post processing triggers off model or recovery tasks.
     """
 
-[cylc]
+[general]
     UTC mode = True
     [[reference test]]
         expected task failures = model.20110101T1200Z

--- a/tests/triggering/04-fam-fail-all/suite.rc
+++ b/tests/triggering/04-fam-fail-all/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = a.1, b.1, c.1
 

--- a/tests/triggering/05-fam-finish-all/suite.rc
+++ b/tests/triggering/05-fam-finish-all/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = a.1, c.1
 

--- a/tests/triggering/06-fam-succeed-any/suite.rc
+++ b/tests/triggering/06-fam-succeed-any/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = a.1, c.1
 

--- a/tests/triggering/07-fam-fail-any/suite.rc
+++ b/tests/triggering/07-fam-fail-any/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = b.1
 

--- a/tests/triggering/09-fail/suite.rc
+++ b/tests/triggering/09-fail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = foo.1
 

--- a/tests/triggering/10-finish/suite.rc
+++ b/tests/triggering/10-finish/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = foo.1
 

--- a/tests/triggering/14-submit-fail/suite.rc
+++ b/tests/triggering/14-submit-fail/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
    [[reference test]]
        expected task failures = foo.1
 

--- a/tests/triggering/15-suicide/suite.rc
+++ b/tests/triggering/15-suicide/suite.rc
@@ -1,6 +1,6 @@
 [meta]
     title = "Hello, Goodbye, Suicide"
-[cylc]
+[general]
     [[reference test]]
         expected task failures = goodbye.1
 

--- a/tests/triggering/17-suicide-multi/suite.rc
+++ b/tests/triggering/17-suicide-multi/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         abort on stalled = True
 

--- a/tests/triggering/19-and-suicide/suite.rc
+++ b/tests/triggering/19-and-suicide/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/triggering/20-and-outputs-suicide/suite.rc
+++ b/tests/triggering/20-and-outputs-suicide/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     UTC mode = True
     [[events]]
         abort on stalled = True

--- a/tests/validate/10-bad-recurrence.t
+++ b/tests/validate/10-bad-recurrence.t
@@ -22,7 +22,7 @@ set_test_number 10
 
 TEST_NAME="${TEST_NAME_BASE}-interval"
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20140101T00
@@ -41,7 +41,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-icp"
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 20140101
@@ -58,7 +58,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-2-digit-century"
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20140101T00
@@ -78,7 +78,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-recurrences"
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     cycle point time zone = +01
 [scheduling]
     initial cycle point = 20100101T00
@@ -92,7 +92,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-old-cycle-point-format"
 cat >'suite.rc' <<'__SUITE__'
-[cylc]
+[general]
     cycle point format = %Y%m%d%H
 [scheduling]
     initial cycle point = 2010010101

--- a/tests/validate/23-fail-old-syntax-7/suite.rc
+++ b/tests/validate/23-fail-old-syntax-7/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     [[events]]
         timeout        = 4320
 [scheduling]

--- a/tests/validate/24-fail-initial-greater-final/suite.rc
+++ b/tests/validate/24-fail-initial-greater-final/suite.rc
@@ -4,7 +4,7 @@
 Initial is set to greater than the final and the suite should report the
 error."""
 
-[cylc]
+[general]
     UTC mode = True
 
 [scheduling]

--- a/tests/validate/25-fail-constrained-initial/suite.rc
+++ b/tests/validate/25-fail-constrained-initial/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Test validation of initial cycle point against constraints"
 
-[cylc]
+[general]
 [scheduling]
 initial cycle point = 20100101T03
 initial cycle point constraints = T00, T06, T12, T18

--- a/tests/validate/27-fail-constrained-final/suite.rc
+++ b/tests/validate/27-fail-constrained-final/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Test validation of final cycle point against constraints"
 
-[cylc]
+[general]
 [scheduling]
 initial cycle point = 20100101T03
 final cycle point = 20100102T17

--- a/tests/validate/29-pass-constrained-initial/suite.rc
+++ b/tests/validate/29-pass-constrained-initial/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Test validation of initial cycle point against constraints"
 
-[cylc]
+[general]
 [scheduling]
 initial cycle point = 20100101T06
 initial cycle point constraints = T00, T06, T12, T18

--- a/tests/validate/30-pass-constrained-final/suite.rc
+++ b/tests/validate/30-pass-constrained-final/suite.rc
@@ -1,7 +1,7 @@
 [meta]
     title = "Test validation of final cycle point against constraints"
 
-[cylc]
+[general]
 [scheduling]
 initial cycle point = 20100101T06
 final cycle point = 20100101T18

--- a/tests/validate/38-degenerate-point-format/suite.rc
+++ b/tests/validate/38-degenerate-point-format/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y-%m
 [scheduling]
     initial cycle point = 2015-08

--- a/tests/validate/51-zero-interval.t
+++ b/tests/validate/51-zero-interval.t
@@ -21,7 +21,7 @@
 set_test_number 2
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2010

--- a/tests/validate/58-icp-quoted-now.t
+++ b/tests/validate/58-icp-quoted-now.t
@@ -22,7 +22,7 @@
 set_test_number 1
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     cycle point format = %Y%m%d
 [scheduling]
     initial cycle point = "now"

--- a/tests/validate/64-circular.t
+++ b/tests/validate/64-circular.t
@@ -58,7 +58,7 @@ SuiteConfigError: self-edge detected: f:succeed => f
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = 2001
@@ -90,7 +90,7 @@ SuiteConfigError: circular edges detected:  foo.8 => bar.8  bar.8 => baz.8  baz.
 __ERR__
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     [[parameters]]
         foo = 1..5
 [scheduling]

--- a/tests/validate/67-relative-icp.t
+++ b/tests/validate/67-relative-icp.t
@@ -23,7 +23,7 @@
 set_test_number 2
 
 cat >'suite.rc' <<'__SUITE_RC__'
-[cylc]
+[general]
     UTC mode = true
 [scheduling]
     initial cycle point = previous(-17T1200Z; -18T1200Z) - P1D

--- a/tests/validate/69-task-proxy-sequence-bounds-err.t
+++ b/tests/validate/69-task-proxy-sequence-bounds-err.t
@@ -21,7 +21,7 @@
 set_test_number 7
 
 cat > suite.rc <<__END__
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2000
@@ -44,7 +44,7 @@ WARNING - R1/P0Y/19990101T0000Z: sequence out of bounds for initial cycle point 
 __ERR__
 
 cat > suite.rc <<__END__
-[cylc]
+[general]
     UTC mode = True
 [scheduling]
     initial cycle point = 2000

--- a/tests/xtriggers/02-persistence/suite.rc
+++ b/tests/xtriggers/02-persistence/suite.rc
@@ -1,4 +1,4 @@
-[cylc]
+[general]
     cycle point format = %Y
 [scheduling]
     initial cycle point = 2010

--- a/tests/xtriggers/03-sequence.t
+++ b/tests/xtriggers/03-sequence.t
@@ -24,7 +24,7 @@ set_test_number 3
 
 # Test suite uses built-in 'echo' xtrigger.
 init_suite "${TEST_NAME_BASE}" << '__SUITE_RC__'
-[cylc]
+[general]
    cycle point format = %Y
 [scheduling]
    initial cycle point = 2025


### PR DESCRIPTION
## Start to implement the combined config file structure.

## Work in progress
- [x] `cylc validate` and `cylc get-config` work for the new file format as a suite.rc
- [ ] Modify tests that fail with simple deprecation warnings.

## Left aside for now
- [ ] `cylc get-site-config` works on exactly the same config file as the suite.rc above. (site.rc commented out for now) 
- [ ] Consider how we are going to merge config items.
- [ ] Create site-locks for config items.
- [ ] Upgrade `host` information for use with Job Platforms.