### PR TITLE
Fix ICP offset var type.

### DIFF
--- a/cylc/flow/graphnode.py
+++ b/cylc/flow/graphnode.py
@@ -93,8 +93,6 @@ class GraphNodeParser(object):
             (name, offset, output,
             offset_is_from_icp, offset_is_irregular, offset_is_absolute)
 
-        TODO: offset_is_from_icp is '^' or None - should be boolean?
-
         NOTE that offsets from ICP like foo[^] and foo[^+P1] are not considered
               absolute like foo[2] etc.
 
@@ -105,7 +103,8 @@ class GraphNodeParser(object):
             match = self.REC_NODE.match(node)
             if not match:
                 raise GraphParseError('Illegal graph node: %s' % node)
-            name, offset_is_from_icp, offset, output = match.groups()
+            name, icp_mark, offset, output = match.groups()
+            offset_is_from_icp = (icp_mark == '^')  # convert to boolean
             if offset_is_from_icp and not offset:
                 offset = self._get_offset()
             offset_is_irregular = False


### PR DESCRIPTION
This is a small change with no associated Issue; it follows https://github.com/cylc/cylc-flow/pull/3515#pullrequestreview-457277970 

Converts a variable (assigned from an `re` match group) from `^` (character) or `None`, to boolean type as per expectations based on name and use of the variable.  This should not result in any functional change as the variable is only used in tests of the kind `if var: ...`.

If tests pass, one review should be enough.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (no functional change).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
