### PR TITLE
Remove dead code in time_parser.py

### DIFF
--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -357,9 +357,6 @@ class CylcTimeParser(object):
                     continue
                 split_expr = self.OFFSET_REGEX.split(item)
                 expr += split_expr.pop(0)
-                if split_expr[1] == "+":
-                    split_expr.pop(1)
-                expr_offset_item = "".join(split_expr[1:])
                 expr_offset_item = self.duration_parser.parse(item[1:])
                 if item[0] == "-":
                     expr_offset_item *= -1


### PR DESCRIPTION
This is a small change with no associated Issue.

Was reading the code while looking at what was not being unit tested (though it could). When I found this `expr_offset_item` being set twice. Clearly the second value is used, whilst the first is discarded.

Removing the first assignment of `expr_offset_item`, the code above it appears to be dangling, not in use, so it should be safe to remove it I guess?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
