### PR TITLE
fix resolve via workflow parent lookup

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -412,10 +412,12 @@ async def get_nodes_by_ids(root, info, **args):
             parent_args.update(
                 {'id': parent_id, 'delta_store': False}
             )
-            parent = await resolvers.get_node_by_id(
-                NODE_MAP[get_type_str(info.parent_type)],
-                parent_args
-            )
+            parent_type = get_type_str(info.parent_type)
+            if parent_type in NODE_MAP:
+                parent = await resolvers.get_node_by_id(
+                    NODE_MAP[parent_type], parent_args)
+            else:
+                parent = await resolvers.get_workflow_by_id(parent_args)
             field_ids = getattr(parent, field_name, None)
         if not field_ids:
             return []


### PR DESCRIPTION
This is a small change with no associated Issue.

Noticed a but when looking up node relationships via the `workflow` parent while resolving GraphQL queries.. This PR addresses this.

One review should do.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (pre-release & not visible).
- [x] No documentation update required.
- [x] No dependency changes.
