### PR TITLE
tests: fix tests/restart/13

### DIFF
--- a/tests/restart/bad-job-host/suite.rc
+++ b/tests/restart/bad-job-host/suite.rc
@@ -34,6 +34,7 @@ rm -f "${CYLC_SUITE_WORK_DIR}/${CYLC_TASK_CYCLE_POINT}/t-remote/file"
             host = {{environ['CYLC_TEST_HOST']}}
     [[t-check-log]]
         script = """
-grep -q 'ERROR - garbage: initialisation did not complete' \
-    "${CYLC_SUITE_LOG_DIR}/log"
+            grep -q 'ERROR - garbage: initialisation did not complete' \
+                "${CYLC_SUITE_LOG_DIR}/log"
+            cylc shutdown --now "${CYLC_SUITE_NAME}"
 """


### PR DESCRIPTION
Test is flaky especially when run in a group.

flaky flow could get stuck with a running task which has actually
succeeded but is not pollable due to a bad hostname

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
