### PR TITLE
Fix sequence bounds check for parent tasks.

### DIFF
--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -139,7 +139,7 @@ class TaskDef:
         """Return the cycle points of my parents, at point."""
         parent_points = set()
         for seq in self.sequences:
-            if not seq.is_on_sequence(point):
+            if not seq.is_valid(point):
                 continue
             if seq in self.dependencies:
                 # task has prereqs in this sequence
@@ -154,7 +154,7 @@ class TaskDef:
         """Return my absolute triggers, if any, at point."""
         abs_triggers = set()
         for seq in self.sequences:
-            if not seq.is_on_sequence(point):
+            if not seq.is_valid(point):
                 continue
             if seq in self.dependencies:
                 # task has prereqs in this sequence

--- a/tests/functional/spawn-on-demand/08-lost-parents.t
+++ b/tests/functional/spawn-on-demand/08-lost-parents.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Check a task gets auto-spawned after losing its parents.
+. "$(dirname "$0")/test_header"
+install_suite "${TEST_NAME_BASE}"
+
+set_test_number 2
+reftest
+exit

--- a/tests/functional/spawn-on-demand/08-lost-parents/flow.cylc
+++ b/tests/functional/spawn-on-demand/08-lost-parents/flow.cylc
@@ -1,0 +1,12 @@
+# bar has a parent to spawn it in the first three cycles, but requires
+# auto-spawning after that
+[scheduling]
+   cycling mode = integer
+   initial cycle point = 1
+   final cycle point = 4
+   [[graph]]
+      R3//P1 = "foo => bar"
+      P1 = "bar"
+[runtime]
+   [[root]]
+      script = true

--- a/tests/functional/spawn-on-demand/08-lost-parents/reference.log
+++ b/tests/functional/spawn-on-demand/08-lost-parents/reference.log
@@ -1,0 +1,9 @@
+Initial point: 1
+Final point: 4
+[foo.1] -triggered off []
+[foo.2] -triggered off []
+[foo.3] -triggered off []
+[bar.1] -triggered off ['foo.1']
+[bar.2] -triggered off ['foo.2']
+[bar.3] -triggered off ['foo.3']
+[bar.4] -triggered off []


### PR DESCRIPTION
This change addresses a bug (and untested functionality, evidently) found by @TomekTrzeciak in https://github.com/cylc/cylc-flow/issues/3740#issuecomment-669130391

In the following example, `bar` should trigger off of `foo` in the first 3 cycles, then subsequent `bar`'s should trigger automatically (no parents):
```
R3//P1 = "foo => bar"
P1 = "bar"
```
On this branch it works, but on master the scheduler shuts down finished after cycle point 3.

Since spawn-on-demand we auto-spawn parent-less tasks when their previous instance leaves the runahead pool (they have no parents to spawn them "on demand").  In this example, `bar.3` has a parent (`foo.3`) but `bar.4` has no parents and so has to be auto-spawned.  To do this, when `bar.3` leaves the runahead pool we look at the next cycle point for `bar` and see if it has parents there by looking for parents in each of its sequences.  This parent-lookup gave the wrong result because `sequence.is_on_sequence(point)` disregards sequence bounds. The fix is to use `sequence.is_valid(point)` (which correctly says that `bar.4` has no parents).

Marking as Draft until I add a test.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] No change log entry needed  (fixes a very recent never-released bug)
<!-- choose one: -->
- [x] No documentation update required
<!-- choose one: -->
- [x] No dependency changes.
