### PR TITLE
parsec: improve file parse error messages

### DIFF
--- a/cylc/flow/parsec/config.py
+++ b/cylc/flow/parsec/config.py
@@ -53,8 +53,11 @@ class ParsecConfig(object):
                     stack.append([value, pars])
                 elif not isinstance(value, list):
                     raise ParsecError(
-                        "Illegal file spec item: %s" % itemstr(
-                            pars, repr(value)))
+                        "Illegal file spec item: "
+                        + itemstr(pars, repr(value))
+                        + " "
+                        + repr(value)
+                    )
 
     def loadcfg(self, rcfile, title=""):
         """Parse a config file, upgrade or deprecate items if necessary,

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -319,8 +319,7 @@ def parse(fpath, output_fname=None, template_vars=None):
                 ndif = nesting_level - nb
                 parents = parents[:-ndif - 1] + [sect_name]
             else:
-                raise FileParseError(
-                    'Error line ' + str(index + 1) + ': ' + line)
+                raise FileParseError('Error line', index=index, line=line)
             nesting_level = nb
             addsect(config, sect_name, parents[:-1])
 
@@ -336,6 +335,6 @@ def parse(fpath, output_fname=None, template_vars=None):
             else:
                 # no match
                 raise FileParseError(
-                    'Invalid line ' + str(index + 1) + ': ' + line)
+                    'Invalid line', index=index, line=line)
 
     return config

--- a/cylc/flow/parsec/include.py
+++ b/cylc/flow/parsec/include.py
@@ -22,7 +22,8 @@ import re
 import sys
 from shutil import copy as shcopy
 
-from cylc.flow.parsec.exceptions import ParsecError, IncludeFileNotFoundError
+from cylc.flow.parsec.exceptions import (
+    FileParseError, IncludeFileNotFoundError)
 
 
 done = []
@@ -91,7 +92,11 @@ def inline(lines, dir_, filename, for_grep=False, for_edit=False, viewcfg=None,
         if m:
             q1, match, q2 = m.groups()
             if q1 and (q1 != q2):
-                raise ParsecError("mismatched quotes: " + line)
+                raise FileParseError(
+                    "mismatched quotes",
+                    line=line,
+                    fpath=filename,
+                )
             inc = os.path.join(dir_, match)
             if inc not in done:
                 if single or for_edit:

--- a/cylc/flow/tests/parsec/test_include.py
+++ b/cylc/flow/tests/parsec/test_include.py
@@ -24,6 +24,7 @@ tests. So this suite of unit tests should not cover all the module features.
 import tempfile
 import unittest
 
+from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.parsec.include import *
 
 

--- a/cylc/flow/tests/parsec/test_parsec.py
+++ b/cylc/flow/tests/parsec/test_parsec.py
@@ -28,8 +28,6 @@ class TestParsec(unittest.TestCase):
         self.assertEqual('', str(parsec_error))
         parsec_error = ParsecError('foo')
         self.assertEqual('foo', str(parsec_error))
-        parsec_error = ParsecError('foo', 'bar', 'baz')
-        self.assertEqual('foo bar baz', str(parsec_error))
 
     def test_parsec_error_str(self):
         msg = 'Turbulence!'

--- a/tests/validate/61-include-missing-quote.t
+++ b/tests/validate/61-include-missing-quote.t
@@ -26,8 +26,9 @@ cat >'suite.rc' <<'__SUITE_RC__'
 __SUITE_RC__
 
 run_fail "${TEST_NAME_BASE}" cylc validate 'suite.rc'
-cmp_ok "${TEST_NAME_BASE}.stderr" <<'__ERR__'
-ParsecError: mismatched quotes: %include 'foo.rc
+cmp_ok "${TEST_NAME_BASE}.stderr" <<__ERR__
+FileParseError: mismatched quotes (in $PWD/suite.rc):
+   %include 'foo.rc
 __ERR__
 
 exit


### PR DESCRIPTION
These changes partially address #2425 

Result of kicking about at a recent conference. Probably enough to close 2425?

**Comparison Of Error Output**

*before*
```
$ cylc validate .
FileParseError: Invalid line 3813: 600
```

*after*
```
$ cylc validate .
FileParseError: Invalid line (line 3813):
   600
(line numbers match 'cylc view -p')
```

**Off Topic Changes**

* Improves the `FileParseError` exception so that its data is stored as attributes. Besides being nicer this means tests can be safer (less fragile to test an attribute of an error than the entire error message).
* Add file path information to `FileParseError` where available (which it almost never is).
* Changes `mismatched quotes` error from `ParsecError` to `FileParseError`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? other items in change log relating to improved err msgs).
- [x] No documentation update required.
