### PR TITLE
GH Actions: run doctests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           pytest -n 5 tests/integration
 
+      - name: Doctests
+        run: |
+          pytest -n 5 cylc/flow
+
 
   functional-tests:
     runs-on: ubuntu-latest

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -34,13 +34,13 @@ def regex_chars_to_text(chars):
 
     Examples:
         >>> regex_chars_to_text(['a', 'b', 'c'])
-        ['a', 'b', 'c']
+        ['``a``', '``b``', '``c``']
         >>> regex_chars_to_text([r'\-', r'\.', r'\/'])
-        ['-', '.', '/']
+        ['``-``', '``.``', '``/``']
         >>> regex_chars_to_text([r'\w'])
         ['alphanumeric']
         >>> regex_chars_to_text(['not_in_map'])
-        ['not_in_map']
+        ['``not_in_map``']
 
     """
     return [
@@ -110,8 +110,8 @@ def not_contains_colon_unless_starts_with(*chars):
     """Restrict use of colons.
 
     Example:
-        >>> regex, message = not_contain_colon_unless_starts_with(
-                'INFO', 'WARNING')
+        >>> regex, message = not_contains_colon_unless_starts_with(
+        ...     'INFO', 'WARNING')
         >>> message
         'cannot contain a colon unless starts with: ``INFO``, ``WARNING``'
         >>> bool(regex.match('Foo: bar'))

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -26,3 +26,21 @@ Don't write integration tests here:
 * If your test sees logic flow through multiple modules it's not a unit test.
 * If you are constructing computationally expensive objects it's unlikely
   to be a unit test.
+
+## Doctests
+
+Doctests are Python interactive shell examples embedded in the docstrings of
+functions/methods, that can provide some level of unit testing. E.g.
+```python
+def factorial(n):
+    """
+    Example:
+      >>> factorial(7)
+      5040
+    """
+```
+
+To run doctests:
+```console
+$ pytest cylc/flow
+```


### PR DESCRIPTION
I noticed that the doctests don't seem to be run on GH Actions.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [X] Does not need tests.
- [X] No change log entry required (invisible to users).
- [X] No documentation update required.
- [X] No dependency changes.
