### PR TITLE
tests: broadcast/00 - patch for bash file descriptor bug

### DIFF
--- a/tests/broadcast/00-simple/suite.rc
+++ b/tests/broadcast/00-simple/suite.rc
@@ -74,6 +74,10 @@ set +x
 set -x
 sed -i '/DEBUG -/d' 'prep.out'
 sed -i '/\(DEBUG\|WARNING\|ERROR\) -/d' 'prep.err'
+
+# workaround for platforms affected by https://github.com/cylc/cylc-flow/issues/3585
+sed -i '/BASH_XTRACEFD/d' 'prep.err'
+
 diff -u "${CYLC_SUITE_DEF_PATH}/expected-prep.out" 'prep.out'
 diff -u "${CYLC_SUITE_DEF_PATH}/expected-prep.err" 'prep.err'
 """


### PR DESCRIPTION
Quick patch to prevent a test from failing as a result of https://github.com/cylc/cylc-flow/issues/3585.

Explanation: Those pesky bash filedescriptor lines are getting into a file which is compared to "known good output" during the test.

Simple fix, one review should be sufficient.