### PR TITLE
workflow config update: remove force/require run mode

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -165,18 +165,6 @@ with Conf(
                (e.g. ``+05:30``), given that the time zone is used as part of
                task output filenames.
         ''')
-        Conf('required run mode', VDR.V_STRING, '',
-             options=['', 'live', 'dummy', 'dummy-local', 'simulation'],
-             desc='''
-            If this item is set cylc will abort if the suite is not started in
-            the specified mode. This can be used for demo suites that have to
-            be run in simulation mode, for example, because they have been
-            taken out of their normal operational context; or to prevent
-            accidental submission of expensive real tasks during suite
-            development.
-        ''')
-        Conf('force run mode', VDR.V_STRING, '',
-             options=['', 'live', 'dummy', 'dummy-local', 'simulation'])
         Conf('task event mail interval', VDR.V_INTERVAL)
         Conf('disable automatic shutdown', VDR.V_BOOLEAN, desc='''
             This has the same effect as the ``--no-auto-shutdown`` flag for
@@ -1288,6 +1276,7 @@ def upg(cfg, descr):
         ['runtime', '__MANY__', 'suite state polling', 'template'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
+    u.obsolete('8.0.0', ['cylc', 'force run mode'])
     u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
     u.obsolete('8.0.0', ['cylc', 'authentication'])
     u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
@@ -1301,6 +1290,7 @@ def upg(cfg, descr):
         '8.0.0',
         ['cylc', 'reference test', 'simulation mode suite timeout'])
     u.obsolete('8.0.0', ['cylc', 'reference test', 'required run mode'])
+    u.obsolete('8.0.0', ['cylc', 'required run mode'])
     u.obsolete(
         '8.0.0',
         ['cylc', 'reference test', 'suite shutdown event handler'])

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1515,8 +1515,6 @@ class SuiteConfig:
         """
         mode = getattr(self.options, 'run_mode', None)
         if not mode:
-            mode = self.cfg['cylc']['force run mode']
-        if not mode:
             mode = 'live'
         if reqmodes:
             return mode in reqmodes

--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -158,7 +158,6 @@
         <keyword>handler retry delays</keyword>
         <keyword>handler events</keyword>
         <keyword>graph</keyword>
-        <keyword>force run mode</keyword>
         <keyword>final cycle point constraints</keyword>
         <keyword>final cycle point</keyword>
         <keyword>failed handler</keyword>

--- a/cylc/flow/etc/syntax/cylc.xml
+++ b/cylc/flow/etc/syntax/cylc.xml
@@ -55,7 +55,6 @@
         <RegExpr attribute='Keyword' String=' retrieve job logs retry delays '/>
         <RegExpr attribute='Keyword' String=' retrieve job logs max size '/>
         <RegExpr attribute='Keyword' String=' retrieve job logs '/>
-        <RegExpr attribute='Keyword' String=' required run mode '/>
         <RegExpr attribute='Keyword' String=' public '/>
         <RegExpr attribute='Keyword' String=' pre-script '/>
         <RegExpr attribute='Keyword' String=' post-script '/>

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -431,10 +431,6 @@ class Scheduler:
 
         self.suite_db_mgr.on_suite_start(self.is_restart)
 
-        reqmode = self.config.cfg['cylc']['required run mode']
-        if reqmode and not self.config.run_mode(reqmode):
-            raise ValueError('this suite requires the %s run mode' % reqmode)
-
         if not self.is_restart:
             # Set suite params that would otherwise be loaded from database:
             self.options.utc_mode = get_utc_mode()

--- a/tests/flakyfunctional/execution-time-limit/04-poll.t
+++ b/tests/flakyfunctional/execution-time-limit/04-poll.t
@@ -18,6 +18,6 @@
 # Test execution time limit polling.
 . "$(dirname "$0")/test_header"
 set_test_number 2
-export ABORT_ON_TASK_FAIL=true
+export REFTEST_OPTS="--abort-if-any-task-fails"
 reftest
 exit

--- a/tests/functional/broadcast/08-space.t
+++ b/tests/functional/broadcast/08-space.t
@@ -18,6 +18,6 @@
 # Test broadcast -s '[foo]  bar=baz' syntax. cylc/cylc-flow#1680
 . "$(dirname "$0")/test_header"
 set_test_number 2
-export ABORT_ON_TASK_FAIL=true
+export REFTEST_OPTS="--abort-if-any-task-fails"
 reftest
 exit

--- a/tests/functional/deprecations/01-cylc8-basic.t
+++ b/tests/functional/deprecations/01-cylc8-basic.t
@@ -29,6 +29,7 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
+ * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][allow task failures] - DELETED (OBSOLETE)
@@ -37,6 +38,7 @@ cmp_ok val.out <<__END__
  * (8.0.0) [cylc][reference test][dummy-local mode suite timeout] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][simulation mode suite timeout] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][required run mode] - DELETED (OBSOLETE)
+ * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -5,6 +5,8 @@
     log resolved dependencies =
     abort if any task fails =
     authentication =
+    required run mode =
+    force run mode =
     [[reference test]]
         allow task failures =
         live mode suite timeout =

--- a/tests/functional/hold-release/18-hold-cycle-globs.t
+++ b/tests/functional/hold-release/18-hold-cycle-globs.t
@@ -18,6 +18,6 @@
 # Test hold cycle point glob
 . "$(dirname "$0")/test_header"
 set_test_number 2
-export ABORT_ON_TASK_FAIL=true
+export REFTEST_OPTS="--abort-if-any-task-fails"
 reftest
 exit

--- a/tests/functional/hold-release/19-no-reset-prereq-on-waiting.t
+++ b/tests/functional/hold-release/19-no-reset-prereq-on-waiting.t
@@ -18,6 +18,6 @@
 # Test on release of a waiting task, don't reset its prerequisites
 . "$(dirname "$0")/test_header"
 set_test_number 2
-export ABORT_ON_TASK_FAIL=true
+export REFTEST_OPTS="--abort-if-any-task-fails"
 reftest
 exit

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -701,12 +701,18 @@ reftest() {
     local TEST_NAME="${1:-${TEST_NAME_BASE}}"
     install_suite "$@"
     run_ok "${TEST_NAME}-validate" cylc validate "${SUITE_NAME}"
-    if [[ "${ABORT_ON_TASK_FAIL:-}" == true ]]; then
+    if [[ -n "${REFTEST_OPTS:-}" ]]; then
         suite_run_ok "${TEST_NAME}-run" \
-            cylc run --reference-test --debug --no-detach --abort-if-any-task-fails "${SUITE_NAME}"
+            cylc run --reference-test --debug --no-detach \
+            "${REFTEST_OPTS}" "${SUITE_NAME}"
+    elif [[ "${ABORT_ON_TASK_FAIL:-}" == true ]]; then
+        suite_run_ok "${TEST_NAME}-run" \
+            cylc run --reference-test --debug --no-detach \
+            --abort-if-any-task-fails "${SUITE_NAME}"
     else
         suite_run_ok "${TEST_NAME}-run" \
-            cylc run --reference-test --debug --no-detach "${SUITE_NAME}"
+            cylc run --reference-test --debug --no-detach \
+            "${SUITE_NAME}"
     fi
     purge_suite "${SUITE_NAME}"
 }

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -705,10 +705,6 @@ reftest() {
         suite_run_ok "${TEST_NAME}-run" \
             cylc run --reference-test --debug --no-detach \
             "${REFTEST_OPTS}" "${SUITE_NAME}"
-    elif [[ "${ABORT_ON_TASK_FAIL:-}" == true ]]; then
-        suite_run_ok "${TEST_NAME}-run" \
-            cylc run --reference-test --debug --no-detach \
-            --abort-if-any-task-fails "${SUITE_NAME}"
     else
         suite_run_ok "${TEST_NAME}-run" \
             cylc run --reference-test --debug --no-detach \

--- a/tests/functional/modes/01-dummy.t
+++ b/tests/functional/modes/01-dummy.t
@@ -18,5 +18,6 @@
 # Test dummy mode
 . "$(dirname "$0")/test_header"
 set_test_number 2
+export REFTEST_OPTS="--mode=dummy"
 reftest
 exit

--- a/tests/functional/modes/01-dummy/flow.cylc
+++ b/tests/functional/modes/01-dummy/flow.cylc
@@ -1,5 +1,4 @@
 [cylc]
-    force run mode = dummy
     [[reference test]]
         expected task failures = a.1, b.1, c.1
 [scheduling]


### PR DESCRIPTION
Partially addresses #3696 #3690 

Refers to Cylc8 [Config Proposal agreed at CylcCon Wellington](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-config-changes.md#cylcforce-run-mode--required-run-mode---obsolete).

[cylc]force run mode & required run mode -> obsolete