### PR TITLE
setup: pin isodatetime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     'click>=7.0',
     'graphene>=2.1,<3',
     'jinja2==2.11.*',
-    'metomi-isodatetime==1!2.0.*',
+    'metomi-isodatetime==1!2.0.1',
     'protobuf==3.12.1',
     'pyzmq==18.1.*',
     'psutil>=5.6.0',


### PR DESCRIPTION
Fix the unit tests to deal with a change in isodatetime.

In retrospect, maybe we should have released this as `2.1.0`. My bad, anyway, for now this is a simple, if crude fix.

We should upgrade isodatetime in 8.0a3.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
