### PR TITLE
Remove dead code in rundb

### DIFF
--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -499,25 +499,6 @@ class CylcSuiteDAO(object):
         for row_idx, row in enumerate(self.connect().execute(stmt, stmt_args)):
             callback(row_idx, list(row))
 
-    def pre_select_broadcast_events(self, order=None):
-        """Query statement and args formation for select_broadcast_events."""
-        form_stmt = r"SELECT time,change,point,namespace,key,value FROM %s"
-        if order == "DESC":
-            ordering = (" ORDER BY " +
-                        "time DESC, point DESC, namespace DESC, key DESC")
-            form_stmt = form_stmt + ordering
-        return form_stmt % self.TABLE_BROADCAST_EVENTS, []
-
-    def select_broadcast_events(self, callback, id_key=None, sort=None):
-        """Select from broadcast_events.
-
-        Invoke callback(row_idx, row) on each row, where each row contains:
-            [time, change, point, namespace, key, value]
-        """
-        stmt, stmt_args = self.pre_select_broadcast_events(order=sort)
-        for row_idx, row in enumerate(self.connect().execute(stmt, stmt_args)):
-            callback(row_idx, list(row))
-
     def select_checkpoint_id(self, callback, id_key=None):
         """Select from checkpoint_id.
 
@@ -573,16 +554,6 @@ class CylcSuiteDAO(object):
         for row_idx, row in enumerate(self.connect().execute(
                 r"SELECT key,value FROM %s" % self.TABLE_SUITE_TEMPLATE_VARS)):
             callback(row_idx, list(row))
-
-    def select_table_schema(self, my_type, my_name):
-        """Select from task_action_timers for restart.
-
-        Invoke callback(row_idx, row) on each row.
-        """
-        for sql, in self.connect().execute(
-                r"SELECT sql FROM sqlite_master where type==? and name==?",
-                [my_type, my_name]):
-            return sql
 
     def select_task_action_timers(self, callback):
         """Select from task_action_timers for restart.


### PR DESCRIPTION
This is a small change with no associated Issue.

Left-over from #2800 #3361 . When migrating the code to SqlAlchemy was looking at their usages, but found nothing for `select_table_schema`. Then ran `vulture` against `rundb.py` (which I am a wee more familiar with now) and it pointed that `select_broadcast_events` was not used as well.

Waited for Travis CI to run on my fork before submitting. Should pass when it builds again this PR :crossed_fingers: 

Double checked using IDE, found no other usages with IDE code & file searches. 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? removing code)
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
