### PR TITLE
Fix remote tidy subprocess call.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@ never transient, and in practice job polling is the only way to recover).
 [#3409](https://github.com/cylc/cylc-flow/pull/3409) - prevent cylc-run from
 creating directories when executed for suites that do not exist.
 
+[#3433](https://github.com/cylc/cylc-flow/pull/3433) - fix server abort at
+shutdown during remote run dir tidy (introduced during Cylc 8 development).
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a1 (2019-09-18)__
 

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -70,7 +70,7 @@ def run_cmd(command, stdin=None, capture_process=False, capture_status=False,
             command inclusive of all opts and args required to run via ssh.
         stdin (file):
             If specified, it should be a readable file object.
-            If None, `open(DEVNULL)` is set if output is to be captured.
+            If None, DEVNULL is set if output is to be captured.
         capture_process (boolean):
             If True, set stdout=PIPE and return the Popen object.
         capture_status (boolean):

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -241,7 +241,7 @@ class TaskRemoteMgr(object):
             cmd.append(get_remote_suite_run_dir(host, owner, self.suite))
             procs[(host, owner)] = (
                 cmd,
-                Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=open(DEVNULL)))
+                Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=DEVNULL))
         # Wait for commands to complete for a max of 10 seconds
         timeout = time() + 10.0
         while procs and time() < timeout:


### PR DESCRIPTION

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Already covered by existing **remote job** tests (although no one is currently running those).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required. (Fixing functionality broken during Cylc 8 development)

If a workflow has a remote job, remote run remote directory tidy at suite shutdown will fail here:
```
  File "/home/oliverh/cylc/cylc-flow/venv/lib/python3.7/site-packages/cylc/flow/task_remote_mgr.py", line 244, in remote_tidy
    Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=open(DEVNULL)))
ValueError: negative file descriptor
```