### PR TITLE
flow-cfg-update.authentication

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -21,7 +21,6 @@ import packaging.version
 from cylc.flow import LOG
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.hostuserutil import get_user_home
-from cylc.flow.network.authorisation import Priv
 from cylc.flow.parsec.config import ParsecConfig, ConfigNode as Conf
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.parsec.upgrade import upgrader
@@ -596,37 +595,6 @@ with Conf('global.cylc', desc='''
             Use this item to explicitly set the name or IP address of the suite
             host if you have to use the *hardwired* self-identification method.
         ''')
-
-    # suite
-    with Conf('authentication', desc='''
-        Authentication of client programs with suite server programs can be
-        configured here, and overridden in suites if necessary with
-        :cylc:conf:`flow.cylc[cylc][authentication]`.
-
-        The suite-specific passphrase must be installed on a user's account to
-        authorize full control privileges (see
-        :ref:`ConnectionAuthentication`). In the future we plan to move to a
-        more traditional user account model so that each authorized user can
-        have their own password.
-    '''):
-        # Allow owners to grant public shutdown rights at the most, not full
-        # control.
-        Conf(
-            'public',
-            VDR.V_STRING,
-            default=Priv.STATE_TOTALS.name.lower().replace('_', '-'),
-            options=[
-                level.name.lower().replace('_', '-')
-                for level in [
-                    Priv.IDENTITY, Priv.DESCRIPTION,
-                    Priv.STATE_TOTALS, Priv.READ, Priv.SHUTDOWN
-                ]
-            ],
-            desc='''
-                This sets the client privilege level for public access - i.e.
-                no suite passphrase required.
-            '''
-        )
 
     # suite
     with Conf('suite servers', desc='''

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -21,7 +21,6 @@ from metomi.isodatetime.data import Calendar
 
 from cylc.flow import LOG
 from cylc.flow.parsec.exceptions import UpgradeError
-from cylc.flow.network.authorisation import Priv
 from cylc.flow.parsec.config import ParsecConfig, ConfigNode as Conf
 from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.upgrade import upgrader
@@ -269,22 +268,6 @@ with Conf(
 
         with Conf('reference test'):
             Conf('expected task failures', VDR.V_STRING_LIST)
-
-        with Conf('authentication'):
-            # Allow owners to grant public shutdown rights at the most, not
-            # full control.
-            Conf(
-                'public',
-                VDR.V_STRING,
-                default=Priv.STATE_TOTALS.name.lower().replace('_', '-'),
-                options=[
-                    level.name.lower().replace('_', '-')
-                    for level in [
-                        Priv.IDENTITY, Priv.DESCRIPTION,
-                        Priv.STATE_TOTALS, Priv.READ, Priv.SHUTDOWN
-                    ]
-                ]
-            )
 
     with Conf('scheduling', desc='''
         This section allows cylc to determine when tasks are ready to run.
@@ -1306,6 +1289,7 @@ def upg(cfg, descr):
     u.obsolete('7.8.1', ['cylc', 'events', 'reset timer'])
     u.obsolete('7.8.1', ['cylc', 'events', 'reset inactivity timer'])
     u.obsolete('7.8.1', ['runtime', '__MANY__', 'events', 'reset timer'])
+    u.obsolete('8.0.0', ['cylc', 'authentication'])
     u.obsolete('8.0.0', ['cylc', 'log resolved dependencies'])
     u.obsolete('8.0.0', ['cylc', 'reference test', 'allow task failures'])
     u.obsolete('8.0.0', ['cylc', 'reference test', 'live mode suite timeout'])

--- a/cylc/flow/network/authorisation.py
+++ b/cylc/flow/network/authorisation.py
@@ -15,59 +15,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Network authorisation layer."""
 
-from enum import IntEnum
 from functools import wraps
 
 from cylc.flow import LOG
 
 
-class Priv(IntEnum):
-    """Cylc privilege levels.
-
-    In Cylc configurations use the lower-case form of each privilege level
-    e.g. ``control`` for ``Priv.CONTROL``.
-
-    These levels are ordered (by the integer associated with each) from 0.
-    Each privilege level grants access to the levels below it.
-
-    """
-
-    CONTROL = 6
-    """Provides full control of a suite."""
-
-    SHUTDOWN = 5  # (Not used yet - for the post-passphrase era.)
-    """Allows issuing of the shutdown command."""
-
-    READ = 4
-    """Permits read access to the suite's state."""
-
-    STATE_TOTALS = 3
-    """Provides access to the count of tasks in each state."""
-
-    DESCRIPTION = 2
-    """Permits reading of suite metadata."""
-
-    IDENTITY = 1
-    """Provides read access to the suite name, owner and Cylc version."""
-
-    NONE = 0
-    """No access."""
-
-    @classmethod
-    def parse(cls, key):
-        """Obtain a privilege enumeration from a string."""
-        return cls.__members__[key.upper().replace('-', '_')]
-
-
-def authorise(req_priv_level):
+def authorise():
     """Add authorisation to an endpoint.
 
     This decorator extracts the `user` field from the incoming message to
     determine the client's privilege level.
-
-    Args:
-        req_priv_level (cylc.flow.network.Priv): A privilege level for the
-            method.
 
     Wrapped function args:
         user
@@ -88,20 +45,9 @@ def authorise(req_priv_level):
 
             # Hardcoded, for new - but much of this functionality can be
             # removed more swingingly.
-            usr_priv_level = Priv.CONTROL
-            if usr_priv_level < req_priv_level:
-                LOG.warn(
-                    "[client-connect] DENIED (privilege '%s' < '%s') %s@%s:%s",
-                    usr_priv_level, req_priv_level, user, host, prog)
-                raise Exception('Authorisation failure')
             LOG.info(
                 '[client-command] %s %s@%s:%s', fcn.__name__, user, host, prog)
             return fcn(self, *args, **kwargs)
 
-        # add authorisation level to docstring
-        _authorise.__doc__ += (
-            f'Authentication:\n{" " * 12}'
-            f':py:obj:`{__loader__.name}.{str(req_priv_level)}`\n'
-        )
         return _authorise
     return wrapper

--- a/cylc/flow/network/authorisation.py
+++ b/cylc/flow/network/authorisation.py
@@ -86,7 +86,9 @@ def authorise(req_priv_level):
             host = meta.get('host', '?')
             prog = meta.get('prog', '?')
 
-            usr_priv_level = self._get_priv_level(user)
+            # Hardcoded, for new - but much of this functionality can be
+            # removed more swingingly.
+            usr_priv_level = Priv.CONTROL
             if usr_priv_level < req_priv_level:
                 LOG.warn(
                     "[client-connect] DENIED (privilege '%s' < '%s') %s@%s:%s",

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -25,7 +25,7 @@ import zmq
 
 from cylc.flow import LOG
 from cylc.flow.network import encode_, decode_, ZMQSocketBase
-from cylc.flow.network.authorisation import Priv, authorise
+from cylc.flow.network.authorisation import authorise
 from cylc.flow.network.graphql import (
     CylcGraphQLBackend, IgnoreFieldMiddleware, instantiate_middleware
 )
@@ -259,7 +259,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
                           for name, obj in self.__class__.__dict__.items()
                           if hasattr(obj, 'exposed')}
 
-    @authorise(Priv.IDENTITY)
+    @authorise()
     @expose
     def api(self, endpoint=None):
         """Return information about this API.
@@ -292,7 +292,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
             return '%s\n%s' % (head, tail)
         return 'No method by name "%s"' % endpoint
 
-    @authorise(Priv.READ)
+    @authorise()
     @expose
     def graphql(self, request_string=None, variables=None):
         """Return the GraphQL scheme execution result.
@@ -335,7 +335,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
             return errors
         return executed.data
 
-    @authorise(Priv.READ)
+    @authorise()
     @expose
     def get_graph_raw(self, start_point_string, stop_point_string,
                       group_nodes=None, ungroup_nodes=None,
@@ -400,7 +400,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
             ungroup_all=ungroup_all)
 
     # UIServer Data Commands
-    @authorise(Priv.READ)
+    @authorise()
     @expose
     def pb_entire_workflow(self):
         """Send the entire data-store in a single Protobuf message.
@@ -413,7 +413,7 @@ class SuiteRuntimeServer(ZMQSocketBase):
         pb_msg = self.schd.data_store_mgr.get_entire_workflow()
         return pb_msg.SerializeToString()
 
-    @authorise(Priv.READ)
+    @authorise()
     @expose
     def pb_data_elements(self, element_type):
         """Send the specified data elements in delta form.

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Server for suite runtime API."""
 
-import getpass
+import getpass  # noqa: F401
 from queue import Queue
 from textwrap import dedent
 from time import sleep
@@ -24,7 +24,6 @@ from graphql.execution.executors.asyncio import AsyncioExecutor
 import zmq
 
 from cylc.flow import LOG
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network import encode_, decode_, ZMQSocketBase
 from cylc.flow.network.authorisation import Priv, authorise
 from cylc.flow.network.graphql import (
@@ -253,23 +252,6 @@ class SuiteRuntimeServer(ZMQSocketBase):
                 'message': str(exc), 'traceback': traceback.format_exc()}}
 
         return {'data': response}
-
-    def _get_public_priv(self):
-        """Return the public privilege level of this suite."""
-        if self.schd.config.cfg['cylc']['authentication']['public']:
-            return Priv.parse(
-                self.schd.config.cfg['cylc']['authentication']['public'])
-        return Priv.parse(glbl_cfg().get(['authentication', 'public']))
-
-    def _get_priv_level(self, user):
-        """Return the privilege level for the given user for this suite."""
-        if user == getpass.getuser():
-            return Priv.CONTROL
-        if self.public_priv is None:
-            # cannot do this on initialisation as the suite configuration has
-            # not yet been parsed
-            self.public_priv = self._get_public_priv()
-        return self.public_priv
 
     def register_endpoints(self):
         """Register all exposed methods."""

--- a/tests/functional/deprecations/01-cylc8-basic.t
+++ b/tests/functional/deprecations/01-cylc8-basic.t
@@ -29,6 +29,7 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
+ * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][allow task failures] - DELETED (OBSOLETE)
  * (8.0.0) [cylc][reference test][live mode suite timeout] - DELETED (OBSOLETE)

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -4,6 +4,7 @@
 [cylc]
     log resolved dependencies =
     abort if any task fails =
+    authentication =
     [[reference test]]
         allow task failures =
         live mode suite timeout =


### PR DESCRIPTION
Refers to Cylc8 [Config Proposal agreed at CylcCon Wellington](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-config-changes.md#cylcforce-run-mode--required-run-mode---obsolete).

Do we want to attach a follow on to carry out more heavy-duty removal of this functionality?