### PR TITLE
Load DB jobs on restart

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -404,7 +404,7 @@ see `COPYING' in the Cylc source distribution.
         self.message_queue = Queue()
         self.ext_trigger_queue = Queue()
         self.suite_event_handler = SuiteEventHandler(self.proc_pool)
-        self.job_pool = JobPool(self.suite, self.owner)
+        self.job_pool = JobPool(self)
         self.task_events_mgr = TaskEventsManager(
             self.suite, self.proc_pool, self.suite_db_mgr, self.broadcast_mgr,
             self.job_pool)
@@ -576,6 +576,8 @@ see `COPYING' in the Cylc source distribution.
             self._load_task_run_times)
         self.suite_db_mgr.pri_dao.select_task_pool_for_restart(
             self.pool.load_db_task_pool_for_restart, self.options.checkpoint)
+        self.suite_db_mgr.pri_dao.select_job_pool_for_restart(
+            self.job_pool.insert_db_job, self.options.checkpoint)
         self.suite_db_mgr.pri_dao.select_task_action_timers(
             self.pool.load_db_task_action_timers)
         self.suite_db_mgr.pri_dao.select_xtriggers_for_restart(

--- a/cylc/flow/scripts/cylc_client.py
+++ b/cylc/flow/scripts/cylc_client.py
@@ -62,7 +62,10 @@ def main(_, options, suite, func):
     sys.stdin.close()
     res = pclient(func, kwargs, timeout=options.comms_timeout)
     if func in PB_METHOD_MAP:
-        pb_msg = PB_METHOD_MAP[func]()
+        if 'element_type' in kwargs:
+            pb_msg = PB_METHOD_MAP[func][kwargs['element_type']]()
+        else:
+            pb_msg = PB_METHOD_MAP[func]()
         pb_msg.ParseFromString(res)
         res_msg = MessageToDict(pb_msg)
     else:

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -797,8 +797,6 @@ class TaskJobManager(object):
             # Job pool insertion
             job_config = deepcopy(job_conf)
             job_config['logfiles'] = deepcopy(itask.summary['logfiles'])
-            job_config['job_log_dir'] = get_task_job_log(
-                suite, itask.point, itask.tdef.name, itask.submit_num)
             itask.jobs.append(job_config['job_d'])
             self.job_pool.insert_job(job_config)
 

--- a/cylc/flow/tests/util.py
+++ b/cylc/flow/tests/util.py
@@ -119,7 +119,7 @@ class CylcWorkflowTestCase(TestCase):
         self.suite_db_mgr.on_suite_start(is_restart=False)
 
         # JobPool
-        self.job_pool = JobPool(self.suite_name, self.owner)
+        self.job_pool = JobPool(self.scheduler)
         self.scheduler.job_pool = self.job_pool
 
         # TaskPool


### PR DESCRIPTION
This is a small change with no associated Issue.

This PR fixes a bug where no job display data is available on restart.
DB data is used to create job elements for display by WUI/TUI data-store on restart using DB data.
**Before**
![image](https://user-images.githubusercontent.com/11400777/78598392-59cf9480-78a3-11ea-9f13-72cb7d8d8f3d.png)

**After**
![image](https://user-images.githubusercontent.com/11400777/78598307-33115e00-78a3-11ea-9fae-dc6ecc8aee96.png)






**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required, pre-released feature fix.
- [x] No documentation update required.
