### PR TITLE
portability: /bin/true -> /usr/bin/true

### DIFF
--- a/flakytests/events/05-timeout-ref-dummy/suite.rc
+++ b/flakytests/events/05-timeout-ref-dummy/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/usr/bin/true"
+        script = "true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/flakytests/events/05-timeout-ref-dummy/suite.rc
+++ b/flakytests/events/05-timeout-ref-dummy/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/bin/true"
+        script = "/usr/bin/true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/authentication/basic/suite.rc
+++ b/tests/authentication/basic/suite.rc
@@ -19,8 +19,8 @@
         R/2 = bar[-P1] => pub
 [runtime]
     [[foo]]
-        script = /usr/bin/false
+        script = false
     [[bar]]
-        script = /usr/bin/true
+        script = true
     [[pub]]
-        script = /usr/bin/true
+        script = true

--- a/tests/authentication/basic/suite.rc
+++ b/tests/authentication/basic/suite.rc
@@ -19,8 +19,8 @@
         R/2 = bar[-P1] => pub
 [runtime]
     [[foo]]
-        script = /bin/false
+        script = /usr/bin/false
     [[bar]]
-        script = /bin/true
+        script = /usr/bin/true
     [[pub]]
-        script = /bin/true
+        script = /usr/bin/true

--- a/tests/authentication/override/suite.rc
+++ b/tests/authentication/override/suite.rc
@@ -17,8 +17,8 @@ Suite overrides global authentication settings."""
         R/2 = bar[-P1] => pub
 [runtime]
     [[foo]]
-        script = /usr/bin/false
+        script = false
     [[bar]]
-        script = /usr/bin/true
+        script = true
     [[pub]]
-        script = /usr/bin/true
+        script = true

--- a/tests/authentication/override/suite.rc
+++ b/tests/authentication/override/suite.rc
@@ -17,8 +17,8 @@ Suite overrides global authentication settings."""
         R/2 = bar[-P1] => pub
 [runtime]
     [[foo]]
-        script = /bin/false
+        script = /usr/bin/false
     [[bar]]
-        script = /bin/true
+        script = /usr/bin/true
     [[pub]]
-        script = /bin/true
+        script = /usr/bin/true

--- a/tests/cli/00-cycle-points/suite.rc
+++ b/tests/cli/00-cycle-points/suite.rc
@@ -10,4 +10,4 @@
         P1D = foo
 [runtime]
     [[foo]]
-        script = /bin/true
+        script = /usr/bin/true

--- a/tests/cli/00-cycle-points/suite.rc
+++ b/tests/cli/00-cycle-points/suite.rc
@@ -10,4 +10,4 @@
         P1D = foo
 [runtime]
     [[foo]]
-        script = /usr/bin/true
+        script = true

--- a/tests/clock-expire/00-basic/suite.rc
+++ b/tests/clock-expire/00-basic/suite.rc
@@ -25,7 +25,7 @@ Skip a daily post-processing workflow if the 'copy' task has expired."""
         """
 [runtime]
     [[root]]
-        script = /usr/bin/true
+        script = true
     [[copy]]
         script = """
 # Abort if I run in either of the first two cycle points.

--- a/tests/clock-expire/00-basic/suite.rc
+++ b/tests/clock-expire/00-basic/suite.rc
@@ -25,7 +25,7 @@ Skip a daily post-processing workflow if the 'copy' task has expired."""
         """
 [runtime]
     [[root]]
-        script = /bin/true
+        script = /usr/bin/true
     [[copy]]
         script = """
 # Abort if I run in either of the first two cycle points.

--- a/tests/cylc-insert/04-insert-family/suite.rc
+++ b/tests/cylc-insert/04-insert-family/suite.rc
@@ -14,7 +14,7 @@ The ref test will fail if either operation fails to work properly."""
         """
 [runtime]
     [[root]]
-        script = /bin/true
+        script = /usr/bin/true
     [[remover]]
         # Remove both families (also tests removal by pattern).
         script = """

--- a/tests/cylc-insert/04-insert-family/suite.rc
+++ b/tests/cylc-insert/04-insert-family/suite.rc
@@ -14,7 +14,7 @@ The ref test will fail if either operation fails to work properly."""
         """
 [runtime]
     [[root]]
-        script = /usr/bin/true
+        script = true
     [[remover]]
         # Remove both families (also tests removal by pattern).
         script = """

--- a/tests/cylc-insert/08-insert-family-compat/suite.rc
+++ b/tests/cylc-insert/08-insert-family-compat/suite.rc
@@ -14,7 +14,7 @@ The ref test will fail if either operation fails to work properly."""
         """
 [runtime]
     [[root]]
-        script = /bin/true
+        script = /usr/bin/true
     [[remover]]
         # Remove both families (also tests removal by pattern).
         script = """

--- a/tests/cylc-insert/08-insert-family-compat/suite.rc
+++ b/tests/cylc-insert/08-insert-family-compat/suite.rc
@@ -14,7 +14,7 @@ The ref test will fail if either operation fails to work properly."""
         """
 [runtime]
     [[root]]
-        script = /usr/bin/true
+        script = true
     [[remover]]
         # Remove both families (also tests removal by pattern).
         script = """

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -42,8 +42,8 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  
  cylc__job__inst__script() {
  # SCRIPT:
--/usr/bin/false
-+/usr/bin/true
+-false
++true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"
@@ -61,7 +61,7 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  cylc__job__inst__script() {
  # SCRIPT:
 -\$(x
-+/usr/bin/true
++true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -42,8 +42,8 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  
  cylc__job__inst__script() {
  # SCRIPT:
--/bin/false
-+/bin/true
+-/usr/bin/false
++/usr/bin/true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"
@@ -61,7 +61,7 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  cylc__job__inst__script() {
  # SCRIPT:
 -\$(x
-+/bin/true
++/usr/bin/true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"

--- a/tests/cylc-trigger/03-edit-run.t
+++ b/tests/cylc-trigger/03-edit-run.t
@@ -33,9 +33,7 @@ run_ok "${TEST_NAME}" cylc run --no-detach "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-diff"
 DIFF_LOG="$(cylc cat-log -m p -f d "${SUITE_NAME}" 'broken-task.1')"
-# Python 2.6 difflib adds an extra space after the filename,
-# but Python 2.7 does not. Remove it if it exists.
-sed -i 's/^\(--- original\|+++ edited\) $/\1/; /^@@/d' "${DIFF_LOG}"
+sed -i '/^@@/d' "${DIFF_LOG}"
 cmp_ok "${DIFF_LOG}" - <<__END__
 --- original
 +++ edited
@@ -51,9 +49,7 @@ __END__
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-diff2"
 DIFF_LOG="$(cylc cat-log -m p -f d "${SUITE_NAME}" 'syntax_errored_task.1')"
-# Python 2.6 difflib adds an extra space after the filename,
-# but Python 2.7 does not. Remove it if it exists.
-sed -i 's/^\(--- original\|+++ edited\) $/\1/; /^@@/d' "${DIFF_LOG}"
+sed -i '/^@@/d' "${DIFF_LOG}"
 cmp_ok "${DIFF_LOG}" - <<__END__
 --- original
 +++ edited

--- a/tests/cylc-trigger/03-edit-run/bin/my-edit
+++ b/tests/cylc-trigger/03-edit-run/bin/my-edit
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # shellcheck disable=SC2016
-sed -i 's@\(/usr/bin/false\|$(x\)@/usr/bin/true@' "$@"
+sed -i 's@\(false\|$(x\)@true@' "$@"

--- a/tests/cylc-trigger/03-edit-run/bin/my-edit
+++ b/tests/cylc-trigger/03-edit-run/bin/my-edit
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # shellcheck disable=SC2016
-sed -i 's@\(/bin/false\|$(x\)@/bin/true@' "$@"
+sed -i 's@\(/usr/bin/false\|$(x\)@/usr/bin/true@' "$@"

--- a/tests/cylc-trigger/03-edit-run/bin/my-edit
+++ b/tests/cylc-trigger/03-edit-run/bin/my-edit
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+sed -i 's|^false|true|' "$@"
 # shellcheck disable=SC2016
-sed -i 's@\(false\|$(x\)@true@' "$@"
+sed -i 's|$(x|true|' "$@"

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -15,7 +15,7 @@ second task fixes and retriggers it with an edit-run."""
         """
 [runtime]
     [[broken-task]]
-        script = /usr/bin/false
+        script = false
     [[fixer-task]]
         script = """
 cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END1__

--- a/tests/cylc-trigger/03-edit-run/suite.rc
+++ b/tests/cylc-trigger/03-edit-run/suite.rc
@@ -15,7 +15,7 @@ second task fixes and retriggers it with an edit-run."""
         """
 [runtime]
     [[broken-task]]
-        script = /bin/false
+        script = /usr/bin/false
     [[fixer-task]]
         script = """
 cylc trigger --edit $CYLC_SUITE_NAME 'broken-task.1' << __END1__

--- a/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
+++ b/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@echo HELLO@echo OOPS; /usr/bin/false@' "$@"
+sed -i 's@echo HELLO@echo OOPS; false@' "$@"

--- a/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
+++ b/tests/cylc-trigger/07-edit-run-abort/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@echo HELLO@echo OOPS; /bin/false@' "$@"
+sed -i 's@echo HELLO@echo OOPS; /usr/bin/false@' "$@"

--- a/tests/cylc-trigger/08-edit-run-host-select.t
+++ b/tests/cylc-trigger/08-edit-run-host-select.t
@@ -42,8 +42,8 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  
  cylc__job__inst__script() {
  # SCRIPT:
--/bin/false
-+/bin/true
+-/usr/bin/false
++/usr/bin/true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"

--- a/tests/cylc-trigger/08-edit-run-host-select.t
+++ b/tests/cylc-trigger/08-edit-run-host-select.t
@@ -42,8 +42,8 @@ cmp_ok "${DIFF_LOG}" - <<__END__
  
  cylc__job__inst__script() {
  # SCRIPT:
--/usr/bin/false
-+/usr/bin/true
+-false
++true
  }
  
  . "${SUITE_RUN_DIR}/.service/etc/job.sh"

--- a/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
+++ b/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@/usr/bin/false@/usr/bin/true@' "$@"
+sed -i 's@false@true@' "$@"

--- a/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
+++ b/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@/bin/false@/bin/true@' "$@"
+sed -i 's@/usr/bin/false@/usr/bin/true@' "$@"

--- a/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
+++ b/tests/cylc-trigger/08-edit-run-host-select/bin/my-edit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i 's@false@true@' "$@"
+sed -i 's@^false@true@' "$@"

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -12,7 +12,7 @@ second task fixes and retriggers it with an edit-run."""
         R1 = broken-task:fail => fixer-task
 [runtime]
     [[broken-task]]
-        script = /bin/false
+        script = /usr/bin/false
         [[[remote]]]
             host = $(echo localhost)
     [[fixer-task]]

--- a/tests/cylc-trigger/08-edit-run-host-select/suite.rc
+++ b/tests/cylc-trigger/08-edit-run-host-select/suite.rc
@@ -12,7 +12,7 @@ second task fixes and retriggers it with an edit-run."""
         R1 = broken-task:fail => fixer-task
 [runtime]
     [[broken-task]]
-        script = /usr/bin/false
+        script = false
         [[[remote]]]
             host = $(echo localhost)
     [[fixer-task]]

--- a/tests/events/suite/hidden/shutdown/suite.rc
+++ b/tests/events/suite/hidden/shutdown/suite.rc
@@ -1,6 +1,6 @@
 [cylc]
     [[events]]
-        shutdown handler = "/usr/bin/false"
+        shutdown handler = "false"
         abort if shutdown handler fails = True
 
 [scheduling]
@@ -9,4 +9,4 @@
 
 [runtime]
     [[root]]
-        script = "/usr/bin/true" # no sleep
+        script = "true" # no sleep

--- a/tests/events/suite/hidden/shutdown/suite.rc
+++ b/tests/events/suite/hidden/shutdown/suite.rc
@@ -1,6 +1,6 @@
 [cylc]
     [[events]]
-        shutdown handler = "/bin/false"
+        shutdown handler = "/usr/bin/false"
         abort if shutdown handler fails = True
 
 [scheduling]
@@ -9,4 +9,4 @@
 
 [runtime]
     [[root]]
-        script = "/bin/true" # no sleep
+        script = "/usr/bin/true" # no sleep

--- a/tests/events/suite/hidden/startup/suite.rc
+++ b/tests/events/suite/hidden/startup/suite.rc
@@ -1,6 +1,6 @@
 [cylc]
     [[events]]
-        startup handler = "/usr/bin/false"
+        startup handler = "false"
         abort if startup handler fails = True
 
 [scheduling]
@@ -9,4 +9,4 @@
 
 [runtime]
     [[root]]
-        script = "/usr/bin/true" # no sleep
+        script = "true" # no sleep

--- a/tests/events/suite/hidden/startup/suite.rc
+++ b/tests/events/suite/hidden/startup/suite.rc
@@ -1,6 +1,6 @@
 [cylc]
     [[events]]
-        startup handler = "/bin/false"
+        startup handler = "/usr/bin/false"
         abort if startup handler fails = True
 
 [scheduling]
@@ -9,4 +9,4 @@
 
 [runtime]
     [[root]]
-        script = "/bin/true" # no sleep
+        script = "/usr/bin/true" # no sleep

--- a/tests/events/suite/hidden/timeout/suite.rc
+++ b/tests/events/suite/hidden/timeout/suite.rc
@@ -6,7 +6,7 @@ deliberately fails."""
 [cylc]
     [[events]]
         timeout = PT5S
-        timeout handler = "/usr/bin/false"
+        timeout handler = "false"
         abort if timeout handler fails = True
 
 [scheduling]
@@ -16,7 +16,7 @@ deliberately fails."""
 
 [runtime]
     [[foo]]
-        script = "/usr/bin/true"
+        script = "true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/events/suite/hidden/timeout/suite.rc
+++ b/tests/events/suite/hidden/timeout/suite.rc
@@ -6,7 +6,7 @@ deliberately fails."""
 [cylc]
     [[events]]
         timeout = PT5S
-        timeout handler = "/bin/false"
+        timeout handler = "/usr/bin/false"
         abort if timeout handler fails = True
 
 [scheduling]
@@ -16,7 +16,7 @@ deliberately fails."""
 
 [runtime]
     [[foo]]
-        script = "/bin/true"
+        script = "/usr/bin/true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/events/timeout-ref/suite.rc
+++ b/tests/events/timeout-ref/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/usr/bin/true"
+        script = "true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/events/timeout-ref/suite.rc
+++ b/tests/events/timeout-ref/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/bin/true"
+        script = "/usr/bin/true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/events/timeout/suite.rc
+++ b/tests/events/timeout/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/usr/bin/true"
+        script = "true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/events/timeout/suite.rc
+++ b/tests/events/timeout/suite.rc
@@ -13,7 +13,7 @@
 
 [runtime]
     [[foo]]
-        script = "/bin/true"
+        script = "/usr/bin/true"
     [[bar]]
         # this task is never meant to run (thanks to the fail trigger),
         # it is just present to keep the suite alive after foo finishes

--- a/tests/host-select/00-simple/suite.rc
+++ b/tests/host-select/00-simple/suite.rc
@@ -15,7 +15,7 @@ by many of the other test suites (see "cylc test-battery --help")."""
         R1 = "foo1 & foo2 & foo3 & bar"
 [runtime]
     [[root]]
-        script = "/usr/bin/true" # fast
+        script = "true" # fast
     [[foo1, foo2, foo3]]
         [[[remote]]]
             # in suite bin directory:

--- a/tests/host-select/00-simple/suite.rc
+++ b/tests/host-select/00-simple/suite.rc
@@ -15,7 +15,7 @@ by many of the other test suites (see "cylc test-battery --help")."""
         R1 = "foo1 & foo2 & foo3 & bar"
 [runtime]
     [[root]]
-        script = "/bin/true" # fast
+        script = "/usr/bin/true" # fast
     [[foo1, foo2, foo3]]
         [[[remote]]]
             # in suite bin directory:

--- a/tests/intercycle/00-past/suite.rc
+++ b/tests/intercycle/00-past/suite.rc
@@ -15,4 +15,4 @@ Task A should only run at 0, 12 hours; Task B at 6, 18"""
         T06,T18 = "A[-PT6H] => B"
 [runtime]
     [[root]]
-        script = "/bin/true" # fast
+        script = "/usr/bin/true" # fast

--- a/tests/intercycle/00-past/suite.rc
+++ b/tests/intercycle/00-past/suite.rc
@@ -15,4 +15,4 @@ Task A should only run at 0, 12 hours; Task B at 6, 18"""
         T06,T18 = "A[-PT6H] => B"
 [runtime]
     [[root]]
-        script = "/usr/bin/true" # fast
+        script = "true" # fast

--- a/tests/intercycle/01-future/suite.rc
+++ b/tests/intercycle/01-future/suite.rc
@@ -9,4 +9,4 @@
         R/+PT6H/PT6H = a
 [runtime]
     [[a,b]]
-        script = "/bin/true" # fast
+        script = "/usr/bin/true" # fast

--- a/tests/intercycle/01-future/suite.rc
+++ b/tests/intercycle/01-future/suite.rc
@@ -9,4 +9,4 @@
         R/+PT6H/PT6H = a
 [runtime]
     [[a,b]]
-        script = "/usr/bin/true" # fast
+        script = "true" # fast

--- a/tests/message-triggers/00-basic/suite.rc
+++ b/tests/message-triggers/00-basic/suite.rc
@@ -23,4 +23,4 @@ cylc message -- "${CYLC_SUITE_NAME} "${CYLC_TASK_JOB} "file 2 done"
             out1 = "file 1 done"
             out2 = "file 2 done"
     [[bar, baz]]
-        script = /bin/true
+        script = /usr/bin/true

--- a/tests/message-triggers/00-basic/suite.rc
+++ b/tests/message-triggers/00-basic/suite.rc
@@ -23,4 +23,4 @@ cylc message -- "${CYLC_SUITE_NAME} "${CYLC_TASK_JOB} "file 2 done"
             out1 = "file 1 done"
             out2 = "file 2 done"
     [[bar, baz]]
-        script = /usr/bin/true
+        script = true

--- a/tests/remote/basic/suite.rc
+++ b/tests/remote/basic/suite.rc
@@ -10,11 +10,11 @@
         R1 = "foo => bar"
 [runtime]
     [[foo]]
-        script = "/bin/true" # fast
+        script = "/usr/bin/true" # fast
         [[[remote]]]
             host = {{ HOST }}
             owner = {{ OWNER }}
     [[bar]]
-        script = "/bin/true"
+        script = "/usr/bin/true"
         [[[remote]]]
             host = {{ HOST }}

--- a/tests/remote/basic/suite.rc
+++ b/tests/remote/basic/suite.rc
@@ -10,11 +10,11 @@
         R1 = "foo => bar"
 [runtime]
     [[foo]]
-        script = "/usr/bin/true" # fast
+        script = "true" # fast
         [[[remote]]]
             host = {{ HOST }}
             owner = {{ OWNER }}
     [[bar]]
-        script = "/usr/bin/true"
+        script = "true"
         [[[remote]]]
             host = {{ HOST }}

--- a/tests/restart/pre-init-2/suite.rc
+++ b/tests/restart/pre-init-2/suite.rc
@@ -21,6 +21,6 @@
         """
 [runtime]
     [[root]]
-        script = /bin/true
+        script = /usr/bin/true
     [[foo]]
     [[bar]]

--- a/tests/restart/pre-init-2/suite.rc
+++ b/tests/restart/pre-init-2/suite.rc
@@ -21,6 +21,6 @@
         """
 [runtime]
     [[root]]
-        script = /usr/bin/true
+        script = true
     [[foo]]
     [[bar]]

--- a/tests/shutdown/05-auto/suite.rc
+++ b/tests/shutdown/05-auto/suite.rc
@@ -12,4 +12,4 @@
         P1D = foo
 [runtime]
     [[foo]]
-        script = /bin/true
+        script = /usr/bin/true

--- a/tests/shutdown/05-auto/suite.rc
+++ b/tests/shutdown/05-auto/suite.rc
@@ -12,4 +12,4 @@
         P1D = foo
 [runtime]
     [[foo]]
-        script = /usr/bin/true
+        script = true

--- a/tests/suite-state/upstream/suite.rc
+++ b/tests/suite-state/upstream/suite.rc
@@ -13,7 +13,7 @@
     [[good-stuff]]
         script = "sleep 20"
     [[bad]]
-        script = "sleep 20; /bin/false"
+        script = "sleep 20; /usr/bin/false"
     [[messenger]]
         script = """
           sleep 20

--- a/tests/suite-state/upstream/suite.rc
+++ b/tests/suite-state/upstream/suite.rc
@@ -13,7 +13,7 @@
     [[good-stuff]]
         script = "sleep 20"
     [[bad]]
-        script = "sleep 20; /usr/bin/false"
+        script = "sleep 20; false"
     [[messenger]]
         script = """
           sleep 20


### PR DESCRIPTION
This is a small change with no associated Issue.

* `true` is a shell builtin available everywhere.
* `/bin/true` is not available on all platforms.
* `/usr/bin/true` would appear to be present on most.

Options:

1) ~Change to `/usr/bin/true`.~ Not a valid option.
2) Change to `true`.

Happy to go either way.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
