### PR TITLE
Improve the thoroughness of dummy-local functional test

### DIFF
--- a/tests/flakyfunctional/modes/03-dummy-env.t
+++ b/tests/flakyfunctional/modes/03-dummy-env.t
@@ -18,6 +18,21 @@
 # Test that user environment is disabled along with env-script in dummy mode.
 # And that remote host is disabled in dummy local mode.
 . "$(dirname "$0")/test_header"
-set_test_number 2
-reftest
+set_test_number 5
+
+install_suite "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --reference-test --debug --no-detach "${SUITE_NAME}"\
+        --mode=dummy-local
+
+# Check that each of pre, main and post script do not leave a trace in the
+# job out when --mode=dummy-local.
+declare -a GREPFOR=('MY-PRE-SCRIPT' 'MY-SCRIPT' 'MY-POST-SCRIPT')
+for BAD_PHRASE in "${GREPFOR[@]}"; do
+    cp "${SUITE_RUN_DIR}/log/job/1/oxygas/NN/job.out" "${BAD_PHRASE}"
+    grep_fail "${BAD_PHRASE}" "${BAD_PHRASE}"
+done
+
 exit

--- a/tests/flakyfunctional/modes/03-dummy-env/flow.cylc
+++ b/tests/flakyfunctional/modes/03-dummy-env/flow.cylc
@@ -1,14 +1,16 @@
-[cylc]
-    force run mode = dummy-local
 [scheduling]
     [[graph]]
         R1 = oxygas
 [runtime]
     [[root]]
-        script = true
         [[[simulation]]]
             default run length = PT0S
     [[oxygas]]
+        pre-script = echo "[MY-PRE-SCRIPT] \${CYLC_TASK_NAME} is ${CYLC_TASK_NAME}"
+        script = """
+            echo "[MY-SCRIPT] \${CYLC_TASK_NAME} is ${CYLC_TASK_NAME}"
+        """
+        post-script = echo "[MY-POST-SCRIPT] \${CYLC_TASK_NAME} is ${CYLC_TASK_NAME}"
         env-script = ELSE=foo
         [[[environment]]]
             SOMETHING = "some-modification-$ELSE"


### PR DESCRIPTION
Follow up a larger PR on #3482 

I do not believe that previously there was any test that dummy-local turns off pre and post scripts.