### PR TITLE
Make write jobfile test more robust

### DIFF
--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -61,7 +61,7 @@ def test_write_prelude_invalid_cylc_command(mocked_glbl_cfg):
     "os.environ", {'CYLC_SUITE_DEF_PATH': 'cylc/suite/def/path'})
 @mock.patch("cylc.flow.job_file.get_remote_suite_run_dir")
 def test_write(mocked_get_remote_suite_run_dir):
-    """Test write function outputs jobscript file correctly"""
+    """Test write function outputs jobscript file correctly."""
     with NamedTemporaryFile() as local_job_file_path:
         local_job_file_path = local_job_file_path.name
         job_conf = {
@@ -100,7 +100,9 @@ def test_write(mocked_get_remote_suite_run_dir):
 
         assert (os.path.exists(local_job_file_path))
         size_of_file = os.stat(local_job_file_path).st_size
-        assert(size_of_file == 1845)
+        # This test only needs to check that the file is created and is
+        # non-empty as each section is covered by individual unit tests.
+        assert(size_of_file > 10)
 
 
 def test_write_header():


### PR DESCRIPTION
Change test write job file to just check non-empty file is created, rather than tying it to a size of file which can change on updated cylc version. 
This is a small change with no associated Issue.
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
