### PR TITLE
Ignore *.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ lib/cherrypy/test/test.conf
 
 # pipenv
 Pipfile
+
+# distutils files
+*.egg-info


### PR DESCRIPTION
I have a `cylc_flow.egg-info` directory that is not ignored on this branch (but is on master)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [X] Does not need tests.
- [X] No change log entry required (invisible to users).
- [X] No documentation update required.
