### PR TITLE
Divorce local jobs from scheduler environment.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,9 @@ installation defined in $path rather than hardcoding to /bin/bash.
 [#3774](https://github.com/cylc/cylc-flow/pull/3774) - Removed support for
 interactive prompt.
 
+[#3712](https://github.com/cylc/cylc-flow/pull/3712) - Global config option to
+divorce all jobs from the scheduler environment.
+
 ### Fixes
 
 [#3732](https://github.com/cylc/cylc-flow/pull/3732) - XTrigger labels

--- a/cylc/flow/batch_sys_handlers/background.py
+++ b/cylc/flow/batch_sys_handlers/background.py
@@ -75,6 +75,7 @@ class BgCommandHandler:
                      timeout_str),
                     job_file_path,
                 ],
+                env=submit_opts.get('env'),
                 preexec_fn=os.setpgrp,
                 stdin=DEVNULL,
                 stdout=open(os.devnull, "wb"),

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -81,6 +81,29 @@ with Conf('global.cylc', desc='''
     Conf('run directory rolling archive length', VDR.V_INTEGER, -1, desc='''
         The number of old run directory trees to retain at start-up.
     ''')
+    with Conf('job submission environment', desc='''
+        Blah
+    '''):
+        Conf('divorce from scheduler', VDR.V_BOOLEAN, False, desc='''
+            Divorce the job submission shell from the scheduler environment.
+            Recommended to ensure that local and remote jobs are treated
+            consistently, but not the default because even local jobs will need
+            a central "cylc" wrapper or global "cylc executable" setting in
+            order to find Cylc commands.
+        ''')
+        Conf('environment', VDR.V_STRING_LIST, desc='''
+            Minimal list of environment variables to pass to the job submission
+            subprocess, if "divorce from scheduler" is enabled.
+            $HOME is passed automatically (needed by job scripts). You might
+            possibly need to include other variables if all jobs fail due to
+            undefined variables being referenced in profile scripts (e.g. in
+            /etc/profile.d).
+        ''')
+        Conf('path', VDR.V_STRING_LIST,
+             ['/bin', '/usr/bin', '/usr/local/bin'], desc='''
+            Minimal list of executable file locations to pass to the job
+            submission subprocess if "divorce from scheduler" is enabled.
+        ''')
 
     # suite
     with Conf('cylc', desc='''

--- a/tests/flakyfunctional/events/01-task.t
+++ b/tests/flakyfunctional/events/01-task.t
@@ -27,9 +27,13 @@ create_test_global_config '
         hosts = NOHOST.NODOMAIN
 '
 #-------------------------------------------------------------------------------
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate \
+    --set=SUITE_LOG_DIR="${SUITE_RUN_DIR}/log/suite" \
+    "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug --no-detach "${SUITE_NAME}"
+    cylc run --reference-test --debug --no-detach \
+    --set=SUITE_LOG_DIR="${SUITE_RUN_DIR}/log/suite" \
+    "${SUITE_NAME}"
 sort -u 'events.log' >'expected.events.log'
 sed 's/ (after .*)$//' "${SUITE_RUN_DIR}/log/suite/events.log" | sort -u \
     >'actual.events.log'

--- a/tests/flakyfunctional/events/01-task/flow.cylc
+++ b/tests/flakyfunctional/events/01-task/flow.cylc
@@ -61,8 +61,10 @@ cylc task message -p WARNING 'this is a user-defined warning message'
             submission retry delays = PT3S
      [[baz]]
         # submitted, submission timeout, started, failed
+        # Delay in init-script to cause submission timeout.
+        # (Note CYLC_SUITE_LOG_DIR is not defined at this point!)
         init-script = """
-while ! grep -q 'submission timeout *baz\.1' "${CYLC_SUITE_LOG_DIR}/events.log"
+while ! grep -q 'submission timeout *baz\.1' "{{SUITE_LOG_DIR}}/events.log"
 do
     sleep 1
 done

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -18,6 +18,12 @@
 # Test job submission with a very chatty command.
 # + Simulate "cylc jobs-submit" getting killed half way through.
 
+# WARNING: this test relies on jobs inheriting the scheduler environment: the
+# job submission command "bin/talkingnonsense reads COPYING from $CYLC_REPO_DIR
+# and writes to $CYLC_SUITE_RUN_DIR (with a clean environment, the run dir is
+# available to jobs via the job script, but not to the job submission shell).
+# To fix this it could read some other text file and write to a temp directory.
+
 . "$(dirname "$0")/test_header"
 
 skip_darwin 'atrun hard to configure on Mac OS'

--- a/tests/functional/job-submission/18-clean-env.t
+++ b/tests/functional/job-submission/18-clean-env.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that local jobs can be divorced from the scheduler environment.
+. "$(dirname "$0")/test_header"
+
+create_test_global_config "" "
+[job submission environment]
+   divorce from scheduler = True
+   environment = BEEF
+[platforms]
+   [[localhost]]
+      # required - or central cylc wrapper - if divorced from scheduler:
+      cylc executable = $(which cylc)
+"
+
+set_test_number 4
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+# Export a variable and try to access from a task job.
+export BEEF=wellington
+export CHEESE=melted
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+cylc cat-log "${SUITE_NAME}" foo.1 > job.out
+
+grep_ok "BEEF wellington" job.out
+grep_ok "CHEESE undefined" job.out
+
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/functional/job-submission/18-clean-env/flow.cylc
+++ b/tests/functional/job-submission/18-clean-env/flow.cylc
@@ -1,0 +1,16 @@
+[cylc]
+    [[events]]
+        timeout = PT30S
+        inactivity = PT30S
+        abort on inactivity = True
+        abort on timeout = True
+        abort on stalled = True
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = """
+            echo "BEEF ${BEEF:-undefined}"
+            echo "CHEESE ${CHEESE:-undefined}"
+                 """

--- a/tests/functional/shutdown/12-bad-port-file-check/flow.cylc
+++ b/tests/functional/shutdown/12-bad-port-file-check/flow.cylc
@@ -20,7 +20,7 @@
         script = """
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 # Corrupt port file and don't report back to suite
-SRVD="$RUN_DIR/${CYLC_SUITE_NAME}/.service"
+SRVD="${CYLC_SUITE_RUN_DIR}/.service"
 echo 'Haha! I have corrupted the port file!' >"${SRVD}/contact"
 trap '' EXIT
 exit

--- a/tests/functional/shutdown/13-no-port-file-check/flow.cylc
+++ b/tests/functional/shutdown/13-no-port-file-check/flow.cylc
@@ -20,8 +20,7 @@
         script = """
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 # Remove contact file and don't report back to suite
-SRVD="$RUN_DIR/${CYLC_SUITE_NAME}/.service"
-rm -f "${SRVD}/contact"
+rm -f "${CYLC_SUITE_RUN_DIR}/.service/contact"
 trap '' EXIT
 exit
 """


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

Close #3710 
Close #3487 

Pass only a minimal `$PATH` and `$HOME` to the subprocess in which the batch system job submission command is executed.

This ensures that local and remote jobs are consistent in not seeing the scheduler environment, and in using the `cylc` wrapper.

~~Draft PR until agreed that we should do this or not, and (if yes)  exactly what minimal env should be passed to jobs.~~

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation Issue at https://github.com/cylc/cylc-doc/issues/152
- [x] No dependency changes.
