### PR TITLE
conf: fix work directory reference

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -681,8 +681,8 @@ with Conf(
 
                 The top level share and work directory location can be changed
                 (e.g. to a large data area) by a global config setting (see
-                :cylc:conf:`global.cylc[hosts][<hostname glob>]
-                work directory`).
+                :cylc:conf:`global.cylc[hosts][<hostname glob>]work directory`
+                ).
 
                 .. note::
 


### PR DESCRIPTION
Remove whitespace from a configuration reference which causes a parsing error in the docs.