### PR TITLE
3535: prevent subprocpool infinite loop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,9 @@ validation shows incorrect context.
 [#3531](https://github.com/cylc/cylc-flow/pull/3531) - Fix job submission to
 SLURM when task name has a percent `%` character.
 
+[#3543](https://github.com/cylc/cylc-flow/pull/3403) - fixed pipe polling
+issue observed on darwin (BSD) which could cause Cylc to hang.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a1 (2019-09-18)__
 

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -311,10 +311,13 @@ class SubProcPool(object):
                         ctx.err = ''
                     ctx.err += data
             if received_data and not all(received_data):
-                # if no data was pushed down the pipe exit the polling loop
-                # (this suppresses an infinite polling-loop observed
-                # on darwin) see
+                # if no data was pushed down the pipe exit the polling loop,
+                # we can always re-enter the polling loop later if there is
+                # more data
+                # NOTE: this suppresses an infinite polling-loop observed
+                # on darwin see:
                 # https://github.com/cylc/cylc-flow/issues/3535
+                # https://github.com/cylc/cylc-flow/pull/3543
                 return
         self.pipepoller.unregister(proc.stdout.fileno())
         self.pipepoller.unregister(proc.stderr.fileno())

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -288,6 +288,7 @@ class SubProcPool(object):
             if not fileno_list:
                 # Nothing readable
                 break
+            received_data = []
             for fileno in fileno_list:
                 # If a file handle is readable, read something from it, add
                 # results into the command context object's `.out` or `.err`,
@@ -300,6 +301,7 @@ class SubProcPool(object):
                     data = os.read(fileno, 65536).decode()  # 64K
                 except OSError:
                     continue
+                received_data.append(data != '')
                 if fileno == proc.stdout.fileno():
                     if ctx.out is None:
                         ctx.out = ''
@@ -308,6 +310,12 @@ class SubProcPool(object):
                     if ctx.err is None:
                         ctx.err = ''
                     ctx.err += data
+            if received_data and not all(received_data):
+                # if no data was pushed down the pipe exit the polling loop
+                # (this suppresses an infinite polling-loop observed
+                # on darwin) see
+                # https://github.com/cylc/cylc-flow/issues/3535
+                return
         self.pipepoller.unregister(proc.stdout.fileno())
         self.pipepoller.unregister(proc.stderr.fileno())
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ install_requires = [
     'protobuf==3.11.*',
     'pyzmq==18.1.*',
     'click>=7.0',
-    'psutil>=5.6.0'
+    'psutil>=5.6.0',
     'urwid==2.*'
 ]
 tests_require = [


### PR DESCRIPTION
These changes close #3535 

This is a potential fix for the infinite loop observed in the subprocpool process polling logic on darwin (BSD).

Not sure what is causing the bug, however, in the Cylc code it surfaces in `_poll_proc_pipes` where every time we go around the loop we get `data == ''` even long after the process has completed.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (impossible to test when you don't know what the underlying issue actually is).
- [x] No documentation update required.
