### PR TITLE
Queue warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@ order 1, 2, 10, 11, and not 1, 10, 11, 2.
 [#3532](https://github.com/cylc/cylc-flow/pull/3532) - Fix job submission to
 SLURM when task name has a percent `%` character.
 
+[#3539](https://github.com/cylc/cylc-flow/pull/3539) - Don't warn that a task
+was already added to an internal queue, if the queue is the same.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.4 (2019-09-04)__
 

--- a/tests/queues/03-warnings.t
+++ b/tests/queues/03-warnings.t
@@ -1,0 +1,51 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that reassigning a task to the same queue does not result in a warning.
+# GitHub #3539
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+init_suite $TEST_NAME_BASE <<'__SUITE_RC__'
+[scheduling]
+   [[queues]]
+       [[[q1]]]
+           members = A, B
+       [[[q2]]]
+           members = x
+   [[dependencies]]
+       graph = "x => y"
+[runtime]
+   [[A]]
+   [[B]]
+   [[x]]
+       inherit = A, B
+   [[y]]
+__SUITE_RC__
+#-------------------------------------------------------------------------------
+TEST_NAME=$TEST_NAME_BASE-validate
+run_ok $TEST_NAME cylc validate $SUITE_NAME
+#-------------------------------------------------------------------------------
+# Validation should not warn about x being added to q1 from family B
+# but it should warn about x being added to q2 (already added to q1).
+cmp_ok ${TEST_NAME}.stderr - <<'__STDOUT__'
+WARNING - Queue configuration warnings:
+	+ q2: ignoring x (already assigned to a queue)
+__STDOUT__
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME


### PR DESCRIPTION

These changes partially address #3470 (close after PR port to 7.9.x and master as well)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.

- [x] No documentation update required. (No significant change to users, just fewer warnings)
