### PR TITLE
xtriggers: validate labels (master)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,10 @@ installation defined in $path rather than hardcoding to /bin/bash.
 
 ### Fixes
 
+[#3732](https://github.com/cylc/cylc-flow/pull/3732) - XTrigger labels
+are now validated to ensure that runtime errors can not occur when
+exporting environment variables.
+
 [#3632](https://github.com/cylc/cylc-flow/pull/3632) - Fix a bug that was causing
 `UTC mode` specified in global config to be pretty much ignored.
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -68,6 +68,7 @@ from cylc.flow.taskdef import TaskDef
 from cylc.flow.task_id import TaskID
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.task_trigger import TaskTrigger, Dependency
+from cylc.flow.unicode_rules import XtriggerNameValidator
 from cylc.flow.wallclock import (
     get_current_time_string, set_utc_mode, get_utc_mode)
 from cylc.flow.xtrigger_mgr import XtriggerManager
@@ -1670,6 +1671,14 @@ class SuiteConfig(object):
         if triggers:
             dependency = Dependency(expr_list, set(triggers.values()), suicide)
             self.taskdefs[right].add_dependency(dependency, seq)
+
+        validator = XtriggerNameValidator.validate
+        for label in self.cfg['scheduling']['xtriggers']:
+            valid, msg = validator(label)
+            if not valid:
+                raise SuiteConfigError(
+                    f'Invalid xtrigger name "{label}" - {msg}'
+                )
 
         for label in xtrig_labels:
             try:

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -21,6 +21,7 @@ import re
 
 ENGLISH_REGEX_MAP = {
     r'\w': 'alphanumeric',
+    r'a-zA-Z0-9': 'latin letters and numbers',
     r'\-': '-',
     r'\.': '.',
     r'\/': '/'
@@ -141,4 +142,12 @@ class SuiteNameValidator(UnicodeRuleChecker):
         length(1, 254),
         not_starts_with(r'\.', r'\-'),
         allowed_characters(r'\w', r'\/', '_', '+', r'\-', r'\.', '@')
+    ]
+
+
+class XtriggerNameValidator(UnicodeRuleChecker):
+    """The rules for valid xtrigger labels:"""
+
+    RULES = [
+        allowed_characters(r'a-zA-Z0-9', '_')
     ]

--- a/tests/functional/validate/73-xtrigger-names.t
+++ b/tests/functional/validate/73-xtrigger-names.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validating xtrigger names in suite.
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+TEST_NAME="${TEST_NAME_BASE}-val"
+
+# test a valid xtrigger
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 2000
+    [[xtriggers]]
+        foo = wall_clock():PT1S
+    [[graph]]
+        R1 = @foo => bar
+__SUITE_RC__
+run_ok "${TEST_NAME}-valid" cylc validate suite.rc
+
+# test an invalid xtrigger
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 2000
+    [[xtriggers]]
+        foo-1 = wall_clock():PT1S
+    [[graph]]
+            R1 = @foo-1 => bar
+__SUITE_RC__
+
+run_fail "${TEST_NAME}-invalid" cylc validate suite.rc
+grep_ok 'Invalid xtrigger name' "${TEST_NAME}-invalid.stderr"
+
+exit


### PR DESCRIPTION
C-lose https://github.com/cylc/cylc-flow/issues/3703 (master)
Companion to: https://github.com/cylc/cylc-doc/pull/140

Validate xtrigger names to prevent nasty runtime issues.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/140.
- [x] No dependency changes.
