### PR TITLE
Fix global config default-to-localhost.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@ SLURM when task name has a percent `%` character.
 [#3539](https://github.com/cylc/cylc-flow/pull/3539) - Don't warn that a task
 was already added to an internal queue, if the queue is the same.
 
+[#3508](https://github.com/cylc/cylc-flow/pull/3508) - Fix list-valued global
+config items not defaulting to localhost values.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.4 (2019-09-04)__
 

--- a/lib/cylc/cfgspec/globalcfg.py
+++ b/lib/cylc/cfgspec/globalcfg.py
@@ -41,6 +41,9 @@ from cylc.version import CYLC_VERSION
 # - value_type: value type (compulsory).
 # - default: the default value (optional).
 # - allowed_2, ...: the only other allowed values of this setting (optional).
+
+# List-valued items under hosts need to default to None, not empty list, for
+# default-to-localhost to work.
 SPEC = {
     'process pool size': [VDR.V_INTEGER, 4],
     'process pool timeout': [VDR.V_INTERVAL, DurationFloat(600)],
@@ -155,19 +158,19 @@ SPEC = {
             'work directory': [VDR.V_STRING],
             'task communication method': [
                 VDR.V_STRING, 'default', 'ssh', 'poll'],
-            'submission polling intervals': [VDR.V_INTERVAL_LIST],
-            'execution polling intervals': [VDR.V_INTERVAL_LIST],
+            'submission polling intervals': [VDR.V_INTERVAL_LIST, None],
+            'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
             'scp command': [VDR.V_STRING],
             'ssh command': [VDR.V_STRING],
             'use login shell': [VDR.V_BOOLEAN],
             'cylc executable': [VDR.V_STRING],
             'global init-script': [VDR.V_STRING],
-            'copyable environment variables': [VDR.V_STRING_LIST],
+            'copyable environment variables': [VDR.V_STRING_LIST, None],
             'retrieve job logs': [VDR.V_BOOLEAN],
             'retrieve job logs command': [VDR.V_STRING],
             'retrieve job logs max size': [VDR.V_STRING],
-            'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST],
-            'task event handler retry delays': [VDR.V_INTERVAL_LIST],
+            'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST, None],
+            'task event handler retry delays': [VDR.V_INTERVAL_LIST, None],
             'tail command template': [VDR.V_STRING],
             'batch systems': {
                 '__MANY__': {
@@ -177,7 +180,7 @@ SPEC = {
                     'err viewer': [VDR.V_STRING],
                     'job name length maximum': [VDR.V_INTEGER],
                     'execution time limit polling intervals': [
-                        VDR.V_INTERVAL_LIST],
+                        VDR.V_INTERVAL_LIST, None],
                 },
             },
         },

--- a/lib/cylc/tests/test_global_config.py
+++ b/lib/cylc/tests/test_global_config.py
@@ -50,7 +50,7 @@ class TestGlobalConfig(unittest.TestCase):
             'retrieve job logs retry delays': 'PT10S, PT30S, PT1M, PT3M',
             'submission polling intervals': 'PT10S, PT30S',
             'execution polling intervals': 'PT10S, PT30S'
-            }
+        }
 
         globalrc_content = """
 [hosts]

--- a/lib/cylc/tests/test_global_config.py
+++ b/lib/cylc/tests/test_global_config.py
@@ -60,7 +60,8 @@ class TestGlobalConfig(unittest.TestCase):
             globalrc_content += "%s = %s\n" % (key, val)
         globalrc_content += """
    [[foo]]
-      # (default to localhost!)"""
+      # (default to localhost!)
+"""
 
         # Write the global config file.
         with open(globalrc_file, mode="w") as f:
@@ -69,7 +70,7 @@ class TestGlobalConfig(unittest.TestCase):
 
         # Parse the global config file and check values for host "foo" have
         # inherited localhost values.
-        global_config = GlobalConfig.get_inst()
+        global_config = GlobalConfig.get_inst(cached=False)
         validator = CylcConfigValidator()
 
         for key in items.keys():

--- a/lib/cylc/tests/test_global_config.py
+++ b/lib/cylc/tests/test_global_config.py
@@ -27,7 +27,7 @@ class TestGlobalConfig(unittest.TestCase):
     """Test class for the Cylc global config object."""
 
     def test_localhost_default_list_items(self):
-        """List items shold default to localhost values, like non-list items.
+        """List items should default to localhost values, like non-list items.
 
         See GitHub 3508
 
@@ -77,7 +77,7 @@ class TestGlobalConfig(unittest.TestCase):
                 coercer = validator.coerce_str_list
             else:
                 coercer = validator.coerce_interval_list
-            host_item = global_config.get_host_item(item=key, host='foo')
+            host_item = global_config.dense['hosts']['foo'][key]
             self.assertTrue(host_item == coercer(items[key], []))
 
         shutil.rmtree(conf_dir)

--- a/lib/cylc/tests/test_global_config.py
+++ b/lib/cylc/tests/test_global_config.py
@@ -1,0 +1,87 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import unittest
+from tempfile import mkdtemp
+
+from cylc.cfgspec.globalcfg import GlobalConfig
+from cylc.cfgvalidate import CylcConfigValidator
+
+
+class TestGlobalConfig(unittest.TestCase):
+    """Test class for the Cylc global config object."""
+
+    def test_localhost_default_list_items(self):
+        """List items shold default to localhost values, like non-list items.
+
+        See GitHub 3508
+
+        NOTE: still not working for batch system settings
+        because globalcfg:transform() needs to distinguish empty dict from None
+        and recurse into sub-sections to do the localhost defaulting:
+
+        [[[batch systems]]]
+          [[[[pbs]]]]
+             execution time limit polling intervals = PT10S, PT30S
+
+        """
+        conf_dir = mkdtemp()
+        os.environ["CYLC_CONF_PATH"] = conf_dir
+        globalrc_file = os.path.join(conf_dir, "global.rc")
+
+        items = {
+            'copyable environment variables': 'FOO, BAR',
+            'task event handler retry delays': 'PT99S, PT1H',
+            'retrieve job logs retry delays': 'PT10S, PT30S, PT1M, PT3M',
+            'submission polling intervals': 'PT10S, PT30S',
+            'execution polling intervals': 'PT10S, PT30S'
+            }
+
+        globalrc_content = """
+[hosts]
+   [[localhost]]
+"""
+        for key, val in items.items():
+            globalrc_content += "%s = %s\n" % (key, val)
+        globalrc_content += """
+   [[foo]]
+      # (default to localhost!)"""
+
+        # Write the global config file.
+        with open(globalrc_file, mode="w") as f:
+            f.write(globalrc_content)
+            f.flush()
+
+        # Parse the global config file and check values for host "foo" have
+        # inherited localhost values.
+        global_config = GlobalConfig.get_inst()
+        validator = CylcConfigValidator()
+
+        for key in items.keys():
+            if key == 'copyable environment variables':
+                coercer = validator.coerce_str_list
+            else:
+                coercer = validator.coerce_interval_list
+            host_item = global_config.get_host_item(item=key, host='foo')
+            self.assertTrue(host_item == coercer(items[key], []))
+
+        shutil.rmtree(conf_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3507 

In global config host settings, default-to-localhost was broken for list-valued items.  In the spec, these need to default to `None` (It was empty list looks like "item-set-to-nothing" rather than "item-not-set").

Apparently broken in 7.8.0 ?

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required. (Fix conforms to documented behaviour).

Once finished, this needs to go to 7.9.x as well.  But not to master as the platforms changes will render this irrelevant there? - ping @wxtim 