### PR TITLE
slurm: sbatch output/error: handle % character

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,9 @@ shutdown during remote run dir tidy (introduced during Cylc 8 development).
 pyzmq, as well as some test/dev dependencies. Fixes Jinja2 error where
 validation shows incorrect context.
 
+[#3531](https://github.com/cylc/cylc-flow/pull/3531) - Fix job submission to
+SLURM when task name has a percent `%` character.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a1 (2019-09-18)__
 

--- a/cylc/flow/batch_sys_handlers/slurm.py
+++ b/cylc/flow/batch_sys_handlers/slurm.py
@@ -48,8 +48,8 @@ class SLURMHandler():
         directives = job_conf['directives'].__class__()
         directives['--job-name'] = (
             job_conf['task_id'] + '.' + job_conf['suite_name'])
-        directives['--output'] = job_file_path + ".out"
-        directives['--error'] = job_file_path + ".err"
+        directives['--output'] = job_file_path.replace('%', '%%') + ".out"
+        directives['--error'] = job_file_path.replace('%', '%%') + ".err"
         if (job_conf["execution_time_limit"] and
                 directives.get("--time") is None):
             directives["--time"] = "%d:%02d" % (

--- a/cylc/flow/tests/batch_sys_handlers/test_slurm.py
+++ b/cylc/flow/tests/batch_sys_handlers/test_slurm.py
@@ -38,6 +38,30 @@ from cylc.flow.batch_sys_handlers.slurm import BATCH_SYS_HANDLER
                 '#SBATCH --time=3:00',
             ],
         ),
+        (  # task name with % character
+            {
+                'batch_system_conf': {},
+                'directives': {},
+                'execution_time_limit': 180,
+                'job_file_path': (
+                    '$HOME/cylc-run/chop/log/job/1/axe%40HEAD/01/job'
+                ),
+                'suite_name': 'chop',
+                'task_id': 'axe%40HEAD.1',
+            },
+            [
+                '#SBATCH --job-name=axe%40HEAD.1.chop',
+                (
+                    '#SBATCH --output'
+                    '=cylc-run/chop/log/job/1/axe%%40HEAD/01/job.out'
+                ),
+                (
+                    '#SBATCH --error'
+                    '=cylc-run/chop/log/job/1/axe%%40HEAD/01/job.err'
+                ),
+                '#SBATCH --time=3:00',
+            ],
+        ),
         (  # some useful directives
             {
                 'batch_system_conf': {},


### PR DESCRIPTION
The `%` character in `--output=...` and `--error=...` needs escape.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
- [x] Need 7.8.x/~7.9x~ back port. (#3532)