### PR TITLE
Run pycodestyle only on cylc/flow (avoid build).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Style
         run: |
-          pycodestyle
+          pycodestyle cylc/flow
           etc/bin/shellchecker
 
       - name: Unit Test


### PR DESCRIPTION
In our Github Actions setup: pycodestyle is running unnecessarily on the build directory:

![shot](https://user-images.githubusercontent.com/2362137/81997295-7087b900-96a3-11ea-8c9c-9e1fed5695ad.png)
