### PR TITLE
jinja2: test that cylc logger is available to jinja2 at load time

### DIFF
--- a/tests/jinja2/11-logging.t
+++ b/tests/jinja2/11-logging.t
@@ -1,0 +1,37 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that the Cylc logger is available to Jinja2 at load time.
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+init_suite "${TEST_NAME_BASE}" <<'__SUITERC__'
+#!Jinja2
+
+{% from "cylc.flow" import LOG %}
+{% do LOG.debug("Hello World!") %}
+
+[scheduling]
+    [[graph]]
+        R1 = foo
+__SUITERC__
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}" --debug
+grep_ok 'Hello World!' "${TEST_NAME}.stderr"  # debug lines go to stderr
+
+exit


### PR DESCRIPTION
Test associated with https://github.com/cylc/cylc-doc/pull/102.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/102.
