### PR TITLE
fix param inherit family bug

### DIFF
--- a/lib/cylc/param_expand.py
+++ b/lib/cylc/param_expand.py
@@ -61,7 +61,7 @@ foo_m1=>bar_m1_n2
 import re
 
 from cylc.task_id import TaskID
-from parsec.OrderedDict import OrderedDictWithDefaults
+from parsec.OrderedDict import OrderedDictWithDefaults, OrderedDict
 
 # To split runtime heading name lists.
 REC_NAMES = re.compile(r'(?:[^,<]|\<[^>]*\>)+')
@@ -222,7 +222,7 @@ class NameExpander(object):
         head, p_list_str, tail = REC_P_ALL.match(parent).groups()
         if not p_list_str:
             return head
-        used = {}
+        used = OrderedDict()
         for item in (i.strip() for i in p_list_str.split(',')):
             if '-' in item or '+' in item:
                 raise ParamExpandError(


### PR DESCRIPTION
A Python 2 bug which should not require forward porting.

The `expand_parent_params` method is dependent on dictionary ordering which produces incorrect results.

```ini
[cylc]
    [[parameters]]
        a = 1..1
        b = 1..1
        c = 1..1
        d = 1..1

[scheduling]
    [[dependencies]]
        graph = <a, b, c, d>

[runtime]
    [[<a>]]
    [[<a, b>]]
    [[<a, b, c>]]  # Cylc converts this to <a, c, b> because of py2 dict ordering

    [[foo<a>]]
        inherit = <a>
        # this is ok

    [[foo<a, b>]]
        inherit = "<a, b>"
        # this is fine too

    [[foo<a, b, c>]]
        inherit = "<a, b, c>"
        # oh noes
```

At 7.8.x this happens:

```console
$ cylc get-config --sparse .        
ERROR, undefined parent for foo_a1_b1_c1: _a1_c1_b1
```