### PR TITLE
cli: highlight comments in usage strings

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -18,7 +18,10 @@
 import logging
 from optparse import OptionParser, OptionConflictError, Values
 import os
+import re
 import sys
+
+from ansimarkup import parse as cparse
 
 from cylc.flow import LOG
 import cylc.flow.flags
@@ -82,6 +85,16 @@ match name and cycle point patterns against instances already in the pool).
                 argdoc = [('SUITE', 'Suite name or path')]
             else:
                 argdoc = [('REG', 'Suite name')]
+
+        # make comments grey in usage for reasability
+        usage = cparse(
+            re.sub(
+                r'^(\s*(?:\$[^#]+)?)(#.*)$',
+                r'\1<dim>\2</dim>',
+                usage,
+                flags=re.M
+            )
+        )
 
         # noforce=True is for commands not using interactive prompts at all
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -86,7 +86,7 @@ match name and cycle point patterns against instances already in the pool).
             else:
                 argdoc = [('REG', 'Suite name')]
 
-        # make comments grey in usage for reasability
+        # make comments grey in usage for readability
         usage = cparse(
             re.sub(
                 r'^(\s*(?:\$[^#]+)?)(#.*)$',

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -49,12 +49,13 @@ The scheduler will run as a daemon unless you specify --no-detach.
 If the suite is not already registered (by "cylc register" or a previous run)
 it will be registered on the fly before start up.
 
-% cylc run REG
-  Run the suite registered with name REG.
+Examples:
+    # Run the suite registered with name REG.
+    $ cylc run REG
 
-% cylc run
-  Register $PWD/suite.rc as $(basename $PWD) and run it.
- (Note REG must be given explicitly if START_POINT is on the command line.)
+    # Register $PWD/suite.rc as $(basename $PWD) and run it.
+    # Note REG must be given explicitly if START_POINT is on the command line.
+    $ cylc run
 
 A "cold start" (the default) starts from the suite initial cycle point
 (specified in the suite.rc or on the command line). Any dependence on tasks


### PR DESCRIPTION
Quick change to highlight bash comments in CLI usage.

The idea is to improve the readability of examples e.g:

```bash
Lorel ipsum dolor sid amet apising elit.

Examples:
    # example 1
    $ foo bar baz

    # example 2
    # Note: dolor imit elast
    $ bar baz pub

    # example 3
    # ...
```

To reduce any unwanted effects this only highlights comments which are prefixed by spaces or on lines beginning with `$` i.e:

```
# will highlight
   # will highlight
$ foo # will highlight
foo # won't highlight 
```

We can re-format CLI help as and when.

Caveats:

* I've picked `$` for `$PS1` since this is the most common choice (I know total [bashism](https://linux.die.net/man/1/checkbashisms) right).
* The `--help` text will come out in colour whether you want it or not.