### PR TITLE
Test Cylc with different bash versions

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -1,0 +1,48 @@
+# Workflow for testing multiple bash versions with Docker
+name: bash
+
+on: [pull_request]
+
+jobs:
+  bash-docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bash-version:
+          - '3.2'
+          - '4.2'
+          # if you use a value like 5.0, YAML will round it to 5, which will cause an error later on
+          - '5.0'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Docker container
+        run: |
+          docker build -t bash:test dockerfiles/bash/
+          docker run --name bash -v $(pwd -P):/root/cylc-flow --rm -t -d bash:test /bin/bash
+          docker ps -a
+
+      - name: Install Cylc dependencies in the container
+        run: |
+          docker exec bash python3.7 -m pip install six==1.12
+          docker exec -w /root/cylc-flow bash python3.7 -m pip install -e .[all]
+
+      - name: Set the container bash version
+        run: docker exec bash update-alternatives --set bash /bash/bash-${{ matrix.bash-version }}
+
+      - name: Run functional tests that validate or are related to how Cylc uses bash
+        run: |
+          docker exec -e CYLC_TEST_RUN_GENERIC=true -w /root/cylc-flow bash \
+            ./etc/bin/run-functional-tests -v \
+            tests/functional/broadcast/00-simple.t \
+            tests/functional/cylc-poll/11-event-time.t \
+            tests/functional/cylc-poll/15-job-st-file-no-batch.t \
+            tests/functional/events/28-inactivity.t \
+            tests/functional/events/34-task-abort.t \
+            tests/functional/hold-release/12-hold-then-retry.t \
+            tests/functional/job-file-trap/00-sigusr1.t \
+            tests/functional/job-file-trap/02-pipefail.t \
+            tests/functional/shutdown/09-now2.t \
+            tests/functional/shutdown/13-no-port-file-check.t \
+            tests/functional/shutdown/14-no-dir-check.t

--- a/dockerfiles/bash/Dockerfile
+++ b/dockerfiles/bash/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Based on:
+#  - https://github.com/themattrix/bashup
+
+RUN apt-get update && apt-get install -y \
+    at \
+    lsof \
+    python3.7 \
+    python3-pip \
+    python3.7-dev \
+    sqlite3 \
+    wget \
+    && python3.7 -m pip install -U pip setuptools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /docker-scripts
+COPY build-bash /docker-scripts/
+COPY build-bash-versions /docker-scripts/
+RUN chmod +x /docker-scripts/* \
+    && mv /docker-scripts/* /usr/local/bin/ \
+    && rm -rf /docker-scripts
+
+VOLUME ["/root/cylc-flow"]
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV USER=root
+
+WORKDIR /
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+
+ENV BASH_VERSIONS_DIR /bash
+RUN mkdir $BASH_VERSIONS_DIR \
+    && build-bash-versions 3.2 4.2 5.0
+
+# the last parameter is the priority, the highest value is picked by default
+RUN update-alternatives --install /bin/bash bash /bash/bash-3.2 1 && \
+    update-alternatives --install /bin/bash bash /bash/bash-4.2 2 && \
+    update-alternatives --install /bin/bash bash /bash/bash-5.0 3 && \
+    update-alternatives --force --all && \
+    update-alternatives --list bash
+
+# To change the system bash version, use for example:
+# `update-alternatives --set bash /bash/bash-4.2`
+# Or if using a terminal, `update-alternatives --config bash` then choose one

--- a/dockerfiles/bash/build-bash
+++ b/dockerfiles/bash/build-bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+readonly VERSION=${1}
+readonly BASH_DIR="bash-${VERSION}"
+readonly BASH_TAR="bash-${VERSION}.tar.gz"
+
+wget -q "http://ftpmirror.gnu.org/bash/bash-${VERSION}.tar.gz"
+tar -xzf "${BASH_TAR}"
+cd "${BASH_DIR}"
+./configure
+make
+mv bash "${BASH_VERSIONS_DIR}/bash-${VERSION}"

--- a/dockerfiles/bash/build-bash-versions
+++ b/dockerfiles/bash/build-bash-versions
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+mkdir /build
+(cd /build; echo "$@" | xargs -n 1 -P 8 build-bash)
+rm -rf /build


### PR DESCRIPTION
Related to #3572

This PR uses a Docker image with several versions of bash (3.2, 4.2, 5.0) and sets up Python and a few more Linux utilities to enable Cylc Flow to run (re-using work from the SLURM PR #3521).

It would take too long to run the test battery for each bash version, so I was thinking more along the lines of selecting a few (5-20) tests that were useful for confirm the `job.sh` and other Shell-related features/code in Cylc 8 work correctly with different versions of `bash`.

Docker image and Travis implementation based on [bashup's excellent CI setup](https://github.com/themattrix/bashup). 

We could have other Bash versions, but not being very familiar with Bash or Shell, I chose the versions above without thinking too hard :grimacing: 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
