### PR TITLE
Catch CancelledError in scheduler_cli run function

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -442,7 +442,7 @@ async def _run(parser, options, reg, is_restart, scheduler):
     # stop cylc stop
     except SchedulerError:
         ret = 1
-    except KeyboardInterrupt as exc:
+    except (KeyboardInterrupt, asyncio.exceptions.CancelledError) as exc:
         try:
             await scheduler.shutdown(exc)
         except Exception as exc2:


### PR DESCRIPTION
This is a small change with no associated Issue.

I am using the workflow five with Cylc UI, on Python 3.8. And it's really inconvenient having to press CTRL+C twice (and often I forget it). So I did a quick debugging before lunch to see what was going on.

Apparently, the `scheduler_cli` run function now sees a `CancelledError` when I hit the CTRL+C (in PyCharm you just need to debug with the option to emulate a terminal, so that the signals are sent and trigger the debugger).

![image](https://user-images.githubusercontent.com/304786/87486586-b3f4a880-c68f-11ea-90ba-bdae7036c2b5.png)

(image above is where the exception was [re]raised, in the image below I added a global `except` + `traceback` to see what was going on, as the first time I tried it, the `finally` block got `ret=0`, even though there was an error).

![image](https://user-images.githubusercontent.com/304786/87486653-da1a4880-c68f-11ea-9287-46a2e31cd403.png)

I think the change in Python 3.8 that is related to this issue is [bpo-32528](https://bugs.python.org/issue32528). Implemented in [this commit](https://github.com/python/cpython/commit/431b540bf79f0982559b1b0e420b1b085f667bb7#diff-d359b31803c079e5a840bded473a24cb).

The `CancelledError` would be caught in the `except Exception` block before Python 3.8. But now it passes through the `scheduler_cli` try/except error handling. Actually any `BaseException` error will do the same, and `ret` will be `0`, which I think is not desirable (not sure, but not the main issue here I guess)?

**I am not sure if this is the right fix**. Even though this works, it's not clear to me why I'm getting the `CancelledError` when hitting CTRL+C instead of `KeyboardInterrupt`. Just thought it could be a good starting point for others to troubleshoot and investigate this issue :+1: (and works for me as a temporary local-patch so I can continue working on Cylc UI)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
