### PR TITLE
Better queue config warning.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@ files are now auto-documented from their definitions.
 
 ### Fixes
 
+[#3618](https://github.com/cylc/cylc-flow/pull/3618) - Clear queue configuration
+warnings for referencing undefined or unused tasks.
+
 [#3596](https://github.com/cylc/cylc-flow/pull/3596) - Fix a bug that could
 prevent housekeeping of the task_action_timers DB table and cause many warnings
 at restart.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1138,8 +1138,12 @@ class SuiteConfig(object):
                                     'already assigned to a queue')
                                 warnings.append(msg)
                             elif qmember not in all_task_names:
+                                if qmember not in self.cfg['runtime']:
+                                    err = 'task not defined'
+                                else:
+                                    err = 'task not used in the graph'
                                 msg = "%s: ignoring %s (%s)" % (
-                                    key, qmember, 'task not defined')
+                                    key, qmember, err)
                                 warnings.append(msg)
                             else:
                                 # Ignore: task not used in the graph.


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->
This is a small change with no associated Issue.  Result of a user complaint today.

The following queue validation warning applies if the task `bar` (assigned to a queue) is not defined under `[runtime]` **or** if it is defined there but is simply not used in the graph:
```
WARNING - Queue configuration warnings:
        + q1: ignoring bar (task not defined)
```

On this branch, the warning in the latter case changes to: 
```
WARNING - Queue configuration warnings:
        + q1: ignoring bar (task not used in the graph)
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.

