### PR TITLE
setup: loosen version pinning

### DIFF
--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -266,8 +266,8 @@ class GraphParser(object):
             if not self.__class__.REC_PARAMS.search(line):
                 line_set.add(line)
                 continue
-            for l in graph_expander.expand(line):
-                line_set.add(l)
+            for line_ in graph_expander.expand(line):
+                line_set.add(line_)
 
         # Process chains of dependencies as pairs: left => right.
         # Parameterization can duplicate some dependencies, so use a set.

--- a/cylc/flow/scripts/cylc_report_timings.py
+++ b/cylc/flow/scripts/cylc_report_timings.py
@@ -151,7 +151,7 @@ def format_rows(header, rows):
             (len(h) for h in header)
         )
     ]
-    formatter = ' '.join('%%-%ds' % l for l in max_lengths) + '\n'
+    formatter = ' '.join('%%-%ds' % line for line in max_lengths) + '\n'
     sio.write(formatter % header)
     for r in rows:
         sio.write(formatter % r)

--- a/setup.py
+++ b/setup.py
@@ -51,17 +51,16 @@ install_requires = [
     'markupsafe==1.1.*',
     'protobuf==3.12.0rc1',
     'pyzmq==18.1.*',
-    'click>=7.0',
     'psutil>=5.6.0',
     'urwid==2.*'
 ]
 tests_require = [
-    'codecov==2.0.*',
-    'coverage==5.0.*',
-    'pytest-cov==2.8.*',
-    'pytest==5.3.*',
-    'pycodestyle==2.5.*',
-    'testfixtures==6.11.*'
+    'codecov>=2.0.0',
+    'coverage>=5.0.0',
+    'pytest-cov>=2.8.0',
+    'pytest>=5.3.0',
+    'pycodestyle>=2.5.0',
+    'testfixtures>=6.11.0'
 ]
 
 extra_requires = {

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ install_requires = [
     'graphene>=2.1,<3',
     'jinja2==2.11.*',
     'metomi-isodatetime==1!2.0.*',
-    'markupsafe==1.1.*',
     'protobuf==3.12.0rc1',
     'pyzmq==18.1.*',
     'psutil>=5.6.0',


### PR DESCRIPTION
I think we are being overly specific with dependency versions, particularly for testing.

We now have conflicting dependencies between different Cylc repositories which causes pip to install dependencies at undesirable versions which is worse than not version pinning at all.

Today's annoying conflict was between the version of pycodestyle used be Cylc-flow and flake8.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.