### PR TITLE
scheduler: remote-init after server start

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -574,6 +574,8 @@ class Scheduler:
         try:
             self.data_store_mgr.initiate_data_model()
             self._configure_contact()
+            if self.is_restart:
+                self.restart_remote_init()
             self.run_event_handlers(self.EVENT_STARTUP, 'suite starting')
             await asyncio.gather(
                 *main_loop.get_runners(
@@ -687,9 +689,12 @@ class Scheduler:
         self.suite_db_mgr.pri_dao.select_xtriggers_for_restart(
             self.xtrigger_mgr.load_xtrigger_for_restart)
 
-        # Re-initialise run directory for user@host for each submitted and
-        # running tasks.
-        # Note: tasks should all be in the runahead pool at this point.
+    def restart_remote_init(self):
+        """Remote init for all submitted / running tasks in the pool.
+
+        Note: tasks should all be in the runahead pool at this point.
+
+        """
         auths = set()
         for itask in self.pool.get_rh_tasks():
             if itask.state(*TASK_STATUSES_ACTIVE):


### PR DESCRIPTION
The integration test changes accidentally broke the restart `remote-init` functionality, this aught to fix it.

The contact file can't be written until the TCP servers have started which now happens later on in the process than it did before.

This bug is covered by the remote tests (e.g. `tests/f/restart/26`) which should fail on master at the moment.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (8.0a3 bug which has not yet been released)
- [x] No documentation update required.
- [x] No dependency changes.