### PR TITLE
setup: bump pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ tests_require = [
     'pycodestyle>=2.5.0',
     'pytest-asyncio>=0.14.0',
     'pytest-cov>=2.8.0',
-    'pytest-xdist>=1.32.0',
-    'pytest>=5.3.0',
+    'pytest-xdist>=2',
+    'pytest>=6',
     'testfixtures>=6.11.0'
 ]
 


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/3776

> Either limit upper version of pytest-xdist, or upgrade pytest to fix setuptools issue

¿Porque no los dos?


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
