### PR TITLE
async util: handle empty dirs better

### DIFF
--- a/cylc/flow/async_util.py
+++ b/cylc/flow/async_util.py
@@ -389,6 +389,7 @@ def _scandir(future, path, request):
     """Callback helper for scandir()."""
     future.set_result([
         Path(path, directory.name)
+        # request.result can be None (maybe because of an empty directory in cylc-run)
         for directory in request.result or []
     ])
 

--- a/cylc/flow/async_util.py
+++ b/cylc/flow/async_util.py
@@ -389,7 +389,7 @@ def _scandir(future, path, request):
     """Callback helper for scandir()."""
     future.set_result([
         Path(path, directory.name)
-        for directory in request.result
+        for directory in request.result or []
     ])
 
 

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -74,6 +74,7 @@ from cylc.flow.suite_files import (
 SERVICE = Path(SuiteFiles.Service.DIRNAME)
 CONTACT = Path(SuiteFiles.Service.CONTACT)
 SUITERC = Path(SuiteFiles.SUITE_RC)
+FLOW_FILE = Path(SuiteFiles.FLOW_FILE)
 
 
 def dir_is_flow(listing):
@@ -95,7 +96,7 @@ def dir_is_flow(listing):
     return (
         SERVICE.name in listing
         or SUITERC.name in listing  # cylc7 flow definition file name
-        or 'flow.cylc' in listing  # cylc8 flow definition file name
+        or FLOW_FILE in listing  # cylc8 flow definition file name
         or 'log' in listing
     )
 


### PR DESCRIPTION
Just noticed a warning which can occur if `scandir` attempts to scan an empty directory.

I think this is harmless ATM as the only use of `scandir` is workflow scanning, if a workflow dir is empty then it's not a workflow dir so can be safely skipped.

Also add a small update post-#3755.