### PR TITLE
Fix jinja2 test failures

### DIFF
--- a/tests/unit/parsec/test_jinja2support.py
+++ b/tests/unit/parsec/test_jinja2support.py
@@ -81,7 +81,7 @@ def test_pymoduleloader(tmp_path):
     filters_dir.mkdir()
     with open(filters_dir / 'jinja2jinja.py', 'bw+') as tf:
         tf.write(
-            "def jinja2jinja()\n    raise Exception('It works!')".encode())
+            "def jinja2jinja():\n    raise Exception('It works!')".encode())
         tf.seek(0)
         env = jinja2environment(tmp_path)
 
@@ -100,7 +100,7 @@ def test_pymoduleloader_invalid_module(tmp_path):
     filters_dir.mkdir()
     with open(filters_dir / 'jinja2jinja.py', 'bw+') as tf:
         tf.write(
-            "def jinja2jinja()\n    raise Exception('It works!')".encode())
+            "def jinja2jinja():\n    raise Exception('It works!')".encode())
         tf.seek(0)
         env = jinja2environment(tmp_path)
 

--- a/tests/unit/parsec/test_jinja2support.py
+++ b/tests/unit/parsec/test_jinja2support.py
@@ -14,110 +14,96 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import tempfile
-import unittest
-
 import jinja2
+
+import pytest
 
 from cylc.flow.parsec.jinja2support import *
 
 
-class TestJinja2support(unittest.TestCase):
+def test_raise_helper():
+    message = 'Ops'
+    error_type = 'CRITICAL'
+    with pytest.raises(Exception) as cm:
+        raise_helper(message=message)
 
-    def test_raise_helper(self):
-        message = 'Ops'
-        error_type = 'CRITICAL'
-        with self.assertRaises(Exception) as cm:
-            raise_helper(message=message)
+    assert str(cm.value) == "Jinja2 Error: Ops"
 
-        ex = cm.exception
-        self.assertEqual("Jinja2 Error: Ops", str(ex))
+    with pytest.raises(Exception) as cm:
+        raise_helper(message=message, error_type=error_type)
 
-        with self.assertRaises(Exception) as cm:
-            raise_helper(message=message, error_type=error_type)
-
-        ex = cm.exception
-        self.assertEqual("Jinja2 CRITICAL: Ops", str(ex))
-
-    def test_assert_helper(self):
-        assert_helper(logical=True, message="Doesn't matter")  # harmless
-
-        with self.assertRaises(Exception):
-            assert_helper(logical=False, message="Doesn't matter")
-
-    def test_jinja2environment(self):
-        # create a temp directory, in the temp directory, to prevent
-        # issues running multiple test suites in parallel
-        temp_directory = tempfile.mkdtemp(prefix='cylc', suffix='test_jinja2')
-        filters_dir = os.path.join(temp_directory, 'Jinja2Filters')
-        os.mkdir(filters_dir)
-        with open(os.path.join(filters_dir, "min.py"), "w") as tf:
-            tf.write("def min():\n    raise ArithmeticError('UP!')")
-            tf.seek(0)
-            dir_ = temp_directory
-            env = jinja2environment(dir_)
-            # our jinja env contains the following keys in the global namespace
-            self.assertTrue('environ' in env.globals)
-            self.assertTrue('raise' in env.globals)
-            self.assertTrue('assert' in env.globals)
-
-            with self.assertRaises(ArithmeticError) as cm:
-                # jinja2environment must have loaded the function from the .py
-                env.filters['min']()
-            self.assertEqual('UP!', str(cm.exception))
-
-    def test_jinja2process(self):
-        lines = ["skipped", "My name is {{ name }}", ""]
-        variables = {'name': 'Cylc'}
-        template_dir = tempfile.gettempdir()
-
-        r = jinja2process(lines, template_dir, variables)
-
-        self.assertEqual(['My name is Cylc'], r)
-
-    def test_jinja2process_missing_variables(self):
-        lines = ["skipped", "My name is {{ name }}", ""]
-        template_dir = tempfile.gettempdir()
-
-        with self.assertRaises(Jinja2Error) as exc:
-            jinja2process(lines, template_dir, template_vars=None)
-            self.assertIn('jinja2.UndefinedError', str(exc))
-
-    def test_pymoduleloader(self):
-        temp_directory = tempfile.mkdtemp(prefix='cylc', suffix='test_jinja2')
-        filters_dir = os.path.join(temp_directory, 'Jinja2filters')
-        os.mkdir(filters_dir)
-        with tempfile.NamedTemporaryFile(dir=filters_dir, suffix=".py") as tf:
-            tf.write(
-                "def jinja2jinja()\n    raise Exception('It works!')".encode())
-            tf.seek(0)
-            dir_ = temp_directory
-            env = jinja2environment(dir_)
-
-            module_loader = PyModuleLoader()
-            template = module_loader.load(environment=env, name='sys')
-            self.assertEqual(sys.path, template.module.path)
-
-            template2 = module_loader.load(
-                environment=env, name='__python__.sys')
-
-            self.assertEqual(template.module.path, template2.module.path)
-
-    def test_pymoduleloader_invalid_module(self):
-        temp_directory = tempfile.mkdtemp(prefix='cylc', suffix='test_jinja2')
-        filters_dir = os.path.join(temp_directory, 'Jinja2filters')
-        os.mkdir(filters_dir)
-        with tempfile.NamedTemporaryFile(dir=filters_dir, suffix=".py") as tf:
-            tf.write(
-                "def jinja2jinja()\n    raise Exception('It works!')".encode())
-            tf.seek(0)
-            dir_ = temp_directory
-            env = jinja2environment(dir_)
-
-            module_loader = PyModuleLoader()
-            with self.assertRaises(jinja2.TemplateNotFound):
-                module_loader.load(environment=env, name='no way jose')
+    assert str(cm.value) == "Jinja2 CRITICAL: Ops"
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_assert_helper():
+    assert_helper(logical=True, message="Doesn't matter")  # harmless
+
+    with pytest.raises(Exception):
+        assert_helper(logical=False, message="Doesn't matter")
+
+
+def test_jinja2environment(tmp_path):
+    # create a temp directory, in the temp directory, to prevent
+    # issues running multiple test suites in parallel
+    filters_dir = tmp_path / 'Jinja2Filters'
+    filters_dir.mkdir()
+    with open(filters_dir / "min.py", "w") as tf:
+        tf.write("def min():\n    raise ArithmeticError('UP!')")
+        tf.seek(0)
+        env = jinja2environment(tmp_path)
+        # our jinja env contains the following keys in the global namespace
+        assert 'environ' in env.globals
+        assert 'raise' in env.globals
+        assert 'assert' in env.globals
+
+        with pytest.raises(ArithmeticError) as cm:
+            # jinja2environment must have loaded the function from the .py
+            env.filters['min']()
+        assert str(cm.value) == 'UP!'
+
+
+def test_jinja2process(tmp_path):
+    lines = ["skipped", "My name is {{ name }}", ""]
+    variables = {'name': 'Cylc'}
+    r = jinja2process(lines, tmp_path, variables)
+    assert ['My name is Cylc'] == r
+
+
+def test_jinja2process_missing_variables(tmp_path):
+    lines = ["skipped", "My name is {{ name }}", ""]
+    with pytest.raises(Jinja2Error) as exc:
+        jinja2process(lines, tmp_path, template_vars=None)
+        assert 'jinja2.UndefinedError' in str(exc)
+
+
+def test_pymoduleloader(tmp_path):
+    filters_dir = tmp_path / 'Jinja2filters'
+    filters_dir.mkdir()
+    with open(filters_dir / 'jinja2jinja.py', 'bw+') as tf:
+        tf.write(
+            "def jinja2jinja()\n    raise Exception('It works!')".encode())
+        tf.seek(0)
+        env = jinja2environment(tmp_path)
+
+        module_loader = PyModuleLoader()
+        template = module_loader.load(environment=env, name='sys')
+        assert sys.path == template.module.path
+
+        template2 = module_loader.load(
+            environment=env, name='__python__.sys')
+
+        assert template.module.path == template2.module.path
+
+
+def test_pymoduleloader_invalid_module(tmp_path):
+    filters_dir = tmp_path / 'Jinja2filters'
+    filters_dir.mkdir()
+    with open(filters_dir / 'jinja2jinja.py', 'bw+') as tf:
+        tf.write(
+            "def jinja2jinja()\n    raise Exception('It works!')".encode())
+        tf.seek(0)
+        env = jinja2environment(tmp_path)
+
+        module_loader = PyModuleLoader()
+        with pytest.raises(jinja2.TemplateNotFound):
+            module_loader.load(environment=env, name='no way jose')


### PR DESCRIPTION
There would appear to be a platform-dependent bug in this test. On my system the python syntax error causes the test to fail. It seems that this doesn't happen on all platforms. Not sure what's going on here, easy solution is to fix the test, which I've done in the second commit. I also upgraded from unittest to pytest in the process.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.