### PR TITLE
cylc run: parsable output

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -18,6 +18,7 @@
 from collections import deque
 from errno import ENOENT
 from itertools import zip_longest
+import json
 import logging
 import os
 from shlex import quote
@@ -247,7 +248,8 @@ class Scheduler(object):
 
     def start(self):
         """Start the server."""
-        self._start_print_blurb()
+        if self.options.format == 'plain':
+            self._start_print_blurb()
 
         make_suite_run_tree(self.suite)
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -18,7 +18,6 @@
 from collections import deque
 from errno import ENOENT
 from itertools import zip_longest
-import json
 import logging
 import os
 from shlex import quote
@@ -163,6 +162,9 @@ class Scheduler(object):
 
     def __init__(self, is_restart, options, args):
         self.options = options
+        if self.options.no_detach:
+            self.options.format = 'plain'
+        self.options.format
         self.profiler = Profiler(self.options.profile_mode)
         self.suite = args[0]
         self.uuid_str = SchedulerUUID()

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -208,6 +208,13 @@ def get_option_parser(is_restart):
         ),
         metavar="HOST", action="store", dest="host")
 
+    parser.add_option(
+        "--format",
+        help="The format of the output: 'plain'=human readable, 'json'",
+        choices=("plain", "json"),
+        default="plain"
+    )
+
     parser.set_defaults(stop_point_string=None)
 
     return parser

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -89,7 +89,8 @@ def get_option_parser(is_restart):
             argdoc=[SUITE_NAME_ARG_DOC, START_POINT_ARG_DOC])
 
     parser.add_option(
-        "-n", "--no-detach", "--non-daemon", help="Do not daemonize the suite",
+        "-n", "--no-detach", "--non-daemon",
+        help="Do not daemonize the suite (infers --format=plain)",
         action="store_true", dest="no_detach")
 
     parser.add_option(

--- a/cylc/flow/tests/test_scheduler.py
+++ b/cylc/flow/tests/test_scheduler.py
@@ -28,6 +28,8 @@ class Options(object):
 
     def __init__(self):
         # Variables needed to create a Scheduler instance
+        self.format = 'plain'
+        self.no_detach = False
         self.profile_mode = False
         self.templatevars = {}
         self.templatevars_file = ""

--- a/tests/cylc-run/02-format.t
+++ b/tests/cylc-run/02-format.t
@@ -1,0 +1,61 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------
+
+# test the output of `cylc run` with different `--format` options
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 7
+
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[scheduling]
+    [[dependencies]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = cylc stop --now --now "${CYLC_SUITE_NAME}"
+__SUITE_RC__
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
+
+# format=plain
+TEST_NAME="${TEST_NAME_BASE}-run-format=plain"
+suite_run_ok "${TEST_NAME}" cylc run --format plain "${SUITE_NAME}"
+grep_ok 'listening on tcp:' "${TEST_NAME}.stdout"
+grep_ok 'publishing on tcp:' "${TEST_NAME}.stdout"
+grep_ok 'To view suite server program contact information:' \
+    "${TEST_NAME}.stdout"
+grep_ok 'Other ways to see if the suite is still running:' \
+    "${TEST_NAME}.stdout"
+poll_suite_stopped
+
+# format=json
+TEST_NAME="${TEST_NAME_BASE}-run-format=plain"
+suite_run_ok "${TEST_NAME}" cylc run --format json "${SUITE_NAME}"
+run_ok "${TEST_NAME}-fields" python3 -c '
+import json
+import sys
+data = json.load(open(sys.argv[1], "r"))
+print(list(sorted(data)), file=sys.stderr)
+assert list(sorted(data)) == [
+    "host", "pid", "ps_opts", "pub_url", "suite", "url"]
+' "${TEST_NAME}.stdout" >&2 2>&2
+poll_suite_stopped
+
+purge_suite "${SUITE_NAME}"


### PR DESCRIPTION
These changes close #3451 

* Add a `--format` option to `cylc run`.
* Add `json` format which dumps the host,pid,port info to stdout.
* Testy test.

This should make the workflow spawner service slightly easier as otherwise we would have to go to the filesystem to get this information.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? too small to be significant).
- [x] No documentation update required.
