### PR TITLE
add protobuf field number warning

### DIFF
--- a/cylc/flow/data_messages.proto
+++ b/cylc/flow/data_messages.proto
@@ -33,6 +33,17 @@ syntax = "proto3";
  * If merge/rebase conflicts arise, then regenerate the module.
  * (DO NOT manually resolve conflicts)
  *
+ *
+ * WARNING: Avoid re-indexing existing fields!
+ *    - Field numbers do not need to be continuous/sequential (gaps are fine).
+ *    - These numbers are used by the client to know which field they correspond to,
+ *      so changing them can break back-compatibility (i.e. already running or old UIS).
+ *    - If in doubt, just leave the current fields as is, and just take a number
+ *      not in use for new fields.
+ *
+ * https://developers.google.com/protocol-buffers/docs/proto3#assigning_field_numbers
+ *
+ *
  * */
 
 


### PR DESCRIPTION
This is a small change with no associated Issue.
(brought up here: https://github.com/cylc/cylc-flow/pull/3515#discussion_r444628940)

A warning to leave the field number of in-use fields alone (no tidying or re-indexing to remove gaps or order the fields after addition):
https://developers.google.com/protocol-buffers/docs/proto3#assigning_field_numbers

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
