### PR TITLE
Forwards compatible fs search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ addons:
   apt:
     # instruct travis-ci to always run apt-get before each build
     update: true
+# disabling the shallow-cloning so that it works with Cylc 7 cylc version (uses git commit and tag)
+git:
+  depth: false
 
 stages:
 - unit-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ requests_).
  - Alexander Paulsell
  - David Sutherland
  - Martin Ryan
+ - Mel Hall
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -27,6 +27,7 @@ import traceback
 import socket
 from uuid import uuid4
 
+from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
 import cylc.flags
 from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
@@ -308,6 +309,13 @@ def get_scan_items_from_fs(owner_pattern=None, updater=None):
             reg = os.path.relpath(dirpath, run_d)
             try:
                 contact_data = srv_files_mgr.load_contact_file(reg, owner)
+                cylc_ver = contact_data[srv_files_mgr.KEY_VERSION]
+                major_ver = int(cylc_ver.split(".", 1)[0])
+                if (major_ver > 7):
+                    LOG.debug("Suite %s is running in Cylc version %s "
+                              "and will not be displayed." % (reg, cylc_ver)
+                              )
+                    continue
             except (SuiteServiceFileError, IOError, TypeError, ValueError):
                 continue
             else:

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -309,6 +309,10 @@ def get_scan_items_from_fs(owner_pattern=None, updater=None):
             reg = os.path.relpath(dirpath, run_d)
             try:
                 contact_data = srv_files_mgr.load_contact_file(reg, owner)
+
+            except (SuiteServiceFileError, IOError, TypeError, ValueError):
+                continue
+            else:
                 cylc_ver = contact_data[srv_files_mgr.KEY_VERSION]
                 major_ver = int(cylc_ver.split(".", 1)[0])
                 if (major_ver > 7):
@@ -316,9 +320,6 @@ def get_scan_items_from_fs(owner_pattern=None, updater=None):
                               "and will not be displayed." % (reg, cylc_ver)
                               )
                     continue
-            except (SuiteServiceFileError, IOError, TypeError, ValueError):
-                continue
-            else:
                 items.append((
                     contact_data[srv_files_mgr.KEY_HOST],
                     contact_data[srv_files_mgr.KEY_PORT]))


### PR DESCRIPTION
These changes partially address #3516
These changes close #3518
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] Does not need tests (why? manually tested for now. No current unit tests for port_scan.py - possibly worth adding some?).