### PR TITLE
7.8.x: slurm: sbatch output/error: handle % character

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,11 +42,13 @@ was expanded in GScan.
 tasks in the tree view. Uses natural order, so that it follows the
 order 1, 2, 10, 11, and not 1, 10, 11, 2.
 
+[#3532](https://github.com/cylc/cylc-flow/pull/3532) - Fix job submission to
+SLURM when task name has a percent `%` character.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.4 (2019-09-04)__
 
 Bug fix release.
-=======
 
 Selected user-facing changes:
 

--- a/lib/cylc/batch_sys_handlers/slurm.py
+++ b/lib/cylc/batch_sys_handlers/slurm.py
@@ -47,8 +47,8 @@ class SLURMHandler(object):
         directives = job_conf['directives'].__class__()
         directives['--job-name'] = (
             job_conf['suite_name'] + '.' + job_conf['task_id'])
-        directives['--output'] = job_file_path + ".out"
-        directives['--error'] = job_file_path + ".err"
+        directives['--output'] = job_file_path.replace('%', '%%') + ".out"
+        directives['--error'] = job_file_path.replace('%', '%%') + ".err"
         if (job_conf["execution_time_limit"] and
                 directives.get("--time") is None):
             directives["--time"] = "%d:%02d" % (

--- a/tests/jobscript/06-slurm-no-directives.t
+++ b/tests/jobscript/06-slurm-no-directives.t
@@ -18,7 +18,7 @@
 # Test that directives are written correctly when no extra ones are supplied.
 . "$(dirname "${0}")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 5
+set_test_number 9
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
@@ -28,6 +28,13 @@ TEST_NAME="${TEST_NAME_BASE}-script"
 TASK_LOG_PATH="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job/1/foo/01"
 run_ok "${TEST_NAME}" cylc jobscript "${SUITE_NAME}" foo.1
 grep_ok "^#SBATCH --job-name=${SUITE_NAME}.foo.1" "${TEST_NAME}.stdout"
+grep_ok "^#SBATCH --output=${TASK_LOG_PATH}/job.out" "${TEST_NAME}.stdout"
+grep_ok "^#SBATCH --error=${TASK_LOG_PATH}/job.err" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-script"
+TASK_LOG_PATH="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}/log/job/1/bar%%bar/01"
+run_ok "${TEST_NAME}" cylc jobscript "${SUITE_NAME}" 'bar%bar.1'
+grep_ok "^#SBATCH --job-name=${SUITE_NAME}.bar%bar.1" "${TEST_NAME}.stdout"
 grep_ok "^#SBATCH --output=${TASK_LOG_PATH}/job.out" "${TEST_NAME}.stdout"
 grep_ok "^#SBATCH --error=${TASK_LOG_PATH}/job.err" "${TEST_NAME}.stdout"
 #-------------------------------------------------------------------------------

--- a/tests/jobscript/06-slurm-no-directives/suite.rc
+++ b/tests/jobscript/06-slurm-no-directives/suite.rc
@@ -5,10 +5,14 @@
 
 [scheduling]
     [[dependencies]]
-        graph = foo
+        graph = foo & bar%bar
 
 [runtime]
     [[foo]]
+        script = echo hello
+        [[[job]]]
+            batch system = slurm
+    [[bar%bar]]
         script = echo hello
         [[[job]]]
             batch system = slurm


### PR DESCRIPTION
Back port of #3531. The `%` character in `--output=...` and `--error=...` needs escape.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
