### PR TITLE
Remove job-init-env.sh support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,9 @@ Jinja filters were moved from its `Jinja2Filters` folder to within the
 
 ### Enhancements
 
+[#3377](https://github.com/cylc/cylc-flow/pull/3377) - removed support for
+sourcing `job-init-env.sh` in task job scripts. Use bash login scripts instead.
+
 [#3302](https://github.com/cylc/cylc-flow/pull/3302) - improve CLI
 task-globbing help.
 

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -35,7 +35,6 @@ cylc__job__main() {
         fi
         set -x
     fi
-    # Prelude
     # Init-Script
     cylc__job__run_inst_func 'global_init_script'
     cylc__job__run_inst_func 'init_script'

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -36,16 +36,6 @@ cylc__job__main() {
         set -x
     fi
     # Prelude
-    typeset JOB_INIT_ENV=
-    # conf/job-init-env.sh for back-compat pre 7.7.0.
-    JOB_INIT_ENV="${HOME}/.cylc/job-init-env.sh"
-    if [[ -f "${JOB_INIT_ENV}" ]]; then
-        if "${CYLC_DEBUG:-false}"; then
-            . "${JOB_INIT_ENV}"
-        else
-            . "${JOB_INIT_ENV}" 1>'/dev/null' 2>&1
-        fi
-    fi
     # Init-Script
     cylc__job__run_inst_func 'global_init_script'
     cylc__job__run_inst_func 'init_script'


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3376
- remove support for sourcing user `job-init-env.sh` in task job scripts
  - (site `job-init-env.sh` already removed during CYLC_DIR removal for Cylc 8)
- I have retained support for `init-script` because it provides some additional flexibility (e.g.: can be configured centrally on the suite host, rather than by modifying login scripts on all job hosts) but documented that use of login scripts is preferred

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests (code deletion only).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/82


