### PR TITLE
tests: fix hold-release/13

### DIFF
--- a/flakytests/hold-release/13-ready-restart/suite.rc
+++ b/flakytests/hold-release/13-ready-restart/suite.rc
@@ -29,8 +29,11 @@ bar
 
             # Kill the suite (cylc stop --now --now also kills the foo-1 job submit process
             # and may result in foo-1 going to the submit-failed state instead of ready).
-            SUITE_PROC=$(cylc get-suite-contact $CYLC_SUITE_NAME | grep PROCESS)
-            SUITE_PID=$(expr "$SUITE_PROC" : '.*=\([0-9].*\) python.*')
+            SUITE_PID="$(
+                cylc get-suite-contact "${CYLC_SUITE_NAME}" \
+                | sed -n 's/CYLC_SUITE_PROCESS=\([0-9]*\).*/\1/p'
+            )"
+
             kill -9 $SUITE_PID
 
             # Let the old job submit process finish.


### PR DESCRIPTION
Fixes `flakytests/hold-release/13` on `sgaist/move_to_entry_points` (#3413)

I think this test failure is due to the way cylc commands get re-executed causing a different process signature which jiggered up the pattern matching employed.

`sed` is a better solution.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
