### PR TITLE
xtriggers: validate labels (7.8.x)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,13 @@ cylc-7.9.x (which requires Python 2.7) bundles Jinja2 2.11.
 cylc-8 (master branch, Python 3 - not yet released) uses proper Python package
 management and does not bundle Jinja2.
 
+## __cylc-7.8.7 (pending)__
+
+### Fixes
+
+[#3734](https://github.com/cylc/cylc-flow/pull/3734) - Validate XTrigger
+labels to prevent runtime bugs when exporting environment variables.
+
 -------------------------------------------------------------------------------
 ## __cylc-7.8.6 (2020-05-14)__
 

--- a/doc/src/external-triggers.rst
+++ b/doc/src/external-triggers.rst
@@ -97,7 +97,7 @@ Argument keywords can be omitted if called in the right order, so the
    [[xtriggers]]
        clock_1 = wall_clock(PT1H)
 
-Finally, a zero-offset clock trigger does not need to be declared under
+A zero-offset clock trigger does not need to be declared under
 the ``[xtriggers]`` section:
 
 .. code-block:: cylc
@@ -111,6 +111,9 @@ the ``[xtriggers]`` section:
    [runtime]
        [[foo]]
            script = run-foo.sh
+
+However, when xtriggers are declared the name used must contain only
+the letters ``a`` to ``z`` in upper or lower case and underscores.
 
 
 .. _Built-in Suite State Triggers:

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -63,6 +63,7 @@ from cylc.taskdef import TaskDef, TaskDefError
 from cylc.task_id import TaskID
 from cylc.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.task_trigger import TaskTrigger, Dependency
+from cylc.unicode_rules import XtriggerNameValidator
 from cylc.wallclock import get_current_time_string, set_utc_mode, get_utc_mode
 from cylc.xtrigger_mgr import XtriggerManager
 
@@ -1744,6 +1745,14 @@ class SuiteConfig(object):
         if triggers:
             dependency = Dependency(expr_list, set(triggers.values()), suicide)
             self.taskdefs[right].add_dependency(dependency, seq)
+
+        validator = XtriggerNameValidator.validate
+        for label in self.cfg['scheduling']['xtriggers']:
+            valid, msg = validator(label)
+            if not valid:
+                raise SuiteConfigError(
+                    'Invalid xtrigger name "%s" - %s' % (label, msg)
+                )
 
         for label in xtrig_labels:
             try:

--- a/lib/cylc/unicode_rules.py
+++ b/lib/cylc/unicode_rules.py
@@ -1,0 +1,87 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Module for unicode restrictions"""
+
+import re
+
+
+ENGLISH_REGEX_MAP = {
+    r'\w': 'alphanumeric',
+    r'\-': '-',
+    r'\.': '.',
+    r'\/': '/'
+}
+
+
+def regex_chars_to_text(chars):
+    r"""Return a string representing a regex component.
+
+    Examples:
+        >>> regex_chars_to_text(['a', 'b', 'c'])
+        ['a', 'b', 'c']
+        >>> regex_chars_to_text([r'\-', r'\.', r'\/'])
+        ['-', '.', '/']
+        >>> regex_chars_to_text([r'\w'])
+        ['alphanumeric']
+
+    """
+    return [
+        ENGLISH_REGEX_MAP.get(char, char)
+        for char in chars
+    ]
+
+
+def allowed_characters(*chars):
+    """Restrict permitted characters.
+
+    """
+    return (
+        re.compile(r'^[%s]+$' % ''.join(chars)),
+        'can only contain: %s' % ", ".join(regex_chars_to_text(chars))
+    )
+
+
+class UnicodeRuleChecker(object):
+
+    RULES = []
+
+    @classmethod
+    def validate(cls, string):
+        """Run this collection of rules against the given string.
+
+        Args:
+            string (str):
+                String to validate.
+
+        Returns:
+            tuple - (outcome, message)
+            outcome (bool) - True if all patterns match.
+            message (str) - User-friendly error message.
+
+        """
+        for rule, message in cls.RULES:
+            if not rule.match(string):
+                return (False, message)
+        return (True, None)
+
+
+class XtriggerNameValidator(UnicodeRuleChecker):
+    """The rules for valid xtrigger labels:"""
+
+    RULES = [
+        allowed_characters(r'a-zA-Z0-9', '_')
+    ]

--- a/tests/validate/73-xtrigger-names.t
+++ b/tests/validate/73-xtrigger-names.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validating xtrigger names in suite.
+. "$(dirname "$0")/test_header"
+
+set_test_number 3
+
+TEST_NAME="${TEST_NAME_BASE}-val"
+
+# test a valid xtrigger
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 2000
+    [[xtriggers]]
+        foo = wall_clock():PT1S
+    [[dependencies]]
+        [[[T00]]]
+            graph = @foo => bar
+__SUITE_RC__
+run_ok "${TEST_NAME}-valid" cylc validate suite.rc
+
+# test an invalid xtrigger
+cat >'suite.rc' <<'__SUITE_RC__'
+[scheduling]
+    initial cycle point = 2000
+    [[xtriggers]]
+        foo-1 = wall_clock():PT1S
+    [[dependencies]]
+        [[[T00]]]
+            graph = @foo-1 => bar
+__SUITE_RC__
+
+run_fail "${TEST_NAME}-invalid" cylc validate suite.rc
+grep_ok 'Invalid xtrigger name' "${TEST_NAME}-invalid.stderr"
+
+exit


### PR DESCRIPTION
Closes ~~3707~~ #3703 (7.8.x, 7.9.x)

Back port of #3732 with:

* Some of the unicode_rules stuff stripped out.
* Fstrings converted to `%` syntax.
* Manual docs.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] docs updated
- [x] No dependency changes.
