### PR TITLE
host-select: remove the assurance of socket.gaierror

### DIFF
--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -3,7 +3,6 @@ import ast
 from collections import namedtuple
 from functools import lru_cache
 from io import BytesIO
-from itertools import dropwhile
 import json
 import random
 from time import sleep
@@ -34,7 +33,10 @@ def select_suite_host(cached=True):
         tuple - See `select_host` for details.
 
     Raises:
-        HostSelectException: See `select_host` for details.
+        HostSelectException:
+            See `select_host` for details.
+        socket.gaierror:
+            See `select_host` for details.
 
     """
     # get the global config, if cached = False a new config instance will
@@ -93,6 +95,14 @@ def select_host(
         blacklist_name (str):
             The reason for blacklisting these hosts
             (used for exceptions).
+
+    Raises:
+        HostSelectException:
+            In the event that no hosts are available / meet the specified
+            criterion.
+        socket.gaierror:
+            This may be raised in the event of unknown host names
+            for some installations or not for others.
 
     Returns:
         tuple - (hostname, fqdn) the chosen host

--- a/tests/unit/test_host_select.py
+++ b/tests/unit/test_host_select.py
@@ -32,12 +32,6 @@ localhost_aliases = [
 ]
 
 
-def test_hostname_checking():
-    """Check that unknown hosts raise an error"""
-    with pytest.raises(socket.gaierror):
-        select_host(['beefwellington'])
-
-
 def test_localhost():
     """Basic test with one host to choose from."""
     assert select_host([localhost]) == (
@@ -133,19 +127,6 @@ def test_suite_host_select(mock_glbl_cfg):
         '''
     )
     assert select_suite_host() == (localhost, localhost_fqdn)
-
-
-def test_suite_host_select_invalid_host(mock_glbl_cfg):
-    """Ensure hosts are parsed before evaluation."""
-    mock_glbl_cfg(
-        'cylc.flow.host_select.glbl_cfg',
-        '''
-            [suite servers]
-                run hosts = elephant
-        '''
-    )
-    with pytest.raises(socket.gaierror):
-        select_suite_host()
 
 
 def test_suite_host_select_default(mock_glbl_cfg):


### PR DESCRIPTION
`socket.gethostbyname_ex` raises `socket.gaierror` in the event that a hostname is not recognised e.g. `socket.gethostbyname_ex('elephant')`, however, this behaviour it would appear, is dependent on network configuration/platform.

I don't think anything is *depending* on this behaviour ATM so I'm whipping out the tests (which can fail) and updating the docs in this PR.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
