### PR TITLE
Remove unnecessary catch for re.error

### DIFF
--- a/cylc/flow/scripts/cylc_get_host_metrics.py
+++ b/cylc/flow/scripts/cylc_get_host_metrics.py
@@ -119,12 +119,12 @@ def run_command(cmd):
 
 def extract_pattern(data_pattern: Pattern, raw_string):
     """Try to return first parenthesized subgroup of a regex string search."""
-    error_msg = "No 're.search' matches for:\n  %s\non the string:\n  %s" % (
-        data_pattern.pattern, raw_string)
     matches = re.search(data_pattern, raw_string)
     if matches:
         return matches.groups()
     else:
+        error_msg = "No 're.search' matches for:\n  %s\non the string:\n  %s" \
+                    % (data_pattern.pattern, raw_string)
         raise AttributeError(error_msg)
 
 

--- a/cylc/flow/scripts/cylc_get_host_metrics.py
+++ b/cylc/flow/scripts/cylc_get_host_metrics.py
@@ -45,6 +45,7 @@ if '--use-ssh' in sys.argv[1:]:
 import re
 from subprocess import Popen, PIPE, CalledProcessError, DEVNULL
 import json
+from typing import Pattern
 
 from cylc.flow.option_parsers import OptionParser
 from cylc.flow.terminal import cli_function
@@ -116,14 +117,11 @@ def run_command(cmd):
         return stdout
 
 
-def extract_pattern(data_pattern, raw_string):
+def extract_pattern(data_pattern: Pattern, raw_string):
     """Try to return first parenthesized subgroup of a regex string search."""
     error_msg = "No 're.search' matches for:\n  %s\non the string:\n  %s" % (
         data_pattern.pattern, raw_string)
-    try:
-        matches = re.search(data_pattern, raw_string)
-    except re.error:
-        sys.stderr.write(error_msg)
+    matches = re.search(data_pattern, raw_string)
     if matches:
         return matches.groups()
     else:


### PR DESCRIPTION
These changes close #3398 

I think this change should be harmless. The `re.error` is raised when you compile an invalid regex (e.g. `re.compile(r'(?gP=1)')`). In `cylc_get_host_metrics.py`, the function changed receives a `re.Pattern` object, not a string, so the regex is already compiled.

Also, the error message doesn't need to be created unless the error happens, so moved it further down to the `else` statement.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests. (there are functional tests for the cylc-get-host-metrics in tests/cylc-get-host-metrics)
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
