### PR TITLE
Fix DB action timers housekeeping.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.7']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Configure Python
         uses: actions/setup-python@v1
@@ -55,7 +55,7 @@ jobs:
       CHUNK: ${{ matrix.tests[1] }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Configure Python
         uses: actions/setup-python@v1

--- a/cylc/flow/suite_db_mgr.py
+++ b/cylc/flow/suite_db_mgr.py
@@ -355,19 +355,18 @@ class SuiteDatabaseManager(object):
 
     def put_task_event_timers(self, task_events_mgr):
         """Put statements to update the task_action_timers table."""
-        if task_events_mgr.event_timers:
-            self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
-            for key, timer in task_events_mgr.event_timers.items():
-                key1, point, name, submit_num = key
-                self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
-                    "name": name,
-                    "cycle": point,
-                    "ctx_key": json.dumps((key1, submit_num,)),
-                    "ctx": self._namedtuple2json(timer.ctx),
-                    "delays": json.dumps(timer.delays),
-                    "num": timer.num,
-                    "delay": timer.delay,
-                    "timeout": timer.timeout})
+        self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
+        for key, timer in task_events_mgr.event_timers.items():
+            key1, point, name, submit_num = key
+            self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
+                "name": name,
+                "cycle": point,
+                "ctx_key": json.dumps((key1, submit_num,)),
+                "ctx": self._namedtuple2json(timer.ctx),
+                "delays": json.dumps(timer.delays),
+                "num": timer.num,
+                "delay": timer.delay,
+                "timeout": timer.timeout})
 
     def put_xtriggers(self, sat_xtrig):
         """Put statements to update external triggers table."""

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -58,8 +58,9 @@
 #     contains_ok FILE_TEST [FILE_CONTROL]
 #         Make sure that each line in FILE_TEST is present in FILE_CONTROL
 #         (stdin if FILE_CONTROL is "-" or missing).
-#     grep_ok PATTERN FILE
-#         Run "grep -q -e PATTERN FILE".
+#     grep_ok PATTERN FILE [$OPTS]
+#         Run "grep [$OPTS] -q -e PATTERN FILE".
+#         OPTS: put grep options like '-E' (extended regex) at end of line.
 #     grep_fail PATTERN FILE
 #         Run "grep -q -e PATTERN FILE", expect no match.
 #     count_ok PATTERN FILE COUNT
@@ -324,11 +325,14 @@ count_ok() {
 }
 
 grep_ok() {
+    # (Put extra grep options like '-E' at end of the command line)
     local BRE="$1"
     local FILE="$2"
+    shift 2
+    OPTS=$@
     local TEST_NAME
     TEST_NAME="$(basename "${FILE}")-grep-ok"
-    if grep -q -e "${BRE}" "${FILE}"; then
+    if grep $OPTS -q -e "${BRE}" "${FILE}"; then
         ok "${TEST_NAME}"
         return
     fi

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -329,10 +329,10 @@ grep_ok() {
     local BRE="$1"
     local FILE="$2"
     shift 2
-    OPTS=$@
+    OPTS="$*"
     local TEST_NAME
     TEST_NAME="$(basename "${FILE}")-grep-ok"
-    if grep $OPTS -q -e "${BRE}" "${FILE}"; then
+    if grep "${OPTS}" -q -e "${BRE}" "${FILE}"; then
         ok "${TEST_NAME}"
         return
     fi

--- a/tests/shutdown/14-no-dir-check.t
+++ b/tests/shutdown/14-no-dir-check.t
@@ -42,7 +42,7 @@ suite_run_fail "${TEST_NAME_BASE}-run" \
 # - (TODO: if other failure modes show up, add to the list here!)
 FAIL1="Suite run directory does not exist: ${SYM_SUITE_RUND}"
 FAIL2="sqlite3.OperationalError: unable to open database file"
-grep_ok "($FAIL1|$FAIL2)" "${SUITE_RUN_DIR}/log/suite/log".* -E
+grep_ok "(${FAIL1}|${FAIL2})" "${SUITE_RUN_DIR}/log/suite/log".* -E
 rm -f "${SYM_SUITE_RUND}"
 purge_suite "${SUITE_NAME}"
 exit

--- a/tests/shutdown/14-no-dir-check.t
+++ b/tests/shutdown/14-no-dir-check.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test suite shuts down with error on missing port file
+# Test suite shuts down with error on missing run directory
 . "$(dirname "$0")/test_header"
 set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
@@ -36,9 +36,13 @@ ln -s "$(basename "${SUITE_NAME}")" "${SYM_SUITE_RUND}"
 # shellcheck disable=SC2086
 suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --no-detach ${OPT_SET} "${SYM_SUITE_NAME}"
-grep_ok "Suite run directory does not exist: ${SYM_SUITE_RUND}" \
-    "${SUITE_RUN_DIR}/log/suite/log".*
-
+# Possible failure modes:
+# - health check detects missing run directory
+# - DB housekeeping cannot access DB because run directory missing
+# - (TODO: if other failure modes show up, add to the list here!)
+FAIL1="Suite run directory does not exist: ${SYM_SUITE_RUND}"
+FAIL2="sqlite3.OperationalError: unable to open database file"
+grep_ok "($FAIL1|$FAIL2)" "${SUITE_RUN_DIR}/log/suite/log".* -E
 rm -f "${SYM_SUITE_RUND}"
 purge_suite "${SUITE_NAME}"
 exit


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->
These changes close #3590 

Bug allows `task_action_timers` DB table housekeeping to be skipped, so the table grows forever, and causes screeds of warning messages on restart.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required. (Not user-facing)
