### PR TITLE
conf: default to $EDITOR/$GEDITOR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,18 @@ namespace, under `cylc.jinja.filters`.
 Cylc Review was also removed in this version.
 
 -------------------------------------------------------------------------------
+## __cylc-8.0a3 (2020-08?)__
+
+Fourth alpha release of Cylc 8.
+
+(See note on cylc-8 backward-incompatible changes, above)
+
+### Enhancements
+
+[#3692](https://github.com/cylc/cylc-flow/pull/3692) - Use the `$EDITOR`
+and `$GEDITOR` environment variables to determine the default editor to use.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 
 Third alpha release of Cylc 8.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -188,21 +188,47 @@ with Conf('flow.rc', desc='''
     with Conf('editors', desc='''
         Choose your favourite text editor for editing suite configurations.
     '''):
-        Conf('terminal', VDR.V_STRING, 'vim', desc='''
-            The editor to be invoked by the cylc command line interface.
+        Conf('terminal', VDR.V_STRING, desc='''
+            An in-terminal text editor to be used by the cylc command line.
+
+            If unspecified Cylc will use the environment variable
+            ``$EDITOR`` which is the preferred way to set your text editor.
+
+            If neither this or ``$EDITOR`` are specified then Cylc will
+            default to ``vi``.
+
+            .. Note::
+               You can set your ``$EDITOR`` in your shell profile file
+               (e.g. ``~.bashrc``)
 
             Examples::
 
+                ed
                 emacs -nw
-                vi -f
+                nano
+                vi
         ''')
-        Conf('gui', VDR.V_STRING, 'gvim -f', desc='''
-            GUI Text editor to be invoked by Cylc:
+        Conf('gui', VDR.V_STRING, desc='''
+            A graphical text editor to be used by cylc.
+
+            If unspecified Cylc will use the environment variable
+            ``$GEDITOR`` which is the preferred way to set your text editor.
+
+            If neither this or ``$GEDITOR`` are specified then Cylc will
+            default to ``gvim -fg``.
+
+            .. Note::
+               You can set your ``$GEDITOR`` in your shell profile file
+               (e.g. ``~.bashrc``)
 
             Examples::
 
-                gvim -g
+                atom --wait
+                code -nw
                 emacs
+                gedit -s
+                gvim -fg
+                nedit
         ''')
 
     # job platforms
@@ -845,6 +871,13 @@ class GlobalConfig(ParsecConfig):
         Ensure os.environ['HOME'] is defined with the correct value.
         """
         cfg = self.get()
+
+        # default to $[G]EDITOR unless an editor is defined in the config
+        # NOTE: use `or` to handle cases where an env var is set to ''
+        if not cfg['editors']['terminal']:
+            cfg['editors']['terminal'] = os.environ.get('EDITOR') or 'vi'
+        if not cfg['editors']['gui']:
+            cfg['editors']['gui'] = os.environ.get('GEDITOR') or 'gvim -fg'
 
         for host in cfg['hosts']:
             if host == 'localhost':

--- a/tests/functional/rnd/01-editors.t
+++ b/tests/functional/rnd/01-editors.t
@@ -1,0 +1,58 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test that the cylc [editors] can be set via the config or envvars.
+. "$(dirname "$0")/test_header"
+set_test_number 6
+#-------------------------------------------------------------------------------
+
+# editors not set in the config or with envvars
+TEST_NAME="$TEST_NAME_BASE-defaults"
+export EDITOR=
+export GEDITOR=
+run_ok "$TEST_NAME" cylc get-global-config -i '[editors]'
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+terminal = vi
+gui = gvim -fg
+__HERE__
+
+# editors set with envvars
+TEST_NAME="$TEST_NAME_BASE-envvar-override"
+export EDITOR=editor
+export GEDITOR=geditor
+run_ok "$TEST_NAME" cylc get-global-config -i '[editors]'
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+terminal = editor
+gui = geditor
+__HERE__
+
+# editors set with envvars and the config (which should take precedence)
+TEST_NAME="$TEST_NAME_BASE-config-override"
+export EDITOR=editor
+export GEDITOR=geditor
+create_test_globalrc '' '
+[editors]
+    terminal = myeditor
+    gui = mygeditor
+'
+run_ok "$TEST_NAME" cylc get-global-config -i '[editors]'
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+terminal = myeditor
+gui = mygeditor
+__HERE__
+
+exit


### PR DESCRIPTION
From the platforms proposal document: https://cylc.github.io/cylc-admin/proposal-config-changes.html#editors

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required (docs auto-generated from the config).
