### PR TITLE
Bugfix: cylc-gui - tasks momentarily out of sequence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ requests_).
  - Martin Ryan
  - Mel Hall
  - Ronnie Dutta
+ - Glenn Creighton
 
 
 (All contributors are identifiable with email addresses in the git version

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -264,11 +264,11 @@ class ControlTree(object):
         return self._nat_cmp(prop1, prop2)
 
     def default_sort_column(self, model, iter1, iter2):
-        point_string1 = model.get_value(iter1, 1)
-        point_string2 = model.get_value(iter2, 1)
-        if point_string1 is None or point_string2 is None:
-            return cmp(point_string1, point_string2)
-        return self._nat_cmp(point_string1, point_string2)
+        task_name_string1 = model.get_value(iter1, 1)
+        task_name_string2 = model.get_value(iter2, 1)
+        if task_name_string1 is None or task_name_string2 is None:
+            return cmp(task_name_string1, task_name_string2)
+        return self._nat_cmp(task_name_string1, task_name_string2)
 
     def _get_interval_in_seconds(self, val):
         """Convert the IOS 8601 date/time to seconds."""

--- a/lib/cylc/gui/view_tree.py
+++ b/lib/cylc/gui/view_tree.py
@@ -264,8 +264,8 @@ class ControlTree(object):
         return self._nat_cmp(prop1, prop2)
 
     def default_sort_column(self, model, iter1, iter2):
-        point_string1 = model.get_value(iter1, 0)
-        point_string2 = model.get_value(iter2, 0)
+        point_string1 = model.get_value(iter1, 1)
+        point_string2 = model.get_value(iter2, 1)
         if point_string1 is None or point_string2 is None:
             return cmp(point_string1, point_string2)
         return self._nat_cmp(point_string1, point_string2)


### PR DESCRIPTION
gui: fix tree-view out-of-sequence tasks caused by default sorting on wrong column index

Unclear as to the reason why this bug does not show up with newer versions of Python or GTK, but this fixes the problem on my end and does not appear to hurt anything else.


<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3698 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
