### PR TITLE
remote_init: prevent init skipping for polling configurations

### DIFF
--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -26,6 +26,7 @@ import os
 import sys
 
 
+from cylc.flow.exceptions import SuiteStopped
 import cylc.flow.flags
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.pathutil import get_suite_run_job_dir
@@ -74,6 +75,12 @@ def record_messages(suite, task_job, messages):
     # Send messages
     try:
         pclient = SuiteRuntimeClient(suite)
+    except SuiteStopped:
+        # on a remote host this means the contact file is not present
+        # either the suite is stopped or the contact file is not present
+        # on the job host (i.e. comms method is polling)
+        # eitherway don't try messaging
+        pass
     except Exception:
         # Backward communication not possible
         if cylc.flow.flags.debug:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -169,10 +169,6 @@ class TaskRemoteMgr(object):
             owner_at_host = owner + '@' + owner_at_host
         LOG.debug('comm_meth[%s]=%s' % (owner_at_host, comm_meth))
         items = self._remote_init_items(comm_meth)
-        # No item to install
-        if not items:
-            self.remote_init_map[(host, owner)] = REMOTE_INIT_NOT_REQUIRED
-            return self.remote_init_map[(host, owner)]
 
         # Create a TAR archive with the service files,
         # so they can be sent later via SSH's STDIN to the task remote.
@@ -314,6 +310,7 @@ class TaskRemoteMgr(object):
               at target remote.
         """
         items = []
+
         if comm_meth in ['ssh', 'zmq']:
             # Contact file
             items.append((
@@ -323,7 +320,6 @@ class TaskRemoteMgr(object):
                     SuiteFiles.Service.CONTACT)))
 
         if comm_meth in ['zmq']:
-
             suite_srv_dir = get_suite_srv_dir(self.suite)
             server_pub_keyinfo = KeyInfo(
                 KeyType.PUBLIC,


### PR DESCRIPTION
* Fix Cylc remote functionality when `task communication method = poll`.
 * Presently `remote_init` is getting skipped in this event.
* Use the presence of the `contact` file to determine when to use TCP messaging.
  * Presently TCP messaging is always attempted which results in traceback.
  * Since the removal of `contact2` (a good thing) we need a new indicator of comms method, ATM we only have polling and TCP so the presence of the `contact` will do. We will need to review this when we add tcp+ssh as a method.

Example development configuration for a remote host with polling:

```ini
[hosts]
    [[ubuntu]]
        task communication method = poll
        # aggressive task polling
        execution polling intervals = 5*PT1S, 5*PT5S, PT15S
        submission polling intervals = PT1S
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.