### PR TITLE
Fix cylc ping verbose (and a few minor docs improvements)

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Cylc dependencies in the container
         run: |
           docker exec bash python3.7 -m pip install six==1.12
-          docker exec -w /root/cylc-flow bash python3.7 -m pip install -e .[all]
+          docker exec -w /root/cylc-flow bash python3.7 -m pip install .[all]
 
       - name: Set the container bash version
         run: docker exec bash update-alternatives --set bash /bash/bash-${{ matrix.bash-version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,9 @@ restarts using the same time zone as the last `cylc run`.
 [#3788](https://github.com/cylc/cylc-flow/pull/3788) - Task messages are now
 validated.
 
+[#3614](https://github.com/cylc/cylc-flow/pull/3795) - Fix error when running
+`cylc ping --verbose $SUITE`.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/network/__init__.py
+++ b/cylc/flow/network/__init__.py
@@ -67,8 +67,6 @@ def get_location(suite: str):
 
     Args:
         suite (str): suite name
-        owner (str): owner of the suite
-        host (str): host name
     Returns:
         Tuple[str, int, int]: tuple with the host name and port numbers.
     Raises:

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -74,6 +74,10 @@ class SuiteRuntimeClient(ZMQSocketBase):
             the contact file.
 
     Attributes:
+        host (str):
+            Suite host name.
+        port (int):
+            Suite host port.
         timeout_handler (function):
             Optional function which runs before ClientTimeout is raised.
             This provides an interface for raising more specific exceptions in
@@ -121,6 +125,8 @@ class SuiteRuntimeClient(ZMQSocketBase):
             host, port, _ = get_location(suite)
         else:
             port = int(port)
+        self.host = host
+        self.port = port
         if timeout is None:
             timeout = self.DEFAULT_TIMEOUT
         else:
@@ -130,7 +136,7 @@ class SuiteRuntimeClient(ZMQSocketBase):
             self._timeout_handler, suite, host, port)
         self.poller = None
         # Connect the ZMQ socket on instantiation
-        self.start(host, port, srv_public_key_loc)
+        self.start(self.host, self.port, srv_public_key_loc)
         # gather header info post start
         self.header = self.get_header()
 

--- a/cylc/flow/network/graphql.py
+++ b/cylc/flow/network/graphql.py
@@ -243,7 +243,7 @@ def execute_and_validate_and_strip(
     """
     result = execute_and_validate(schema, document_ast, *args, **kwargs)
 
-    # Search request docuement to determine if 'stripNull: true' is set
+    # Search request document to determine if 'stripNull: true' is set
     # as and argument. It can not be done in the middleware, as they
     # can be Promises/futures (so may not been resolved at this point).
     variable_values = kwargs['variable_values'] or {}

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -422,7 +422,7 @@ class BaseResolvers:
             raise
         except Exception:
             import traceback
-            logger.warn(traceback.format_exc())
+            logger.warning(traceback.format_exc())
         finally:
             for w_id in w_ids:
                 if delta_queues.get(w_id, {}).get(sub_id):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -165,7 +165,7 @@ class Scheduler:
     owner: str = None
     host: str = None
     id: str = None  # owner|suite
-    uuid_str: str = None
+    uuid_str: SchedulerUUID = None
     contact_data: dict = None
 
     # run options

--- a/cylc/flow/scripts/cylc_ping.py
+++ b/cylc/flow/scripts/cylc_ping.py
@@ -48,7 +48,7 @@ def main(parser, options, suite, task_id=None):
     # cylc ping SUITE
     pclient('ping_suite')  # (no need to check the result)
     if cylc.flow.flags.verbose:
-        host, port = SuiteRuntimeClient.get_location(suite)
+        host, port = pclient.host, pclient.port
         sys.stdout.write("Running on %s:%s\n" % (host, port))
     if task_id is None:
         sys.exit(0)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1043,7 +1043,7 @@ class TaskPool:
         try:
             children = itask.graph_children[output]
         except KeyError:
-            # No children depend on this ouput
+            # No children depend on this output
             children = []
 
         suicide = []

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -142,6 +142,10 @@ class TaskRemoteMgr:
         Args:
             platform_name (str):
                 The name of the platform to be initialized.
+            curve_auth (ThreadAuthenticator):
+                The ZMQ authenticator.
+            client_pub_key_dir (str):
+                Client public key directory, used by the ZMQ authenticator.
 
         Return:
             REMOTE_INIT_NOT_REQUIRED:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -163,7 +163,7 @@ class TaskRemoteMgr:
             return REMOTE_INIT_NOT_REQUIRED
 
         # See if a previous failed attempt to initialize this platform has
-        # occured.
+        # occurred.
         try:
             status = self.remote_init_map[platform['name']]
         except KeyError:

--- a/cylc/flow/tui/tree.py
+++ b/cylc/flow/tui/tree.py
@@ -26,6 +26,8 @@ def find_closest_focus(app, old_node, new_node):
     3. Otherwise it returns the root node of the new tree.
 
     Arguments:
+        app (TuiApp):
+            Tui app instance.
         old_node (MonitiorNode):
             The in-focus node from the deceased tree.
         new_node (MonitorNode):

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -122,7 +122,6 @@ class XtriggerManager:
         proc_pool: SubProcPool = None,
         suite_run_dir: str = None,
         suite_share_dir: str = None,
-        suite_work_dir: str = None,
         suite_source_dir: str = None,
     ):
         """Initialize the xtrigger manager.

--- a/cylc/flow/xtriggers/suite_state.py
+++ b/cylc/flow/xtriggers/suite_state.py
@@ -35,6 +35,8 @@ def suite_state(suite, task, point, offset=None, status='succeeded',
             The suite to interrogate.
         task (str):
             The name of the task to query.
+        point (str):
+            The cycle point.
         offset (str):
             The offset between the cycle this xtrigger is used in and the one
             it is querying for as an ISO8601 time duration.

--- a/tests/functional/cylc-ping/00-simple/flow.cylc
+++ b/tests/functional/cylc-ping/00-simple/flow.cylc
@@ -3,6 +3,9 @@
         R1 = "foo => bar"
 [runtime]
     [[foo]]
-        script = cylc ping $CYLC_SUITE_NAME
+        script = """
+            cylc ping $CYLC_SUITE_NAME
+            cylc ping --verbose $CYLC_SUITE_NAME
+            """
     [[bar]]
         script = [[ ! $(cylc ping $CYLC_SUITE_NAME-non-existent) ]]


### PR DESCRIPTION
This is a small change with no associated Issue.

`cylc ping --verbose five` is broken :cry: 

```bash
(venv) kinow@ranma:~/Development/python/workspace/cylc-flow$ cylc ping five --verbose
2020-08-29T23:25:03+12:00 DEBUG - Loading site/user config
	files
2020-08-29T23:25:03+12:00 DEBUG - zmq:send {'command':
	'ping_suite', 'args': {}, 'meta': {'prog': 'cylc-ping', 'host': 'ranma'}}
2020-08-29T23:25:03+12:00 DEBUG - zmq:recv {'data': True,
	'user': 'kinow'}
Traceback (most recent call last):
  File "/home/kinow/Development/python/workspace/cylc-flow/venv/bin/cylc-ping", line 11, in <module>
    load_entry_point('cylc-flow', 'console_scripts', 'cylc-ping')()
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/terminal.py", line 183, in wrapper
    wrapped_function(*wrapped_args, **wrapped_kwargs)
  File "/home/kinow/Development/python/workspace/cylc-flow/cylc/flow/scripts/cylc_ping.py", line 51, in main
    host, port = SuiteRuntimeClient.get_location(suite)
AttributeError: type object 'SuiteRuntimeClient' has no attribute 'get_location'
```

This PR fixes it, also adding missing docstrings, fixing some typos, and applying a few more suggestions from a linter.

```bash
(venv) kinow@ranma:~/Development/python/workspace/cylc-flow$ cylc ping five --verbose
2020-08-29T23:30:01+12:00 DEBUG - Loading site/user config files
2020-08-29T23:30:01+12:00 DEBUG - zmq:send {'command': 'ping_suite', 'args': {}, 'meta': {'prog': 'cylc-ping', 'host': 'ranma'}}
2020-08-29T23:30:01+12:00 DEBUG - zmq:recv {'data': True, 'user': 'kinow'}
Running on ranma:43082
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? let me know if others prefer to have a functional test for this, I thought it would be OK to skip it).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
