### PR TITLE
config node: inheritance

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -130,17 +130,18 @@ with Conf('flow.rc', desc='''
                 starting up new suites.
             ''')
 
-            with Conf('health check', desc='''
+            with Conf('<plugin name>', desc='''
+                Configure a main loop plugin.
+            ''') as MainLoopPlugin:
+                Conf('interval', VDR.V_INTERVAL, desc='''
+                    The interval with which this plugin is run.
+                ''')
+                Conf('foo', VDR.V_STRING, default='X')
+
+            with Conf('health check', meta=MainLoopPlugin, desc='''
                 Checks the intrigity of the suite run directory.
             '''):
                 Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
-                    The interval with which this plugin is run.
-                ''')
-
-            with Conf('<plugin name>', desc='''
-                Configure a main loop plugin.
-            '''):
-                Conf('interval', VDR.V_INTERVAL, desc='''
                     The interval with which this plugin is run.
                 ''')
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -139,7 +139,7 @@ with Conf('flow.rc', desc='''
                 Conf('foo', VDR.V_STRING, default='X')
 
             with Conf('health check', meta=MainLoopPlugin, desc='''
-                Checks the intrigity of the suite run directory.
+                Checks the integrity of the suite run directory.
             '''):
                 Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
                     The interval with which this plugin is run.

--- a/cylc/flow/context_node.py
+++ b/cylc/flow/context_node.py
@@ -77,15 +77,21 @@ class ContextNode():
         return self
 
     def __exit__(self, *args):
+        # list the nodes already present on this node
+        older_siblings = self._children or {}
         # list the nodes which were created since we
         # __entered__ this node
-        self._children = {
+        new_borns = {
             value.name: value
             for value in self.DATA
             if value is not self
-            if value not in self.DATA[self]
+            if value not in self.DATA.get(self, {})
         }
-        for child in self._children.values():
+        self._children = {
+            **older_siblings,
+            **new_borns
+        }
+        for child in new_borns.values():
             # remove our children from self.DATA
             del self.DATA[child]
             # set our children to see us as their parent

--- a/cylc/flow/tests/test_context_node.py
+++ b/cylc/flow/tests/test_context_node.py
@@ -152,3 +152,17 @@ def test_context_parents():
     assert list(a.parents()) == []
     assert list(b.parents()) == [a]
     assert list(c.parents()) == [b, a]
+
+
+def test_re_enter():
+    """It should be able to re __enter__ multiple times."""
+    # create a node with one child
+    with ContextNode('x') as x:
+        ContextNode('y')
+    assert 'y' in x
+
+    # go back and add another child retrospectively
+    with x:
+        ContextNode('z')
+    assert 'y' in x
+    assert 'z' in x


### PR DESCRIPTION
Allow sections in the specification to inherit from other sections e.g:

```python
with Conf('foo.rc'):
    with Conf('<animal>') as Animal:
        Conf('legs', VDR.V_INTEGER, default=0)
        Conf('noise', VDR.V_STRING)
    with Conf('elephant', meta=Animal) as Elephant:
        Conf('legs', VDR.V_INTEGER, default=4)

>>> Animal['legs'].default
0
>>> Elephant['legs'].default
4
>>> Elephant['noise'].default
None
```

This is desirable for defining `localhost` in the ongoing platforms work.

I've also converted `[cylc][main loop][health check]` to inherit from `[<plugin name>]`.

In the documentation the configuration is marked as inheriting from the template section and only configurations made on the new section are documented (as the inherited configurations are already documented in the template section).

<img width="386" alt="Screenshot 2020-05-28 at 17 24 10" src="https://user-images.githubusercontent.com/16705946/83167619-405f0200-a108-11ea-8bd9-9e117d8f460e.png">

> **Note** Requires https://github.com/cylc/cylc-sphinx-extensions/pull/27

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
