### PR TITLE
fix tui task parent grouping

### DIFF
--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -16,7 +16,7 @@ QUERY = '''
         cyclePoint
         state
         isHeld
-        parents {
+        firstParent {
           id
           name
         }

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -127,18 +127,14 @@ def compute_tree(flow):
 
     # add leaves
     for task in flow['taskProxies']:
-        parents = task['parents']
-        if not parents:
-            # handle inherit none by defaulting to root
-            parents = [{'name': 'root'}]
         task_node = add_node(
             'task', task['id'], nodes, data=task)
-        if parents[0]['name'] == 'root':
+        if task['firstParent']['name'] == 'root':
             family_node = add_node(
                 'cycle', idpop(task['id']), nodes)
         else:
             family_node = add_node(
-                'family', parents[0]['id'], nodes)
+                'family', task['firstParent']['id'], nodes)
         family_node['children'].append(task_node)
         for job in task['jobs']:
             job_node = add_node(

--- a/tests/unit/tui/test_util.py
+++ b/tests/unit/tui/test_util.py
@@ -174,41 +174,31 @@ def test_compute_tree():
             },
         ],
         'taskProxies': [
-            {  # orphan task (belongs to no family)
-                'name': 'baz',
-                'id': '1|baz',
-                'parents': [],
-                'cyclePoint': '1',
-                'jobs': []
-            },
             {  # top level task
                 'name': 'pub',
                 'id': '1|pub',
-                'parents': [{'name': 'root', 'id': '1|root'}],
+                'firstParent': {'name': 'root', 'id': '1|root'},
                 'cyclePoint': '1',
                 'jobs': []
             },
             {  # child task (belongs to family)
                 'name': 'fan',
                 'id': '1|fan',
-                'parents': [{'name': 'fan', 'id': '1|fan'}],
+                'firstParent': {'name': 'fan', 'id': '1|fan'},
                 'cyclePoint': '1',
                 'jobs': []
             },
             {  # nested child task (belongs to incestuous family)
                 'name': 'fool',
                 'id': '1|fool',
-                'parents': [
-                    {'name': 'FOOT', 'id': '1|FOOT'},
-                    {'name': 'FOO', 'id': '1|FOO'}
-                ],
+                'firstParent': {'name': 'FOOT', 'id': '1|FOOT'},
                 'cyclePoint': '1',
                 'jobs': []
             },
             {  # a task which has jobs
                 'name': 'worker',
                 'id': '1|worker',
-                'parents': [],
+                'firstParent': {'name': 'root', 'id': '1|root'},
                 'cyclePoint': '1',
                 'jobs': [
                     {'id': 'job3', 'submitNum': '3'},
@@ -239,14 +229,13 @@ def test_compute_tree():
         'id',
         'cyclePoint'
     ]
-    assert len(cycle['children']) == 4
+    assert len(cycle['children']) == 3
     assert [
         node['id_']
         for node in cycle['children']
     ] == [
         # test alphabetical sorting
         '1|FOO',
-        '1|baz',
         '1|pub',
         '1|worker'
     ]
@@ -282,7 +271,7 @@ def test_compute_tree():
     assert list(task['data']) == [
         'name',
         'id',
-        'parents',
+        'firstParent',
         'cyclePoint',
         'jobs'
     ]


### PR DESCRIPTION
This is a small change with no associated Issue.

Given a multiple parents, i.e.:
```
    [[qux]]
        inherit = FAM4
        [[[meta]]]
            description = "some task qux"
        [[[environment]]]
            GREETING = "Hello from qux!"


    [[qaz]]
        inherit = FAM4, FAM
        [[[meta]]]
            description = "some task qaz"
        [[[environment]]]
            GREETING = "Hello from qaz!"
        [[[outputs]]]
            trigger1 = "data ready"

    [[qar]]
        inherit = FAM, FAM5, FAM4
        [[[meta]]]
            description = "some task qar"
        [[[environment]]]
            GREETING = "Hello from qar!"
        [[[outputs]]]
            trigger1 = "data ready"
```
The visual parent in TUI could be any one of those in the inheritance, because the node `task.parents` doesn't conserve order:
![image](https://user-images.githubusercontent.com/11400777/88393881-8982b800-ce12-11ea-95f0-7015180966e6.png)

This PR fixes the issue by using `task.firstParent` field instead:
![image](https://user-images.githubusercontent.com/11400777/88393932-a1f2d280-ce12-11ea-8e5c-ae9138451720.png)



**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required, TUI is pre-release.
- [x] No documentation update required.
- [x] No dependency changes.
