### PR TITLE
portability: fix relpath related test failures

### DIFF
--- a/etc/bin/run-functional-tests.sh
+++ b/etc/bin/run-functional-tests.sh
@@ -93,6 +93,11 @@ for ARG in "$@"; do
     esac
 done
 
+# ensure that TMPDIR is not a symlink
+# (we rely on path comparisons in many tests)
+TMPDIR="$(realpath "${TMPDIR:-/tmp}")"
+export TMPDIR
+
 # (Should be the same as $TRAVIS_BUILD_DIR, on Travis CI)
 cd "$(dirname "$0")/../.." || exit 1
 export CYLC_REPO_DIR="${PWD}"


### PR DESCRIPTION
This is a small change with no associated Issue.

Fix tests which are testing for the presence of `$PWD` in output on platforms where `TMPDIR` is a symlink.

This will cause `etc/bin/run-functional-tests` to bail if `TMPDIR` is not defined, but actually that's quite nice as the tests would pass anyway.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
