### PR TITLE
test-fix: platforms/05

### DIFF
--- a/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
+++ b/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
@@ -22,13 +22,13 @@
 export CYLC_TEST_IS_GENERIC=false
 . "$(dirname "$0")/test_header"
 require_remote_platform
-set_test_number 3
+set_test_number 4
 
 create_test_global_config '' "
 [platforms]
-  [[wibble]]
-    hosts = ${CYLC_TEST_HOST}
-    retrieve job logs = True
+    [[wibble]]
+        hosts = ${CYLC_TEST_HOST}
+        retrieve job logs = True
 "
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
@@ -36,17 +36,21 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 # Both of these cases should validate ok.
 run_ok "${TEST_NAME_BASE}-validate" \
-  cylc validate "${SUITE_NAME}" \
-     -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+    cylc validate "${SUITE_NAME}" \
+         -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
 
 # Check that the cfgspec/suite.py has issued a warning about upgrades.
 grep_ok "\[not_upgradable_cylc7_settings\]\[remote\]host = parasite"\
-  "${TEST_NAME_BASE}-validate.stderr"
+    "${TEST_NAME_BASE}-validate.stderr"
 
 # Run the suite
 suite_run_fail "${TEST_NAME_BASE}-run" \
-  cylc run --debug --no-detach \
-  -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+    cylc run --debug --no-detach \
+    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+
+# Check that the suite failed because no matching platfrom could be found.
+grep_ok "\[jobs-submit err\] No platform found matching your task"\
+    "${SUITE_RUN_DIR}/log/suite/log"
 
 purge_suite_platform "${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"

--- a/tests/functional/platforms/05-host-to-platform-upgrade-fail/flow.cylc
+++ b/tests/functional/platforms/05-host-to-platform-upgrade-fail/flow.cylc
@@ -1,17 +1,24 @@
+[meta]
+description = """
+The task settings for not_upgradable_cylc7_settings should not match any
+platform: The workflow should fail as a result.
+"""
+
 [cylc]
-  UTC mode = True
+    UTC mode = True
+    [[events]]
+        abort on stalled = True
 
 [scheduling]
-  [[graph]]
-    R1 = """
-      not_upgradable_cylc7_settings
-    """
-[runtime]
-  [[root]]
-    script = true
+    [[graph]]
+        R1 = """
+            not_upgradable_cylc7_settings
+        """
 
-  [[not_upgradable_cylc7_settings]]
-    [[[remote]]]
-      host = parasite
-    [[[job]]]
-      batch system = 'loaf'
+[runtime]
+    [[not_upgradable_cylc7_settings]]
+        script = True
+        [[[remote]]]
+            host = parasite
+        [[[job]]]
+            batch system = 'loaf'


### PR DESCRIPTION
This is a small change with no associated Issue.

@datamel found a test which hung rather than worked as desired. On examination I also fixed:
- Incorrect tab size for project.
- Added a grep to ensure that the suite had failed for the reason we are testing for.
- Added a description of the workflow to the metadata section of the test `flow.cylc`