### PR TITLE
Suppress KeyboardInterrupt for cat-log

### DIFF
--- a/bin/cylc-cat-log
+++ b/bin/cylc-cat-log
@@ -60,6 +60,7 @@ if remrun(abort_if='edit', forward_x11=True):
 
 import os
 import shlex
+from contextlib import suppress
 from glob import glob
 from shlex import quote
 from stat import S_IRUSR
@@ -221,7 +222,8 @@ def view_log(logpath, mode, tailer_tmpl, batchview_cmd=None, remote=False,
         else:
             cmd = tailer_tmpl % {"filename": logpath}
         proc = Popen(shlex.split(cmd), stdin=open(os.devnull))
-        watch_and_kill(proc)
+        with suppress(KeyboardInterrupt):
+            watch_and_kill(proc)
         return proc.wait()
 
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Low priority. Without the change:

![image](https://user-images.githubusercontent.com/304786/68469336-d459a100-027e-11ea-83d6-18443fbe3fe9.png)

After change:

![image](https://user-images.githubusercontent.com/304786/68469359-e2a7bd00-027e-11ea-9b23-04f1ec12a6ca.png)


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? not sure how to cover this, but can easily be tested manually?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
