### PR TITLE
Ignore *.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ lib/cherrypy/test/test.conf
 
 # pipenv
 Pipfile
+
+# distutils files
+*.egg-info


### PR DESCRIPTION
Copied from #3563 on 7.8.x

> I have a `cylc_flow.egg-info` directory that is not ignored on this branch (but is on master)