### PR TITLE
tox: exclude pb2.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ exclude=
     .git,
     __pycache__,
     .tox,
-    ./cylc/flow/data_messages_pb2.py
+    **data_messages_pb2.py


### PR DESCRIPTION
Allow the GH actions tests to pass by fixing an exclusion for the compiled protobuf file.

One review should be sufficient.