### PR TITLE
Platforms.fix tests

### DIFF
--- a/tests/flakyfunctional/cyclers/19-async_integer.t
+++ b/tests/flakyfunctional/cyclers/19-async_integer.t
@@ -42,7 +42,7 @@ if [[ -f "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}-find.out" ]]; then
     TEST_NAME="${TEST_NAME_BASE}-find"
     SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
     SUITE_WRK_DIR="$(cylc get-global-config -i \
-        '[platforms][localhost]work directory')/${SUITE_NAME}"
+        '[hosts][localhost]work directory')/${SUITE_NAME}"
     {
         (cd "${SUITE_RUN_DIR}" && find 'log/job' -type f)
         (cd "${SUITE_WRK_DIR}" && find 'work' -type f)

--- a/tests/flakyfunctional/cyclers/19-async_integer.t
+++ b/tests/flakyfunctional/cyclers/19-async_integer.t
@@ -42,7 +42,7 @@ if [[ -f "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}-find.out" ]]; then
     TEST_NAME="${TEST_NAME_BASE}-find"
     SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
     SUITE_WRK_DIR="$(cylc get-global-config -i \
-        '[hosts][localhost]work directory')/${SUITE_NAME}"
+        '[platforms][localhost]work directory')/${SUITE_NAME}"
     {
         (cd "${SUITE_RUN_DIR}" && find 'log/job' -type f)
         (cd "${SUITE_WRK_DIR}" && find 'work' -type f)

--- a/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
+++ b/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
@@ -38,7 +38,7 @@ set_test_number 2
 create_test_global_config "" "
 [platforms]
   [[pbs-test-platform]]
-    hosts = "${CYLC_TEST_HOST}"
+    hosts = ${CYLC_TEST_HOST}
     batch system = pbs
     err viewer = ${ERR_VIEWER}
     out viewer = ${OUT_VIEWER}"

--- a/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
+++ b/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs.t
@@ -37,11 +37,11 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[${CYLC_TEST_HOST}]]
-        [[[batch systems]]]
-            [[[[pbs]]]]
-                err viewer = ${ERR_VIEWER}
-                out viewer = ${OUT_VIEWER}"
+  [[pbs-test-platform]]
+    hosts = "${CYLC_TEST_HOST}"
+    batch system = pbs
+    err viewer = ${ERR_VIEWER}
+    out viewer = ${OUT_VIEWER}"
 reftest
 purge_suite_platform "${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
 exit

--- a/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs/flow.cylc
+++ b/tests/functional/cylc-cat-log/02-remote-custom-runtime-viewer-pbs/flow.cylc
@@ -10,10 +10,7 @@ echo garbage >&2
 cylc message 'echo done'
 sleep 60
 """
-        [[[remote]]]
-            host={{environ["CYLC_TEST_HOST"]}}
-        [[[job]]]
-            batch system=pbs
+        platform = pbs-test-platform
         [[[directives]]]
 {% if "CYLC_TEST_DIRECTIVES" in environ and environ["CYLC_TEST_DIRECTIVES"] %}
             {{environ["CYLC_TEST_DIRECTIVES"]}}

--- a/tests/functional/cylc-poll/06-loadleveler.t
+++ b/tests/functional/cylc-poll/06-loadleveler.t
@@ -35,9 +35,9 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[loadleveler-platform]]
+    [[lsf-platform]]
         hosts = $CYLC_TEST_BATCH_TASK_HOST
-        batch system = loadleveler
+        batch system = lsf
 "
 
 reftest

--- a/tests/functional/cylc-poll/06-loadleveler.t
+++ b/tests/functional/cylc-poll/06-loadleveler.t
@@ -35,9 +35,9 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[slurm-test-platform]]
+    [[${BATCH_SYS_NAME}-test-platform]]
         hosts = $CYLC_TEST_BATCH_TASK_HOST
-        batch system = slurm
+        batch system = $BATCH_SYS_NAME
 "
 
 reftest

--- a/tests/functional/cylc-poll/06-loadleveler.t
+++ b/tests/functional/cylc-poll/06-loadleveler.t
@@ -35,9 +35,9 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[lsf-platform]]
+    [[slurm-test-platform]]
         hosts = $CYLC_TEST_BATCH_TASK_HOST
-        batch system = lsf
+        batch system = slurm
 "
 
 reftest

--- a/tests/functional/cylc-poll/06-loadleveler/flow.cylc
+++ b/tests/functional/cylc-poll/06-loadleveler/flow.cylc
@@ -6,7 +6,7 @@
     [[a]]
         script = sleep 20
 {% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        platform = loadleveler-platform
+        platform = loadleveler-test-platform
         [[[directives]]]
             class=serial
             job_type=serial

--- a/tests/functional/cylc-poll/07-pbs/flow.cylc
+++ b/tests/functional/cylc-poll/07-pbs/flow.cylc
@@ -5,12 +5,7 @@
 [runtime]
     [[a]]
         script = sleep 20
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        [[[job]]]
-            batch system = pbs
+        platform = pbs-test-platform
         [[[directives]]]
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and
         environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}

--- a/tests/functional/cylc-poll/08-slurm/flow.cylc
+++ b/tests/functional/cylc-poll/08-slurm/flow.cylc
@@ -5,12 +5,7 @@
 [runtime]
     [[a]]
         script = sleep 20
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        [[[job]]]
-            batch system = slurm
+        platform = slurm-test-platform
         [[[directives]]]
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and
         environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}

--- a/tests/functional/cylc-poll/09-lsf/flow.cylc
+++ b/tests/functional/cylc-poll/09-lsf/flow.cylc
@@ -5,11 +5,7 @@
 [runtime]
     [[a]]
         script = sleep 20
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        platform = lsf-platform
+        platform = lsf-test-platform
         [[[directives]]]
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and
         environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}

--- a/tests/functional/cylc-poll/09-lsf/flow.cylc
+++ b/tests/functional/cylc-poll/09-lsf/flow.cylc
@@ -9,8 +9,7 @@
         [[[remote]]]
             host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
 {% endif %}
-        [[[job]]]
-            batch system = lsf
+        platform = lsf-platform
         [[[directives]]]
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and
         environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}

--- a/tests/functional/cylc-poll/17-pbs-cant-connect.t
+++ b/tests/functional/cylc-poll/17-pbs-cant-connect.t
@@ -33,6 +33,15 @@ fi
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_BATCH_SITE_DIRECTIVES
 
 set_test_number 4
+
+create_test_global_config "" "
+[platforms]
+  [[test-pbs-platform]]
+    batch system = pbs
+    hosts = "${CYLC_TEST_BATCH_TASK_HOST}"
+"
+
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 if [[ "${CYLC_TEST_BATCH_TASK_HOST}" != 'localhost' ]]; then
     # shellcheck disable=SC2029

--- a/tests/functional/cylc-poll/17-pbs-cant-connect.t
+++ b/tests/functional/cylc-poll/17-pbs-cant-connect.t
@@ -38,7 +38,7 @@ create_test_global_config "" "
 [platforms]
   [[test-pbs-platform]]
     batch system = pbs
-    hosts = "${CYLC_TEST_BATCH_TASK_HOST}"
+    hosts = ${CYLC_TEST_BATCH_TASK_HOST}
 "
 
 

--- a/tests/functional/cylc-poll/17-pbs-cant-connect/flow.cylc
+++ b/tests/functional/cylc-poll/17-pbs-cant-connect/flow.cylc
@@ -6,12 +6,8 @@
 [runtime]
     [[t1]]
         script = sleep 60
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
+        platform = test-pbs-platform
         [[[job]]]
-            batch system = my_pbs
             execution time limit = PT2M
             execution polling intervals = PT20S
         [[[directives]]]

--- a/tests/functional/directives/00-loadleveler.t
+++ b/tests/functional/directives/00-loadleveler.t
@@ -41,7 +41,7 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[test-platform]]
+    [[${BATCH_SYS_NAME}-test-platform]]
         hosts = $CYLC_TEST_BATCH_TASK_HOST
         batch system = ${BATCH_SYS_NAME}
 "

--- a/tests/functional/directives/00-loadleveler.t
+++ b/tests/functional/directives/00-loadleveler.t
@@ -41,9 +41,9 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-    [[slurm-test-platform]]
+    [[test-platform]]
         hosts = $CYLC_TEST_BATCH_TASK_HOST
-        batch system = slurm
+        batch system = ${BATCH_SYS_NAME}
 "
 
 reftest "${TEST_NAME_BASE}" "${BATCH_SYS_NAME}"

--- a/tests/functional/directives/00-loadleveler.t
+++ b/tests/functional/directives/00-loadleveler.t
@@ -38,6 +38,14 @@ fi
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_BATCH_SITE_DIRECTIVES
 
 set_test_number 2
+
+create_test_global_config "" "
+[platforms]
+    [[slurm-test-platform]]
+        hosts = $CYLC_TEST_BATCH_TASK_HOST
+        batch system = slurm
+"
+
 reftest "${TEST_NAME_BASE}" "${BATCH_SYS_NAME}"
 purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"
 exit

--- a/tests/functional/directives/loadleveler/flow.cylc
+++ b/tests/functional/directives/loadleveler/flow.cylc
@@ -1,5 +1,4 @@
 #!Jinja2
-{% set HOST = environ['CYLC_TEST_BATCH_TASK_HOST'] %}
 {% set SITE_DIRECTIVES = environ['CYLC_TEST_BATCH_SITE_DIRECTIVES'] %}
 [cylc]
    [[reference test]]
@@ -11,16 +10,13 @@
                    """
 [runtime]
     [[LLSETTINGS]]
-        [[[job]]]
-            batch system = loadleveler
+        platform = test-platform
         [[[directives]]]
             class            = serial
             job_type         = serial
             notification     = error
             wall_clock_limit = '120,60'
             {{SITE_DIRECTIVES}}
-        [[[remote]]]
-            host = {{ HOST }}
     [[rem1]]
         inherit = LLSETTINGS
         script = "sleep 10; true"

--- a/tests/functional/directives/loadleveler/flow.cylc
+++ b/tests/functional/directives/loadleveler/flow.cylc
@@ -10,7 +10,7 @@
                    """
 [runtime]
     [[LLSETTINGS]]
-        platform = test-platform
+        platform = loadleveler-test-platform
         [[[directives]]]
             class            = serial
             job_type         = serial

--- a/tests/functional/directives/pbs/flow.cylc
+++ b/tests/functional/directives/pbs/flow.cylc
@@ -11,7 +11,7 @@
                    """
 [runtime]
     [[PBS_SETTINGS]]
-        platform = test-platform
+        platform = pbs-test-platform
         [[[directives]]]
             -l walltime=00:60:00
             -l cput=00:02:00

--- a/tests/functional/directives/pbs/flow.cylc
+++ b/tests/functional/directives/pbs/flow.cylc
@@ -11,14 +11,11 @@
                    """
 [runtime]
     [[PBS_SETTINGS]]
-        [[[job]]]
-            batch system = pbs
+        platform = test-platform
         [[[directives]]]
             -l walltime=00:60:00
             -l cput=00:02:00
             {{SITE_DIRECTIVES}}
-        [[[remote]]]
-            host = {{ HOST }}
     [[rem1]]
         inherit = PBS_SETTINGS
         script = "sleep 10; true"

--- a/tests/functional/directives/slurm/flow.cylc
+++ b/tests/functional/directives/slurm/flow.cylc
@@ -1,5 +1,4 @@
 #!Jinja2
-{% set HOST = environ['CYLC_TEST_BATCH_TASK_HOST'] %}
 {% set SITE_DIRECTIVES = environ['CYLC_TEST_BATCH_SITE_DIRECTIVES'] %}
 [cylc]
    [[reference test]]
@@ -11,13 +10,10 @@
                    """
 [runtime]
     [[SLURM_SETTINGS]]
-        [[[job]]]
-            batch system = slurm
+        platform = slurm-test-platform
         [[[directives]]]
             --time = 02:00
             {{SITE_DIRECTIVES}}
-        [[[remote]]]
-            host = {{ HOST }}
     [[rem1]]
         inherit = SLURM_SETTINGS
         script = "sleep 10; true"

--- a/tests/functional/events/suite/flow.cylc
+++ b/tests/functional/events/suite/flow.cylc
@@ -18,14 +18,11 @@ else
     fi
 fi
 """
+        platform = localhost
         [[[environment]]]
             DEF = $CYLC_SUITE_DEF_PATH/hidden/${CYLC_TASK_NAME}
             REG = ${CYLC_SUITE_NAME}-${CYLC_TASK_NAME}
             LOG = ${CYLC_TASK_NAME}.log
             GREP = "ERROR - ${CYLC_TASK_NAME} EVENT HANDLER FAILED"
-        [[[remote]]]
-            # divorce sub-suites from the task execution environments
-            # that launch them
-            host = localhost
     [[startup, timeout, shutdown]]
         inherit = common

--- a/tests/functional/job-file-trap/01-loadleveler.t
+++ b/tests/functional/job-file-trap/01-loadleveler.t
@@ -30,6 +30,14 @@ if [[ -z $CYLC_TEST_BATCH_TASK_HOST ]]; then
     skip_all '"[test battery][batch systems][loadleveler]host": not defined'
 fi
 set_test_number 6
+
+create_test_global_config "" "
+[platforms]
+  [[test-platform-loadleveler]]
+    host = $CYLC_TEST_BATCH_TASK_HOST
+    batch system = loadleveler
+"
+
 CYLC_TEST_DIRECTIVES="$( \
     cylc get-global-config -i "${RC_PREF}[directives]" 2>'/dev/null')"
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_DIRECTIVES

--- a/tests/functional/job-file-trap/01-loadleveler/flow.cylc
+++ b/tests/functional/job-file-trap/01-loadleveler/flow.cylc
@@ -9,8 +9,7 @@ t2
 [runtime]
     [[root]]
         script=true
-        [[[job]]]
-            batch system=loadleveler
+        platform = test-platform-loadleveler
         [[[directives]]]
             class=serial
             job_type=serial
@@ -20,8 +19,6 @@ t2
 {% if "CYLC_TEST_DIRECTIVES" in environ and environ["CYLC_TEST_DIRECTIVES"] %}
             {{environ["CYLC_TEST_DIRECTIVES"]}}
 {% endif %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_HOST"]}}
     [[t1]]
     [[t2]]
         [[[directives]]]

--- a/tests/functional/job-kill/00-local/flow.cylc
+++ b/tests/functional/job-kill/00-local/flow.cylc
@@ -11,10 +11,6 @@
 [runtime]
     [[T]]
         script=sleep 120 & echo $! >file; wait
-{% if "CYLC_TEST_HOST" in environ and environ["CYLC_TEST_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_HOST"]}}
-{% endif %}
     [[t1, t2, t3, t4]]
         inherit=T
     [[stop1]]

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -32,6 +32,14 @@ then
 fi
 export CYLC_TEST_BATCH_TASK_HOST CYLC_TEST_BATCH_SITE_DIRECTIVES
 set_test_number 2
+
+create_test_global_config "" "
+[platforms]
+  [[slurm-test-platform]]
+    hosts = "${CYLC_TEST_BATCH_TASK_HOST}"
+    batch system = slurm
+"
+
 reftest
 if [[ $CYLC_TEST_BATCH_TASK_HOST != 'localhost' ]]; then
     purge_suite_remote "${CYLC_TEST_BATCH_TASK_HOST}" "${SUITE_NAME}"

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -35,7 +35,7 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-  [[test-platform]]
+  [[${BATCH_SYS_NAME}-test-platform]]
     hosts = ${CYLC_TEST_BATCH_TASK_HOST}
     batch system = ${BATCH_SYS_NAME}
 "

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -35,9 +35,9 @@ set_test_number 2
 
 create_test_global_config "" "
 [platforms]
-  [[slurm-test-platform]]
+  [[test-platform]]
     hosts = "${CYLC_TEST_BATCH_TASK_HOST}"
-    batch system = slurm
+    batch system = ${BATCH_SYS_NAME}
 "
 
 reftest

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -36,7 +36,7 @@ set_test_number 2
 create_test_global_config "" "
 [platforms]
   [[test-platform]]
-    hosts = "${CYLC_TEST_BATCH_TASK_HOST}"
+    hosts = ${CYLC_TEST_BATCH_TASK_HOST}
     batch system = ${BATCH_SYS_NAME}
 "
 

--- a/tests/functional/job-kill/02-loadleveler/flow.cylc
+++ b/tests/functional/job-kill/02-loadleveler/flow.cylc
@@ -8,12 +8,7 @@
 [runtime]
     [[t1]]
         script=sleep 120
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        [[[job]]]
-            batch system=loadleveler
+        platform = loadleveler-test-platform
         [[[directives]]]
             class=serial
             job_type=serial

--- a/tests/functional/job-kill/03-slurm/flow.cylc
+++ b/tests/functional/job-kill/03-slurm/flow.cylc
@@ -8,12 +8,7 @@
 [runtime]
     [[t1]]
         script=sleep 120
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
-        [[[job]]]
-            batch system=slurm
+        platform = slurm-test-platform
         [[[directives]]]
             --time=03:00
 {% if "CYLC_TEST_BATCH_SITE_DIRECTIVES" in environ and environ["CYLC_TEST_BATCH_SITE_DIRECTIVES"] %}

--- a/tests/functional/job-kill/04-pbs/flow.cylc
+++ b/tests/functional/job-kill/04-pbs/flow.cylc
@@ -8,12 +8,8 @@
 [runtime]
     [[t1]]
         script=sleep 120
-{% if "CYLC_TEST_BATCH_TASK_HOST" in environ and environ["CYLC_TEST_BATCH_TASK_HOST"] %}
-        [[[remote]]]
-            host={{environ["CYLC_TEST_BATCH_TASK_HOST"]}}
-{% endif %}
+        platform = test-platform
         [[[job]]]
-            batch system=pbs
             execution time limit=PT2M
         [[[directives]]]
             -l select=1:ncpus=1:mem=15mb

--- a/tests/functional/job-kill/04-pbs/flow.cylc
+++ b/tests/functional/job-kill/04-pbs/flow.cylc
@@ -8,7 +8,7 @@
 [runtime]
     [[t1]]
         script=sleep 120
-        platform = test-platform
+        platform = pbs-test-platform
         [[[job]]]
             execution time limit=PT2M
         [[[directives]]]

--- a/tests/functional/jobscript/00-torture/flow.cylc
+++ b/tests/functional/jobscript/00-torture/flow.cylc
@@ -15,6 +15,7 @@ expressions."""
         R1 = "foo"
 [runtime]
     [[foo]]
+        platform = localhost
         init-script = """
 echo "HELLO FROM INIT-SCRIPT"
 # define a variable
@@ -74,7 +75,3 @@ export VAR_PostCS=postcs"""
             E_FOU = $CYLC_TASK_NAME
             # the suite bin must be in $PATH already:
             E_FIV = $( foo.sh )
-        [[[remote]]]
-            # force use of ssh job submission to disconnect local tasks
-            # from the submitting suite environment.
-            host = localhost

--- a/tests/functional/startup/01-log-flow-config.t
+++ b/tests/functional/startup/01-log-flow-config.t
@@ -56,16 +56,16 @@ run.cylc
 __OUT__
 
 LOGD="${RUN_DIR}/${SUITE_NAME}/log/flow-config"
-RUN_RC="$(ls "${LOGD}/"*-run.cylc)"
-REL_RC="$(ls "${LOGD}/"*-reload.cylc)"
-RES_RC="$(ls "${LOGD}/"*-restart.cylc)"
+RUN_CONFIG="$(ls "${LOGD}/"*-run.cylc)"
+REL_CONFIG="$(ls "${LOGD}/"*-reload.cylc)"
+RES_CONFIG="$(ls "${LOGD}/"*-restart.cylc)"
 # The generated *-run.cylc and *-reload.cylc should be identical
 # The generated *.cylc files should validate
-cmp_ok "${RUN_RC}" "${REL_RC}"
-run_ok "${TEST_NAME_BASE}-validate-run-rc" cylc validate "${RUN_RC}"
-run_ok "${TEST_NAME_BASE}-validate-restart-rc" cylc validate "${RES_RC}"
+cmp_ok "${RUN_CONFIG}" "${REL_CONFIG}"
+run_ok "${TEST_NAME_BASE}-validate-run-config" cylc validate "${RUN_CONFIG}"
+run_ok "${TEST_NAME_BASE}-validate-restart-config" cylc validate "${RES_CONFIG}"
 
-diff -u "${RUN_RC}" "${RES_RC}" >'diff.out'
+diff -u "${RUN_CONFIG}" "${RES_CONFIG}" >'diff.out'
 contains_ok 'diff.out' <<'__DIFF__'
 -    description = the weather is bad
 +    description = the weather is good

--- a/tests/functional/startup/01-log-flow-config.t
+++ b/tests/functional/startup/01-log-flow-config.t
@@ -56,16 +56,16 @@ run.cylc
 __OUT__
 
 LOGD="${RUN_DIR}/${SUITE_NAME}/log/flow-config"
-RUN_CONFIG="$(ls "${LOGD}/"*-run.cylc)"
-REL_CONFIG="$(ls "${LOGD}/"*-reload.cylc)"
-RES_CONFIG="$(ls "${LOGD}/"*-restart.cylc)"
+RUN_RC="$(ls "${LOGD}/"*-run.cylc)"
+REL_RC="$(ls "${LOGD}/"*-reload.cylc)"
+RES_RC="$(ls "${LOGD}/"*-restart.cylc)"
 # The generated *-run.cylc and *-reload.cylc should be identical
 # The generated *.cylc files should validate
-cmp_ok "${RUN_CONFIG}" "${REL_CONFIG}"
-run_ok "${TEST_NAME_BASE}-validate-run-config" cylc validate "${RUN_CONFIG}"
-run_ok "${TEST_NAME_BASE}-validate-restart-config" cylc validate "${RES_CONFIG}"
+cmp_ok "${RUN_RC}" "${REL_RC}"
+run_ok "${TEST_NAME_BASE}-validate-run-rc" cylc validate "${RUN_RC}"
+run_ok "${TEST_NAME_BASE}-validate-restart-rc" cylc validate "${RES_RC}"
 
-diff -u "${RUN_CONFIG}" "${RES_CONFIG}" >'diff.out'
+diff -u "${RUN_RC}" "${RES_RC}" >'diff.out'
 contains_ok 'diff.out' <<'__DIFF__'
 -    description = the weather is bad
 +    description = the weather is good


### PR DESCRIPTION
I missed a set of tests (mainly those dependent on batch systems that I don't have immediate access to) when I created the platforms work. This PR attempts to remedy this failure.

Additionally, I messed up tests `tests/functional[job kill|directives]/[loadleveler|slurm|lsf|pbs]` because in many cases these have a single test with different `flow.cylc` files for each batch system: I had hardcoded the batch system name into the `global.cylc` file created in the base test which would have broken all the tests which were symlinked to it.

Review -
Unless you happen to have the batch system in question set up locally you probably cannot check that these tests actually work so this review may need to be a proof-read and sanity check only. (Slurm tests work at the Met Office)