### PR TITLE
Cylc Review: stop line numbers detaching from lines

### DIFF
--- a/lib/cylc/cylc-review/template/view.html
+++ b/lib/cylc/cylc-review/template/view.html
@@ -52,7 +52,7 @@
 <div class="container-fluid">
 <div class="row">
 <div id="file-container">
-<div class="col-md-1 text-right">
+<div class="col-xs-1 text-right">
 <pre class="prettyprint">
 {% for i in range(1, lines|length + 1) -%}
 <span><a id="{{i}}" class="line-number" href="#{{i}}">{{i}}</a></span>


### PR DESCRIPTION
(There is one ``7.8.x``-tagged PR up, so I'll put in this small PR in case there is ever enough to warrant a ``7.8.5`` release.)

When viewing any files under Cylc Review, if the window width is made small enough, the line numbers will detach from the lines they describe:

![scr-width-smaller](https://user-images.githubusercontent.com/30274190/68608172-30543d80-04aa-11ea-9542-a6a6c475f22f.png)

This small change prevents this from happening without influencing the UI otherwise. Otherwise, the design is largely responsive & could probably be viewed on a mobile or tablet without any glaring UI issues.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests [reason: layout/UI, & there is no mechanism to test that for Cylc 7].
- [x] No change log entry required [minor UI issue that is not worth documenting].
- [x] No documentation update required.