### PR TITLE
Call colorama color_init only when use_color is True

### DIFF
--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -200,8 +200,8 @@ def cli_function(parser_function=None, **parser_kwargs):
                 wrapped_kwargs['color'] = use_color
 
             # configure Cylc to use colour
-            color_init(autoreset=True, strip=not use_color)
             if use_color:
+                color_init(autoreset=True, strip=not use_color)
                 ansi_log()
 
             try:


### PR DESCRIPTION
These changes close #3233 

@oliver-sanders PyCharm was failing when running unit tests. Not sure why, even though the command `cylc psutils ...` is executed normally without any color, the wrapper that is set up by `color_init` (`colorama` function) appears to add extra string at the end of the JSON, and then the test fails. But only when using PyCharm.

Looking at `terminal.py`, looks like we have a flag `use_color`. But the `colorama` function is always called, regardless of that flag. Which means the console stdout wrapper is always set up too.

This PR moves `color_init` so that it's called iff the `use_color` flag is `True`. Did a quick testing with `cylc run --no-detach --color=always five` & `cylc run --no-detach --color=never five`. Hitting CTRL+C after a couple seconds gives the correct output (i.e. colors when `color=always`, no colors otherwise).

Would it be OK to call `color_init` only in that case, or do we need to always call it for some other reason?

After this all 515 run (2 ignored) with no issues under PyCharm :tada: , which means I can also run profiler/coverage and other tools on the unit test battery.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
