### PR TITLE
job platforms: Forward lookup

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -167,3 +167,8 @@ class CylcMissingContextPointError(CyclingError):
 
 class CylcMissingFinalCyclePointError(CyclingError):
     """An error denoting a missing (but required) final cycle point."""
+
+
+class PlatformLookupError(CylcConfigError):
+    """Unable to determine the correct job platform from the information
+    given"""

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -17,6 +17,7 @@
 # Tests for the platform lookup.
 
 import re
+from cylc.flow.exceptions import PlatformLookupError
 
 def forward_lookup(task_platform, platforms):
     """
@@ -36,8 +37,7 @@ def forward_lookup(task_platform, platforms):
     Examples:
         Mel - write some doctests here...
     """
-    platform = "to be implemented"
-    return platform
+    raise NotImplementedError
 
 
 def reverse_lookup(task_job, task_remote, platforms):
@@ -61,5 +61,4 @@ def reverse_lookup(task_job, task_remote, platforms):
         Tim - write some doctests here...
 
     """
-    platform = "to be implemented"
-    return platform
+    raise NotImplementedError

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -41,29 +41,29 @@ def forward_lookup(platforms, task_platform):
 
     Example:
     Example Input:
-    platforms = {
-            'suite server platform': None,
-            'desktop[0-9][0-9]|laptop[0-9][0-9]': None,
-            'sugar': {
-                'login hosts': 'localhost',
-                'batch system': 'slurm'
-            },
-            'hpc': {
-                'login hosts': ['hpc1', 'hpc2'],
-                'batch system': 'pbs'
-            },
-            'hpc1-bg': {
-                'login hosts': 'hpc1',
-                'batch system': 'background'
-            },
-            'hpc2-bg': {
-                'login hosts': 'hpc2',
-                'batch system': 'background'
-            }
-        }
-    task_platform = desktop22
-
-    Example Output: desktop22
+    >>> platforms = {
+    ...     'suite server platform': None,
+    ...     'desktop[0-9][0-9]|laptop[0-9][0-9]': None,
+    ...     'sugar': {
+    ...         'login hosts': 'localhost',
+    ...         'batch system': 'slurm'
+    ...     },
+    ...     'hpc': {
+    ...         'login hosts': ['hpc1', 'hpc2'],
+    ...         'batch system': 'pbs'
+    ...     },
+    ...     'hpc1-bg': {
+    ...         'login hosts': 'hpc1',
+    ...         'batch system': 'background'
+    ...     },
+    ...     'hpc2-bg': {
+    ...         'login hosts': 'hpc2',
+    ...         'batch system': 'background'
+    ...     }
+    ... }
+    >>> task_platform = 'desktop22'
+    >>> forward_lookup(platforms, task_platform)
+    'desktop22'
     """
     if task_platform is None:
         return 'localhost'

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -19,25 +19,62 @@
 import re
 from cylc.flow.exceptions import PlatformLookupError
 
-def forward_lookup(task_platform, platforms):
+
+def forward_lookup(platforms, task_platform):
     """
     Find out which job platform to use given a list of possible platforms and
     a task platform string.
 
+    Verifies selected platform is present in global.rc file and returns it,
+    raises error if platfrom is not in global.rc or returns 'localhost' if
+    no platform is initally selected.
+
     Args:
         task_platform (str):
             platform item from config [runtime][TASK][platform]
-        platforms (list):
+        platforms (dictionary):
             list of possible platforms defined by global.rc
 
     Returns:
         platform (str):
             string representing a platform from the global config.
 
-    Examples:
-        Mel - write some doctests here...
+    Example:
+    Example Input:
+    platforms = {
+            'suite server platform': None,
+            'desktop[0-9][0-9]|laptop[0-9][0-9]': None,
+            'sugar': {
+                'login hosts': 'localhost',
+                'batch system': 'slurm'
+            },
+            'hpc': {
+                'login hosts': ['hpc1', 'hpc2'],
+                'batch system': 'pbs'
+            },
+            'hpc1-bg': {
+                'login hosts': 'hpc1',
+                'batch system': 'background'
+            },
+            'hpc2-bg': {
+                'login hosts': 'hpc2',
+                'batch system': 'background'
+            }
+        }
+    task_platform = desktop22
+
+    Example Output: desktop22
     """
-    raise NotImplementedError
+    if task_platform is None:
+        return 'localhost'
+    platforms = list(platforms.keys())
+    reversed_platforms = platforms[::-1]
+    for platform in reversed_platforms:
+        if re.fullmatch(platform, task_platform):
+            return task_platform
+
+    raise PlatformLookupError(
+        f"No matching platform \"{task_platform}\" found")
 
 
 def reverse_lookup(task_job, task_remote, platforms):

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -20,7 +20,7 @@ import re
 from cylc.flow.exceptions import PlatformLookupError
 
 
-def forward_lookup(platforms, task_platform):
+def forward_lookup(platforms, job_platform):
     """
     Find out which job platform to use given a list of possible platforms and
     a task platform string.
@@ -30,8 +30,8 @@ def forward_lookup(platforms, task_platform):
     no platform is initally selected.
 
     Args:
-        task_platform (str):
-            platform item from config [runtime][TASK][platform]
+        job_platform (str):
+            platform item from config [runtime][TASK]platform
         platforms (dictionary):
             list of possible platforms defined by global.rc
 
@@ -40,7 +40,6 @@ def forward_lookup(platforms, task_platform):
             string representing a platform from the global config.
 
     Example:
-    Example Input:
     >>> platforms = {
     ...     'suite server platform': None,
     ...     'desktop[0-9][0-9]|laptop[0-9][0-9]': None,
@@ -61,20 +60,18 @@ def forward_lookup(platforms, task_platform):
     ...         'batch system': 'background'
     ...     }
     ... }
-    >>> task_platform = 'desktop22'
-    >>> forward_lookup(platforms, task_platform)
+    >>> job_platform = 'desktop22'
+    >>> forward_lookup(platforms, job_platform)
     'desktop22'
     """
-    if task_platform is None:
+    if job_platform is None:
         return 'localhost'
-    platforms = list(platforms.keys())
-    reversed_platforms = platforms[::-1]
-    for platform in reversed_platforms:
-        if re.fullmatch(platform, task_platform):
-            return task_platform
+    for platform in reversed(list(platforms)):
+        if re.fullmatch(platform, job_platform):
+            return job_platform
 
     raise PlatformLookupError(
-        f"No matching platform \"{task_platform}\" found")
+        f"No matching platform \"{job_platform}\" found")
 
 
 def reverse_lookup(task_job, task_remote, platforms):

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -1,0 +1,65 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Tests for the platform lookup.
+
+import re
+
+def forward_lookup(task_platform, platforms):
+    """
+    Find out which job platform to use given a list of possible platforms and
+    a task platform string.
+
+    Args:
+        task_platform (str):
+            platform item from config [runtime][TASK][platform]
+        platforms (list):
+            list of possible platforms defined by global.rc
+
+    Returns:
+        platform (str):
+            string representing a platform from the global config.
+
+    Examples:
+        Mel - write some doctests here...
+    """
+    platform = "to be implemented"
+    return platform
+
+
+def reverse_lookup(task_job, task_remote, platforms):
+    """
+    Find out which job platform to use given a list of possible platforms
+    and the task dictionary with cylc 7 definitions in it.
+
+    Args:
+        task_job (dict):
+            Suite config [runtime][TASK][job] section
+        task_remote (dict):
+            Suite config [runtime][TASK][remote] section
+        platforms (dict):
+            Dictionary containing platfrom definitions.
+
+    Returns:
+        platfrom (str):
+            string representing a platform from the global config.
+
+    Examples:
+        Tim - write some doctests here...
+
+    """
+    platform = "to be implemented"
+    return platform

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -16,7 +16,9 @@
 #
 # Tests for the platform lookup.
 
+import pytest
 from cylc.flow.platform_lookup import forward_lookup, reverse_lookup
+from cylc.flow.exceptions import PlatformLookupError
 
 # The platforms list for testing is set as a constant
 # [platforms]
@@ -39,23 +41,41 @@ from cylc.flow.platform_lookup import forward_lookup, reverse_lookup
 #         retrieve job logs = True
 #         batch system = background
 PLATFORMS = {
+    'suite server platform': None,
     'desktop\d\d|laptop\d\d': None,
     'sugar': {
-        'hosts': 'localhost',
+        'login hosts': 'localhost',
         'batch system': 'slurm',
     },
     'hpc': {
-        'hosts': ['hpc1', 'hpc2'],
+        'login hosts': ['hpc1', 'hpc2'],
         'batch system': 'pbs',
     },
     'hpc1-bg': {
-        'hosts': 'hpc1',
+        'login hosts': 'hpc1',
         'batch system': 'background',
     },
     'hpc2-bg': {
-        'hosts': 'hpc2',
+        'login hosts': 'hpc2',
         'batch system': 'background'
     }
+}
+
+PLATFORMS_NO_UNIQUE = {
+    'sugar': {
+        'login hosts': 'localhost',
+        'batch system': 'slurm',
+    },
+    'pepper': {
+        'login hosts': ['hpc1', 'hpc2'],
+        'batch system': 'slurm',
+    },
+
+}
+
+
+PLATFORMS_WITH_RE = {
+    # Mel - make up some amusing platforms doing wierd stuff with regexes
 }
 
 
@@ -67,10 +87,7 @@ class TestForwardLookup():
         assert 1 == 1
 
 
-class TestReversLookup():
+class TestReverseLookup():
     """
     Tests to ensure that job platform reverse lookup works as intended.
     """
-
-    def test_basic(self):
-        assert 'Hello' == 'Hello'

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -18,6 +18,46 @@
 
 from cylc.flow.platform_lookup import forward_lookup, reverse_lookup
 
+# The platforms list for testing is set as a constant
+# [platforms]
+#     [[desktop\d\d|laptop\d\d]]
+#         # hosts = platform name (default)
+#         # Note: "desktop01" and "desktop02" are both valid and distinct platforms
+#     [[sugar]]
+#         hosts = localhost
+#         batch system = slurm
+#     [[hpc]]
+#         hosts = hpcl1, hpcl2
+#         retrieve job logs = True
+#         batch system = pbs
+#     [[hpcl1-bg]]
+#         hosts = hpcl1
+#         retrieve job logs = True
+#         batch system = background
+#     [[hpcl2-bg]]
+#         hosts = hpcl2
+#         retrieve job logs = True
+#         batch system = background
+PLATFORMS = {
+    'desktop\d\d|laptop\d\d': None,
+    'sugar': {
+        'hosts': 'localhost',
+        'batch system': 'slurm',
+    },
+    'hpc': {
+        'hosts': ['hpc1', 'hpc2'],
+        'batch system': 'pbs',
+    },
+    'hpc1-bg': {
+        'hosts': 'hpc1',
+        'batch system': 'background',
+    },
+    'hpc2-bg': {
+        'hosts': 'hpc2',
+        'batch system': 'background'
+    }
+}
+
 
 class TestForwardLookup():
     """
@@ -31,5 +71,6 @@ class TestReversLookup():
     """
     Tests to ensure that job platform reverse lookup works as intended.
     """
+
     def test_basic(self):
         assert 'Hello' == 'Hello'

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -1,0 +1,35 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Tests for the platform lookup.
+
+from cylc.flow.platform_lookup import forward_lookup, reverse_lookup
+
+
+class TestForwardLookup():
+    """
+    Tests to ensure that the job platform forward lookup works as intended.
+    """
+    def test_basic(self):
+        assert 1 == 1
+
+
+class TestReversLookup():
+    """
+    Tests to ensure that job platform reverse lookup works as intended.
+    """
+    def test_basic(self):
+        assert 'Hello' == 'Hello'

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -20,28 +20,6 @@ import pytest
 from cylc.flow.platform_lookup import forward_lookup, reverse_lookup
 from cylc.flow.exceptions import PlatformLookupError
 
-# The platforms list for testing is set as a constant
-# [platforms]
-#     [[desktop\d\d|laptop\d\d]]
-#         # hosts = platform name (default)
-#         # Note: "desktop01" and "desktop02" are both valid and distinct
-#                  platforms
-#     [[sugar]]
-#         hosts = localhost
-#         batch system = slurm
-#     [[hpc]]
-#         hosts = hpcl1, hpcl2
-#         retrieve job logs = True
-#         batch system = pbs
-#     [[hpcl1-bg]]
-#         hosts = hpcl1
-#         retrieve job logs = True
-#         batch system = background
-#     [[hpcl2-bg]]
-#         hosts = hpcl2
-#         retrieve job logs = True
-#         batch system = background
-
 PLATFORMS_STANDARD = {
     'suite server platform': None,
     'desktop[0-9][0-9]|laptop[0-9][0-9]': None,

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -78,7 +78,7 @@ PLATFORMS_NO_UNIQUE = {
 PLATFORMS_WITH_RE = {
     'hpc.*': {'login hosts': 'hpc1', 'batch system': 'background'},
     'h.*': {'login hosts': 'hpc3'},
-    r'vld\d{3}|vld\d{2}': None,
+    r'vld\d{2,3}': None,
     'nu.*': {'batch system': 'slurm'}
 }
 


### PR DESCRIPTION
Added forward lookup method 
- checks if specified platform (will come from suite.rc file) is a valid platfrom (listed in global.rc file). 
- checks in reverse order to ensure user platform selection overrides global setting. 
- If no platform is selected by user, defaults to 'localhost'.
- If platform not found in list, returns a Platform error.
 
Tests added to ensure working as required.
These changes relate to Platform support #3453

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required as yet.
