### PR TITLE
Write to stream, then flush

### DIFF
--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -69,7 +69,7 @@ def record_messages(suite, task_job, messages):
         else:
             handle = sys.stdout
         handle.write('%s %s - %s\n' % (event_time, severity, message))
-    handle.flush()
+        handle.flush()
     # Write to job.status
     _append_job_status_file(suite, task_job, event_time, messages)
     # Send messages


### PR DESCRIPTION
This is a small change with no associated Issue.

Found this one yesterday while reviewing @dwsutherland 's #3757 . I think there was some change in `task_message.py` but on different lines (IOW this was not part of his change, so I added a post-it to review this separately later)

I think if you have 2 messages, one with one severity level, and the other with another severity level, then you could miss flushing one of the handle/streams.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (I think it's covered by tests, although we could write a unit test with a mock... if necessary?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
