### PR TITLE
made job file test work against kgo

### DIFF
--- a/etc/bin/shellchecker
+++ b/etc/bin/shellchecker
@@ -24,7 +24,7 @@ cd "$(dirname "$0")/../../"
 # find shell files under the specified directory
 find_files () {
     SEARCH_PATH="$1"
-    grep --color=never -Rl '^#\!.*bash' "${SEARCH_PATH}" | sed 's/^\.\///'
+    grep --color=never -Rl --exclude="*.kgo" '^#\!.*bash' "${SEARCH_PATH}" | sed 's/^\.\///'
     find "${SEARCH_PATH}" -name '*.sh' | sed 's/^\.\///'
 }
 

--- a/tests/unit/kgo/job_file.kgo
+++ b/tests/unit/kgo/job_file.kgo
@@ -1,0 +1,87 @@
+#!/bin/bash -l
+#
+# ++++ THIS IS A CYLC TASK JOB SCRIPT ++++
+# Suite: farm_noises
+# Task: baa
+# Job log directory: 1/baa/01
+# Job submit method: background
+# Job submit command template: woof
+# Execution time limit: moo
+if [[ $1 == 'noreinvoke' ]]; then
+    shift
+else
+    exec bash -l "$0" noreinvoke "$@"
+fi
+
+CYLC_FAIL_SIGNALS='EXIT ERR TERM XCPU'
+export CYLC_VERSION='8.0a3.dev'
+
+cylc__job__inst__cylc_env() {
+    # CYLC SUITE ENVIRONMENT:
+
+    export CYLC_SUITE_RUN_DIR="run/dir"
+    CYLC_SUITE_WORK_DIR_ROOT="~me/cylc-run/farm_noises"
+    export CYLC_SUITE_DEF_PATH="remote/suite/dir"
+    export CYLC_SUITE_DEF_PATH_ON_SUITE_HOST="cylc/suite/def/path"
+    export CYLC_SUITE_UUID="neigh"
+
+    # CYLC TASK ENVIRONMENT:
+    export CYLC_TASK_JOB="1/baa/01"
+    export CYLC_TASK_NAMESPACE_HIERARCHY="root baa moo"
+    export CYLC_TASK_DEPENDENCIES="moo neigh quack"
+    export CYLC_TASK_TRY_NUMBER=1
+    export CYLC_TASK_FLOW_LABEL=aZ
+    export param_env_tmpl_1="moo"
+    export param_env_tmpl_2="baa"
+    export CYLC_TASK_PARAM_duck="quack"
+    export CYLC_TASK_PARAM_mouse="squeak"
+    CYLC_TASK_WORK_DIR_BASE='farm_noises/work_d'
+}
+
+cylc__job__inst__user_env() {
+    # TASK RUNTIME ENVIRONMENT:
+    export cow sheep duck
+    cow=~/"moo"
+    sheep=~baa/"baa"
+    duck=~quack
+}
+
+cylc__job__inst__init_script() {
+# INIT-SCRIPT:
+This is the init script
+}
+
+cylc__job__inst__env_script() {
+# ENV-SCRIPT:
+This is the env script
+}
+
+cylc__job__inst__err_script() {
+# ERR-SCRIPT:
+This is the err script
+}
+
+cylc__job__inst__pre_script() {
+# PRE-SCRIPT:
+This is the pre script
+}
+
+cylc__job__inst__script() {
+# SCRIPT:
+This is the script
+}
+
+cylc__job__inst__post_script() {
+# POST-SCRIPT:
+This is the post script
+}
+
+cylc__job__inst__exit_script() {
+# EXIT-SCRIPT:
+This is the exit script
+}
+
+. "run/dir/.service/etc/job.sh"
+cylc__job__main
+
+#EOF: 1/baa/01

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -122,14 +122,14 @@ def test_write(mocked_get_remote_suite_run_dir, request):
             difflib.unified_diff(
                 kgo_content,
                 test_content,
-                fromfile='known good output',
-                tofile='test output'
+                fromfile='known good job_file',
+                tofile='test job_file'
             )
         )
 
-        # If there is any diff write it like this for ease of reading
-        sys.stdout.writelines(diff)
-        assert [i for i in diff] == []
+        # The manipulation into string format should make
+        # any error easier to read.
+        assert ''.join(list(diff)) == ''
 
 
 def test_write_header():


### PR DESCRIPTION
### Problem
The comparison of job file sizes in `test_job_file.py` is brittle, and doesn't give any sense of the nature of changes to the job file. Two job files the same size but with no other similarity will pass this test.

### Possible solutions
* Using an MD5 or similar hash to ensure that the content as well as the size of the file remains the same. The test remains fragile and is still totally uninformative.
* explicitly reading files line by line asserting each line is the same. This would be slow, but easy to understand.
* Using `filecmp.cmp(a, b, shallow=False)` - quick, but uninformative.
* Using difflib - still slower, but much more usful if changes occur. ⭐  - I went with this solution.

### Uncertainties
Whether I should have put the kgo inside this file. The trade off here is that it'd be faster if I had done this: I believe that having a standalone file makes it easier for devs to make changes in future - they can use their fave graphical diff program along with the commented code to examine what is happening.

### How a reviewer might test this
* Change items in the file `tests/unit/kgo/job_file.kgo` and see what happens.
* Change items in the `job_conf` dict in `test_write` in `tests/unit/test_job_file.py`.