### PR TITLE
Centralise general id delimiter

### DIFF
--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -23,6 +23,10 @@ CYLC_LOG = 'cylc'
 LOG = logging.getLogger(CYLC_LOG)
 LOG.addHandler(logging.NullHandler())  # Start with a null handler
 
+# Used widely with data element ID (internally and externally),
+# scope may widen further with internal and CLI adoption.
+ID_DELIM = '|'
+
 
 def environ_init():
     """Initialise cylc environment."""

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -55,7 +55,7 @@ from copy import deepcopy
 from time import time
 import zlib
 
-from cylc.flow import __version__ as CYLC_VERSION
+from cylc.flow import __version__ as CYLC_VERSION, ID_DELIM
 from cylc.flow.cycling.loader import get_point
 from cylc.flow.data_messages_pb2 import (
     PbEdge, PbEntireWorkflow, PbFamily, PbFamilyProxy,
@@ -70,7 +70,6 @@ from cylc.flow.wallclock import (
     TIME_ZONE_LOCAL_INFO, TIME_ZONE_UTC_INFO, get_utc_mode)
 
 
-ID_DELIM = '|'
 EDGES = 'edges'
 FAMILIES = 'families'
 FAMILY_PROXIES = 'family_proxies'

--- a/cylc/flow/job_pool.py
+++ b/cylc/flow/job_pool.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 import os
 from time import time
 
-from cylc.flow import LOG
+from cylc.flow import LOG, ID_DELIM
 from cylc.flow.exceptions import SuiteConfigError
 from cylc.flow.task_job_logs import get_task_job_log
 from cylc.flow.parsec.util import pdeepcopy, poverride
@@ -33,7 +33,6 @@ from cylc.flow.task_state import (
     TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED,
     TASK_STATUS_FAILED)
 from cylc.flow.data_messages_pb2 import PbJob, JDeltas
-from cylc.flow.data_store_mgr import ID_DELIM
 
 JOB_STATUSES_ALL = [
     TASK_STATUS_READY,

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -21,8 +21,10 @@ from getpass import getuser
 from operator import attrgetter
 from graphene.utils.str_converters import to_snake_case
 
+from cylc.flow import ID_DELIM
 from cylc.flow.data_store_mgr import (
-    ID_DELIM, EDGES, FAMILY_PROXIES, TASK_PROXIES, WORKFLOW)
+    EDGES, FAMILY_PROXIES, TASK_PROXIES, WORKFLOW
+)
 from cylc.flow.network.schema import NodesEdges, PROXY_NODES
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -29,6 +29,7 @@ from graphene import (
 from graphene.types.generic import GenericScalar
 from graphene.utils.str_converters import to_snake_case
 
+from cylc.flow import ID_DELIM
 from cylc.flow.task_state import (
     TASK_STATUSES_ORDERED,
     TASK_STATUS_DESC,
@@ -46,8 +47,7 @@ from cylc.flow.task_state import (
     TASK_STATUS_SUCCEEDED
 )
 from cylc.flow.data_store_mgr import (
-    ID_DELIM, FAMILIES, FAMILY_PROXIES,
-    JOBS, TASKS, TASK_PROXIES
+    FAMILIES, FAMILY_PROXIES, JOBS, TASKS, TASK_PROXIES
 )
 from cylc.flow.suite_status import StopMode
 

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -18,6 +18,7 @@
 
 import math
 
+from cylc.flow import ID_DELIM
 from cylc.flow.conditional_simplifier import ConditionalSimplifier
 from cylc.flow.cycling.loader import get_point
 from cylc.flow.exceptions import TriggerExpressionError
@@ -236,7 +237,7 @@ class Prerequisite(object):
         num_length = math.ceil(len(self.satisfied) / 10)
         for ind, message_tuple in enumerate(sorted(self.satisfied)):
             name, point = message_tuple[0:2]
-            t_id = f"{workflow_id}/{point}/{name}"
+            t_id = f"{workflow_id}{ID_DELIM}{point}{ID_DELIM}{name}"
             char = 'c%.{0}d'.format(num_length) % ind
             c_msg = self.MESSAGE_TEMPLATE % message_tuple
             c_val = self.satisfied[message_tuple]

--- a/cylc/flow/tests/network/test_resolvers.py
+++ b/cylc/flow/tests/network/test_resolvers.py
@@ -18,9 +18,10 @@ from unittest import main
 from copy import deepcopy
 import asyncio
 
+from cylc.flow import ID_DELIM
 from cylc.flow.tests.util import CylcWorkflowTestCase, create_task_proxy
 from cylc.flow.data_store_mgr import (
-    DataStoreMgr, ID_DELIM, EDGES, TASK_PROXIES, WORKFLOW
+    DataStoreMgr, EDGES, TASK_PROXIES, WORKFLOW
 )
 from cylc.flow.network.schema import parse_node_id
 from cylc.flow.network.resolvers import node_filter, Resolvers

--- a/cylc/flow/tests/test_data_store_mgr.py
+++ b/cylc/flow/tests/test_data_store_mgr.py
@@ -16,9 +16,10 @@
 
 from unittest import main
 
+from cylc.flow import ID_DELIM
 from cylc.flow.tests.util import CylcWorkflowTestCase, create_task_proxy
 from cylc.flow.data_store_mgr import (
-    DataStoreMgr, task_mean_elapsed_time, ID_DELIM,
+    DataStoreMgr, task_mean_elapsed_time,
     FAMILY_PROXIES, TASKS, TASK_PROXIES, WORKFLOW
 )
 

--- a/cylc/flow/tests/test_job_pool.py
+++ b/cylc/flow/tests/test_job_pool.py
@@ -17,9 +17,8 @@
 from unittest import main
 from copy import copy, deepcopy
 
-from cylc.flow import LOG
+from cylc.flow import LOG, ID_DELIM
 from cylc.flow.job_pool import JobPool, JOB_STATUSES_ALL
-from cylc.flow.data_store_mgr import ID_DELIM
 from cylc.flow.tests.util import CylcWorkflowTestCase, create_task_proxy
 from cylc.flow.wallclock import get_current_time_string
 

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -18,7 +18,7 @@
 
 from time import time
 
-from cylc.flow.data_store_mgr import ID_DELIM
+from cylc.flow import ID_DELIM
 from cylc.flow.task_state import (
     TASK_STATUS_RUNNING
 )

--- a/tests/graphql/02-root-queries.t
+++ b/tests/graphql/02-root-queries.t
@@ -27,7 +27,7 @@ run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
 
 # query suite
 TEST_NAME="${TEST_NAME_BASE}-root-queries"
-ID_DELIM='|'
+ID_DELIM="$(python -c 'from cylc.flow import ID_DELIM;print(ID_DELIM)')"
 read -r -d '' rootQueries <<_args_
 {
   "request_string": "

--- a/tests/graphql/03-is-held-arg.t
+++ b/tests/graphql/03-is-held-arg.t
@@ -29,7 +29,7 @@ sleep 1
 
 # query suite
 TEST_NAME="${TEST_NAME_BASE}-is-held-arg"
-ID_DELIM='|'
+ID_DELIM="$(python -c 'from cylc.flow import ID_DELIM;print(ID_DELIM)')"
 read -r -d '' isHeld <<_args_
 {
   "request_string": "


### PR DESCRIPTION
This PR:
- Centralises the ID delimiter.
- Fixes bug in ID generated in prerequisites dump.
- Imports to functional tests

Sibling PR: https://github.com/cylc/cylc-uiserver/pull/140
(needs to be merge after this one)

The centralisation/put-at-lower-level is needed due to:
- A circular import error occurred while trying to fix the prerequisite dump. (ID_DELIM defined in `data_store_mgr`, but `prerequisites` is imported to `data_store_mgr` indirectly)
- Future proofing.

Justification for `cylc/flow/__init__.py` location:
- Not only used by tasks (i.e. shouldn't go in `cylc/flow/task_id.py`), used for workflow/jobs/families ...etc.
- Used by multiple modules (i.e. tasks/jobs/data-store/..etc) and UIS, but also as we become more event driven (i.e. the change in state might create a data element with only fields changed which gets merged locally and sent).
- If we decide on a delimiter for external use that jumps through the def/datetime/shell CLI/Cylc constraints then it can be used internally too (which means more reliance on centralized `ID_DELIM`). See #3592 

Could be it's own module.. But, as a one-liner and used by UIS, `cylc.flow` seems appropriate.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
