### PR TITLE
Platforms.eval platform cmd.no backticks

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -31,7 +31,8 @@ FORBIDDEN_WITH_PLATFORM = (
 )
 
 # Regex to check whether a string is a command
-REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
+HOST_REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
+PLATFORM_REC_COMMAND = re.compile(r'(\$\()\s*(.*)\s*([)])$')
 
 
 def get_platform(task_conf=None, task_id='unknown task', warn_only=False):
@@ -69,11 +70,17 @@ def get_platform(task_conf=None, task_id='unknown task', warn_only=False):
         output = platform_from_name(task_conf)
 
     elif 'platform' in task_conf and task_conf['platform']:
-        if REC_COMMAND.match(task_conf['platform']) and warn_only:
+        if PLATFORM_REC_COMMAND.match(task_conf['platform']) and warn_only:
             # In warning mode this function might have been passed an
             # un-expanded platform string - warn that they won't deal with
             # with this until job submit.
             return None
+        if HOST_REC_COMMAND.match(task_conf['platform']) and warn_only:
+            raise PlatformLookupError(
+                f"platform = {task_conf['platform']}: "
+                "backticks are not supported; "
+                "please use $()"
+            )
 
         # Check whether task has conflicting Cylc7 items.
         fail_if_platform_and_host_conflict(task_conf, task_id)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -51,7 +51,10 @@ from cylc.flow.task_job_logs import (
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED, TASK_OUTPUT_SUCCEEDED,
     TASK_OUTPUT_FAILED)
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import (
+    get_platform, get_host_from_platform,
+    HOST_REC_COMMAND, PLATFORM_REC_COMMAND
+)
 from cylc.flow.task_remote_mgr import (
     REMOTE_INIT_FAILED, TaskRemoteMgr)
 from cylc.flow.task_state import (
@@ -827,11 +830,11 @@ class TaskJobManager:
         try:
             if rtconfig['remote']['host'] is not None:
                 host_n = self.task_remote_mgr.subshell_eval(
-                    rtconfig['remote']['host']
+                    rtconfig['remote']['host'], HOST_REC_COMMAND
                 )
             else:
                 platform_n = self.task_remote_mgr.subshell_eval(
-                    rtconfig['platform'], host_check=False
+                    rtconfig['platform'], PLATFORM_REC_COMMAND
                 )
         except TaskRemoteMgmtError as exc:
             # Submit number not yet incremented

--- a/tests/functional/job-submission/18-platform_select/flow.cylc
+++ b/tests/functional/job-submission/18-platform_select/flow.cylc
@@ -16,6 +16,7 @@ purpose = """
             host_subshell
             platform_no_subshell
             host_no_subshell
+            host_subshell_backticks
         """
 
 [runtime]
@@ -34,4 +35,8 @@ purpose = """
 
     [[host_subshell]]
         [[[remote]]]
-            host = $(echo localhost)
+            host = $(echo hostname)
+
+    [[host_subshell_backticks]]
+        [[[remote]]]
+            host = `echo hostname`

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -190,3 +190,16 @@ def test_get_platform_groups_basic(mock_glbl_cfg):
     assert get_platform('hebrew_letters')['name'] == 'aleph'
     random.seed(44)
     assert get_platform('hebrew_letters')['name'] == 'bet'
+
+
+def test_get_platform_warn_mode_fail_if_backticks():
+    # Platform = `cmd in backticks` not allowed.
+    task_conf = {
+        'platform': '`echo ${chamber}`'
+    }
+    with pytest.raises(PlatformLookupError) as err:
+        get_platform(task_conf, warn_only=True)
+    assert err.match(
+        r'platform = `echo \$\{chamber\}`: '
+        r'backticks are not supported; please use \$\(\)'
+    )


### PR DESCRIPTION
Fix: #3825 , subsidiary response to #3672 

Built on #3791 

In Cylc 7 the host setting for a task could be set as a bash subshell either in the form
```bash
$(my-command)   # or
`my-command`
```
my-command```. @dpmatthews proposes dropping support for the backtick ``my-command`` syntax for platforms at Cylc 8. 

Reasons why:
- This is very, very old syntax.
- Handling of single quotes and backslash escaping inside backticks is horrible.
- Nested backticks are hard to read.
- Backticks are visually difficult to distinguish from single quotes.
- Backticks are increasingly rarely used.