### PR TITLE
Upgrade one functional test.

### DIFF
--- a/tests/functional/spawn-on-demand/08-lost-parents/flow.cylc
+++ b/tests/functional/spawn-on-demand/08-lost-parents/flow.cylc
@@ -1,12 +1,13 @@
-# bar has a parent to spawn it in the first three cycles, but requires
-# auto-spawning after that
+# A task with parents in some cycles but not others must be spawned on demand
+# by parents (when it has them) and auto-spawned otherwise.
 [scheduling]
    cycling mode = integer
    initial cycle point = 1
-   final cycle point = 4
+   final cycle point = 6
    [[graph]]
-      R3//P1 = "foo => bar"
-      P1 = "bar"
+      R3//P1 = "dad => child"
+      R1/5/P1 = "mum => child"
+      P1 = "child"
 [runtime]
    [[root]]
       script = true

--- a/tests/functional/spawn-on-demand/08-lost-parents/reference.log
+++ b/tests/functional/spawn-on-demand/08-lost-parents/reference.log
@@ -1,9 +1,12 @@
 Initial point: 1
-Final point: 4
-[foo.1] -triggered off []
-[foo.2] -triggered off []
-[foo.3] -triggered off []
-[bar.1] -triggered off ['foo.1']
-[bar.2] -triggered off ['foo.2']
-[bar.3] -triggered off ['foo.3']
-[bar.4] -triggered off []
+Final point: 6
+[dad.1] -triggered off []
+[dad.2] -triggered off []
+[dad.3] -triggered off []
+[child.1] -triggered off ['dad.1']
+[child.2] -triggered off ['dad.2']
+[child.3] -triggered off ['dad.3']
+[mum.5] -triggered off []
+[child.4] -triggered off []
+[child.5] -triggered off ['mum.5']
+[child.6] -triggered off []


### PR DESCRIPTION

Small follow-up to #3756 - makes the new test more stringent by briefly bringing back the parent task (so, a task has to be spawned on demand by a parent for a few cycles, then auto-spawned, then on demand again, then auto-spawned until FCP). @oliver-sanders - one brief sanity check will do (this was semi-inspired by your test case on 3756).