### PR TITLE
Deprecate [runtime][X][parameter environment templates]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,10 @@ installation defined in $path rather than hardcoding to /bin/bash.
 [#3774](https://github.com/cylc/cylc-flow/pull/3774) - Removed support for
 interactive prompt.
 
+[#3798](https://github.com/cylc/cylc-flow/pull/3798) - Deprecated the
+[runtime][X][parameter environment templates] section and instead allow
+templates in [runtime][X][environment].
+
 ### Fixes
 
 [#3732](https://github.com/cylc/cylc-flow/pull/3732) - XTrigger labels

--- a/cylc/flow/data_messages.proto
+++ b/cylc/flow/data_messages.proto
@@ -125,7 +125,6 @@ message PbJob {
     repeated string batch_sys_conf = 24;
     repeated string environment = 25;
     repeated string directives = 26;
-    repeated string param_env_tmpl = 27;
     repeated string param_var = 28;
     repeated string extra_logs = 29;
     optional string name = 30; /* filter item */

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -269,7 +269,7 @@ class JobFileWriter:
             #   BAR=$(script_using_FOO)
             handle.write("\n    export")
             for var in job_conf['environment']:
-                handle.write(" " + var)
+                handle.write(f' {var}')
             for var, val in job_conf['environment'].items():
                 value = JobFileWriter._get_variable_value_definition(
                     str(val), job_conf.get('param_var', {})

--- a/cylc/flow/job_pool.py
+++ b/cylc/flow/job_pool.py
@@ -108,9 +108,6 @@ class JobPool:
         j_buf.environment.extend(
             [f'{key}={val}'
              for key, val in job_conf['environment'].items()])
-        j_buf.param_env_tmpl.extend(
-            [f'{key}={val}'
-             for key, val in job_conf['param_env_tmpl'].items()])
         j_buf.param_var.extend(
             [f'{key}={val}'
              for key, val in job_conf['param_var'].items()])

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -667,7 +667,6 @@ class Job(ObjectType):
     batch_sys_conf = List(String)
     environment = List(String)
     directives = List(String)
-    param_env_tmpl = List(String)
     param_var = List(String)
     extra_logs = List(String)
     messages = List(String)

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -117,8 +117,7 @@ class upgrader:
             return [upg]
         if upg['old'].count('__MANY__') > 1:
             raise UpgradeError(
-                'Multiple simultaneous __MANY__ not supported: %s' %
-                upg['old'])
+                f"Multiple simultaneous __MANY__ not supported: {upg['old']}")
         exp_upgs = []
         pre = []
         post = []
@@ -202,12 +201,11 @@ class upgrader:
                                 self.put_item(upg['new'],
                                               upg['cvt'].convert(old))
                             else:
-                                errMsg = (
+                                raise UpgradeError(
                                     'ERROR: Cannot upgrade deprecated '
-                                    'item "' + msg + '" because the upgraded '
+                                    f'item "{msg}" because the upgraded '
                                     'item already exists'
                                 )
-                                raise UpgradeError(errMsg)
         if warnings:
             level = WARNING
             if self.descr == self.SITE_CONFIG:
@@ -218,10 +216,9 @@ class upgrader:
                 # User level configuration, user should be able to fix.
                 # Log at warning level.
                 level = WARNING
-            LOG.log(
-                level,
-                "deprecated items were automatically upgraded in '%s':",
-                self.descr)
+            LOG.log(level,
+                    'deprecated items were automatically upgraded in '
+                    f'"{self.descr}"')
             for vn, msgs in warnings.items():
                 for msg in msgs:
                     LOG.log(level, ' * (%s) %s', vn, msg)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -921,7 +921,6 @@ class TaskJobManager:
             'job_d': job_d,
             'namespace_hierarchy': itask.tdef.namespace_hierarchy,
             'owner': itask.task_owner,
-            'param_env_tmpl': rtconfig['parameter environment templates'],
             'param_var': itask.tdef.param_var,
             'post-script': scripts[2],
             'pre-script': scripts[0],

--- a/tests/functional/param_expand/03-env-tmpl/flow.cylc
+++ b/tests/functional/param_expand/03-env-tmpl/flow.cylc
@@ -7,7 +7,7 @@
         R1 = "t1<num,stuff> => t2<num,stuff>"
 [runtime]
     [[T]]
-        [[[parameter environment templates]]]
+        [[[environment]]]
             MYNUM = %(num)d
             MYSTUFF = stuff %(stuff)s
             MY_FILE = %(num)04d-%(stuff)s

--- a/tests/integration/test_job_pool.py
+++ b/tests/integration/test_job_pool.py
@@ -41,7 +41,6 @@ def job_config(schd):
         'batch_system_conf': {},
         'directives': {},
         'environment': {},
-        'param_env_tmpl': {},
         'param_var': {},
         'logfiles': [],
         'platform': {'name': 'platform'},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,7 +26,6 @@ from cylc.flow.config import SuiteConfig
 from cylc.flow.cycling import loader
 from cylc.flow.exceptions import SuiteConfigError
 from cylc.flow.wallclock import get_utc_mode, set_utc_mode
-from tests.unit.conftest import mock_glbl_cfg
 
 
 def get_test_inheritance_quotes():
@@ -281,7 +280,7 @@ def test_queue_config_repeated(caplog, tmp_path):
     """
     flow_file = tmp_path / "flow.cylc"
     flow_file.write_text(flow_file_content)
-    config = SuiteConfig(suite="qtest", fpath=flow_file.absolute())
+    SuiteConfig(suite="qtest", fpath=flow_file.absolute())
     log = caplog.messages[0].split('\n')
     assert log[0] == "Queue configuration warnings:"
     assert log[1] == "+ q2: ignoring x (already assigned to a queue)"
@@ -307,7 +306,7 @@ def test_queue_config_not_used_not_defined(caplog, tmp_path):
     """
     flow_file = tmp_path / "flow.cylc"
     flow_file.write_text(flow_file_content)
-    config = SuiteConfig(suite="qtest", fpath=flow_file.absolute())
+    SuiteConfig(suite="qtest", fpath=flow_file.absolute())
     log = caplog.messages[0].split('\n')
     assert log[0] == "Queue configuration warnings:"
     assert log[1] == "+ q1: ignoring foo (task not used in the graph)"

--- a/tests/unit/test_config_upgrader.py
+++ b/tests/unit/test_config_upgrader.py
@@ -1,0 +1,106 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Tests that configs can be upgraded from earlier versions of Cylc.
+
+import pytest
+from cylc.flow.cfgspec.suite import upgrade_param_env_templates
+from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults as ord_dict
+
+
+@pytest.mark.parametrize(
+    'cfg, expected',
+    [
+        (   # No clashes - order is important:
+            {
+                'parameter environment templates': ord_dict([
+                    ('FOO', 'jupiter'),
+                    ('MOO', 'pluto')
+                ]),
+                'environment': ord_dict([
+                    ('BAR', 'neptune'),
+                    ('BAZ', 'ares')
+                ])
+            },
+            {
+                'environment': ord_dict([
+                    ('FOO', 'jupiter'),
+                    ('MOO', 'pluto'),
+                    ('BAR', 'neptune'),
+                    ('BAZ', 'ares')
+                ])
+            }
+        ),
+        (   # Clashes - environment wins:
+            {
+                'parameter environment templates': ord_dict([
+                    ('FOO', 'jupiter'),
+                    ('BAR', 'neptune')
+                ]),
+                'environment': ord_dict([
+                    ('FOO', 'zeus'),
+                    ('BAR', 'poseidon')
+                ])
+            },
+            {
+                'environment': ord_dict([
+                    ('FOO', 'zeus'),
+                    ('BAR', 'poseidon')
+                ])
+            }
+        ),
+        (   # No environment section:
+            {
+                'parameter environment templates': ord_dict([
+                    ('FOO', 'jupiter'),
+                    ('BAR', 'neptune')
+                ])
+            },
+            {
+                'environment': ord_dict([
+                    ('FOO', 'jupiter'),
+                    ('BAR', 'neptune')
+                ])
+            }
+        )
+    ]
+)
+def test_upgrade_param_env_templates(cfg, expected):
+    """Test that the deprecated [runtime][X][parameter environment templates]
+    contents are prepended to [runtime][X][environment], in the correct
+    order"""
+
+    def _cfg(dic):
+        """Return OrderedDictWithDefaults config populated with values from
+        dic (dictionary)"""
+        result = ord_dict({
+            'runtime': ord_dict({
+                '<foo>': ord_dict({
+                    'script': 'echo whatever'
+                })
+            })
+        })
+        if 'parameter environment templates' in dic:
+            result['runtime']['<foo>']['parameter environment templates'] = (
+                dic['parameter environment templates']
+            )
+        if 'environment' in dic:
+            result['runtime']['<foo>']['environment'] = dic['environment']
+        return result
+
+    config = _cfg(cfg)
+    upgrade_param_env_templates(config, 'suite.rc')
+    assert config == _cfg(expected)

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -102,8 +102,6 @@ def test_write(mocked_get_remote_suite_run_dir, fixture_get_platform):
             'environment': {'cow': '~/moo',
                             'sheep': '~baa/baa',
                             'duck': '~quack'},
-            "param_env_tmpl": {"param_env_tmpl_1": "moo",
-                               "param_env_tmpl_2": "baa"},
             "job_d": "1/baa/01",
             "try_num": 1,
             "flow_label": "aZ",
@@ -447,8 +445,6 @@ def test_write_task_environment():
                 'CYLC_TASK_DEPENDENCIES="moo neigh quack"\n    export '
                 'CYLC_TASK_TRY_NUMBER=1\n    export '
                 'CYLC_TASK_FLOW_LABEL=aZ\n    export '
-                'param_env_tmpl_1="moo"\n    export '
-                'param_env_tmpl_2="baa"\n    export '
                 'CYLC_TASK_PARAM_duck="quack"\n    export '
                 'CYLC_TASK_PARAM_mouse="squeak"\n    '
                 'CYLC_TASK_WORK_DIR_BASE=\'farm_noises/work_d\'\n}')
@@ -458,8 +454,6 @@ def test_write_task_environment():
         "dependencies": ['moo', 'neigh', 'quack'],
         "try_num": 1,
         "flow_label": "aZ",
-        "param_env_tmpl": {"param_env_tmpl_1": "moo",
-                           "param_env_tmpl_2": "baa"},
         "param_var": {"duck": "quack",
                       "mouse": "squeak"},
         "work_d": "farm_noises/work_d"

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -28,21 +28,20 @@ import cylc.flow.flags
 from cylc.flow.job_file import JobFileWriter
 from cylc.flow.platforms import platform_from_name
 
-# List of tilde variable inputs
-# input value, expected output value
-TILDE_IN_OUT = [('~foo/bar bar', '~foo/"bar bar"'),
-                ('~/bar bar', '~/"bar bar"'),
-                ('~/a', '~/"a"'),
-                ('test', '"test"'),
-                ('~', '~'),
-                ('~a', '~a')]
 
-
-def test_get_variable_value_definition():
+@pytest.mark.parametrize(
+    'in_value, out_value',
+    [('~foo/bar bar', '~foo/"bar bar"'),
+     ('~/bar bar', '~/"bar bar"'),
+     ('~/a', '~/"a"'),
+     ('test', '"test"'),
+     ('~', '~'),
+     ('~a', '~a')]
+)
+def test_get_variable_value_definition(in_value, out_value):
     """Test the value for single/tilde variables are correctly quoted"""
-    for in_value, out_value in TILDE_IN_OUT:
-        res = JobFileWriter._get_variable_value_definition(in_value)
-        assert(out_value == res)
+    res = JobFileWriter._get_variable_value_definition(in_value, param_vars={})
+    assert(out_value == res)
 
 
 @pytest.fixture
@@ -237,8 +236,6 @@ def test_write(mocked_get_remote_suite_run_dir, fixture_get_platform):
 def test_write_directives(fixture_get_platform, job_conf: dict, expected: str):
     """"Test the directives section of job script file is correctly
         written"""
-    platform = fixture_get_platform(job_conf['platform'])
-
     with io.StringIO() as fake_file:
         JobFileWriter()._write_directives(fake_file, job_conf)
         assert(fake_file.getvalue() == expected)

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -36,11 +36,15 @@ from cylc.flow.platforms import platform_from_name
      ('~/a', '~/"a"'),
      ('test', '"test"'),
      ('~', '~'),
-     ('~a', '~a')]
+     ('~a', '~a'),
+     ('foo%s', '"foo%s"'),
+     ('foo%(i)d', '"foo3"')]
 )
 def test_get_variable_value_definition(in_value, out_value):
-    """Test the value for single/tilde variables are correctly quoted"""
-    res = JobFileWriter._get_variable_value_definition(in_value, param_vars={})
+    """Test the value for single/tilde variables are correctly quoted, and
+    parameter environment templates are handled"""
+    param_dict = {'i': 3}
+    res = JobFileWriter._get_variable_value_definition(in_value, param_dict)
     assert(out_value == res)
 
 


### PR DESCRIPTION
This is #3784 ported to master. These changes address #3446

Merge `[runtime][X][parameter environment templates]` into `[runtime][X][environment]` so that users can choose the order of definition of the variables.
- Any valid Python template in the `[environment]` section that matches a parameter will be interpolated/substituted.
- An existing `[parameter environment templates]` section in a suiterc will get prepended to `[environment]` to maintain backwards compatibility with the current behaviour.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [X] Appropriate tests are included (unit).
<!-- choose one: -->
- [X] Appropriate change log entry included.
<!-- choose one: -->
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/155.
<!-- choose one: -->
- [X] No dependency changes.
