### PR TITLE
Task was destroyed but it is pending

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -234,4 +234,9 @@ def event_loop():
     """
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
+    # gracefully exit async generators
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    # cancel any tasks still running in this event loop
+    for task in asyncio.all_tasks(loop):
+        task.cancel()
     loop.close()

--- a/tests/integration/test_scan_api.py
+++ b/tests/integration/test_scan_api.py
@@ -78,7 +78,7 @@ async def flows(mod_flow, mod_scheduler, mod_run, mod_one_conf):
 
 
 @pytest.mark.asyncio
-async def test_state_filter(flows, mod_test_dir, capsys):
+async def test_state_filter(flows, mod_test_dir):
     """It should filter flows by state."""
     # one stopped flow
     opts = ScanOptions(states='stopped')
@@ -115,7 +115,7 @@ async def test_state_filter(flows, mod_test_dir, capsys):
 
 
 @pytest.mark.asyncio
-async def test_name_filter(flows, mod_test_dir, capsys):
+async def test_name_filter(flows, mod_test_dir):
     """It should filter flows by name regex."""
     # one stopped flow
     opts = ScanOptions(states='all', name=['.*held.*'])
@@ -126,7 +126,7 @@ async def test_name_filter(flows, mod_test_dir, capsys):
 
 
 @pytest.mark.asyncio
-async def test_name_sort(flows, mod_test_dir, capsys):
+async def test_name_sort(flows, mod_test_dir):
     """It should sort flows by name."""
     # one stopped flow
     opts = ScanOptions(states='all', sort=True)
@@ -139,7 +139,7 @@ async def test_name_sort(flows, mod_test_dir, capsys):
 
 
 @pytest.mark.asyncio
-async def test_format_json(flows, mod_test_dir, capsys):
+async def test_format_json(flows, mod_test_dir):
     """It should dump results in json format."""
     # one stopped flow
     opts = ScanOptions(states='all', format='json')
@@ -151,7 +151,7 @@ async def test_format_json(flows, mod_test_dir, capsys):
 
 
 @pytest.mark.asyncio
-async def test_format_tree(flows, run_dir, ses_test_dir, mod_test_dir, capsys):
+async def test_format_tree(flows, run_dir, ses_test_dir, mod_test_dir):
     """It should dump results in an ascii tree format."""
     # one stopped flow
     opts = ScanOptions(states='running', format='tree')
@@ -167,7 +167,7 @@ async def test_format_tree(flows, run_dir, ses_test_dir, mod_test_dir, capsys):
 
 
 @pytest.mark.asyncio
-async def test_format_rich(flows, mod_test_dir, capsys):
+async def test_format_rich(flows, mod_test_dir):
     """It should print results in a long human-friendly format."""
     # one stopped flow (--colour-blind)
     opts = ScanOptions(states='running', format='rich', colour_blind=True)


### PR DESCRIPTION
**built on #3805**

On master you get some cryptic feedback when running tests:

```console
$ pytest tests/i/test_scan_api.py
...
RuntimeError: Event loop is closed
Task was destroyed but it is pending!
task: <Task pending coro=<Queue.get() done, defined at /Users/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/queues.py:150> wait_for=<Future cancelled>>
Task was destroyed but it is pending!
task: <Task pending coro=<Queue.get() running at /Users/oliver/miniconda3/envs/cylc8/lib/python3.7/asyncio/queues.py:159> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7ffa32096dd0>()]>>
Exception ignored in: <coroutine object Queue.get at 0x7ffa32042dd0>
...
```

These `Queue.get` tasks appear to be orphaned, since we only use `asyncio.Queue` in one place I'm guessing this is the fault of the async pipes (dammit).

I've added some teardown logic to the async generator stuff to ensure all running tasks get canceled when the generator exists:

```python
async for item in pipe:
    print(item)
    # if there are more items in the pipe then the teardown logic will kick in at this stage,
    # due to the maximum concurrency one shouldn't use async pipes like this though
    return
```

However, this didn't clear up the test warnings so I've added logic to the `conftest` to ensure that all tasks in the event loop get canceled before it is closed, which, for async tests, is probably a good idea anyway.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
