### PR TITLE
Remove unused code block, and function parameter in cylc.config

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -991,6 +991,12 @@ class SuiteConfig(object):
     def compute_inheritance(self):
         LOG.debug("Parsing the runtime namespace hierarchy")
 
+        # TODO: Note an unused alternative mechanism was removed here
+        # (March 2020). It stored the result of each completed MRO and
+        # re-used these wherever possible. This could be more efficient
+        # for full namespaces in deep hierarchies. We should go back and
+        # look if inheritance computation becomes a problem.
+
         results = OrderedDictWithDefaults()
         # n_reps = 0
         already_done = {}  # to store already computed namespaces by mro

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -988,7 +988,7 @@ class SuiteConfig(object):
                 if name not in self.runtime['first-parent descendants'][p]:
                     self.runtime['first-parent descendants'][p].append(name)
 
-    def compute_inheritance(self, use_simple_method=True):
+    def compute_inheritance(self):
         LOG.debug("Parsing the runtime namespace hierarchy")
 
         results = OrderedDictWithDefaults()
@@ -1006,39 +1006,11 @@ class SuiteConfig(object):
 
             result = OrderedDictWithDefaults()
 
-            if use_simple_method:
-                # Go up the linearized MRO from root, replicating or
-                # overriding each namespace element as we go.
-                for name in hierarchy:
-                    replicate(result, self.cfg['runtime'][name])
-                    # n_reps += 1
-
-            else:
-                # As for the simple method, but store the result of each
-                # completed MRO (full or partial) as we go, and re-use
-                # these wherever possible. This ought to be a lot more
-                # efficient for big namespaces (e.g. lots of environment
-                # variables) in deep hierarchies, but results may vary...
-                prev_shortcut = False
-                mro = []
-                for name in hierarchy:
-                    mro.append(name)
-                    i_mro = '*'.join(mro)
-                    if i_mro in already_done:
-                        ad_result = already_done[i_mro]
-                        prev_shortcut = True
-                    else:
-                        if prev_shortcut:
-                            prev_shortcut = False
-                            # copy ad_result (to avoid altering already_done)
-                            result = OrderedDictWithDefaults()
-                            replicate(result, ad_result)  # ...and use stored
-                            # n_reps += 1
-                        # override name content into tmp
-                        replicate(result, self.cfg['runtime'][name])
-                        # n_reps += 1
-                        # record this mro as already done
-                        already_done[i_mro] = result
+            # Go up the linearized MRO from root, replicating or
+            # overriding each namespace element as we go.
+            for name in hierarchy:
+                replicate(result, self.cfg['runtime'][name])
+                # n_reps += 1
 
             results[ns] = result
 


### PR DESCRIPTION
These changes close #3043 

See linked issue for more. The `else` statement is never used in our code. We never override the default value of the parameter removed.

And the code in the `else` statement would raise an error due to the unbound `ad_result` variable. This PR simply removes that code, and the parameter too. (I guess it should be safe, as we can use `git` to look at the old versions and re-implement the code if necessary?)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? removing code).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
