### PR TITLE
Fix 3494 deprecation upgrade bug on master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ requests_).
  - Dima Veselov
  - Gilliano Menezes
  - Mel Hall
+ - Ronnie Dutta
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -325,16 +325,16 @@ def upg(cfg, descr):
     u.upgrade()
 
     # Upgrader cannot do this type of move:
-    if 'dependencies' in cfg['scheduling']:
-        msgOld = '[scheduling][dependencies][X]graph'
-        msgNew = '[scheduling][graph]X'
-        if 'graph' in cfg['scheduling']:
-            raise UpgradeError(
-                "Cannot upgrade deprecated item '{0} -> {1}' because "
-                "{2} already exists".format(msgOld, msgNew, msgNew[:-1])
-            )
-        else:
-            try:  # Upgrade cfg['scheduling']['dependencies']['graph']
+    try:  # Upgrade cfg['scheduling']['dependencies']['graph']
+        if 'dependencies' in cfg['scheduling']:
+            msgOld = '[scheduling][dependencies][X]graph'
+            msgNew = '[scheduling][graph]X'
+            if 'graph' in cfg['scheduling']:
+                raise UpgradeError(
+                    "Cannot upgrade deprecated item '{0} -> {1}' because "
+                    "{2} already exists".format(msgOld, msgNew, msgNew[:-1])
+                )
+            else:
                 keys = set()
                 cfg['scheduling'].setdefault('graph', {})
                 cfg['scheduling']['graph'].update(
@@ -355,8 +355,8 @@ def upg(cfg, descr):
                             msgOld, msgNew, '\n'.join(sorted(keys))
                         )
                     )
-            except KeyError:
-                pass
+    except KeyError:
+        pass
 
     # TODO - uncomment this fn so that we actually use the host to platform
     # upgrader

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -327,12 +327,12 @@ def upg(cfg, descr):
     # Upgrader cannot do this type of move:
     try:  # Upgrade cfg['scheduling']['dependencies']['graph']
         if 'dependencies' in cfg['scheduling']:
-            msgOld = '[scheduling][dependencies][X]graph'
-            msgNew = '[scheduling][graph]X'
+            msg_old = '[scheduling][dependencies][X]graph'
+            msg_new = '[scheduling][graph]X'
             if 'graph' in cfg['scheduling']:
                 raise UpgradeError(
                     "Cannot upgrade deprecated item '{0} -> {1}' because "
-                    "{2} already exists".format(msgOld, msgNew, msgNew[:-1])
+                    "{2} already exists".format(msg_old, msg_new, msg_new[:-1])
                 )
             else:
                 keys = set()
@@ -352,7 +352,7 @@ def upg(cfg, descr):
                     )
                     LOG.warning(
                         ' * (8.0.0) {0} -> {1} - for X in:\n{2}'.format(
-                            msgOld, msgNew, '\n'.join(sorted(keys))
+                            msg_old, msg_new, '\n'.join(sorted(keys))
                         )
                     )
     except KeyError:

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -194,7 +194,20 @@ class upgrader(object):
                             warnings[vn].append(msg)
                         self.del_item(upg['old'])
                         if upg['cvt'].describe() != "DELETED (OBSOLETE)":
-                            self.put_item(upg['new'], upg['cvt'].convert(old))
+                            # check self.cfg does not already contain a
+                            # non-deprecated item matching upg['new']:
+                            try:
+                                self.get_item(upg['new'])
+                            except KeyError:
+                                self.put_item(upg['new'],
+                                              upg['cvt'].convert(old))
+                            else:
+                                errMsg = (
+                                    'ERROR: Cannot upgrade deprecated '
+                                    'item "' + msg + '" because the upgraded '
+                                    'item already exists'
+                                )
+                                raise UpgradeError(errMsg)
         if warnings:
             level = WARNING
             if self.descr == self.SITE_CONFIG:

--- a/tests/deprecations/02-overwrite.t
+++ b/tests/deprecations/02-overwrite.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that upgraded deprecations don't overwrite existing items
-. "$(dirname $0)/test_header"
+. "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 1
 #-------------------------------------------------------------------------------

--- a/tests/deprecations/02-overwrite.t
+++ b/tests/deprecations/02-overwrite.t
@@ -22,9 +22,8 @@ set_test_number 1
 #-------------------------------------------------------------------------------
 install_suite $TEST_NAME_BASE $TEST_NAME_BASE
 #-------------------------------------------------------------------------------
-cylc get-config --sparse -i '[scheduling]' suite.rc  2> val.out
+cylc validate $SUITE_NAME 2> val.out
 TEST_NAME=${TEST_NAME_BASE}-original-events-not-overwritten
-grep_ok "upgraded item already exists" "val.out"
-# Should probably check validation fails?
+grep_ok "UpgradeError" "val.out"
 #-------------------------------------------------------------------------------
 purge_suite $SUITE_NAME

--- a/tests/deprecations/02-overwrite.t
+++ b/tests/deprecations/02-overwrite.t
@@ -16,14 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test that upgraded deprecations don't overwrite existing items
-. $(dirname $0)/test_header
+. "$(dirname $0)/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 1
 #-------------------------------------------------------------------------------
-install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+install_suite "$TEST_NAME_BASE" "$TEST_NAME_BASE"
 #-------------------------------------------------------------------------------
-cylc validate $SUITE_NAME 2> val.out
-TEST_NAME=${TEST_NAME_BASE}-original-events-not-overwritten
+cylc validate "$SUITE_NAME" 2> val.out
 grep_ok "UpgradeError" "val.out"
 #-------------------------------------------------------------------------------
-purge_suite $SUITE_NAME
+purge_suite "$SUITE_NAME"

--- a/tests/deprecations/02-overwrite.t
+++ b/tests/deprecations/02-overwrite.t
@@ -1,0 +1,30 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that upgraded deprecations don't overwrite existing items
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+set_test_number 1
+#-------------------------------------------------------------------------------
+install_suite $TEST_NAME_BASE $TEST_NAME_BASE
+#-------------------------------------------------------------------------------
+cylc get-config --sparse -i '[scheduling]' suite.rc  2> val.out
+TEST_NAME=${TEST_NAME_BASE}-original-events-not-overwritten
+grep_ok "upgraded item already exists" "val.out"
+# Should probably check validation fails?
+#-------------------------------------------------------------------------------
+purge_suite $SUITE_NAME

--- a/tests/deprecations/02-overwrite/suite.rc
+++ b/tests/deprecations/02-overwrite/suite.rc
@@ -1,0 +1,13 @@
+# Test automatic deprecation and deletion of config items as specified
+# in lib/cylc/cfgspec/suite.py.
+
+[scheduling]
+    initial cycle point = 20150808T00
+
+    # Deprecated:
+    [[dependencies]]
+        [[[P1D]]]
+            graph = bar => horse
+    # New in Cylc 8:
+    [[graph]]
+        P1D = foo => cat & dog


### PR DESCRIPTION
Replica of PR #3524 from 7.8.x, but with extra change to deal with `[scheduling][dependencies][X]graph -> [scheduling][graph]X` which is handled separately