### PR TITLE
hostuserutil: fix accidental breakage

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -107,7 +107,7 @@ class HostUtil(object):
     @staticmethod
     def get_host_ip_by_name(target):
         """Return internal IP address of target."""
-        return socket.getfqdn(target)
+        return socket.gethostbyname(target)
 
     def _get_host_info(self, target=None):
         """Return the extended info of the current host."""


### PR DESCRIPTION
Whoops, I didn't fix it properly, again, sorry 😐.

But to confirm that it's definitely back the way it was:

```diff
$ git diff 8.0a1 cylc/flow/hostuserutil.py 
diff --git a/cylc/flow/hostuserutil.py b/cylc/flow/hostuserutil.py
index b992d70e0..1b0bfc37d 100644
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python3
-
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
-# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
```