### PR TITLE
schema: move default into schema for set-outputs

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1678,7 +1678,7 @@ class SetOutputs(Mutation, TaskMutation):
     class Arguments(TaskMutation.Arguments):
         outputs = List(
             String,
-            default_value=[],
+            required=True
         )
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -33,6 +33,7 @@ from graphene.utils.str_converters import to_snake_case
 from cylc.flow import ID_DELIM
 from cylc.flow.broadcast_mgr import ALL_CYCLE_POINTS_STRS, addict
 from cylc.flow.task_state import (
+    TASK_OUTPUT_SUCCEEDED,
     TASK_STATUSES_ORDERED,
     TASK_STATUS_DESC,
     TASK_STATUS_WAITING,
@@ -1671,14 +1672,20 @@ class Remove(Mutation, TaskMutation):
 class SetOutputs(Mutation, TaskMutation):
     class Meta:
         description = sstrip('''
-            Mark task outputs as completed.
+            Artificially mark task outputs as completed.
+
+            This allows you to manually intervene with Cylc's scheduling
+            algorithm by artificially satisfying outputs of tasks.
+
+            By default this makes tasks appear as if they succeeded.
         ''')
         resolver = partial(mutator, command='force_spawn_children')
 
     class Arguments(TaskMutation.Arguments):
         outputs = List(
             String,
-            required=True
+            default_value=[TASK_OUTPUT_SUCCEEDED],
+            description='List of task outputs to satisfy.'
         )
 
 

--- a/cylc/flow/scripts/cylc_set_outputs.py
+++ b/cylc/flow/scripts/cylc_set_outputs.py
@@ -64,6 +64,9 @@ def get_option_parser():
 def main(parser, options, suite, *task_globs):
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
+    if not options.outputs:
+        parser.error('No outputs specified')
+
     mutation_kwargs = {
         'request_string': MUTATION,
         'variables': {

--- a/cylc/flow/scripts/cylc_set_outputs.py
+++ b/cylc/flow/scripts/cylc_set_outputs.py
@@ -55,7 +55,7 @@ def get_option_parser():
             ('TASK-GLOB [...]', 'Task match pattern')])
     parser.add_option(
         "--output", metavar="OUTPUT",
-        help="set task output OUTPUT completed",
+        help="Set task output OUTPUT completed, defaults to 'succeeded'.",
         action="append", dest="outputs")
     return parser
 
@@ -63,9 +63,6 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
-
-    if not options.outputs:
-        parser.error('No outputs specified')
 
     mutation_kwargs = {
         'request_string': MUTATION,

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1259,8 +1259,6 @@ class TaskPool:
 
     def force_spawn_children(self, items, outputs):
         """Spawn downstream children of given task outputs on user command."""
-        if not outputs:
-            outputs = [TASK_OUTPUT_SUCCEEDED]
         n_warnings, task_items = self.match_taskdefs(items)
         for (_, point), taskdef in sorted(task_items.items()):
             # This the upstream target task:


### PR DESCRIPTION
Related to https://github.com/cylc/cylc-ui/pull/504

The `setOutputs` mutation has no required fields which means that on the surface it looks like something you can do without providing any input (like `kill` or `trigger`).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
