### PR TITLE
profiler: use psutil

### DIFF
--- a/cylc/flow/profiler.py
+++ b/cylc/flow/profiler.py
@@ -55,5 +55,5 @@ class Profiler(object):
         """Print a message to standard out with the current memory usage."""
         if not self.enabled:
             return
-        memory = psutil.Process(os.getpid()).memory_info().rss / 1000
+        memory = psutil.Process(os.getpid()).memory_info().rss / 1024
         print("PROFILE: Memory: %d KiB: %s" % (memory, message))

--- a/cylc/flow/profiler.py
+++ b/cylc/flow/profiler.py
@@ -19,7 +19,8 @@ import os
 import cProfile
 import io
 import pstats
-from subprocess import Popen, PIPE, DEVNULL
+
+import psutil
 
 
 class Profiler(object):
@@ -54,8 +55,5 @@ class Profiler(object):
         """Print a message to standard out with the current memory usage."""
         if not self.enabled:
             return
-        proc = Popen(
-            ["ps", "h", "-orss", str(os.getpid())],
-            stdin=DEVNULL, stdout=PIPE)
-        memory = int(proc.communicate()[0])
+        memory = psutil.Process(os.getpid()).memory_info().rss / 1000
         print("PROFILE: Memory: %d KiB: %s" % (memory, message))


### PR DESCRIPTION
The `--profile` options has been broken since the original Python3 upgrade (sorry).

I've not added any tests as I'm not sure what the future for this option is or what the role of on-board profiling will be in Cylc's asynchronous future. Standard profiling libraries may be better placed to take on this role, but for now...

Profiling results look a bit different then they did at Cylc7 largley due to changes in code structure:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   58.706   58.706 /home/oliver/cylc-flow/cylc/flow/scheduler.py:1503(run)
        4    0.000    0.000   58.704   14.676 /home/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/base_events.py:533(run_until_complete)
        4    0.001    0.000   58.703   14.676 /home/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/base_events.py:506(run_forever)
      280    0.010    0.000   58.703    0.210 /home/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/base_events.py:1662(_run_once)
      280    0.002    0.000   52.268    0.187 /home/oliver/miniconda3/envs/cylc8/lib/python3.7/selectors.py:451(select)
      280   52.266    0.187   52.266    0.187 {method 'poll' of 'select.epoll' objects}                                                                                                                            
      748    0.002    0.000    6.406    0.009 /home/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/events.py:86(_run)
      748    0.015    0.000    6.405    0.009 {method 'run' of 'Context' objects}
      115    0.022    0.000    6.355    0.055 /home/oliver/cylc-flow/cylc/flow/scheduler.py:1512(main_loop)
       ...
```

Note that the Cylc `main_loop` took a total of 6s but `select.epoll` took a whopping 52s, 90% of the total time.

*It's not what it looks like* I think this is wallclock time rather than CPU time, this is mostly due to the replacement of `sleep` with `asyncio.sleep`.

https://stackoverflow.com/a/52843499

If so then it just means that in this example about 90% of wallclock time was sleep time, which is a good thing!

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
