### PR TITLE
Protobuf from pre-release to 3.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     'jinja2==2.11.*',
     'metomi-isodatetime==1!2.0.*',
     'markupsafe==1.1.*',
-    'protobuf==3.12.0rc1',
+    'protobuf==3.12.1',
     'pyzmq==18.1.*',
     'click>=7.0',
     'psutil>=5.6.0',


### PR DESCRIPTION
This is a small change with no associated Issue.

Change from Protobuf pre-release #3594  to 3.12.1.
Compile with new resulted in no change:
```
(flow) sutherlander@cortex-vbox:flow$ protoc --experimental_allow_proto3_optional -I=./ --python_out=./ data_messages.proto
(flow) sutherlander@cortex-vbox:flow$ git status
On branch protobuf-3.12.1
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   ../../setup.py

no changes added to commit (use "git add" and/or "git commit -a")
(flow) sutherlander@cortex-vbox:flow$ protoc --version
libprotoc 3.12.1
```

One review will probably do.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required.
- [x] No documentation update required.
