### PR TITLE
[7.9.x] Fix expanded ids for GScan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@ pages**.
 2.11.1, fixing Jinja2 error where validation shows incorrect context.
 **This requires Python 2.7**
 
+[#3513](https://github.com/cylc/cylc-flow/pull/3513) - Fix expanded ids
+for GScan, preventing that all suites are expanded after a single suite
+was expanded in GScan.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.5 (2019-Q4?)__
 

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -790,6 +790,8 @@ class ScanAppUpdater(threading.Thread):
 
     @staticmethod
     def _get_row_id(model, row_iter):
+        """Get the unique row ID, composed of group, host, owner,
+        and suite name."""
         return model.get(
             row_iter,
             ScanApp.GROUP_COLUMN,
@@ -807,7 +809,7 @@ class ScanAppUpdater(threading.Thread):
         return False
 
     def _expand_row(self, model, rpath, row_iter, row_ids):
-        """Expand a row if it matches rose_ids suite and host."""
+        """Expand a row if it matches group, host, owner, and suite name."""
         point_string_name_tuple = self._get_row_id(model, row_iter)
         if point_string_name_tuple in row_ids:
             self.treeview.expand_to_path(rpath)

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -789,21 +789,26 @@ class ScanAppUpdater(threading.Thread):
         super(ScanAppUpdater, self).__init__()
 
     @staticmethod
-    def _add_expanded_row(view, rpath, row_ids):
+    def _get_row_id(model, row_iter):
+        return model.get(
+            row_iter,
+            ScanApp.GROUP_COLUMN,
+            ScanApp.HOST_COLUMN,
+            ScanApp.OWNER_COLUMN,
+            ScanApp.SUITE_COLUMN)
+
+    def _add_expanded_row(self, view, rpath, row_ids):
         """Add user-expanded rows to a list of suite and hosts to be
         expanded."""
         model = view.get_model()
         row_iter = model.get_iter(rpath)
-        row_id = model.get(row_iter, ScanApp.HOST_COLUMN,
-                           ScanApp.OWNER_COLUMN, ScanApp.SUITE_COLUMN)
+        row_id = self._get_row_id(model, row_iter)
         row_ids.append(row_id)
         return False
 
     def _expand_row(self, model, rpath, row_iter, row_ids):
         """Expand a row if it matches rose_ids suite and host."""
-        point_string_name_tuple = model.get(
-            row_iter, ScanApp.HOST_COLUMN, ScanApp.OWNER_COLUMN,
-            ScanApp.SUITE_COLUMN)
+        point_string_name_tuple = self._get_row_id(model, row_iter)
         if point_string_name_tuple in row_ids:
             self.treeview.expand_to_path(rpath)
         return False

--- a/lib/cylc/gui/gscan.py
+++ b/lib/cylc/gui/gscan.py
@@ -794,13 +794,16 @@ class ScanAppUpdater(threading.Thread):
         expanded."""
         model = view.get_model()
         row_iter = model.get_iter(rpath)
-        row_id = model.get(row_iter, 0, 1)
+        row_id = model.get(row_iter, ScanApp.HOST_COLUMN,
+                           ScanApp.OWNER_COLUMN, ScanApp.SUITE_COLUMN)
         row_ids.append(row_id)
         return False
 
     def _expand_row(self, model, rpath, row_iter, row_ids):
         """Expand a row if it matches rose_ids suite and host."""
-        point_string_name_tuple = model.get(row_iter, 0, 1)
+        point_string_name_tuple = model.get(
+            row_iter, ScanApp.HOST_COLUMN, ScanApp.OWNER_COLUMN,
+            ScanApp.SUITE_COLUMN)
         if point_string_name_tuple in row_ids:
             self.treeview.expand_to_path(rpath)
         return False


### PR DESCRIPTION
These changes close #3281

I am looking at the old GScan to understand how it creates the states + states totals (related to https://github.com/cylc/cylc-ui/issues/401), and also want to understand how Cylc 8's `cylc monitor` is doing that.

While doing it I remembered there was a bug in GScan regarding expanded rows. And since I had some experience with Cylc UI's tree and expanded/collapsed states decided to check if there was a simple fix. Took 20 mins after attaching a debugger to find one possible solution.

Not sure if the best one as I don't have a lot of experience with the old GUI, but just in case that's helpful.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? manual testing only should do... we don't have many tests for the old GUI).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
