### PR TITLE
auto-restart: only wait for local jobs running on localhost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,6 +70,10 @@ templates in [runtime][X][environment].
 
 ### Fixes
 
+[#3815](https://github.com/cylc/cylc-flow/pull/3815) - Fixes a minor bug in the
+auto-restart functionality which caused suites to wait for local jobs running
+on *any* host to complete before restarting.
+
 [#3732](https://github.com/cylc/cylc-flow/pull/3732) - XTrigger labels
 are now validated to ensure that runtime errors can not occur when
 exporting environment variables.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -47,7 +47,11 @@ from cylc.flow.exceptions import (
 )
 import cylc.flow.flags
 from cylc.flow.host_select import select_suite_host
-from cylc.flow.hostuserutil import get_host, get_user
+from cylc.flow.hostuserutil import (
+    get_host,
+    get_user,
+    is_remote_platform
+)
 from cylc.flow.job_pool import JobPool
 from cylc.flow.loggingutil import (
     TimestampRotatingFileHandler,
@@ -1528,6 +1532,7 @@ class Scheduler:
                 if (
                         itask.state(*TASK_STATUSES_ACTIVE)
                         and itask.summary['batch_sys_name']
+                        and not is_remote_platform(itask.platform)
                         and self.task_job_mgr.batch_sys_mgr
                         .is_job_local_to_host(
                             itask.summary['batch_sys_name'])


### PR DESCRIPTION
Cylc8 port of https://github.com/cylc/cylc-flow/pull/3814.

    Before attempting auto-restart Cylc is supposed to wait for all locally running jobs
    (i.e. those submitted via background or at) on the suite host to finish.

    Unfortunately this functionality is somewhat overzealous and is waiting for all jobs
    submitted via background or at on any host to complete before restarting.

    Some users have exceptionally long-running background jobs (pollers) which
    have highlighted this bug.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
