### PR TITLE
pytest check cover value error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,7 @@ requests_).
  - Tim Pillinger
  - Samuel Gaist
  - Dima Veselov
+ - Mel Hall
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/cylc/flow/tests/test_wallclock.py
+++ b/cylc/flow/tests/test_wallclock.py
@@ -48,3 +48,15 @@ def test_get_unix_time_from_time_string_360(time_str, time_sec):
         assert get_unix_time_from_time_string(time_str) == time_sec
     finally:
         CALENDAR.set_mode(mode)
+
+
+@pytest.mark.parametrize(
+    'value,error',
+    [
+        (None, TypeError),
+        (42, TypeError)
+    ]
+)
+def test_get_unix_time_from_time_string_error(value, error):
+    with pytest.raises(error):
+        get_unix_time_from_time_string(value)


### PR DESCRIPTION
Improve coverage of get_unix_time_from_time_string

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests.
- [x] No change log entry required.
- [x] No documentation update required.
