### PR TITLE
CYLC_CONF_PATH: modify interpretation

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Cylc site and user configuration file spec."""
 
+from pathlib import Path
 import os
 import re
 
@@ -727,8 +728,8 @@ class GlobalConfig(ParsecConfig):
     _DEFAULT = None
     _HOME = os.getenv('HOME') or get_user_home()
     CONF_BASENAME = "flow.rc"
-    SITE_CONF_DIR = os.path.join(os.sep, 'etc', 'cylc', 'flow', CYLC_VERSION)
-    USER_CONF_DIR = os.path.join(_HOME, '.cylc', 'flow', CYLC_VERSION)
+    SITE_CONF_DIR = Path(os.sep, 'etc', 'cylc', 'flow', CYLC_VERSION)
+    USER_CONF_DIR = Path(_HOME, '.cylc', 'flow', CYLC_VERSION)
 
     @classmethod
     def get_inst(cls, cached=True):
@@ -757,16 +758,20 @@ class GlobalConfig(ParsecConfig):
         LOG.debug("Loading site/user config files")
         conf_path_str = os.getenv("CYLC_CONF_PATH")
         if conf_path_str:
-            # Explicit config file override.
-            fname = os.path.join(conf_path_str, self.CONF_BASENAME)
-            if os.access(fname, os.F_OK | os.R_OK):
-                self.loadcfg(fname, upgrader.USER_CONFIG)
+            path = Path(conf_path_str)
+            if path.is_dir():
+                path /= self.CONF_BASENAME
+            if not path.exists():
+                # this check is superfluous but it gives us a nicer error
+                raise ValueError(
+                    f'CYLC_CONF_PATH does not exist: {conf_path_str}')
+            self.loadcfg(path, upgrader.USER_CONFIG)
         elif conf_path_str is None:
             # Use default locations.
             for conf_dir, conf_type in [
                     (self.SITE_CONF_DIR, upgrader.SITE_CONFIG),
                     (self.USER_CONF_DIR, upgrader.USER_CONFIG)]:
-                fname = os.path.join(conf_dir, self.CONF_BASENAME)
+                fname = conf_dir / self.CONF_BASENAME
                 if not os.access(fname, os.F_OK | os.R_OK):
                     continue
                 try:

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -246,8 +246,8 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
             try:
                 from cylc.flow.parsec.empysupport import empyprocess
             except (ImportError, ModuleNotFoundError):
-                raise ParsecError('EmPy Python package must be installed '
-                                  'to process file: ' + fpath)
+                raise ParsecError(f'EmPy Python package must be installed '
+                                  'to process file: {fpath}')
             flines = empyprocess(flines, fdir, template_vars)
 
     # process with Jinja2
@@ -257,8 +257,8 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
             try:
                 from cylc.flow.parsec.jinja2support import jinja2process
             except (ImportError, ModuleNotFoundError):
-                raise ParsecError('Jinja2 Python package must be installed '
-                                  'to process file: ' + fpath)
+                raise ParsecError(f'Jinja2 Python package must be installed '
+                                  'to process file: {fpath}')
             flines = jinja2process(flines, fdir, template_vars)
 
     # concatenate continuation lines

--- a/tests/cylc-get-site-config/06-cylc-conf-path.t
+++ b/tests/cylc-get-site-config/06-cylc-conf-path.t
@@ -1,0 +1,66 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# ensure that CYLC_CONF_PATH works correctly
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 7
+#-------------------------------------------------------------------------------
+mkdir foo
+mkdir bar
+echo 'process pool size = 1' > 'foo/flow.rc'
+echo 'process pool size = 1234' > 'foo/mess.rc'
+
+# if we point CYLC_CONF_PATH at a dir Cylc should load the
+# flow.rc within it
+TEST_NAME="${TEST_NAME_BASE}-dir"
+export CYLC_CONF_PATH=foo
+run_ok "${TEST_NAME}" cylc get-site-config --sparse
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+process pool size = 1
+__HERE__
+
+# if we point CYLC_CONF_PATH at a particular file Cylc should load
+# that particular file
+TEST_NAME="${TEST_NAME_BASE}-file"
+export CYLC_CONF_PATH=foo/mess.rc
+run_ok "${TEST_NAME}" cylc get-site-config --sparse
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+process pool size = 1234
+__HERE__
+
+# if we point CYLC_CONF_PATH at a non-existent dir Cylc should
+# raise an error (else tests could become placebos)
+TEST_NAME="${TEST_NAME_BASE}-missing-dir"
+export CYLC_CONF_PATH=foot
+run_fail "${TEST_NAME}" cylc get-site-config --sparse
+
+# if we point CYLC_CONF_PATH at a non-existent file Cylc should
+# raise an error (else tests could become placebos)
+TEST_NAME="${TEST_NAME_BASE}-missing-file"
+export CYLC_CONF_PATH=foo/foot.rc
+run_fail "${TEST_NAME}" cylc get-site-config --sparse
+
+# if we point CYLC_CONF_PATH at a directory which doesn't contain
+# a config file Cylc should raise an error (else tests could become placebos)
+TEST_NAME="${TEST_NAME_BASE}-no-config-file"
+export CYLC_CONF_PATH=bar
+run_fail "${TEST_NAME}" cylc get-site-config --sparse
+
+rm -r foo bar
+
+exit


### PR DESCRIPTION
Fiddle the way we interpret `CYLC_CONF_PATH`.

* If specified it must exist
* If it's not readable you get and error because thats your fault
* It can specify a file or a directory
* also use pathlib because it's pretty

> **FYI:** The immediate motivation for this change is to allow the integration tests to use the `flow-tests.rc` file which is not really possible at the moment as you cannot change `CYLC_CONF_PATH` from within pytest as the global configuration has already been loaded.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
