### PR TITLE
Cleaned up logging a little

### DIFF
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -29,7 +29,6 @@ from logging import DEBUG, CRITICAL, INFO, WARNING
 import os
 from shutil import rmtree
 from time import time
-import traceback
 from copy import deepcopy
 
 from cylc.flow.parsec.util import pdeepcopy, poverride

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -907,8 +907,6 @@ class TaskJobManager:
     def _prep_submit_task_job_error(self, suite, itask, action, exc):
         """Helper for self._prep_submit_task_job. On error."""
         LOG.debug("submit_num %s" % itask.submit_num)
-        LOG.debug(traceback.format_exc())
-        LOG.error(exc)
         log_task_job_activity(
             SubProcContext(self.JOBS_SUBMIT, action, err=exc, ret_code=1),
             suite,

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -299,8 +299,6 @@ class TaskRemoteMgr:
         """Callback when host select command exits"""
         self.ready = True
         if proc_ctx.ret_code == 0 and proc_ctx.out:
-            # Good status
-            LOG.debug(proc_ctx)
             self.remote_command_map[cmd_str] = proc_ctx.out.splitlines()[0]
         else:
             # Bad status


### PR DESCRIPTION
Follow up to #3791 focused on comments from @oliver-sanders reproduced here:

The log messages contain a bit of duplicated info and could do with being tidied up a bit:

```
DEBUG - ['bash', '-c', 'echo
	localhost']
DEBUG - [remote-host-select cmd] bash -c
	'echo localhost'
	[remote-host-select ret_code] 0
	[remote-host-select out] localhost
DEBUG - for task foo.1: platform =
	$(echo localhost) evaluated as localhost
```
One message should suffice for this case, note the second log message comes from the subprocpool and contains all the required info.
```
DEBUG - Traceback (most recent call
	last):
	  File "/Users/oliver/cylc-flow/cylc/flow/task_job_mgr.py", line 866, in
	_prep_submit_task_job
	    platform = get_platform(rtconfig)
	  File "/Users/oliver/cylc-flow/cylc/flow/platforms.py", line 82, in get_platform
	    output = platform_from_name(task_conf['platform'])
	  File "/Users/oliver/cylc-flow/cylc/flow/platforms.py", line 184, in
	platform_from_name
	    f"No matching platform \"{platform_name}\" found")
	cylc.flow.exceptions.PlatformLookupError: No matching platform "elephant" found

ERROR - No matching platform "elephant" found
ERROR - [jobs-submit cmd] (platform not defined)
	[jobs-submit ret_code] 1
	[jobs-submit err] No matching platform "elephant" found
```
One message should suffice for this case, the traceback isn't helpful here as we already know where the exception was raised from.

### Treating each message in order:
1. Seems to be heavily baked into `subprocpool.py`: I'm a bit reluctant to remove this, since I haven't changed it, and I fear that other things may require it.
2. Got rid of.
3. Kept.
4. Got rid of.
5. Got rid of.
6. Kept.

