### PR TITLE
Global config hierarchy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,8 +65,11 @@ installation defined in $path rather than hardcoding to /bin/bash.
 interactive prompt.
 
 [#3798](https://github.com/cylc/cylc-flow/pull/3798) - Deprecated the
-[runtime][X][parameter environment templates] section and instead allow
-templates in [runtime][X][environment].
+`[runtime][X][parameter environment templates]` section and instead allow
+templates in `[runtime][X][environment]`.
+
+[#3802](https://github.com/cylc/cylc-flow/pull/3802) - New global config
+hierarchy and ability to set site config directory.
 
 ### Fixes
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -790,10 +790,10 @@ class GlobalConfig(ParsecConfig):
                     if conf_type == upgrader.SITE_CONFIG:
                         # Warn on bad site file (users can't fix it).
                         LOG.warning(
-                            'ignoring bad %s %s:\n%s', conf_type, fname, exc)
+                            f'ignoring bad {conf_type} {fname}:\n{exc}')
                     else:
                         # Abort on bad user file (users can fix it).
-                        LOG.error('bad %s %s', conf_type, fname)
+                        LOG.error(f'bad {conf_type} {fname}')
                         raise
 
         self._set_default_editors()

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -43,15 +43,15 @@ with Conf('global.cylc', desc='''
        $ cylc get-global-config --sparse
 
 
-    Cylc will attempt to load the global configuration (global.cylc) from a
-    hierarchy of locations, including the site directory at ``/etc/cylc/flow/``
-    and the user directory at ``~/.cylc/flow/``. E.g. for Cylc version 8.0.1,
-    the hierarchy would be, in order of ascending priority:
+    Cylc will attempt to load the global configuration (``global.cylc``) from a
+    hierarchy of locations, including the site directory (defaults to
+    ``/etc/cylc/flow/``) and the user directory at ``~/.cylc/flow/``. E.g. for
+    Cylc version 8.0.1, the hierarchy would be, in order of ascending priority:
 
-    * ``/etc/cylc/flow/global.cylc``
-    * ``/etc/cylc/flow/8/global.cylc``
-    * ``/etc/cylc/flow/8.0/global.cylc``
-    * ``/etc/cylc/flow/8.0.1/global.cylc``
+    * ``${CYLC_SITE_CONF_PATH}/global.cylc``
+    * ``${CYLC_SITE_CONF_PATH}/8/global.cylc``
+    * ``${CYLC_SITE_CONF_PATH}/8.0/global.cylc``
+    * ``${CYLC_SITE_CONF_PATH}/8.0.1/global.cylc``
     * ``~/.cylc/flow/global.cylc``
     * ``~/.cylc/flow/8/global.cylc``
     * ``~/.cylc/flow/8.0/global.cylc``
@@ -61,7 +61,12 @@ with Conf('global.cylc', desc='''
     from those higher up (but if a setting is present in a file higher up and
     not in any files lower down, it will not be overridden).
 
-    To override the default configuration path use ``CYLC_CONF_PATH``.
+    To override the default configuration path, set the ``CYLC_CONF_PATH``
+    environment variable to the directory containing your ``global.cylc`` file.
+    If this is set, the hierarchy above is ignored.
+
+    Setting the ``CYLC_SITE_CONF_PATH`` environment variable overrides the
+    default value of ``/etc/cylc/flow/``, without ignoring the hierarchy.
 
     .. note::
 
@@ -721,10 +726,12 @@ class GlobalConfig(ParsecConfig):
     _DEFAULT = None
     _HOME = os.getenv('HOME') or get_user_home()
     CONF_BASENAME = "global.cylc"
+    SITE_CONF_PATH = (os.getenv('CYLC_SITE_CONF_PATH') or
+                      os.path.join(os.sep, 'etc', 'cylc', 'flow'))
 
     def __init__(self, *args, **kwargs):
         self.SITE_CONF_DIR_HIERARCHY = [
-            os.path.join(os.sep, 'etc', 'cylc', 'flow', version) for version in
+            os.path.join(self.SITE_CONF_PATH, version) for version in
             get_version_hierarchy(CYLC_VERSION)
         ]
         self.USER_CONF_DIR_HIERARCHY = [

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -705,13 +705,17 @@ def get_version_hierarchy(version):
         version (str): A PEP 440 compliant version number.
 
     Example:
-        >>> get_version_hierarchy('8.0.1a2')
-        ['', '8', '8.0', '8.0.1', '8.0.1a2']
+        >>> get_version_hierarchy('8.0.1a2.dev')
+        ['', '8', '8.0', '8.0.1', '8.0.1a2', '8.0.1a2.dev']
 
     """
-    base = [str(i) for i in packaging.version.Version(version).release]
+    smart_ver = packaging.version.Version(version)
+    base = [str(i) for i in smart_ver.release]
     hierarchy = ['']
-    hierarchy += ['.'.join(base[:i+1]) for i in range(len(base))]
+    hierarchy += ['.'.join(base[:i]) for i in range(1, len(base) + 1)]
+    if smart_ver.pre:
+        hierarchy.append(
+            hierarchy[-1] + ''.join(str(i) for i in smart_ver.pre))
     if version not in hierarchy:
         hierarchy.append(version)
     return hierarchy

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -721,8 +721,6 @@ class GlobalConfig(ParsecConfig):
     _DEFAULT = None
     _HOME = os.getenv('HOME') or get_user_home()
     CONF_BASENAME = "global.cylc"
-    SITE_CONF_DIR = os.path.join(os.sep, 'etc', 'cylc', 'flow', CYLC_VERSION)
-    USER_CONF_DIR = os.path.join(_HOME, '.cylc', 'flow', CYLC_VERSION)
 
     def __init__(self, *args, **kwargs):
         self.SITE_CONF_DIR_HIERARCHY = [

--- a/cylc/flow/scripts/cylc_get_site_config.py
+++ b/cylc/flow/scripts/cylc_get_site_config.py
@@ -54,16 +54,6 @@ def get_option_parser():
         help="Print the configured top level run directory.",
         action="store_true", default=False, dest="run_dir")
 
-    parser.add_option(
-        "--print-site-dir",
-        help="Print the site configuration directory location.",
-        action="store_true", default=False, dest="site_dir")
-
-    parser.add_option(
-        "--print-user-dir",
-        help="Print the user configuration directory location.",
-        action="store_true", default=False, dest="user_dir")
-
     return parser
 
 
@@ -71,10 +61,6 @@ def get_option_parser():
 def main(parser, options):
     if options.run_dir:
         print(get_platform()['run directory'])
-    elif options.site_dir:
-        print(glbl_cfg().SITE_CONF_DIR)
-    elif options.user_dir:
-        print(glbl_cfg().USER_CONF_DIR)
     else:
         glbl_cfg().idump(
             options.item, sparse=options.sparse, pnative=options.pnative)

--- a/etc/bin/run-functional-tests
+++ b/etc/bin/run-functional-tests
@@ -27,10 +27,8 @@ NPROC is the number of concurrent processes to run, which defaults to the
 global config "process pool size" setting.
 
 The tests ignore normal site/user global config and instead use:
-   <site-global-config>/global-tests.cylc
-   <user-global-config>/global-tests.cylc
-   (See "cylc get-global --print-site-dir/--print-user-dir for locations).
-These should specify test platforms under the [test battery] section, plus any
+   ~/.cylc/flow/<cylc-version>/global-tests.cylc
+This should specify test platforms under the [test battery] section, plus any
 other critical settings settings, including [platforms] configuration for test
 platforms (and special batchview commands like qcat if available). Additional
 global config items can be added on the fly using the create_test_global_config

--- a/tests/functional/cylc-get-site-config/00-basic.t
+++ b/tests/functional/cylc-get-site-config/00-basic.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -18,12 +18,11 @@
 # Test cylc-get-site-config
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 10
+set_test_number 9
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-get-config"
 run_ok "${TEST_NAME}.validate" cylc get-site-config
 run_ok "${TEST_NAME}.print-run-dir" cylc get-site-config --print-run-dir
-run_ok "${TEST_NAME}.print-site-dir" cylc get-site-config --print-site-dir
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-get-items"
 run_ok "${TEST_NAME}.doc-section" cylc get-site-config --item='[documentation]'

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -124,7 +124,7 @@
 #         test on the suite and run the reference suite with `suite_run_ok`.
 #         Run `purge_suite` on success. Expect 2 OK tests.
 #     create_test_global_config [PRE [POST]]
-#         Create a new global config file $PWD/etc from site global-tests.cylc
+#         Create a new global config file $PWD/etc from global-tests.cylc
 #         with PRE and POST pre- and ap-pended (PRE for top level items with no
 #         section heading). PRE and POST are strings.
 #     require_remote_platform
@@ -729,11 +729,7 @@ create_test_global_config() {
     mkdir 'etc'
     # Suite host self-identification method.
     echo "$PRE" >'etc/global.cylc'
-    SITE_TESTS_CONF_FILE="$(cylc get-global --print-site-dir)/global-tests.cylc"
-    USER_TESTS_CONF_FILE="$(cylc get-global --print-user-dir)/global-tests.cylc"
-    if [[ -f "${SITE_TESTS_CONF_FILE}" ]]; then
-        cat "${SITE_TESTS_CONF_FILE}" >>'etc/global.cylc'
-    fi
+    USER_TESTS_CONF_FILE="${HOME}/.cylc/flow/$(cylc version)/global-tests.cylc"
     if [[ -f "${USER_TESTS_CONF_FILE}" ]]; then
         cat "${USER_TESTS_CONF_FILE}" >>'etc/global.cylc'
     fi


### PR DESCRIPTION
These changes close #3689

> Cylc will attempt to load the global configuration (``global.cylc``) from a hierarchy of locations, including the site directory (defaults to ``/etc/cylc/flow/``) and the user directory at ``~/.cylc/flow/``. E.g. for Cylc version 8.0.1, the hierarchy would be, in order of ascending priority:
>
> * ``${CYLC_SITE_CONF_PATH}/global.cylc``
> * ``${CYLC_SITE_CONF_PATH}/8/global.cylc``
> * ``${CYLC_SITE_CONF_PATH}/8.0/global.cylc``
> * ``${CYLC_SITE_CONF_PATH}/8.0.1/global.cylc``
> * ``~/.cylc/flow/global.cylc``
> * ``~/.cylc/flow/8/global.cylc``
> * ``~/.cylc/flow/8.0/global.cylc``
> * ``~/.cylc/flow/8.0.1/global.cylc``
>
> A setting in a file lower down in the list will override the same setting from those higher up (but if a setting is present in a file higher up and not in any files lower down, it will not be overridden).
>
> To override the default configuration path, set the ``CYLC_CONF_PATH`` environment variable to the directory containing your ``global.cylc`` file. If this is set, the hierarchy above is ignored.
>
> Setting the ``CYLC_SITE_CONF_PATH`` environment variable overrides the default value of ``/etc/cylc/flow/``, without ignoring the hierarchy.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional) - kind of 😛 
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [X] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/156
<!-- choose one: -->
- [X] No dependency changes.
