### PR TITLE
Identify localhost by common IP address.

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -189,8 +189,10 @@ class HostUtil(object):
                 except IOError:
                     self._remote_hosts[name] = True
                 else:
-                    self._remote_hosts[name] = (
-                        host_info != self._get_host_info())
+                    # look for common IP with localhost
+                    self._remote_hosts[name] = not bool(
+                        set(self._get_host_info()[2]).intersection(
+                            set(host_info[2])))
         return self._remote_hosts[name]
 
     def is_remote_user(self, name):


### PR DESCRIPTION
This is a small change with no associated Issue.

Tentatively assigning @matthewrmshin as reviewer, as he authored the `is_remote_host` method and this is a small change - Matt, no worries if you can't spare the time. 

On my Centos 7 work laptop one of our unit tests fails because `$HOSTNAME` gets identified as a remote host:
```
>       self.assertFalse(is_remote_host(os.getenv('HOSTNAME')))
E       AssertionError: True is not false
```


Looking at the code, the "extended host info" (from `socket.gethostbyname_ex`) is expected to be identical for `$HOSTNAME` and `localhost`, which isn't the case on my box.  My `/etc/hosts` and `/etc/hostname` files (not sure if they are "correct", but they weren't configured by me):
```
# /etc/hostname
pastry
```

```
# /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
127.0.0.1   pastry localhost
```
This results in the following extended host info:
```python
>>> socket.gethostbyname_ex("localhost")
('localhost',
 ['localhost.localdomain', 'localhost4', 'localhost4.localdomain4', 'localhost.localdomain', 'localhost6', 'localhost6.localdomain6', 'localhost', 'pastry'],
 ['127.0.0.1', '127.0.0.1', '127.0.0.1'])

>>> socket.gethostbyname_ex("pastry")
('pastry',
 ['localhost'],
 ['127.0.0.1'])
```

So I'm guessing, we should identify "the same host" with different names, by looking for a common IP address (`127.0.0.1` in this case), but not by expecting the full extended host info to be identical.  Does that seem reasonable?


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Covered by existing tests, sort of (depends on system-level host config)
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
<!-- choose one: -->
- [x] No dependency changes.
