### PR TITLE
job_file: fix cylc_suite_def_path issue

### DIFF
--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -201,10 +201,14 @@ class JobFileWriter(object):
                 job_conf['remote_suite_d'])
         else:
             # replace home dir with '$HOME' for evaluation on the task host
+            cylc_suite_def_path = os.environ['CYLC_SUITE_DEF_PATH']
+            if cylc_suite_def_path.startswith(os.environ['HOME']):
+                cylc_suite_def_path = cylc_suite_def_path.replace(
+                    os.environ['HOME'],
+                    '${HOME}'
+                )
             handle.write(
-                '\n    export CYLC_SUITE_DEF_PATH="%s"' %
-                os.environ['CYLC_SUITE_DEF_PATH'].replace(
-                    os.environ['HOME'], '${HOME}'))
+                '\n    export CYLC_SUITE_DEF_PATH="%s"' % cylc_suite_def_path)
         handle.write(
             '\n    export CYLC_SUITE_DEF_PATH_ON_SUITE_HOST="%s"' %
             os.environ['CYLC_SUITE_DEF_PATH'])


### PR DESCRIPTION
There is a niche bug on master at the moment which can strike if:

```bash
[[ $(realpath "$HOME") != "$HOME" ]]
```

For example in this situation:

```console
$ echo $HOME
/b/c/d
$ realpath $HOME
/a/b/c/d
```

Your job script will end up with the line:

```bash
export CYLC_SUITE_DEF_PATH=/a${HOME}/cylc-run/<suitename>
```

> **Note:** The way we handle `$HOME` in configurations is going to change soon anyway but a quick fix for the meantime.

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
