### PR TITLE
tests: document mock_glbl_cfg fixture

### DIFF
--- a/cylc/flow/tests/conftest.py
+++ b/cylc/flow/tests/conftest.py
@@ -13,12 +13,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Standard pytest fixtures for unit tests."""
 import pytest
+from shutil import rmtree
 
+from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.cycling.loader import (
     ISO8601_CYCLING_TYPE,
     INTEGER_CYCLING_TYPE
 )
+from cylc.flow.parsec.config import ParsecConfig
 
 
 @pytest.fixture
@@ -30,3 +34,52 @@ def cycling_mode(monkeypatch):
             (INTEGER_CYCLING_TYPE if integer else ISO8601_CYCLING_TYPE)
         )
     return _cycling_mode
+
+
+@pytest.fixture
+def mock_glbl_cfg(tmp_path, monkeypatch):
+    """A Pytest fixture for fiddling globalrc values.
+
+    * Hacks the specified `glbl_cfg` object.
+    * Can be called multuple times within a test function.
+
+    Args:
+        pypath (str):
+            The python-like path to the global configuation object you want
+            to fiddle.
+            E.G. if you want to hack the `glbl_cfg` in
+            `cylc.flow.scheduler` you would provide
+            `cylc.flow.scheduler.glbl_cfg`
+        rc_string (str):
+            The globlal configuration as a multi-line string.
+
+    Example:
+        Change the value of `UTC mode` in the global config as seen from
+        `the scheduler` module.
+
+        def test_something(mock_glbl_cfg):
+            mock_glbl_cfg(
+                'cylc.flow.scheduler.glbl_cfg',
+                '''
+                    [cylc]
+                        UTC mode = True
+                '''
+            )
+
+    """
+    # TODO: modify Parsec so we can use StringIO rather than a temp file.
+    def _mock(pypath, rc_string):
+        nonlocal tmp_path, monkeypatch
+        global_rc_path = tmp_path / 'flow.rc'
+        global_rc_path.write_text(rc_string)
+        glbl_cfg = ParsecConfig(SPEC)
+        glbl_cfg.loadcfg(global_rc_path)
+
+        def _inner(cached=False):
+            nonlocal glbl_cfg
+            return glbl_cfg
+
+        monkeypatch.setattr(pypath, _inner)
+
+    yield _mock
+    rmtree(tmp_path)

--- a/cylc/flow/tests/conftest.py
+++ b/cylc/flow/tests/conftest.py
@@ -41,7 +41,7 @@ def mock_glbl_cfg(tmp_path, monkeypatch):
     """A Pytest fixture for fiddling globalrc values.
 
     * Hacks the specified `glbl_cfg` object.
-    * Can be called multuple times within a test function.
+    * Can be called multiple times within a test function.
 
     Args:
         pypath (str):

--- a/cylc/flow/tests/test_host_select.py
+++ b/cylc/flow/tests/test_host_select.py
@@ -15,7 +15,6 @@ from cylc.flow.host_select import (
 )
 from cylc.flow.hostuserutil import get_fqdn_by_host
 from cylc.flow.parsec.exceptions import ListValueError
-from cylc.flow.tests.util import mock_glbl_cfg
 
 
 localhost, localhost_aliases, _ = socket.gethostbyname_ex('localhost')

--- a/cylc/flow/tests/test_host_select_remote.py
+++ b/cylc/flow/tests/test_host_select_remote.py
@@ -18,7 +18,6 @@ from cylc.flow.host_select import (
     select_suite_host
 )
 from cylc.flow.hostuserutil import get_fqdn_by_host
-from cylc.flow.tests.util import mock_glbl_cfg
 
 
 local_host, local_host_alises, _ = socket.gethostbyname_ex('localhost')

--- a/cylc/flow/tests/test_rundb.py
+++ b/cylc/flow/tests/test_rundb.py
@@ -23,7 +23,7 @@ from tempfile import mktemp
 from unittest import mock
 
 from cylc.flow.rundb import CylcSuiteDAO
-from cylc.flow.tests.util import set_up_globalrc
+from cylc.flow.tests.util import mock_glbl_cfg
 
 
 GLOBALRC = """
@@ -196,11 +196,11 @@ def test_upgrade_hold_swap():
         assert not dao.upgrade_is_held()
 
 
-def test_upgrade_to_platforms(set_up_globalrc):
+def test_upgrade_to_platforms(mock_glbl_cfg):
     """Test upgrader logic for platforms in the database.
     """
     # Set up the globalrc
-    set_up_globalrc(GLOBALRC)
+    mock_glbl_cfg('cylc.flow.rundb.glbl_cfg', GLOBALRC)
 
     # task name, cycle, user_at_host, batch_system
     initial_data = [

--- a/cylc/flow/tests/test_rundb.py
+++ b/cylc/flow/tests/test_rundb.py
@@ -23,7 +23,6 @@ from tempfile import mktemp
 from unittest import mock
 
 from cylc.flow.rundb import CylcSuiteDAO
-from cylc.flow.tests.util import mock_glbl_cfg
 
 
 GLOBALRC = """

--- a/cylc/flow/tests/util.py
+++ b/cylc/flow/tests/util.py
@@ -15,9 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pytest
-
 from pathlib import Path
+import pytest
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
@@ -164,7 +163,7 @@ def create_task_proxy(task_name: str, suite_config: SuiteConfig,
         is_startup=is_startup)
 
 
-@pytest.fixture()
+@pytest.fixture
 def set_up_globalrc(tmp_path_factory):
     """A Pytest fixture for fiddling globalrc values.
 
@@ -195,7 +194,8 @@ def set_up_globalrc(tmp_path_factory):
 def mock_glbl_cfg(tmp_path, monkeypatch):
     """A Pytest fixture for fiddling globalrc values.
 
-    Hacks the specified `glbl_cfg` object.
+    * Hacks the specified `glbl_cfg` object.
+    * Can be called multuple times within a test function.
 
     Use for:
 
@@ -228,10 +228,10 @@ def mock_glbl_cfg(tmp_path, monkeypatch):
     # TODO: modify Parsec so we can use StringIO rather than a temp file.
     def _mock(pypath, rc_string):
         nonlocal tmp_path, monkeypatch
-        tmp_path = tmp_path / 'flow.rc'
-        tmp_path.write_text(rc_string)
+        global_rc_path = tmp_path / 'flow.rc'
+        global_rc_path.write_text(rc_string)
         glbl_cfg = ParsecConfig(SPEC)
-        glbl_cfg.loadcfg(tmp_path)
+        glbl_cfg.loadcfg(global_rc_path)
 
         def _inner(cached=False):
             nonlocal glbl_cfg
@@ -239,4 +239,5 @@ def mock_glbl_cfg(tmp_path, monkeypatch):
 
         monkeypatch.setattr(pypath, _inner)
 
-    return _mock
+    yield _mock
+    rmtree(tmp_path)

--- a/cylc/flow/tests/util.py
+++ b/cylc/flow/tests/util.py
@@ -14,18 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 from pathlib import Path
-import pytest
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.config import SuiteConfig
 from cylc.flow.job_pool import JobPool
-from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.suite_db_mgr import SuiteDatabaseManager
 from cylc.flow.task_pool import TaskPool
@@ -160,53 +156,5 @@ def create_task_proxy(task_name: str, suite_config: SuiteConfig,
     return TaskProxy(
         tdef=task_def,
         start_point=suite_config.start_point,
-        is_startup=is_startup)
-
-
-@pytest.fixture
-def mock_glbl_cfg(tmp_path, monkeypatch):
-    """A Pytest fixture for fiddling globalrc values.
-
-    * Hacks the specified `glbl_cfg` object.
-    * Can be called multuple times within a test function.
-
-    Args:
-        pypath (str):
-            The python-like path to the global configuation object you want
-            to fiddle.
-            E.G. if you want to hack the `glbl_cfg` in
-            `cylc.flow.scheduler` you would provide
-            `cylc.flow.scheduler.glbl_cfg`
-        rc_string (str):
-            The globlal configuration as a multi-line string.
-
-    Example:
-        Change the value of `UTC mode` in the global config as seen from
-        `the scheduler` module.
-
-        def test_something(mock_glbl_cfg):
-            mock_glbl_cfg(
-                'cylc.flow.scheduler.glbl_cfg',
-                '''
-                    [cylc]
-                        UTC mode = True
-                '''
-            )
-
-    """
-    # TODO: modify Parsec so we can use StringIO rather than a temp file.
-    def _mock(pypath, rc_string):
-        nonlocal tmp_path, monkeypatch
-        global_rc_path = tmp_path / 'flow.rc'
-        global_rc_path.write_text(rc_string)
-        glbl_cfg = ParsecConfig(SPEC)
-        glbl_cfg.loadcfg(global_rc_path)
-
-        def _inner(cached=False):
-            nonlocal glbl_cfg
-            return glbl_cfg
-
-        monkeypatch.setattr(pypath, _inner)
-
-    yield _mock
-    rmtree(tmp_path)
+        is_startup=is_startup
+    )

--- a/cylc/flow/tests/util.py
+++ b/cylc/flow/tests/util.py
@@ -175,6 +175,10 @@ def set_up_globalrc(tmp_path_factory):
     * Functional tests which call out to other scripts.
     * Integration tests which span multiple modules.
 
+    Args:
+        rc_string (str):
+            The globlal configuration as a multi-line string.
+
     """
     def _inner_func(rc_string):
         tempdir = tmp_path_factory.getbasetemp()
@@ -197,13 +201,35 @@ def mock_glbl_cfg(tmp_path, monkeypatch):
 
     * Isolated unit tests within one module.
 
-    # TODO: modify Parsec so we can use StringIO rather than a temp file.
+    Args:
+        pypath (str):
+            The python-like path to the global configuation object you want
+            to fiddle.
+            E.G. if you want to hack the `glbl_cfg` in
+            `cylc.flow.scheduler` you would provide
+            `cylc.flow.scheduler.glbl_cfg`
+        rc_string (str):
+            The globlal configuration as a multi-line string.
+
+    Example:
+        Change the value of `UTC mode` in the global config as seen from
+        `the scheduler` module.
+
+        def test_something(mock_glbl_cfg):
+            mock_glbl_cfg(
+                'cylc.flow.scheduler.glbl_cfg',
+                '''
+                    [cylc]
+                        UTC mode = True
+                '''
+            )
 
     """
-    def _mock(pypath, global_rc):
+    # TODO: modify Parsec so we can use StringIO rather than a temp file.
+    def _mock(pypath, rc_string):
         nonlocal tmp_path, monkeypatch
         tmp_path = tmp_path / 'flow.rc'
-        tmp_path.write_text(global_rc)
+        tmp_path.write_text(rc_string)
         glbl_cfg = ParsecConfig(SPEC)
         glbl_cfg.loadcfg(tmp_path)
 

--- a/cylc/flow/tests/util.py
+++ b/cylc/flow/tests/util.py
@@ -164,42 +164,11 @@ def create_task_proxy(task_name: str, suite_config: SuiteConfig,
 
 
 @pytest.fixture
-def set_up_globalrc(tmp_path_factory):
-    """A Pytest fixture for fiddling globalrc values.
-
-    Creates a globalrc file and modifies CYLC_CONF_PATH to point at it.
-
-    Use for:
-
-    * Functional tests which call out to other scripts.
-    * Integration tests which span multiple modules.
-
-    Args:
-        rc_string (str):
-            The globlal configuration as a multi-line string.
-
-    """
-    def _inner_func(rc_string):
-        tempdir = tmp_path_factory.getbasetemp()
-        globalrc = tempdir / 'flow.rc'
-        with open(str(globalrc), 'w') as file_handle:
-            file_handle.write(rc_string)
-        os.environ['CYLC_CONF_PATH'] = str(tempdir)
-        return globalrc
-
-    return _inner_func
-
-
-@pytest.fixture
 def mock_glbl_cfg(tmp_path, monkeypatch):
     """A Pytest fixture for fiddling globalrc values.
 
     * Hacks the specified `glbl_cfg` object.
     * Can be called multuple times within a test function.
-
-    Use for:
-
-    * Isolated unit tests within one module.
 
     Args:
         pypath (str):


### PR DESCRIPTION
By popular demand, some sort of explanation...

* Document the `mock_glbl_cfg` fixture.
* Move the fixture into the `conftest.py` file (so you don't have to import it to use it).
* Remove the `setup_global_config` fixture
  * We will want to revive this for the integration test battery.
  * Best remove it here to prevent integration tests creeping into the unittests.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
