### PR TITLE
Generate client keys on remote platforms

### DIFF
--- a/cylc/flow/network/authentication.py
+++ b/cylc/flow/network/authentication.py
@@ -1,0 +1,50 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Authentication key setup"""
+
+from cylc.flow.suite_files import (
+    KeyInfo,
+    KeyOwner,
+    KeyType,
+    create_server_keys,
+    get_suite_srv_dir,
+    remove_keys_on_server)
+
+
+def key_setup(reg, platform=None):
+
+    """Clean any existing authentication keys and create new ones."""
+    suite_srv_dir = get_suite_srv_dir(reg)
+    keys = {
+        "client_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.CLIENT,
+            suite_srv_dir=suite_srv_dir, platform=platform),
+        "client_private_key": KeyInfo(
+            KeyType.PRIVATE,
+            KeyOwner.CLIENT,
+            suite_srv_dir=suite_srv_dir),
+        "server_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.SERVER,
+            suite_srv_dir=suite_srv_dir),
+        "server_private_key": KeyInfo(
+            KeyType.PRIVATE,
+            KeyOwner.SERVER,
+            suite_srv_dir=suite_srv_dir)
+    }
+    remove_keys_on_server(keys)
+    create_server_keys(keys, suite_srv_dir)

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -171,7 +171,11 @@ class SuiteRuntimeClient(ZMQSocketBase):
         else:
             if callable(self.timeout_handler):
                 self.timeout_handler()
-            raise ClientTimeout('Timeout waiting for server response.')
+            raise ClientTimeout(
+                'Timeout waiting for server response.'
+                ' This could be due to network or server issues.'
+                ' Check the suite log.'
+            )
 
         if msg['command'] in PB_METHOD_MAP:
             response = {'data': res}

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -212,6 +212,8 @@ class Scheduler(object):
         self.ext_trigger_queue = None
         self.data_store_mgr = None
         self.job_pool = None
+        self.curve_auth = None
+        self.client_pub_key_dir = None
 
         self._profile_amounts = {}
         self._profile_update_times = {}
@@ -621,8 +623,10 @@ see `COPYING' in the Cylc source distribution.
                 auths.add((itask.task_host, itask.task_owner))
         while auths:
             for host, owner in auths.copy():
-                if self.task_job_mgr.task_remote_mgr.remote_init(
-                        host, owner) is not None:
+                if (
+                    self.task_job_mgr.task_remote_mgr.remote_init(
+                        host, owner, self.curve_auth, self.client_pub_key_dir)
+                ) is not None:
                     auths.remove((host, owner))
             if auths:
                 sleep(1.0)

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -23,12 +23,12 @@ import cylc.flow.flags
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.host_select import select_suite_host
 from cylc.flow.hostuserutil import is_remote_host
+from cylc.flow.network.authentication import key_setup
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.pathutil import get_suite_run_dir
 from cylc.flow.remote import remrun, remote_cylc_cmd
 from cylc.flow.scheduler import Scheduler
 from cylc.flow import suite_files
-from cylc.flow.suite_files import (KeyInfo, KeyOwner, KeyType)
 from cylc.flow.resources import extract_resources
 from cylc.flow.terminal import cli_function
 
@@ -274,28 +274,8 @@ def scheduler_cli(parser, options, args, is_restart=False):
             # Prevent recursive host selection
             base_cmd.append("--host=localhost")
             return remote_cylc_cmd(base_cmd, host=options.host)
-    suite_srv_dir = suite_files.get_suite_srv_dir(reg)
-    # Clean any existing authentication keys and create new ones.
-    keys = {
-        "client_public_key": KeyInfo(
-            KeyType.PUBLIC,
-            KeyOwner.CLIENT,
-            suite_srv_dir=suite_srv_dir, platform=options.host),
-        "client_private_key": KeyInfo(
-            KeyType.PRIVATE,
-            KeyOwner.CLIENT,
-            suite_srv_dir=suite_srv_dir),
-        "server_public_key": KeyInfo(
-            KeyType.PUBLIC,
-            KeyOwner.SERVER,
-            suite_srv_dir=suite_srv_dir),
-        "server_private_key": KeyInfo(
-            KeyType.PRIVATE,
-            KeyOwner.SERVER,
-            suite_srv_dir=suite_srv_dir)
-    }
-    suite_files.remove_keys_on_server(keys)
-    suite_files.create_server_keys(keys, suite_srv_dir)
+    # Create ZMQ keys
+    key_setup(reg, platform=options.host)
     if remrun(set_rel_local=True):  # State localhost as above.
         sys.exit()
 

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -265,21 +265,22 @@ def scheduler_cli(parser, options, args, is_restart=False):
 
     # Check whether a run host is explicitly specified, else select one.
     if not options.host:
-        host = select_suite_host()[0]
-        if is_remote_host(host):
+        options.host = select_suite_host()[0]
+        if is_remote_host(options.host):
             if is_restart:
                 base_cmd = ["restart"] + sys.argv[1:]
             else:
                 base_cmd = ["run"] + sys.argv[1:]
             # Prevent recursive host selection
             base_cmd.append("--host=localhost")
-            return remote_cylc_cmd(base_cmd, host=host)
+            return remote_cylc_cmd(base_cmd, host=options.host)
     suite_srv_dir = suite_files.get_suite_srv_dir(reg)
+    # Clean any existing authentication keys and create new ones.
     keys = {
         "client_public_key": KeyInfo(
             KeyType.PUBLIC,
             KeyOwner.CLIENT,
-            suite_srv_dir=suite_srv_dir, platform=host),
+            suite_srv_dir=suite_srv_dir, platform=options.host),
         "client_private_key": KeyInfo(
             KeyType.PRIVATE,
             KeyOwner.CLIENT,
@@ -293,7 +294,6 @@ def scheduler_cli(parser, options, args, is_restart=False):
             KeyOwner.SERVER,
             suite_srv_dir=suite_srv_dir)
     }
-    # Clean any existing authentication keys and create new ones.
     suite_files.remove_keys_on_server(keys)
     suite_files.create_server_keys(keys, suite_srv_dir)
     if remrun(set_rel_local=True):  # State localhost as above.

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -177,7 +177,8 @@ class TaskJobManager(object):
                 bad_tasks.append(itask)
         return [prepared_tasks, bad_tasks]
 
-    def submit_task_jobs(self, suite, itasks, is_simulation=False):
+    def submit_task_jobs(self, suite, itasks, curve_auth,
+                         client_pub_key_dir, is_simulation=False):
         """Prepare and submit task jobs.
 
         Submit tasks where possible. Ignore tasks that are waiting for host
@@ -210,7 +211,8 @@ class TaskJobManager(object):
         # Submit task jobs for each (host, owner) group
         done_tasks = bad_tasks
         for (host, owner), itasks in sorted(auth_itasks.items()):
-            is_init = self.task_remote_mgr.remote_init(host, owner)
+            is_init = self.task_remote_mgr.remote_init(
+                host, owner, curve_auth, client_pub_key_dir)
             if is_init is None:
                 # Remote is waiting to be initialised
                 for itask in itasks:

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -16,12 +16,18 @@
 """Implement "cylc remote-init" and "cylc remote-tidy"."""
 
 import os
-import sys
+import zmq
 import tarfile
+import sys
+import datetime
 
 import cylc.flow.flags
 from cylc.flow.suite_files import (
+    KeyInfo,
+    KeyOwner,
+    KeyType,
     ContactFileFields,
+    get_suite_srv_dir,
     SuiteFiles
 )
 from cylc.flow.resources import extract_resources
@@ -30,6 +36,44 @@ from cylc.flow.resources import extract_resources
 FILE_BASE_UUID = 'uuid'
 REMOTE_INIT_DONE = 'REMOTE INIT DONE'
 REMOTE_INIT_NOT_REQUIRED = 'REMOTE INIT NOT REQUIRED'
+
+
+def remove_keys_on_platform(srvd):
+    """Removes platform-held authentication keys"""
+    keys = {
+        "client_private_key": KeyInfo(
+            KeyType.PRIVATE,
+            KeyOwner.CLIENT,
+            suite_srv_dir=srvd),
+        "client_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.CLIENT,
+            suite_srv_dir=srvd, server_held=False),
+        "server_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.SERVER,
+            suite_srv_dir=srvd),
+    }
+    # WARNING, DESTRUCTIVE. Removes old keys if they already exist.
+
+    for k in keys.values():
+        if os.path.exists(k.full_key_path):
+            os.remove(k.full_key_path)
+
+
+def create_platform_keys(srvd):
+    """Create or renew authentication keys for suite 'reg' in the .service
+     directory.
+     Generate a pair of ZMQ authentication keys"""
+    # ZMQ keys generated in .service directory.
+    # ZMQ keys need to be created with stricter file permissions, changing
+    # umask default denials.
+
+    old_umask = os.umask(0o177)  # u=rw only set as default for file creation
+    _client_public_full_key_path, _client_private_full_key_path = (
+        zmq.auth.create_certificates(srvd, KeyOwner.CLIENT.value))
+    # Return file permissions to default settings.
+    os.umask(old_umask)
 
 
 def remote_init(uuid_str, rund, indirect_comm=None):
@@ -50,7 +94,9 @@ def remote_init(uuid_str, rund, indirect_comm=None):
         if orig_uuid_str == uuid_str:
             print(REMOTE_INIT_NOT_REQUIRED)
             return
-    os.makedirs(rund, exist_ok=True)
+    os.makedirs(srvd, exist_ok=True)
+    remove_keys_on_platform(srvd)
+    create_platform_keys(srvd)
     oldcwd = os.getcwd()
     os.chdir(rund)
     # Extract job.sh from library, for use in job scripts.
@@ -66,6 +112,10 @@ def remote_init(uuid_str, rund, indirect_comm=None):
         with open(fname, 'a') as handle:
             handle.write('%s=%s\n' % (
                 ContactFileFields.COMMS_PROTOCOL_2, indirect_comm))
+    path_to_pub_key = os.path.join(srvd, "client.key")
+    print("KEYSTART", end='')
+    with open(path_to_pub_key) as keyfile:
+        print(keyfile.read(), end='KEYEND')
     print(REMOTE_INIT_DONE)
     return
 
@@ -87,6 +137,7 @@ def remote_tidy(rund):
     else:
         if cylc.flow.flags.debug:
             print('Deleted: %s' % fname)
+    remove_keys_on_platform(srvd)
     try:
         os.rmdir(srvd)  # remove directory if empty
     except OSError:

--- a/cylc/flow/tests/network/key_setup.py
+++ b/cylc/flow/tests/network/key_setup.py
@@ -1,0 +1,53 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Creates authentication keys for use in testing"""
+
+from cylc.flow.suite_files import (
+    create_server_keys,
+    get_suite_srv_dir,
+    KeyInfo,
+    KeyOwner,
+    KeyType,
+    remove_keys_on_server)
+from cylc.flow.task_remote_cmd import (
+    remove_keys_on_platform, create_platform_keys)
+
+
+def setup_keys(suite_name):
+    suite_srv_dir = get_suite_srv_dir(suite_name)
+    server_keys = {
+        "client_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.CLIENT,
+            suite_srv_dir=suite_srv_dir),
+        "client_private_key": KeyInfo(
+            KeyType.PRIVATE,
+            KeyOwner.CLIENT,
+            suite_srv_dir=suite_srv_dir),
+        "server_public_key": KeyInfo(
+            KeyType.PUBLIC,
+            KeyOwner.SERVER,
+            suite_srv_dir=suite_srv_dir),
+        "server_private_key": KeyInfo(
+            KeyType.PRIVATE,
+            KeyOwner.SERVER,
+            suite_srv_dir=suite_srv_dir)
+    }
+    remove_keys_on_server(server_keys)
+    remove_keys_on_platform(suite_srv_dir)
+    create_server_keys(server_keys, suite_srv_dir)
+    create_platform_keys(suite_srv_dir)

--- a/cylc/flow/tests/network/test_client.py
+++ b/cylc/flow/tests/network/test_client.py
@@ -24,7 +24,7 @@ import zmq
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network.server import SuiteRuntimeServer, PB_METHOD_MAP
 from cylc.flow.network.client import SuiteRuntimeClient
-from cylc.flow.suite_files import create_auth_files
+from cylc.flow.tests.network.key_setup import setup_keys
 from cylc.flow.tests.util import CylcWorkflowTestCase, create_task_proxy
 from cylc.flow.data_store_mgr import DataStoreMgr
 
@@ -75,7 +75,7 @@ class TestSuiteRuntimeClient(CylcWorkflowTestCase):
         self.task_pool.release_runahead_tasks()
         self.scheduler.data_store_mgr.initiate_data_model()
         self.workflow_id = self.scheduler.data_store_mgr.workflow_id
-        create_auth_files(self.suite_name)  # auth keys are required for comms
+        setup_keys(self.suite_name)
         barrier = Barrier(2, timeout=20)
         self.server = SuiteRuntimeServer(
             self.scheduler,

--- a/cylc/flow/tests/network/test_server.py
+++ b/cylc/flow/tests/network/test_server.py
@@ -24,7 +24,7 @@ import zmq
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network.authorisation import Priv
 from cylc.flow.network.server import SuiteRuntimeServer, PB_METHOD_MAP
-from cylc.flow.suite_files import create_auth_files
+from cylc.flow.tests.network.key_setup import setup_keys
 from cylc.flow.tests.util import CylcWorkflowTestCase, create_task_proxy
 from cylc.flow.data_store_mgr import DataStoreMgr
 
@@ -81,7 +81,7 @@ class TestSuiteRuntimeServer(CylcWorkflowTestCase):
         self.task_pool.release_runahead_tasks()
         self.scheduler.data_store_mgr.initiate_data_model()
         self.workflow_id = self.scheduler.data_store_mgr.workflow_id
-        create_auth_files(self.suite_name)  # auth keys are required for comms
+        setup_keys(self.suite_name)
         barrier = Barrier(2, timeout=10)
         self.server = SuiteRuntimeServer(
             self.scheduler,

--- a/cylc/flow/tests/network/test_zmq.py
+++ b/cylc/flow/tests/network/test_zmq.py
@@ -29,13 +29,8 @@ import zmq
 from cylc.flow.exceptions import ClientError, CylcError, SuiteServiceFileError
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network import ZMQSocketBase
-from cylc.flow.suite_files import (
-    create_auth_files,
-    get_suite_srv_dir,
-    SuiteFiles,
-    KeyInfo,
-    KeyOwner,
-    KeyType)
+from cylc.flow.suite_files import get_suite_srv_dir, KeyInfo, KeyOwner, KeyType
+from cylc.flow.tests.network.key_setup import setup_keys
 
 
 def get_port_range():
@@ -147,11 +142,11 @@ def test_client_requires_valid_client_private_key():
 def test_single_port():
     """Test server on a single port and port in use exception."""
     context = zmq.Context()
-    create_auth_files('test_zmq')  # auth keys are required for comms
+    setup_keys("test_zmq")  # auth keys are required for comms
     serv1 = ZMQSocketBase(
-        zmq.REP, context=context, suite='test_zmq', bind=True)
+        zmq.REP, context=context, suite="test_zmq", bind=True)
     serv2 = ZMQSocketBase(
-        zmq.REP, context=context, suite='test_zmq', bind=True)
+        zmq.REP, context=context, suite="test_zmq", bind=True)
 
     serv1._socket_bind(*PORT_RANGE)
     port = serv1.port
@@ -166,7 +161,7 @@ def test_single_port():
 
 def test_start():
     """Test socket start."""
-    create_auth_files('test_zmq_start')  # auth keys are required for comms
+    setup_keys('test_zmq_start')  # auth keys are required for comms
     barrier = Barrier(2, timeout=20)
     publisher = ZMQSocketBase(zmq.PUB, suite='test_zmq_start', bind=True,
                               barrier=barrier, threaded=True, daemon=True)
@@ -186,7 +181,7 @@ def test_start():
 
 def test_stop():
     """Test socket/thread stop."""
-    create_auth_files('test_zmq_stop')  # auth keys are required for comms
+    setup_keys('test_zmq_stop')  # auth keys are required for comms
     barrier = Barrier(2, timeout=20)
     publisher = ZMQSocketBase(zmq.PUB, suite='test_zmq_stop', bind=True,
                               barrier=barrier, threaded=True, daemon=True)

--- a/tests/cylc-scan/02-sigstop.t
+++ b/tests/cylc-scan/02-sigstop.t
@@ -33,7 +33,7 @@ sleep 1
 run_ok "${TEST_NAME_BASE}-scan" cylc scan
 # ensure there is no traceback
 grep_ok "TIMEOUT" "${TEST_NAME_BASE}-scan.stdout"
-grep_ok "Timeout waiting for server response" "${TEST_NAME_BASE}-scan.stderr"
+grep_ok "Timeout waiting for server response. This could be due to network or server issues. Check the suite log." "${TEST_NAME_BASE}-scan.stderr"
 # Tell the suite to continue
 kill -SIGCONT "${SUITE_PID}"
 sleep 1


### PR DESCRIPTION
These changes close #3499 and #3443 
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] I have adapted existing tests, I have not yet been able to test this change with a suite with multiple remote hosts.
- [x] No change log entry required (invisible to users).
- [x] Documentation to be updated (PR #123 on cylc-doc)


Client keys are now being generated on remote platforms - private keys are now not travelling!
Instead, server generates a pair of keys, platform generates a pair of keys. The public keys are transferred.


![image](https://user-images.githubusercontent.com/37735232/81812025-72c00b00-951d-11ea-837b-48894262b8dc.png)

