### PR TITLE
Fix global UTC mode bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,11 @@ Fourth alpha release of Cylc 8.
 [#3692](https://github.com/cylc/cylc-flow/pull/3692) - Use the `$EDITOR`
 and `$GEDITOR` environment variables to determine the default editor to use.
 
+### Fixes
+
+[#3632](https://github.com/cylc/cylc-flow/pull/3632) - Fix a bug that was causing
+`UTC mode` specified in global config to be pretty much ignored.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -89,7 +89,7 @@ with Conf('flow.rc', desc='''
     with Conf('cylc', desc='''
         Default values for entries in the suite.rc ``[cylc]`` section.
     '''):
-        Conf('UTC mode', VDR.V_BOOLEAN, desc='''
+        Conf('UTC mode', VDR.V_BOOLEAN, False, desc='''
                 Default for :cylc:conf:`suite.rc[cylc]UTC mode`.
         ''')
         Conf('task event mail interval', VDR.V_INTERVAL, DurationFloat(300),

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -80,7 +80,7 @@ with Conf(
         ''')
 
     with Conf('cylc'):
-        Conf('UTC mode', VDR.V_BOOLEAN, False)
+        Conf('UTC mode', VDR.V_BOOLEAN)
         Conf('cycle point format', VDR.V_CYCLE_POINT_FORMAT)
         Conf('cycle point num expanded year digits', VDR.V_INTEGER, 0)
         Conf('cycle point time zone', VDR.V_CYCLE_POINT_TIME_ZONE)

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -310,16 +310,16 @@ class SuiteConfig(object):
         self.cfg = self.pcfg.get(sparse=False)
         self.mem_log("config.py: after get(sparse=False)")
 
+        # Running in UTC time? (else just use the system clock)
+        if self.cfg['cylc']['UTC mode'] is None:
+            # This must be set before call to init_cyclers(self.cfg):
+            self.cfg['cylc']['UTC mode'] = glbl_cfg().get(['cylc', 'UTC mode'])
+        set_utc_mode(self.cfg['cylc']['UTC mode'])
+
         # after the call to init_cyclers, we can start getting proper points.
         init_cyclers(self.cfg)
         self.cycling_type = get_interval_cls().get_null().TYPE
         self.cycle_point_dump_format = get_dump_format(self.cycling_type)
-
-        # Running in UTC time? (else just use the system clock)
-        if self.cfg['cylc']['UTC mode'] is None:
-            set_utc_mode(glbl_cfg().get(['cylc', 'UTC mode']))
-        else:
-            set_utc_mode(self.cfg['cylc']['UTC mode'])
 
         # Initial point from suite definition (or CLI override above).
         self.process_initial_cycle_point()


### PR DESCRIPTION
- Cycle points now obey value specified in global config
- Suite cfgspec default `False` no longer overrides value specified in global config file

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3631 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [X] Does not need tests.
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [X] No documentation update required.
