### PR TITLE
tests: fix auto restart tests

### DIFF
--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -102,6 +102,12 @@
 #         Shorthand for 'poll test -e "${SUITE_RUN_DIR}/.service/contact"'
 #     poll_suite_stopped
 #         Shorthand for 'poll "!" test -e "${SUITE_RUN_DIR}/.service/contact"'
+#     get_suite_uuid
+#         Extract the UUID from the contact file or echo '' if not present.
+#     poll_suite_restart [TIMEOUT [UUID]]
+#         Wait for the suite to restart.
+#         Provide the UUID from the current run if suite is not
+#         guaranteed to be running.
 #     skip N SKIP_REASON
 #         echo "ok $((++T)) # skip SKIP_REASON" N times.
 #     skip_all SKIP_REASON
@@ -547,6 +553,28 @@ poll_suite_running() {
 
 poll_suite_stopped() {
     poll test '!' -e "${SUITE_RUN_DIR}/.service/contact"
+}
+
+get_suite_uuid() {
+    sed -n 's|CYLC_SUITE_UUID=\(.*\)|\1|p' "${SUITE_RUN_DIR}/.service/contact" 2>/dev/null
+}
+
+poll_suite_restart() {
+    TIMEOUT="${1:-10}"
+    STEP=1
+    UUID="${2:-$(get_suite_uuid)}"
+    TIME=0
+    while true; do
+        if [[ ${TIME} -gt $TIMEOUT ]]; then
+            return 1
+        fi
+        if [[ $(get_suite_uuid) != "${UUID}" ]]; then
+            return 0
+        else
+            TIME=$(( TIME + STEP ))
+            sleep "${STEP}"
+        fi
+    done
 }
 
 skip() {

--- a/tests/restart/34-auto-restart-basic.t
+++ b/tests/restart/34-auto-restart-basic.t
@@ -33,7 +33,7 @@ BASE_GLOBALRC="
     [[main loop]]
         plugins = health check, auto restart
         [[[auto restart]]]
-            interval = PT15S
+            interval = PT2S
     [[events]]
         abort on inactivity = True
         abort on timeout = True
@@ -75,7 +75,7 @@ LATEST_TASK=$(cylc suite-state "${SUITE_NAME}" -S succeeded \
     | cut -d ',' -f 1 | sort | tail -n 1 | sed 's/task_foo//')
 
 # test restart procedure  - scan the second log file created on restart
-poll_suite_stopped
+poll_suite_restart
 FILE=$(cylc cat-log "${SUITE_NAME}" -m p |xargs readlink -f)
 log_scan "${TEST_NAME}-restart" "${FILE}" 20 1 \
     "Suite server: url=tcp://$(get_fqdn_by_host "${CYLC_TEST_HOST}")"

--- a/tests/restart/35-auto-restart-recovery.t
+++ b/tests/restart/35-auto-restart-recovery.t
@@ -39,7 +39,7 @@ BASE_GLOBALRC="
         inactivity = PT2M
         timeout = PT2M
 [suite servers]
-    run hosts = locahost, ${CYLC_TEST_HOST}"
+    run hosts = localhost, ${CYLC_TEST_HOST}"
 
 TEST_NAME="${TEST_NAME_BASE}"
 TEST_DIR="$HOME/cylc-run/" init_suite "${TEST_NAME}" <<< '

--- a/tests/restart/42-auto-restart-ping-pong.t
+++ b/tests/restart/42-auto-restart-ping-pong.t
@@ -104,7 +104,7 @@ for ear in $(seq 1 "${EARS}"); do
         "Attempting to restart on \"${JOKERS}\"" \
         "Suite now running on \"${JOKERS}\"" \
 
-    poll_suite_stopped
+    poll_suite_restart
 
     # test the restart procedure
     FILE=$(cylc cat-log "${SUITE_NAME}" -m p |xargs readlink -f)


### PR DESCRIPTION
These are nasty timing-dependent tests, at some point they have become broken, the functionality they are testing is fine though!

This should make them a bit more robust.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
