### PR TITLE
Validate task messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,9 @@ exporting environment variables.
 [#3614](https://github.com/cylc/cylc-flow/pull/3614) - Ensure the suite always
 restarts using the same time zone as the last `cylc run`.
 
+[#3788](https://github.com/cylc/cylc-flow/pull/3788) - Task messages are now
+validated.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -23,6 +23,15 @@ CYLC_LOG = 'cylc'
 LOG = logging.getLogger(CYLC_LOG)
 LOG.addHandler(logging.NullHandler())  # Start with a null handler
 
+LOG_LEVELS = {
+    "INFO": logging.INFO,
+    "NORMAL": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+    "DEBUG": logging.DEBUG,
+}
+
 # Used widely with data element ID (internally and externally),
 # scope may widen further with internal and CLI adoption.
 ID_DELIM = '|'

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -70,7 +70,8 @@ from cylc.flow.taskdef import TaskDef
 from cylc.flow.task_id import TaskID
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.task_trigger import TaskTrigger, Dependency
-from cylc.flow.unicode_rules import XtriggerNameValidator
+from cylc.flow.unicode_rules import (
+    XtriggerNameValidator, MessageTriggerValidator)
 from cylc.flow.wallclock import (
     get_current_time_string, set_utc_mode, get_utc_mode)
 from cylc.flow.xtrigger_mgr import XtriggerManager
@@ -1661,6 +1662,13 @@ class SuiteConfig:
 
             # Record custom message outputs.
             for item in self.cfg['runtime'][name]['outputs'].items():
+                output, task_message = item
+                valid, msg = MessageTriggerValidator.validate(task_message)
+                if not valid:
+                    raise SuiteConfigError(
+                        f'Invalid task message "[runtime][{name}][outputs]'
+                        f'{output} = {task_message}" - {msg}'
+                    )
                 taskdef.outputs.add(item)
 
     def generate_triggers(self, lexpression, left_nodes, right, seq,

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1604,10 +1604,9 @@ class SuiteConfig:
                 if suicide:
                     continue
                 if orig_lexpr != lexpr:
-                    LOG.error("%s => %s" % (orig_lexpr, right))
+                    LOG.error(f"{orig_lexpr} => {right}")
                 raise SuiteConfigError(
-                    "self-edge detected: %s => %s" % (
-                        left, right))
+                    f"self-edge detected: {left} => {right}")
             self.edges[seq].add((left, right, suicide, conditional))
 
     def generate_taskdefs(self, orig_expr, left_nodes, right, seq, suicide):
@@ -1701,7 +1700,7 @@ class SuiteConfig:
 
             # Qualifier.
             outputs = self.cfg['runtime'][name]['outputs']
-            if outputs and output in outputs:
+            if outputs and (output in outputs):
                 # Qualifier is a task message.
                 qualifier = outputs[output]
             elif output:

--- a/cylc/flow/scripts/cylc_message.py
+++ b/cylc/flow/scripts/cylc_message.py
@@ -111,7 +111,7 @@ def main(parser, options, *args):
     # Read messages from STDIN
     if '-' in message_strs:
         current_message_str = ''
-        while True:  # Note: for line in sys.stdin: can hang
+        while True:  # Note: `for line in sys.stdin:` can hang
             message_str = sys.stdin.readline()
             if message_str.strip():
                 # non-empty line

--- a/cylc/flow/scripts/cylc_message.py
+++ b/cylc/flow/scripts/cylc_message.py
@@ -53,7 +53,7 @@ Note "${CYLC_SUITE_NAME}" and "${CYLC_TASK_JOB}" are made available in task job
 environments - you do not need to write their actual values in task scripting.
 
 Each message can be prefixed with a severity level using the syntax 'SEVERITY:
-MESSAGE'.
+MESSAGE' (colons cannot be used unless such a prefix is provided).
 
 The default message severity is INFO. The --severity=SEVERITY option can be
 used to set the default severity level for all unprefixed messages.

--- a/cylc/flow/scripts/cylc_set_verbosity.py
+++ b/cylc/flow/scripts/cylc_set_verbosity.py
@@ -22,20 +22,10 @@ Change the logging severity level of a running suite.  Only messages at
 or above the chosen severity level will be logged; for example, if you
 choose WARNING, only warnings and critical messages will be logged."""
 
-from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG
-
+from cylc.flow import LOG_LEVELS
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
-
-LOGGING_LVL_OF = {
-    "INFO": INFO,
-    "NORMAL": INFO,
-    "WARNING": WARNING,
-    "ERROR": ERROR,
-    "CRITICAL": CRITICAL,
-    "DEBUG": DEBUG,
-}
 
 
 def get_option_parser():
@@ -43,7 +33,7 @@ def get_option_parser():
         __doc__, comms=True,
         argdoc=[
             ('REG', 'Suite name'),
-            ('LEVEL', ', '.join(LOGGING_LVL_OF.keys()))
+            ('LEVEL', ', '.join(LOG_LEVELS.keys()))
         ]
     )
 
@@ -53,7 +43,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options, suite, severity_str):
     try:
-        severity = LOGGING_LVL_OF[severity_str]
+        severity = LOG_LEVELS[severity_str]
     except KeyError:
         parser.error("Illegal logging level, %s" % severity_str)
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -26,7 +26,7 @@ This module provides logic to:
 """
 
 from collections import namedtuple
-from logging import getLevelName, CRITICAL, ERROR, WARNING, INFO, DEBUG
+from logging import getLevelName, INFO, DEBUG
 import os
 from shlex import quote
 import shlex
@@ -34,7 +34,7 @@ from time import time
 
 from cylc.flow.parsec.config import ItemNotFoundError
 
-from cylc.flow import LOG
+from cylc.flow import LOG, LOG_LEVELS
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.hostuserutil import get_host, get_user
 from cylc.flow.pathutil import (
@@ -124,14 +124,6 @@ class TaskEventsManager():
     FLAG_POLLED = "(polled)"
     FLAG_POLLED_IGNORED = "(polled-ignored)"
     KEY_EXECUTE_TIME_LIMIT = 'execution_time_limit'
-    LEVELS = {
-        "INFO": INFO,
-        "NORMAL": INFO,
-        "WARNING": WARNING,
-        "ERROR": ERROR,
-        "CRITICAL": CRITICAL,
-        "DEBUG": DEBUG,
-    }
     NON_UNIQUE_EVENTS = ('warning', 'critical', 'custom')
 
     def __init__(self, suite, proc_pool, suite_db_mgr,
@@ -454,7 +446,7 @@ class TaskEventsManager():
             LOG.debug(
                 '[%s] status=%s: unhandled: %s',
                 itask, itask.state.status, message)
-            if severity in [CRITICAL, ERROR, WARNING, INFO, DEBUG]:
+            if severity in LOG_LEVELS.values():
                 severity = getLevelName(severity)
             self._db_events_insert(
                 itask, ("message %s" % str(severity).lower()), message)
@@ -501,7 +493,7 @@ class TaskEventsManager():
                 timestamp, submit_num, itask.flow_label)
             return False
         LOG.log(
-            self.LEVELS.get(severity, INFO), logfmt, itask, itask.state, flag,
+            LOG_LEVELS.get(severity, INFO), logfmt, itask, itask.state, flag,
             message, timestamp, submit_num, itask.flow_label)
         return True
 

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -17,6 +17,7 @@
 """Module for unicode restrictions"""
 
 import re
+from cylc.flow import LOG_LEVELS
 
 
 ENGLISH_REGEX_MAP = {
@@ -151,3 +152,18 @@ class XtriggerNameValidator(UnicodeRuleChecker):
     RULES = [
         allowed_characters(r'a-zA-Z0-9', '_')
     ]
+
+
+class MessageTriggerValidator:
+    """Provides a method for validating custom output message trigger
+    contents"""
+
+    @classmethod
+    def validate(cls, string):
+        message = (
+            'a task message cannot contain a colon unless it starts with a '
+            'logging severity level, e.g. "INFO:"')
+        first_part = string.split(':')[0]
+        if first_part == string or first_part in LOG_LEVELS.keys():
+            return (True, None)
+        return (False, message)

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -23,9 +23,9 @@ from cylc.flow import LOG_LEVELS
 ENGLISH_REGEX_MAP = {
     r'\w': 'alphanumeric',
     r'a-zA-Z0-9': 'latin letters and numbers',
-    r'\-': '-',
-    r'\.': '.',
-    r'\/': '/'
+    r'\-': '``-``',
+    r'\.': '``.``',
+    r'\/': '``/``'
 }
 
 
@@ -39,10 +39,12 @@ def regex_chars_to_text(chars):
         ['-', '.', '/']
         >>> regex_chars_to_text([r'\w'])
         ['alphanumeric']
+        >>> regex_chars_to_text(['not_in_map'])
+        ['not_in_map']
 
     """
     return [
-        ENGLISH_REGEX_MAP.get(char, char)
+        ENGLISH_REGEX_MAP.get(char, f'``{char}``')
         for char in chars
     ]
 
@@ -72,7 +74,7 @@ def allowed_characters(*chars):
     Example:
         >>> regex, message = allowed_characters('a', 'b', 'c')
         >>> message
-        'can only contain: a, b, c'
+        'can only contain: ``a``, ``b``, ``c``'
         >>> bool(regex.match('abc'))
         True
         >>> bool(regex.match('def'))
@@ -91,7 +93,7 @@ def not_starts_with(*chars):
     Example:
         >>> regex, message = not_starts_with('a', 'b', 'c')
         >>> message
-        'can not start with: a, b, c'
+        'can not start with: ``a``, ``b``, ``c``'
         >>> bool(regex.match('def'))
         True
         >>> bool(regex.match('adef'))
@@ -111,7 +113,7 @@ def not_contains_colon_unless_starts_with(*chars):
         >>> regex, message = not_contain_colon_unless_starts_with(
                 'INFO', 'WARNING')
         >>> message
-        'cannot contain a colon unless starts with: INFO, WARNING'
+        'cannot contain a colon unless starts with: ``INFO``, ``WARNING``'
         >>> bool(regex.match('Foo: bar'))
         False
         >>> bool(regex.match('INFO: Foo: bar'))

--- a/tests/unit/test_suite_files.py
+++ b/tests/unit/test_suite_files.py
@@ -175,7 +175,7 @@ def get_register_test_cases():
          None,  # expected symlink
          None,  # expected return value
          SuiteServiceFileError,  # expected exception
-         "can not start with: ., -"  # expected part of exception message
+         "can not start with: ``.``, ``-``"  # expected part of exception msg
          )
     ]
 

--- a/tests/unit/test_unicode_rules.py
+++ b/tests/unit/test_unicode_rules.py
@@ -1,0 +1,39 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test validation of unicode rules and similar."""
+
+from cylc.flow.unicode_rules import MessageTriggerValidator
+
+
+def test_task_message_validation():
+    """Test that `[runtime][<task>][outputs]<output> = msg` messages validate
+    correctly."""
+    tests = [
+        ('Chronon Field Regulator', True),
+        # Cannot have colon unless first part of message is logging
+        # severity level:
+        ('Time machine location: Bradbury Swimming Pool', False),
+        # but after that colons are okay:
+        ('INFO: Time machine location: Bradbury Swimming Pool', True),
+        # simply poor form:
+        ('Foo:', False),
+        (':Foo', False),
+        ('::group::', False)
+    ]
+    for task_message, expected in tests:
+        valid, _ = MessageTriggerValidator.validate(task_message)
+        assert valid is expected


### PR DESCRIPTION
These changes close #3428 

Task messages, e.g. in
```
[runtime]
    [[my_task]]
        [[[outputs]]]
            foo = I am an invalid task message: the colon is to blame
```
can only have colons in them if the first part of the message is a logging severity level plus colon, e.g. `INFO:`, because everything before the first colon is treated as a severity level.

This PR causes validation to fail if colons are misused.

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [X] Appropriate tests are included (unit).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
<!-- choose one: -->
- [X] No dependency changes.
