### PR TITLE
remote: remove debug logging to fix tests

### DIFF
--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -224,10 +224,6 @@ def construct_ssh_cmd(raw_cmd, user=None, host=None, forward_x11=False,
         if (cylc.flow.flags.debug or os.getenv('CYLC_DEBUG') in
                 ["True", "true"]):
             command.append(r'--debug')
-    if LOG.handlers:
-        LOG.debug("$ %s", ' '.join(quote(c) for c in command))
-    elif cylc.flow.flags.debug:
-        sys.stderr.write("$ %s\n" % ' '.join(quote(c) for c in command))
 
     return command
 


### PR DESCRIPTION
Remove logging which is causing some remote tests to fail.

This is a small change with no associated Issue.

After this change there should be three failure under `tests/` (fixes upcoming in a future PR):

* `tests/cylc-submit/01`
* `tests/cylc-submit/04`
* `tests/cylc-cat-log/09`

Kinda hard to review, here's an example of a test which would fail before:

* `tests/cylc-kill/00`

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
