### PR TITLE
Fix xtrace redirect for bash-4.1+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ namespace, under `cylc.jinja.filters`.
 [#3541](https://github.com/cylc/cylc-flow/pull/3541) - Don't warn that a task
 was already added to an internal queue, if the queue is the same.
 
+[#3572](https://github.com/cylc/cylc-flow/pull/3572) - Fix debug mode
+redirection of job xtrace (`set -x`) output for bash-4.1 or greater.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2019-Q4?)__
 

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -29,9 +29,21 @@ cylc__job__main() {
     if "${CYLC_DEBUG:-false}"; then
         if [[ -n "${BASH:-}" ]]; then
             PS4='+[\D{%Y%m%dT%H%M%S%z}]\u@\h '
-            exec 19>>"${CYLC_SUITE_RUN_DIR}/log/job/${CYLC_TASK_JOB}/job.xtrace"
-            export BASH_XTRACEFD=19
-            >&2 echo "Sending DEBUG MODE xtrace to job.xtrace"
+            X_Y=${BASH_VERSION:0:3} # e.g. bash 4.2
+            if (( ${X_Y:0:1} < 4 )); then
+                # bash-3 (old!)
+                >&2 echo "WARNING: can't send DEBUG MODE xtrace output to job.xtrace in bash-$X"
+            else
+                >&2 echo "Sending DEBUG MODE xtrace output to job.xtrace"
+                if [[ "$X_Y" == "4.0" ]]; then
+                    exec 19>>"${CYLC_SUITE_RUN_DIR}/log/job/${CYLC_TASK_JOB}/job.xtrace"
+                    # This is an error in bash-4.1 or later:
+                    export BASH_XTRACEFD=19 
+                else
+                    # bash-4.1 or later
+                    exec {BASH_XTRACEFD}>>"${CYLC_SUITE_RUN_DIR}/log/job/${CYLC_TASK_JOB}/job.xtrace"
+                fi
+            fi
         fi
         set -x
     fi

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -32,7 +32,7 @@ cylc__job__main() {
             X_Y=${BASH_VERSION:0:3} # e.g. bash 4.2
             if (( ${X_Y:0:1} < 4 )); then
                 # bash-3 (old!)
-                >&2 echo "WARNING: can't send DEBUG MODE xtrace output to job.xtrace in bash-$X"
+                >&2 echo "WARNING: can't send DEBUG MODE xtrace output to job.xtrace in bash-$X_Y"
             else
                 >&2 echo "Sending DEBUG MODE xtrace output to job.xtrace"
                 if [[ "$X_Y" == "4.0" ]]; then


### PR DESCRIPTION
This is a small change with no associated Issue.
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Already covered by existing tests.
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.

We mess with file descriptors in `job.sh` in order to send `set -x` output from jobs to `job.xtrace` in the log directory.  The method used works for bash-4.0 but is broken for later versions.

One way to check this: `tests/broadcast/00-simple.t` fails horribly on master with a bunch of warnings `-bash: BASH_XTRACEFD: 19: invalid value for trace file descriptor` and no output to `job.xtrace` from the `prep` task.  But the test passes fine on this branch. (Note the particular FD 19 is not the problem).

Ref: https://stackoverflow.com/a/26611009

Tested at home with bash-4.2.

@cylc/core - anyone else have access to bash-4.1 or greater?