### PR TITLE
Reduce data-store family nodes to first parent ancestors

### DIFF
--- a/cylc/flow/network/graphql.py
+++ b/cylc/flow/network/graphql.py
@@ -240,7 +240,7 @@ def execute_and_validate_and_strip(
     variable_values = kwargs['variable_values'] or {}
     doc_args = AstDocArguments(schema, document_ast, variable_values)
     if doc_args.has_arg_val(STRIP_ARG, True):
-        if kwargs.get('return_promise', False):
+        if kwargs.get('return_promise', False) and hasattr(result, 'then'):
             return result.then(null_stripper)
         return null_stripper(result)
     return result

--- a/tests/functional/graphql/02-root-queries.t
+++ b/tests/functional/graphql/02-root-queries.t
@@ -177,9 +177,6 @@ cat > expected << __HERE__
             "id": "${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}FAM4"
         },
         {
-            "id": "${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}FAM5"
-        },
-        {
             "id": "${USER}${ID_DELIM}${SUITE_NAME}${ID_DELIM}root"
         }
     ],


### PR DESCRIPTION
This is a small change containing a fix for the issue described here:
https://github.com/cylc/cylc-ui/pull/458#issuecomment-663472156

The data-store family nodes have been reduced to only the first parent ancestors of the graphed tasks.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required, fix to feature under development.
- [x] No documentation update required.
- [x] No dependency changes.
