### PR TITLE
updated cylc-deprecate tests

### DIFF
--- a/tests/deprecations/00-pre-cylc8.t
+++ b/tests/deprecations/00-pre-cylc8.t
@@ -34,6 +34,11 @@ cmp_ok val.out <<__END__
  * (7.2.2) [cylc][simulation mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][dummy mode] - DELETED (OBSOLETE)
  * (7.2.2) [runtime][foo, cat, dog][simulation mode] - DELETED (OBSOLETE)
+ * (7.6.0) [runtime][foo, cat, dog][enable resurrection] - DELETED (OBSOLETE)
+ * (7.8.0) [runtime][foo, cat, dog][suite state polling][template] - DELETED (OBSOLETE)
+ * (7.8.1) [cylc][events][reset timer] - DELETED (OBSOLETE)
+ * (7.8.1) [cylc][events][reset inactivity timer] - DELETED (OBSOLETE)
+ * (7.8.1) [runtime][foo, cat, dog][events][reset timer] - DELETED (OBSOLETE)
 __END__
-#-------------------------------------------------------------------------------
+
 purge_suite "${SUITE_NAME}"

--- a/tests/deprecations/00-pre-cylc8/suite.rc
+++ b/tests/deprecations/00-pre-cylc8/suite.rc
@@ -1,10 +1,12 @@
-
 # Test automatic deprecation and deletion of config items as specified
 # in cylc/flow/cfgspec/suite.py.
 
 [cylc]
     [[dummy mode]]
     [[simulation mode]]
+    [[events]]
+        reset timer = 10
+        reset inactivity timer = 15
 [scheduling]
     initial cycle point = 20150808T00
     final cycle point = 20150808T00
@@ -18,6 +20,10 @@
             script = "echo script" # deprecate
         [[[dummy mode]]]
             script = "echo script" # deprecate
-
+        [[[enable resurrection]]]
+        [[[suite state polling]]]
+            template = ""
+        [[[events]]]
+            reset timer = 20
 [visualization]
     enable live graph movie = True # obsolete

--- a/tests/deprecations/01-cylc8-basic.t
+++ b/tests/deprecations/01-cylc8-basic.t
@@ -1,0 +1,44 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test all current non-silent suite obsoletions and deprecations.
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-val"
+run_ok "${TEST_NAME}" cylc validate -v "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-cmp
+cylc validate -v "${SUITE_NAME}" 2>&1 \
+    | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
+cmp_ok val.out <<__END__
+ * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][allow task failures] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][live mode suite timeout] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][dummy mode suite timeout] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][dummy-local mode suite timeout] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][simulation mode suite timeout] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][required run mode] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][abort if any task fails] -> [cylc][events][abort if any task fails] - value unchanged
+ * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
+__END__
+
+purge_suite "${SUITE_NAME}"

--- a/tests/deprecations/01-cylc8-basic/suite.rc
+++ b/tests/deprecations/01-cylc8-basic/suite.rc
@@ -1,0 +1,28 @@
+# Test automatic deprecation and deletion of config items as specified
+# in cylc/flow/cfgspec/suite.py.
+
+[cylc]
+    log resolved dependencies =
+    abort if any task fails =
+    [[reference test]]
+        allow task failures =
+        live mode suite timeout =
+        dummy mode suite timeout =
+        dummy-local mode suite timeout =
+        simulation mode suite timeout =
+        required run mode =
+        suite shutdown event handler =
+
+
+[scheduling]
+    initial cycle point = 20150808T00
+    final cycle point = 20150808T00
+    [[graph]]
+        P1D = foo => cat & dog
+
+[runtime]
+    [[foo, cat, dog]]
+        [[[job]]]
+            shell = fish
+
+


### PR DESCRIPTION
Whilst working on the updated `????.rc` file spec I came across the following issue:
There is a test for deprecated/obsolete `suite.rc` config items, but it's not been kept up-to-date. I think that this may be very useful in the config re-alignment work, but I want it up to date on master. 

This PR attempts to rectify this problem.

I have renamed the existing test `00-pre-cylc8` and added a new test `01-cylc8-basic`, on the basis that future work is likely to lead to `0N-cylc8-why-it-is-complex`.