### PR TITLE
CLI option to disable log timestamps.

### DIFF
--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -117,11 +117,11 @@ class TimestampRotatingFileHandler(logging.FileHandler):
     GLBL_KEY = 'suite logging'
     MIN_BYTES = 1024
 
-    def __init__(self, suite, no_detach=False):
+    def __init__(self, suite, no_detach=False, timestamp=True):
         logging.FileHandler.__init__(self, get_suite_run_log_name(suite))
         self.no_detach = no_detach
         self.stamp = None
-        self.formatter = CylcLogFormatter()
+        self.formatter = CylcLogFormatter(timestamp=timestamp)
         self.header_records = []
 
     def emit(self, record):

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -155,6 +155,10 @@ match name and cycle point patterns against instances already in the pool).
             help="Output developer information and show exception tracebacks.",
             action="store_true", dest="debug",
             default=(os.getenv("CYLC_DEBUG", "false").lower() == "true"))
+        self.add_std_option(
+            "--no-timestamp",
+            help="Don't timestamp logged messages.",
+            action="store_false", dest="log_timestamp", default=True)
 
         if self.color:
             self.add_std_option(
@@ -296,7 +300,8 @@ match name and cycle point patterns against instances already in the pool).
             LOG.handlers[0].close()
             LOG.removeHandler(LOG.handlers[0])
         errhandler = logging.StreamHandler(sys.stderr)
-        errhandler.setFormatter(CylcLogFormatter())
+        errhandler.setFormatter(CylcLogFormatter(
+            timestamp=options.log_timestamp))
         LOG.addHandler(errhandler)
 
         return (options, args)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -401,7 +401,8 @@ see `COPYING' in the Cylc source distribution.
                 LOG.handlers[0].close()
                 LOG.removeHandler(LOG.handlers[0])
         LOG.addHandler(
-            TimestampRotatingFileHandler(self.suite, self.options.no_detach))
+            TimestampRotatingFileHandler(self.suite, self.options.no_detach,
+                                         timestamp=self.options.log_timestamp))
 
     def configure(self):
         """Configure suite server program."""

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -418,7 +418,7 @@ see `COPYING' in the Cylc source distribution.
         self.job_pool = JobPool(self)
         self.task_events_mgr = TaskEventsManager(
             self.suite, self.proc_pool, self.suite_db_mgr, self.broadcast_mgr,
-            self.job_pool)
+            self.job_pool, timestamp=self.options.log_timestamp)
         self.task_events_mgr.uuid_str = self.uuid_str
         self.task_job_mgr = TaskJobManager(
             self.suite, self.proc_pool, self.suite_db_mgr,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -134,7 +134,7 @@ class TaskEventsManager():
     NON_UNIQUE_EVENTS = ('warning', 'critical', 'custom')
 
     def __init__(self, suite, proc_pool, suite_db_mgr,
-                 broadcast_mgr, job_pool):
+                 broadcast_mgr, job_pool, timestamp=True):
         self.suite = suite
         self.suite_url = None
         self.suite_cfg = {}
@@ -153,6 +153,7 @@ class TaskEventsManager():
         # Scheduler.process_tasks, to ensure that dependency negotiation occurs
         # when required.
         self.pflag = False
+        self.timestamp = timestamp
 
     @staticmethod
     def check_poll_time(itask, now=None):
@@ -469,13 +470,17 @@ class TaskEventsManager():
         Check whether to process/skip message.
         Return True if `.process_message` should contine, False otherwise.
         """
-        logfmt = r'[%s] status=%s: %s%s at %s for job(%02d)'
+        if self.timestamp:
+            timestamp = " at %s " % event_time
+        else:
+            timestamp = ""
+        logfmt = r'[%s] status=%s: %s%s%s for job(%02d)'
         if flag == self.FLAG_RECEIVED and submit_num != itask.submit_num:
             # Ignore received messages from old jobs
             LOG.warning(
                 logfmt + r' != current job(%02d)',
                 itask, itask.state, self.FLAG_RECEIVED_IGNORED, message,
-                event_time, submit_num, itask.submit_num)
+                timestamp, submit_num, itask.submit_num)
             return False
         if itask.state.status in (
             TASK_STATUS_SUBMIT_RETRYING, TASK_STATUS_RETRYING
@@ -484,11 +489,11 @@ class TaskEventsManager():
             LOG.warning(
                 logfmt,
                 itask, itask.state, self.FLAG_POLLED_IGNORED, message,
-                event_time, submit_num)
+                timestamp, submit_num)
             return False
         LOG.log(
             self.LEVELS.get(severity, INFO),
-            logfmt, itask, itask.state, flag, message, event_time, submit_num)
+            logfmt, itask, itask.state, flag, message, timestamp, submit_num)
         return True
 
     def setup_event_handlers(self, itask, event, message):


### PR DESCRIPTION
Log timestamps are just visual garbage if you're following simple test suites during Cylc development.  This provides CLI access to our existing timestamp switch.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
