### PR TITLE
Update jinja2 and pyzmq, as well as some test/dev dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,10 @@ creating directories when executed for suites that do not exist.
 [#3433](https://github.com/cylc/cylc-flow/pull/3433) - fix server abort at
 shutdown during remote run dir tidy (introduced during Cylc 8 development).
 
+[#3493](https://github.com/cylc/cylc-flow/pull/3493) - Update jinja2 and
+pyzmq, as well as some test/dev dependencies. Fixes Jinja2 error where
+validation shows incorrect context.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a1 (2019-09-18)__
 

--- a/setup.py
+++ b/setup.py
@@ -46,19 +46,19 @@ install_requires = [
     'colorama==0.4.*',
     'graphene>=2.1,<3',
     'metomi-isodatetime==1!2.0.*',
-    'jinja2>=2.10.1, <2.11.0',
+    'jinja2==2.11.*',
     'markupsafe==1.1.*',
     'protobuf==3.11.*',
-    'pyzmq==18.0.*',
+    'pyzmq==18.1.*',
     'click>=7.0'
 ]
 tests_require = [
     'codecov==2.0.*',
-    'coverage==4.5.*',
-    'pytest-cov==2.6.*',
-    'pytest==4.4.*',
+    'coverage==5.0.*',
+    'pytest-cov==2.8.*',
+    'pytest==5.3.*',
     'pycodestyle==2.5.*',
-    'testfixtures==6.6.*'
+    'testfixtures==6.11.*'
 ]
 
 extra_requires = {


### PR DESCRIPTION
These changes partially address #2572 

Updates `jinja2` requirement to **2.11.0** or greater, which effectively means **2.11.1** today, and `pyzmq` to **18.1.***, which means **18.1.0** today.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
