### PR TITLE
Update PR template for conda-forge files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,6 @@ This is a small change with no associated Issue.
 - [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
 - [ ] (7.8.x branch) I have updated the documentation in this PR branch.
 - [ ] No documentation update required.
+<!-- choose one: -->
+- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
+- [ ] No dependency changes.


### PR DESCRIPTION
A change for the pull request template, so that if we change `setup.py`, we are reminded to create an issue with the change.

When someone prepares the next conda release, s/he can go through the open issues, and update the recipe. We cannot prepare a PR as if merged that could create a new release.

Noticed we now have quite a few items in the template. Maybe for this one we could have just the `[ ] Created an issue blabla`, and the OP can choose whether to check or not that box. Same for changelog? That would be less 2 checks required :grimacing: 

