### PR TITLE
suppress traceback for scheduler error

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1767,7 +1767,6 @@ see `COPYING' in the Cylc source distribution.
         if isinstance(reason, SchedulerStop):
             LOG.info('Suite shutting down - %s', reason.args[0])
         elif isinstance(reason, SchedulerError):
-            LOG.exception(reason)
             LOG.error('Suite shutting down - %s', reason)
         else:
             LOG.exception(reason)


### PR DESCRIPTION
Follow-up on comment from @wxtim on Riot.

> Should the exception at cylc/flow/scheduler.py:1700 leave traceback in the log? It looks like this is an inevitable and, presumably, accepted consquence of the way this is written?

@wxtim yes I think you're right, printing traceback isn't particularly helpful as there is nothing to be gained from the stack trace (we already know where the error came from) and it kinda makes it look like something went wrong with Cylc itself.

The `SchedulerError` class, despite its name, is actually used to implement user-defined shutdown behaviour for fail case scenarios.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
