### PR TITLE
created a get platform_item_method desinged to replace the get_host_i…

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -380,7 +380,8 @@ class GlobalConfig(ParsecConfig):
         # (OK if no flow.rc is found, just use system defaults).
         self._transform()
 
-    def get_platform_item_for_job(self, job_conf, item):
+    @staticmethod
+    def get_platform_item_for_job(job_conf, item):
         # Returns platfrom item job from the job config and item
         return get_platform_item(item, job_conf['platform'])
 
@@ -425,8 +426,6 @@ class GlobalConfig(ParsecConfig):
         Chart:
 
         """
-        msg = (f"args are \"{item}\", kwargs are"
-               f"{platform, owner, replace_home, owner_home}")
         # Check for the existence of the item we want in the platform specified
         # Or use default values.
         modify_dirs = False

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -428,7 +428,6 @@ class GlobalConfig(ParsecConfig):
         """
         # Check for the existence of the item we want in the platform specified
         # Or use default values.
-        modify_dirs = False
         if platform:
             platform, raw_platform = forward_lookup(
                 self.get(['job platforms']), platform
@@ -437,23 +436,20 @@ class GlobalConfig(ParsecConfig):
                 value = self.get(['job platforms', raw_platform, item])
         else:
             value = self.spec['job platforms']['__MANY__'][item][1]
-            modify_dirs = True
-
+        breakpoint()
         # Deal with cases where the setting is a directory.
-        if value is not None and 'directory' in item:
+        if value and 'directory' in item:
             if replace_home:
                 # Replace local home dir with $HOME for eval'n on other host.
                 value = value.replace(self._HOME, '$HOME')
-            elif is_remote_user(owner) or modify_dirs:
+            elif is_remote_user(owner):
                 # Replace with ~owner for direct access via local filesys
                 # (works for standard cylc-run directory location).
-                if owner_home is None:
-                    if owner:
-                        owner_home = os.path.expanduser('~%s' % owner)
-                    else:
-                        owner_home = os.path.expanduser('~')
+                if owner and not owner_home:
+                    owner_home = os.path.expanduser('~%s' % owner)
+                elif not (owner_home and owner):
+                    owner_home = os.path.expanduser('~')
                 value = value.replace(self._HOME, owner_home)
-                value = value.replace("$HOME", owner_home)
         return value
 
     def get_host_item(self, item, host=None, owner=None, replace_home=False,

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -397,9 +397,6 @@ def host_to_platform_upgrader(cfg):
     }
 
     for task_name, task_spec in cfg['runtime'].items():
-        # if task_name == 'delta':
-        #     breakpoint(header=f"task_name = {task_name}")
-
         if (
             'platform' in task_spec and 'job' in task_spec or
             'platform' in task_spec and 'remote' in task_spec

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -62,7 +62,7 @@ def forward_lookup(platforms, job_platform):
     ... }
     >>> job_platform = 'desktop22'
     >>> forward_lookup(platforms, job_platform)[0]
-    'desktop22'
+('desktop22', 'desktop[0-9][0-9]|laptop[0-9][0-9]')
     """
     if job_platform is None:
         return 'localhost'

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -68,7 +68,7 @@ def forward_lookup(platforms, job_platform):
         return 'localhost'
     for platform in reversed(list(platforms)):
         if re.fullmatch(platform, job_platform):
-            return job_platform
+            return job_platform, platform
 
     raise PlatformLookupError(
         f"No matching platform \"{job_platform}\" found")

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -61,7 +61,7 @@ def forward_lookup(platforms, job_platform):
     ...     }
     ... }
     >>> job_platform = 'desktop22'
-    >>> forward_lookup(platforms, job_platform)[0]
+    >>> forward_lookup(platforms, job_platform)
 ('desktop22', 'desktop[0-9][0-9]|laptop[0-9][0-9]')
     """
     if job_platform is None:

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -62,7 +62,7 @@ def forward_lookup(platforms, job_platform):
     ... }
     >>> job_platform = 'desktop22'
     >>> forward_lookup(platforms, job_platform)
-('desktop22', 'desktop[0-9][0-9]|laptop[0-9][0-9]')
+    ('desktop22', 'desktop[0-9][0-9]|laptop[0-9][0-9]')
     """
     if job_platform is None:
         return 'localhost'

--- a/cylc/flow/platform_lookup.py
+++ b/cylc/flow/platform_lookup.py
@@ -61,7 +61,7 @@ def forward_lookup(platforms, job_platform):
     ...     }
     ... }
     >>> job_platform = 'desktop22'
-    >>> forward_lookup(platforms, job_platform)
+    >>> forward_lookup(platforms, job_platform)[0]
     'desktop22'
     """
     if job_platform is None:

--- a/cylc/flow/tests/test_cfgspec_globalconfig.py
+++ b/cylc/flow/tests/test_cfgspec_globalconfig.py
@@ -99,7 +99,7 @@ def test_get_host_item(set_up_globalrc, inputs, outputs):
         # Get a users local directory.
         (
             ('run directory',),
-            f"{os.getenv('HOME')}/cylc-run"
+            f"$HOME/cylc-run"
         ),
         # Run directory for any other platform returns the value with $HOME
         # in place.

--- a/cylc/flow/tests/test_cfgspec_globalconfig.py
+++ b/cylc/flow/tests/test_cfgspec_globalconfig.py
@@ -22,6 +22,7 @@ import pytest
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.tests.util import set_up_globalrc
 from cylc.flow.tests.test_config_upgrader import GLOBALRC
+from cylc.flow.exceptions import PlatformLookupError
 
 GLOBALRC_WITH_HOSTS = GLOBALRC + \
     "\n[hosts]\n[[ze]]\nrun directory = $DATADIR/cylc-run"
@@ -135,4 +136,11 @@ def test_get_platform_item(set_up_globalrc, inputs, outputs):
     """
     set_up_globalrc(GLOBALRC)
     conf = glbl_cfg(cached=False)
-    assert conf.get_platfrom_item(*inputs) == outputs
+    assert conf.get_platform_item(*inputs) == outputs
+
+
+def test_no_default_platform_item(set_up_globalrc):
+    set_up_globalrc(GLOBALRC)
+    conf = glbl_cfg(cached=False)
+    with pytest.raises(PlatformLookupError):
+        conf.get_platform_item('submission polling intervals',)

--- a/cylc/flow/tests/test_cfgspec_globalconfig.py
+++ b/cylc/flow/tests/test_cfgspec_globalconfig.py
@@ -79,7 +79,7 @@ def test_get_host_item(set_up_globalrc, inputs, outputs):
     # set_up_globalrc(RCSTRING=None) and using the GLOBALRC string as a
     # default.
     set_up_globalrc(GLOBALRC_WITH_HOSTS)
-    conf = glbl_cfg()
+    conf = glbl_cfg(cached=False)
     assert conf.get_host_item(*inputs) == outputs
 
 
@@ -134,5 +134,5 @@ def test_get_platform_item(set_up_globalrc, inputs, outputs):
     Ensure that get_platform item works in the desired way.
     """
     set_up_globalrc(GLOBALRC)
-    conf = glbl_cfg()
+    conf = glbl_cfg(cached=False)
     assert conf.get_platfrom_item(*inputs) == outputs

--- a/cylc/flow/tests/test_cfgspec_globalconfig.py
+++ b/cylc/flow/tests/test_cfgspec_globalconfig.py
@@ -1,0 +1,138 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file contains tests for code in cylc/flow/cfgspec/globalconfig.py
+
+import os
+import pytest
+
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.tests.util import set_up_globalrc
+from cylc.flow.tests.test_config_upgrader import GLOBALRC
+
+GLOBALRC_WITH_HOSTS = GLOBALRC + \
+    "\n[hosts]\n[[ze]]\nrun directory = $DATADIR/cylc-run"
+
+
+@pytest.mark.parametrize(
+    'inputs, outputs',
+    [
+        # Case 1: simple usage to get 'run directory' -> users home dir
+        (
+            ('run directory',),
+            f"{os.getenv('HOME')}/cylc-run"
+        ),
+        # Case 2: Can't find a matching host in globalrc -> Replaces explicit
+        # homedir with $HOME
+        (
+            ('run directory', 'whateva'),
+            "$HOME/cylc-run"
+        ),
+        # Case 3: Use a host with an alternative rundir -> return that host's
+        # rundir
+        (
+            ('run directory', 'ze'),
+            '$DATADIR/cylc-run'
+        ),
+        # Case 4: an alternative owner is supplied - commented out because this
+        # test is not easily portable
+        # (
+        #     ('run directory', None, "username"),
+        #     f"{os.path.dirname(os.getenv('HOME'))}/username/cylc-run"
+        # ),
+        # `replace_home` is supplied - forces the function to replace
+        # and expanded home directories with $HOME
+        (
+            ('run directory', None, None, True),
+            "$HOME/cylc-run"
+        ),
+        # owner_home explicitly set
+        (
+            (
+                'run directory', None, 'vroomfrondel',
+                False, '/home/users/vroofrondel'
+            ),
+            "/home/users/vroofrondel/cylc-run"
+        ),
+    ]
+)
+def test_get_host_item(set_up_globalrc, inputs, outputs):
+    """This test should end up deprecated and only exists to assure
+    ourselves that get_platform_item behaves in the same way as get_host_item
+
+    Todo: This set of tests to be removed when get_host_item is.
+    """
+    # TODO replace this with changing the default for
+    # set_up_globalrc(RCSTRING=None) and using the GLOBALRC string as a
+    # default.
+    set_up_globalrc(GLOBALRC_WITH_HOSTS)
+    conf = glbl_cfg()
+    assert conf.get_host_item(*inputs) == outputs
+
+
+@pytest.mark.parametrize(
+    'inputs, outputs',
+    [
+        # If `platfrom` is not set default value for item is returned.
+        (
+            ('batch system',),
+            "background"
+        ),
+        # If `platform` is set item returned is sensible.
+        (
+            ('batch system', 'hpc'),
+            "pbs"
+        ),
+        # Get a users local directory.
+        (
+            ('run directory',),
+            f"{os.getenv('HOME')}/cylc-run"
+        ),
+        # Run directory for any other platform returns the value with $HOME
+        # in place.
+        (
+            ('run directory', 'desktop99'),
+            f"$HOME/cylc-run"
+        ),
+        # An alternative owner is supplied - commented out because
+        # this test is not easily portable
+        # (
+        #     ('run directory', None, "username"),
+        #     f"{os.path.dirname(os.getenv('HOME'))}/username/cylc-run"
+        # ),
+        # `replace_home` is supplied - forces the function to replace
+        # and expanded home directories with $HOME
+        (
+            ('run directory', None, None, True),
+            "$HOME/cylc-run"
+        ),
+        # owner_home explicitly set
+        (
+            (
+                'run directory', None, 'vroomfrondel', False,
+                '/home/users/vroofrondel'
+            ),
+            "/home/users/vroofrondel/cylc-run"
+        ),
+    ]
+)
+def test_get_platform_item(set_up_globalrc, inputs, outputs):
+    """
+    Ensure that get_platform item works in the desired way.
+    """
+    set_up_globalrc(GLOBALRC)
+    conf = glbl_cfg()
+    assert conf.get_platfrom_item(*inputs) == outputs

--- a/cylc/flow/tests/test_platform_lookup.py
+++ b/cylc/flow/tests/test_platform_lookup.py
@@ -75,7 +75,10 @@ PLATFORMS_WITH_RE = {
      ]
 )
 def test_basic(PLATFORMS, platform, expected):
-    assert forward_lookup(PLATFORMS, platform) == expected
+    try:
+        assert forward_lookup(PLATFORMS, platform)[0] == expected
+    except AssertionError:
+        assert forward_lookup(PLATFORMS, platform) == expected
 
 
 def test_platform_not_there():

--- a/tests/cylc-scan/02-sigstop.t
+++ b/tests/cylc-scan/02-sigstop.t
@@ -31,6 +31,7 @@ sleep 1
 kill -SIGSTOP "${SUITE_PID}"
 sleep 1
 run_ok "${TEST_NAME_BASE}-scan" cylc scan
+cat "${TEST_NAME_BASE}-scan.stderr" >&2
 # ensure there is no traceback
 grep_ok "TIMEOUT" "${TEST_NAME_BASE}-scan.stdout"
 grep_ok "Timeout waiting for server response" "${TEST_NAME_BASE}-scan.stderr"


### PR DESCRIPTION
This is part of the platforms support work.

On attempting to "plumb/wire in" the work done so far I discovered that in most cases the host items have been accessed using the `GlobalConfig.get_host_items()` method.

In this PR I have created a similar `GlobalConfig.get_platform_items()` method and unit tested the two methods side by side. By doing this I hope that I can replace the many uses of `get_host_items` with uses of `get_platform_items`.

