### PR TITLE
Remove scheduler keys on shutdown

### DIFF
--- a/cylc/flow/network/authentication.py
+++ b/cylc/flow/network/authentication.py
@@ -24,9 +24,11 @@ from cylc.flow.suite_files import (
     remove_keys_on_server)
 
 
-def key_setup(reg, platform=None):
+def key_housekeeping(reg, platform=None, create=True):
 
-    """Clean any existing authentication keys and create new ones."""
+    """Clean any existing authentication keys and create new ones.
+        If create is set to false, keys will only be cleaned from
+        server."""
     suite_srv_dir = get_suite_srv_dir(reg)
     keys = {
         "client_public_key": KeyInfo(
@@ -47,4 +49,5 @@ def key_setup(reg, platform=None):
             suite_srv_dir=suite_srv_dir)
     }
     remove_keys_on_server(keys)
-    create_server_keys(keys, suite_srv_dir)
+    if create:
+        create_server_keys(keys, suite_srv_dir)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -55,6 +55,7 @@ from cylc.flow.loggingutil import (
     ReferenceLogFileHandler
 )
 from cylc.flow.network import API
+from cylc.flow.network.authentication import key_housekeeping
 from cylc.flow.network.server import SuiteRuntimeServer
 from cylc.flow.network.publisher import WorkflowPublisher
 from cylc.flow.parsec.OrderedDict import DictTree
@@ -1778,7 +1779,12 @@ see `COPYING' in the Cylc source distribution.
                 LOG.exception(exc)
             if self.task_job_mgr:
                 self.task_job_mgr.task_remote_mgr.remote_tidy()
-
+        try:
+            # Remove ZMQ keys from scheduler
+            LOG.debug("Removing authentication keys from scheduler")
+            key_housekeeping(self.suite, create=False)
+        except Exception as ex:
+            LOG.exception(ex)
         # disconnect from suite-db, stop db queue
         try:
             self.suite_db_mgr.process_queued_ops()

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -23,7 +23,7 @@ import cylc.flow.flags
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.host_select import select_suite_host
 from cylc.flow.hostuserutil import is_remote_host
-from cylc.flow.network.authentication import key_setup
+from cylc.flow.network.authentication import key_housekeeping
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.pathutil import get_suite_run_dir
 from cylc.flow.remote import remrun, remote_cylc_cmd
@@ -275,7 +275,7 @@ def scheduler_cli(parser, options, args, is_restart=False):
             base_cmd.append("--host=localhost")
             return remote_cylc_cmd(base_cmd, host=options.host)
     # Create ZMQ keys
-    key_setup(reg, platform=options.host)
+    key_housekeeping(reg, platform=options.host)
     if remrun(set_rel_local=True):  # State localhost as above.
         sys.exit()
 

--- a/tests/authentication/03-check-keys-local.t
+++ b/tests/authentication/03-check-keys-local.t
@@ -1,0 +1,48 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Checks ZMQ keys are created and deleted on shutdown - local.
+. "$(dirname "$0")/test_header"
+set_test_number 10
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+    cycle point format = %Y
+[scheduling]
+    initial cycle point = 2020
+    [[graph]]
+        R1 = t1
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+SRVD="${SUITE_RUN_DIR}/.service"
+
+suite_run_ok "${TEST_NAME_BASE}-run-hold" cylc run --hold "${SUITE_NAME}"
+
+exists_ok "${SRVD}/client.key_secret"
+exists_ok "${SRVD}/server.key_secret"
+exists_ok "${SRVD}/server.key"
+exists_ok "${SRVD}/client_public_keys/client_localhost.key"
+
+cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"
+exists_fail "${SRVD}/client.key_secret"
+exists_fail "${SRVD}/server.key_secret"
+exists_fail "${SRVD}/server.key"
+exists_fail "${SRVD}/client_public_keys/client_localhost.key"
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/authentication/04-check-keys-remote.t
+++ b/tests/authentication/04-check-keys-remote.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Checks remote ZMQ keys are created and deleted on shutdown.
+. "$(dirname "$0")/test_header"
+set_test_remote_host
+set_test_number 4
+init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
+[cylc]
+[scheduling]
+    [[graph]]
+        R1 = holder
+[runtime]
+    [[holder]]    
+        script = """cylc hold "${CYLC_SUITE_NAME}" """
+        [[[remote]]]
+            host = $CYLC_TEST_HOST
+__SUITE_RC__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" 
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" 
+RRUND="cylc-run/${SUITE_NAME}"
+RSRVD="${RRUND}/.service"
+poll_grep_suite_log 'Holding all waiting or queued tasks now'
+SSH='ssh -n -oBatchMode=yes -oConnectTimeout=5'
+${SSH} "${CYLC_TEST_HOST}" \
+find "${RSRVD}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
+cmp_ok 'find.out' <<'__OUT__'
+client.key
+client.key_secret
+server.key
+__OUT__
+cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"
+${SSH} "${CYLC_TEST_HOST}" \
+find "${RRUND}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
+cmp_ok 'find.out' <<'__OUT__'
+__OUT__
+purge_suite_remote "${CYLC_TEST_HOST}" "${SUITE_NAME}"
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/authentication/04-check-keys-remote.t
+++ b/tests/authentication/04-check-keys-remote.t
@@ -23,12 +23,14 @@ init_suite "${TEST_NAME_BASE}" <<'__SUITE_RC__'
 [cylc]
 [scheduling]
     [[graph]]
-        R1 = holder
+        R1 = holder => held
 [runtime]
     [[holder]]    
         script = """cylc hold "${CYLC_SUITE_NAME}" """
         [[[remote]]]
             host = $CYLC_TEST_HOST
+    [[held]]
+        script = true
 __SUITE_RC__
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" 


### PR DESCRIPTION
These changes follow on from Generate client keys on remote platforms #3608  
These changes close #3660

Note to reviewers - my functional tests need checking. I'm very much a novice at writing these and have probably made some mistakes! Sorry in advance.


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] Documentation PR issue open cylc/cylc-doc#123
