### PR TITLE
Log if a ZMQError happens in the ZMQServer loop

### DIFF
--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -158,6 +158,9 @@ class ZMQServer(object):
                 # timeout, continue with the loop, this allows the listener
                 # thread to stop
                 continue
+            except zmq.error.ZMQError as exc:
+                LOG.exception(f'unexpected error: {str(exc)}')
+                continue
 
             # attempt to decode the message, authenticating the user in the
             # process


### PR DESCRIPTION
These changes partially address #3414 

`recv_string` may raise a `ZMQError` that is not caught anywhere, which makes it harder to troubleshoot ZMQ errors like in #3414.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? not easy to write a test for this, but it is only for logging an exception, so it should be OK?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
