### PR TITLE
scan: fix hierarchically registered suites

### DIFF
--- a/tests/integration/test_scan_api.py
+++ b/tests/integration/test_scan_api.py
@@ -38,6 +38,9 @@ async def flows(mod_flow, mod_scheduler, mod_run, mod_one_conf):
     # a simple workflow we will leave stopped
     mod_flow(mod_one_conf, name='-stopped-')
 
+    # a simply hierarchically registered workflow we will leave stopped
+    mod_flow(mod_one_conf, name='a/b/c')
+
     # a simple workflow we will leave held
     reg1 = mod_flow(mod_one_conf, name='-held-')
     schd1 = mod_scheduler(reg1, hold_start=True)
@@ -81,11 +84,12 @@ async def flows(mod_flow, mod_scheduler, mod_run, mod_one_conf):
 async def test_state_filter(flows, mod_test_dir):
     """It should filter flows by state."""
     # one stopped flow
-    opts = ScanOptions(states='stopped')
+    opts = ScanOptions(states='stopped', sort=True)
     lines = []
     await main(opts, write=lines.append, scan_dir=mod_test_dir)
-    assert len(lines) == 1
+    assert len(lines) == 2
     assert '-stopped-' in lines[0]
+    assert 'a/b/c' in lines[1]
 
     # one held flow
     opts = ScanOptions(states='held')
@@ -111,7 +115,7 @@ async def test_state_filter(flows, mod_test_dir):
     opts = ScanOptions(states='held,running,stopped')
     lines = []
     await main(opts, write=lines.append, scan_dir=mod_test_dir)
-    assert len(lines) == 3
+    assert len(lines) == 4
 
 
 @pytest.mark.asyncio
@@ -132,10 +136,11 @@ async def test_name_sort(flows, mod_test_dir):
     opts = ScanOptions(states='all', sort=True)
     lines = []
     await main(opts, write=lines.append, scan_dir=mod_test_dir)
-    assert len(lines) == 3
+    assert len(lines) == 4
     assert '-held-' in lines[0]
     assert '-running-' in lines[1]
     assert '-stopped-' in lines[2]
+    assert 'a/b/c' in lines[3]
 
 
 @pytest.mark.asyncio
@@ -146,7 +151,7 @@ async def test_format_json(flows, mod_test_dir):
     lines = []
     await main(opts, write=lines.append, scan_dir=mod_test_dir)
     data = json.loads(lines[0])
-    assert len(data) == 3
+    assert len(data) == 4
     assert data[0]['name']
 
 

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -45,7 +45,7 @@ def _make_flow(run_dir, test_dir, conf, name=None):
     if not name:
         name = str(uuid1())
     flow_run_dir = (test_dir / name)
-    flow_run_dir.mkdir()
+    flow_run_dir.mkdir(parents=True)
     reg = str(flow_run_dir.relative_to(run_dir))
     if isinstance(conf, dict):
         conf = flow_config_str(conf)


### PR DESCRIPTION
Last minute fiddling on my scan PR created a somewhat odd bug which caused the scan client to miss any hierarchically registered suites (note the unit tests have logic to check for hier suites and were still passing 😕).

This is a nice logic simplification removing an unnecessary queue and the related lag it caused, why did I use a queue there, no idea, what was I thinking‽

Added an integration test to make doubly sure hier logic is preserved.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
