### PR TITLE
Use any 2.0.x version of metomi-isodatetime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     'click>=7.0',
     'graphene>=2.1,<3',
     'jinja2==2.11.*',
-    'metomi-isodatetime==1!2.0.2',
+    'metomi-isodatetime>=1!2.0.2, <1!2.1.0',
     'protobuf==3.12.1',
     'pyzmq==18.1.*',
     'psutil>=5.6.0',


### PR DESCRIPTION
This is a small change with no associated Issue.

When building the Conda metapackage, we are seeing issues when instead of 2.0.1, we get 2.0.2 installed.

We should be able to use 2.0.* (i.e. any 2.0.x release). Although I think we had some breaking changes in 2.0.2 by accident (exceptions changed somewhere I think?).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
