### PR TITLE
7.8.x: auto-restart: only wait for local jobs running on localhost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,15 @@ cylc-8 (master branch, Python 3 - not yet released) uses proper Python package
 management and does not bundle Jinja2.
 
 -------------------------------------------------------------------------------
+## __cylc-7.8.7 (2020-05-14)__
+
+### Fixes
+
+[#3814](https://github.com/cylc/cylc-flow/pull/3814) - Fixes a minor bug in the
+auto-restart functionality which caused suites to wait for local jobs running
+on *any* host to complete before restarting.
+
+-------------------------------------------------------------------------------
 ## __cylc-7.8.6 (2020-05-14)__
 
 ### Fixes

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -44,7 +44,12 @@ from cylc.daemonize import daemonize
 from cylc.exceptions import CylcError
 import cylc.flags
 from cylc.host_appointer import HostAppointer, EmptyHostList
-from cylc.hostuserutil import get_host, get_user, get_fqdn_by_host
+from cylc.hostuserutil import (
+    get_host,
+    get_user,
+    get_fqdn_by_host,
+    is_remote_host
+)
 from cylc.loggingutil import CylcLogFormatter, TimestampRotatingFileHandler
 from cylc.log_diagnosis import LogSpec
 from cylc.network import PRIVILEGE_LEVELS
@@ -1349,6 +1354,7 @@ conditions; see `cylc conditions`.
             for itask in self.pool.get_tasks():
                 if (itask.state.status in TASK_STATUSES_ACTIVE and
                         itask.summary['batch_sys_name'] and
+                        (not is_remote_host(itask.task_host)) and
                         self.task_job_mgr.batch_sys_mgr.is_job_local_to_host(
                             itask.summary['batch_sys_name'])):
                     LOG.info('Waiting for jobs running on localhost to '


### PR DESCRIPTION
Small bug in the auto-restart logic which has gone unnoticed since its creation.

Before attempting auto-restart Cylc is supposed to wait for all locally running jobs (i.e. those submitted via background or at) on the suite host to finish.

Unfortunately this functionality is somewhat overzealous and is waiting for all jobs submitted via background or at *on any host* to complete before restarting.

Some users have exceptionally long-running background jobs (pollers) which have highlighted this bug.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
