### PR TITLE
Data store memory leak fixes

### DIFF
--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -121,7 +121,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
         self.endpoints = None
         self.queue = None
         self.resolvers = Resolvers(
-            self.schd.ws_data_mgr.data,
+            self.schd.data_store_mgr.data,
             schd=self.schd)
 
     def _socket_options(self):
@@ -1223,7 +1223,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
                 Serialised Protobuf message
 
         """
-        pb_msg = self.schd.ws_data_mgr.get_entire_workflow()
+        pb_msg = self.schd.data_store_mgr.get_entire_workflow()
         return pb_msg.SerializeToString()
 
     @authorise(Priv.READ)
@@ -1240,5 +1240,5 @@ class SuiteRuntimeServer(ZMQSocketBase):
                 Serialised Protobuf message
 
         """
-        pb_msg = self.schd.ws_data_mgr.get_data_elements(element_type)
+        pb_msg = self.schd.data_store_mgr.get_data_elements(element_type)
         return pb_msg.SerializeToString()

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -206,7 +206,7 @@ class Scheduler(object):
         self.command_queue = None
         self.message_queue = None
         self.ext_trigger_queue = None
-        self.ws_data_mgr = None
+        self.data_store_mgr = None
         self.job_pool = None
 
         self._profile_amounts = {}
@@ -257,7 +257,7 @@ class Scheduler(object):
             if not self.options.no_detach:
                 daemonize(self)
             self._setup_suite_logger()
-            self.ws_data_mgr = DataStoreMgr(self)
+            self.data_store_mgr = DataStoreMgr(self)
 
             # *** Network Related ***
             # TODO: this in zmq asyncio context?
@@ -1563,8 +1563,8 @@ see `COPYING' in the Cylc source distribution.
     def run(self):
         """Main loop."""
         self.initialise_scheduler()
-        self.ws_data_mgr.initiate_data_model()
-        self.publisher.publish(self.ws_data_mgr.get_publish_deltas())
+        self.data_store_mgr.initiate_data_model()
+        self.publisher.publish(self.data_store_mgr.get_publish_deltas())
         while True:  # MAIN LOOP
             tinit = time()
             has_reloaded = False
@@ -1593,9 +1593,9 @@ see `COPYING' in the Cylc source distribution.
 
             # Re-initialise data model on reload
             if has_reloaded:
-                self.ws_data_mgr.initiate_data_model(reloaded=True)
+                self.data_store_mgr.initiate_data_model(reloaded=True)
                 self.publisher.publish(
-                    self.ws_data_mgr.get_publish_deltas())
+                    self.data_store_mgr.get_publish_deltas())
             # Update state summary, database, and uifeed
             self.suite_db_mgr.put_task_event_timers(self.task_events_mgr)
             has_updated = self.update_data_structure()
@@ -1646,10 +1646,10 @@ see `COPYING' in the Cylc source distribution.
             self.pool.get_pool_change_tasks())
         if has_updated:
             # WServer incremental data store update
-            self.ws_data_mgr.update_data_structure(updated_nodes)
+            self.data_store_mgr.update_data_structure(updated_nodes)
             # Publish updates:
             self.publisher.publish(
-                self.ws_data_mgr.get_publish_deltas())
+                self.data_store_mgr.get_publish_deltas())
             # TODO: deprecate after CLI GraphQL migration
             self.state_summary_mgr.update(self)
             # Database update

--- a/cylc/flow/tests/network/test_client.py
+++ b/cylc/flow/tests/network/test_client.py
@@ -64,7 +64,7 @@ class TestSuiteRuntimeClient(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestSuiteRuntimeClient, self).setUp()
-        self.scheduler.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.scheduler.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -78,8 +78,8 @@ class TestSuiteRuntimeClient(CylcWorkflowTestCase):
             )
             assert warnings == 0
         self.task_pool.release_runahead_tasks()
-        self.scheduler.ws_data_mgr.initiate_data_model()
-        self.workflow_id = self.scheduler.ws_data_mgr.workflow_id
+        self.scheduler.data_store_mgr.initiate_data_model()
+        self.workflow_id = self.scheduler.data_store_mgr.workflow_id
         create_auth_files(self.suite_name)  # auth keys are required for comms
         barrier = Barrier(2, timeout=20)
         self.server = SuiteRuntimeServer(

--- a/cylc/flow/tests/network/test_publisher.py
+++ b/cylc/flow/tests/network/test_publisher.py
@@ -66,7 +66,7 @@ class TestWorkflowPublisher(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestWorkflowPublisher, self).setUp()
-        self.scheduler.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.scheduler.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -80,11 +80,11 @@ class TestWorkflowPublisher(CylcWorkflowTestCase):
             )
             assert 0 == warnings
         self.task_pool.release_runahead_tasks()
-        self.scheduler.ws_data_mgr.initiate_data_model()
-        self.workflow_id = self.scheduler.ws_data_mgr.workflow_id
+        self.scheduler.data_store_mgr.initiate_data_model()
+        self.workflow_id = self.scheduler.data_store_mgr.workflow_id
         self.publisher = WorkflowPublisher(
             self.suite_name, threaded=False, daemon=True)
-        self.pub_data = self.scheduler.ws_data_mgr.get_publish_deltas()
+        self.pub_data = self.scheduler.data_store_mgr.get_publish_deltas()
 
     def tearDown(self):
         self.publisher.stop()

--- a/cylc/flow/tests/network/test_resolvers.py
+++ b/cylc/flow/tests/network/test_resolvers.py
@@ -109,7 +109,7 @@ class TestResolvers(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestResolvers, self).setUp()
-        self.scheduler.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.scheduler.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -123,9 +123,9 @@ class TestResolvers(CylcWorkflowTestCase):
             )
             assert 0 == warnings
         self.task_pool.release_runahead_tasks()
-        self.scheduler.ws_data_mgr.initiate_data_model()
-        self.workflow_id = self.scheduler.ws_data_mgr.workflow_id
-        self.data = self.scheduler.ws_data_mgr.data[self.workflow_id]
+        self.scheduler.data_store_mgr.initiate_data_model()
+        self.workflow_id = self.scheduler.data_store_mgr.workflow_id
+        self.data = self.scheduler.data_store_mgr.data[self.workflow_id]
         self.node_ids = [
             node.id
             for node in self.data[TASK_PROXIES].values()]
@@ -133,7 +133,7 @@ class TestResolvers(CylcWorkflowTestCase):
             edge.id
             for edge in self.data[EDGES].values()]
         self.resolvers = Resolvers(
-            self.scheduler.ws_data_mgr.data,
+            self.scheduler.data_store_mgr.data,
             schd=self.scheduler)
 
     def test_constructor(self):

--- a/cylc/flow/tests/network/test_server.py
+++ b/cylc/flow/tests/network/test_server.py
@@ -65,7 +65,7 @@ class TestSuiteRuntimeServer(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestSuiteRuntimeServer, self).setUp()
-        self.scheduler.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.scheduler.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -79,8 +79,8 @@ class TestSuiteRuntimeServer(CylcWorkflowTestCase):
             )
             assert 0 == warnings
         self.task_pool.release_runahead_tasks()
-        self.scheduler.ws_data_mgr.initiate_data_model()
-        self.workflow_id = self.scheduler.ws_data_mgr.workflow_id
+        self.scheduler.data_store_mgr.initiate_data_model()
+        self.workflow_id = self.scheduler.data_store_mgr.workflow_id
         create_auth_files(self.suite_name)  # auth keys are required for comms
         barrier = Barrier(2, timeout=10)
         self.server = SuiteRuntimeServer(

--- a/cylc/flow/tests/network/test_subscriber.py
+++ b/cylc/flow/tests/network/test_subscriber.py
@@ -71,7 +71,7 @@ class TestWorkflowSubscriber(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestWorkflowSubscriber, self).setUp()
-        self.scheduler.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.scheduler.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -85,8 +85,8 @@ class TestWorkflowSubscriber(CylcWorkflowTestCase):
             )
             assert warnings == 0
         self.task_pool.release_runahead_tasks()
-        self.scheduler.ws_data_mgr.initiate_data_model()
-        self.workflow_id = self.scheduler.ws_data_mgr.workflow_id
+        self.scheduler.data_store_mgr.initiate_data_model()
+        self.workflow_id = self.scheduler.data_store_mgr.workflow_id
         self.publisher = WorkflowPublisher(
             self.suite_name, threaded=False, daemon=True)
         self.publisher.start(*PORT_RANGE)
@@ -112,7 +112,7 @@ class TestWorkflowSubscriber(CylcWorkflowTestCase):
 
     def test_subscribe(self):
         """Test publishing data."""
-        pub_data = self.scheduler.ws_data_mgr.get_publish_deltas()
+        pub_data = self.scheduler.data_store_mgr.get_publish_deltas()
         self.publisher.publish(pub_data)
 
         def msg_process(btopic, msg):

--- a/cylc/flow/tests/test_data_store_mgr.py
+++ b/cylc/flow/tests/test_data_store_mgr.py
@@ -59,7 +59,7 @@ class TestDataStoreMgr(CylcWorkflowTestCase):
 
     def setUp(self) -> None:
         super(TestDataStoreMgr, self).setUp()
-        self.ws_data_mgr = DataStoreMgr(self.scheduler)
+        self.data_store_mgr = DataStoreMgr(self.scheduler)
         for name in self.scheduler.config.taskdefs:
             task_proxy = create_task_proxy(
                 task_name=name,
@@ -73,97 +73,97 @@ class TestDataStoreMgr(CylcWorkflowTestCase):
             )
             assert 0 == warnings
         self.task_pool.release_runahead_tasks()
-        self.data = self.ws_data_mgr.data[self.ws_data_mgr.workflow_id]
+        self.data = self.data_store_mgr.data[self.data_store_mgr.workflow_id]
 
     def test_constructor(self):
         self.assertEqual(
             f'{self.owner}{ID_DELIM}{self.suite_name}',
-            self.ws_data_mgr.workflow_id
+            self.data_store_mgr.workflow_id
         )
-        self.assertFalse(self.ws_data_mgr.pool_points)
+        self.assertFalse(self.data_store_mgr.pool_points)
 
     def test_generate_definition_elements(self):
         """Test method that generates all definition elements."""
         task_defs = self.scheduler.config.taskdefs.keys()
         self.assertEqual(0, len(self.data[TASKS]))
-        self.ws_data_mgr.generate_definition_elements()
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.generate_definition_elements()
+        self.data_store_mgr.apply_deltas()
         self.assertEqual(len(task_defs), len(self.data[TASKS]))
 
     def test_generate_graph_elements(self):
         """Test method that generates edge and ghost node elements
         by cycle point."""
-        self.ws_data_mgr.generate_definition_elements()
-        self.ws_data_mgr.apply_deltas()
-        self.ws_data_mgr.pool_points = set(list(self.scheduler.pool.pool))
+        self.data_store_mgr.generate_definition_elements()
+        self.data_store_mgr.apply_deltas()
+        self.data_store_mgr.pool_points = set(list(self.scheduler.pool.pool))
         tasks_proxies_generated = self.data[TASK_PROXIES]
         self.assertEqual(0, len(tasks_proxies_generated))
-        self.ws_data_mgr.clear_deltas()
-        self.ws_data_mgr.generate_graph_elements()
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.clear_deltas()
+        self.data_store_mgr.generate_graph_elements()
+        self.data_store_mgr.apply_deltas()
         self.assertEqual(3, len(tasks_proxies_generated))
 
     def test_get_data_elements(self):
         """Test method that returns data elements by specified type."""
-        flow_msg = self.ws_data_mgr.get_data_elements(TASK_PROXIES)
+        flow_msg = self.data_store_mgr.get_data_elements(TASK_PROXIES)
         self.assertEqual(0, len(flow_msg.deltas))
-        self.ws_data_mgr.initiate_data_model()
-        flow_msg = self.ws_data_mgr.get_data_elements(TASK_PROXIES)
+        self.data_store_mgr.initiate_data_model()
+        flow_msg = self.data_store_mgr.get_data_elements(TASK_PROXIES)
         self.assertEqual(
             len(flow_msg.deltas),
             len(self.data[TASK_PROXIES]))
-        flow_msg = self.ws_data_mgr.get_data_elements(WORKFLOW)
+        flow_msg = self.data_store_mgr.get_data_elements(WORKFLOW)
         self.assertEqual(
             flow_msg.last_updated, self.data[WORKFLOW].last_updated)
-        none_msg = self.ws_data_mgr.get_data_elements('fraggle')
+        none_msg = self.data_store_mgr.get_data_elements('fraggle')
         self.assertEqual(0, len(none_msg.ListFields()))
 
     def test_get_entire_workflow(self):
         """Test method that populates the entire workflow protobuf message."""
-        flow_msg = self.ws_data_mgr.get_entire_workflow()
+        flow_msg = self.data_store_mgr.get_entire_workflow()
         self.assertEqual(0, len(flow_msg.task_proxies))
-        self.ws_data_mgr.initiate_data_model()
-        flow_msg = self.ws_data_mgr.get_entire_workflow()
+        self.data_store_mgr.initiate_data_model()
+        flow_msg = self.data_store_mgr.get_entire_workflow()
         self.assertEqual(
             len(flow_msg.task_proxies),
             len(self.data[TASK_PROXIES]))
 
     def test_increment_graph_elements(self):
         """Test method that adds and removes elements by cycle point."""
-        self.assertFalse(self.ws_data_mgr.pool_points)
+        self.assertFalse(self.data_store_mgr.pool_points)
         self.assertEqual(0, len(self.data[TASK_PROXIES]))
-        self.ws_data_mgr.generate_definition_elements()
-        self.ws_data_mgr.increment_graph_elements()
-        self.ws_data_mgr.apply_deltas()
-        self.assertTrue(self.ws_data_mgr.pool_points)
+        self.data_store_mgr.generate_definition_elements()
+        self.data_store_mgr.increment_graph_elements()
+        self.data_store_mgr.apply_deltas()
+        self.assertTrue(self.data_store_mgr.pool_points)
         self.assertEqual(3, len(self.data[TASK_PROXIES]))
 
     def test_initiate_data_model(self):
         """Test method that generates all data elements in order."""
         self.assertEqual(0, len(self.data[WORKFLOW].task_proxies))
-        self.ws_data_mgr.initiate_data_model()
+        self.data_store_mgr.initiate_data_model()
         self.assertEqual(3, len(self.data[WORKFLOW].task_proxies))
-        self.ws_data_mgr.initiate_data_model(reloaded=True)
+        self.data_store_mgr.initiate_data_model(reloaded=True)
         self.assertEqual(3, len(self.data[WORKFLOW].task_proxies))
 
     def test_prune_points(self):
         """Test method that removes data elements by cycle point."""
-        self.ws_data_mgr.initiate_data_model()
-        points = self.ws_data_mgr.cycle_states.keys()
+        self.data_store_mgr.initiate_data_model()
+        points = self.data_store_mgr.cycle_states.keys()
         point = next(iter(points))
         self.assertTrue(point in points)
-        self.ws_data_mgr.clear_deltas()
-        self.ws_data_mgr.prune_points([point])
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.clear_deltas()
+        self.data_store_mgr.prune_points([point])
+        self.data_store_mgr.apply_deltas()
         self.assertTrue(point not in points)
 
     def test_update_data_structure(self):
         """Test update_data_structure. This method will generate and
         apply deltas/updates given."""
-        self.ws_data_mgr.initiate_data_model()
+        self.data_store_mgr.initiate_data_model()
         self.assertEqual(0, len(self._collect_states(TASK_PROXIES)))
         update_tasks = self.task_pool.get_all_tasks()
-        self.ws_data_mgr.update_data_structure(update_tasks)
+        self.data_store_mgr.update_data_structure(update_tasks)
         self.assertTrue(len(update_tasks) > 0)
         self.assertEqual(
             len(update_tasks), len(self._collect_states(TASK_PROXIES)))
@@ -171,14 +171,14 @@ class TestDataStoreMgr(CylcWorkflowTestCase):
     def test_update_family_proxies(self):
         """Test update_family_proxies. This method will update all
         DataStoreMgr task_proxies of given cycle point strings."""
-        self.ws_data_mgr.initiate_data_model()
+        self.data_store_mgr.initiate_data_model()
         self.assertEqual(0, len(self._collect_states(FAMILY_PROXIES)))
         update_tasks = self.task_pool.get_all_tasks()
         update_points = set((str(t.point) for t in update_tasks))
-        self.ws_data_mgr.clear_deltas()
-        self.ws_data_mgr.update_task_proxies(update_tasks)
-        self.ws_data_mgr.update_family_proxies(update_points)
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.clear_deltas()
+        self.data_store_mgr.update_task_proxies(update_tasks)
+        self.data_store_mgr.update_family_proxies(update_points)
+        self.data_store_mgr.apply_deltas()
         # Find families in updated cycle points
         point_fams = [
             f.id
@@ -192,24 +192,24 @@ class TestDataStoreMgr(CylcWorkflowTestCase):
         """Test update_task_proxies. This method will iterate over given
         task instances (TaskProxy), and update any corresponding
         DataStoreMgr task_proxies."""
-        self.ws_data_mgr.initiate_data_model()
+        self.data_store_mgr.initiate_data_model()
         self.assertEqual(0, len(self._collect_states(TASK_PROXIES)))
         update_tasks = self.task_pool.get_all_tasks()
-        self.ws_data_mgr.clear_deltas()
-        self.ws_data_mgr.update_task_proxies(update_tasks)
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.clear_deltas()
+        self.data_store_mgr.update_task_proxies(update_tasks)
+        self.data_store_mgr.apply_deltas()
         self.assertTrue(len(update_tasks) > 0)
         self.assertEqual(
             len(update_tasks), len(self._collect_states(TASK_PROXIES)))
 
     def test_update_workflow(self):
         """Test method that updates the dynamic fields of the workflow msg."""
-        self.ws_data_mgr.generate_definition_elements()
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.generate_definition_elements()
+        self.data_store_mgr.apply_deltas()
         old_time = self.data[WORKFLOW].last_updated
-        self.ws_data_mgr.clear_deltas()
-        self.ws_data_mgr.update_workflow()
-        self.ws_data_mgr.apply_deltas()
+        self.data_store_mgr.clear_deltas()
+        self.data_store_mgr.update_workflow()
+        self.data_store_mgr.apply_deltas()
         new_time = self.data[WORKFLOW].last_updated
         self.assertTrue(new_time > old_time)
 


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-uiserver/issues/112

The `jobs` topic of the data store wasn't getting pruned, so the job elements were piling up:
```
data-store:   44.45 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 58,   11.74 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   44.62 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 59,   11.91 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   45.44 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 64,   12.73 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   45.60 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 65,   12.89 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   46.42 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 70,   13.71 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   46.59 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 71,   13.88 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   47.41 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 76,   14.70 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
```
This is now fixed, and the a couple of other delta merge field accumulations fixed:
```
data-store:   39.70 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 29,    6.98 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   39.53 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 28,    6.82 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   39.70 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 29,    6.98 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   39.53 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 28,    6.82 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
data-store:   39.70 KB|edges: 32,    8.23 KB|families: 9,    1.70 KB|family_proxies: 45,   12.02 KB|jobs: 29,    6.98 KB|tasks: 8,    1.55 KB|task_proxies: 32,    7.48 KB|workflow: 1,   80     B|delta_times: 7,  960     B
```




**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (Cylc8 not released).
- [x] No documentation update required.
