### PR TITLE
portability: add get_fqdn_by_host function

### DIFF
--- a/flakytests/database/00-simple.t
+++ b/flakytests/database/00-simple.t
@@ -56,7 +56,7 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-LOCALHOST="$(hostname -f)"
+LOCALHOST="$(get_fqdn_by_host)"
 # FIXME: recent Travis CI failure
 sed -i "s/localhost/${LOCALHOST}/" "${NAME}"
 cmp_ok "${NAME}" - <<__SELECT__

--- a/flakytests/database/01-broadcast.t
+++ b/flakytests/database/01-broadcast.t
@@ -52,7 +52,7 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-LOCALHOST="$(hostname -f)"
+LOCALHOST="$(get_fqdn_by_host)"
 # FIXME: recent Travis CI failure
 sed -i "s/localhost/${LOCALHOST}/" "${NAME}"
 cmp_ok "${NAME}" <<__SELECT__

--- a/flakytests/database/02-retry.t
+++ b/flakytests/database/02-retry.t
@@ -38,7 +38,7 @@ sqlite3 "${DB_FILE}" \
             user_at_host, batch_sys_name
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
-LOCALHOST="$(hostname -f)"
+LOCALHOST="$(get_fqdn_by_host)"
 # FIXME: recent Travis CI failure
 sed -i "s/localhost/${LOCALHOST}/" "${NAME}"
 cmp_ok "${NAME}" <<__SELECT__

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -35,7 +35,7 @@ sqlite3 "${DB_FILE}" \
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
 cmp_ok "${NAME}" <<__SELECT__
-20200101T0000Z|t1|1|1|0|0|$(hostname -f)|background
+20200101T0000Z|t1|1|1|0|0|$(get_fqdn_by_host)|background
 20200101T0000Z|t2|1|1|0|0|${CYLC_TEST_HOST}|background
 __SELECT__
 

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -120,6 +120,8 @@
 #         (Remote job tests should really use set_test_remote, below, however).
 #     set_test_remote
 #         set CYLC_TEST_HOST and CYLC_TEST_OWNER for remote job tests.
+#     get_fqdn_by_host [TARGET]
+#         Get a host FQDN using the same mechanism Cylc uses.
 #-------------------------------------------------------------------------------
 set -eu
 
@@ -684,6 +686,18 @@ set_test_remote() {
   fi
   export CYLC_TEST_HOST=${CYLC_TEST_HOST:-"localhost"}
   export CYLC_TEST_OWNER=${CYLC_TEST_OWNER:-${USER}}
+}
+
+get_fqdn_by_host() {
+if [[ $# -eq 1 ]]; then
+    TARGET="'$1'"
+else
+    TARGET='None'
+fi
+python -c "
+from cylc.flow.hostuserutil import get_fqdn_by_host
+print(get_fqdn_by_host(${TARGET}))
+"
 }
 
 

--- a/tests/restart/34-auto-restart-basic.t
+++ b/tests/restart/34-auto-restart-basic.t
@@ -78,7 +78,7 @@ LATEST_TASK=$(cylc suite-state "${SUITE_NAME}" -S succeeded \
 poll_suite_stopped
 FILE=$(cylc cat-log "${SUITE_NAME}" -m p |xargs readlink -f)
 log_scan "${TEST_NAME}-restart" "${FILE}" 20 1 \
-    "Suite server: url=tcp://$(ssh "${CYLC_TEST_HOST}" hostname -f)"
+    "Suite server: url=tcp://$(get_fqdn_by_host "${CYLC_TEST_HOST}")"
 run_ok "${TEST_NAME}-restart-success" cylc suite-state "${SUITE_NAME}" \
     --task="$(printf 'task_foo%02d' $(( LATEST_TASK + 3 )))" \
     --status='succeeded' --point=1 --interval=1 --max-polls=20

--- a/tests/restart/41-auto-restart-local-jobs.t
+++ b/tests/restart/41-auto-restart-local-jobs.t
@@ -97,7 +97,7 @@ grep_fail "$(job-ps-line bar)" "${TEST_NAME}-ps-2.stdout"
 poll_suite_stopped
 FILE=$(cylc cat-log "${SUITE_NAME}" -m p |xargs readlink -f)
 log_scan "${TEST_NAME}-restart" "${FILE}" 20 1 \
-    "Suite server: url=tcp://$(ssh "${CYLC_TEST_HOST2}" hostname -f)"
+    "Suite server: url=tcp://$(get_fqdn_by_host "${CYLC_TEST_HOST2}")"
 sleep 1
 #-------------------------------------------------------------------------------
 # auto stop-restart - force mode:

--- a/tests/restart/42-auto-restart-ping-pong.t
+++ b/tests/restart/42-auto-restart-ping-pong.t
@@ -109,7 +109,7 @@ for ear in $(seq 1 "${EARS}"); do
     # test the restart procedure
     FILE=$(cylc cat-log "${SUITE_NAME}" -m p |xargs readlink -f)
     log_scan2 "${TEST_NAME_BASE}-${ear}-restart" "${FILE}" 20 1 \
-        "Suite server: url=tcp://$(ssh "${JOKERS}" hostname -f)"
+        "Suite server: url=tcp://$(get_fqdn_by_host "${JOKERS}")"
     sleep 2
 done
 


### PR DESCRIPTION
Unfortunately `hostname -f` does not always match `cylc.flow.hostuserutil.get_fqdn_by_host`.

This causes some tests to fail, I've observed this on:

* GitHub Actions - ubuntu-latest
* Mac OS

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
