### PR TITLE
tests: document how to turn xdist off

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -7,6 +7,7 @@ This directory contains Cylc integration tests.
 ```console
 $ pytest tests/i
 $ pytest tests/i -n 5  # run up to 5 tests in parallel
+$ pytest tests/i --dist=no -n0  # turn off xdist (allows --pdb etc)
 ```
 
 ## What Are Integration Tests

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -7,6 +7,7 @@ This directory contains Cylc unit tests.
 ```console
 $ pytest tests/u
 $ pytest tests/u -n 5  # run up to 5 tests in parallel
+$ pytest tests/u --dist=no -n0  # turn off xdist (allows --pdb etc)
 ```
 
 ## What Are Unit Tests


### PR DESCRIPTION
Worked out why we weren't able to disable distribution using `-n0` (as documented in pytest-xdist), it's because of the `--dist` option specified in `pytest.ini` which is set to ensure that tests in the same module get run together (which is needed for the integration tests as otherwise module-level fixtures would compete with each other from different processes).

There is an issue up on pytest to make `--dist=no` implicit with `-n0` but for now lets just document the current workaround.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.