### PR TITLE
move [cylc][events]mail (.*) -> [cylc][mail]

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -135,7 +135,8 @@ with Conf('global.cylc', desc='''
                 DurationFloat(300),
                 desc='''
                     Default for
-                    :cylc:conf:`flow.cylc[cylc]task event mail interval`.
+                    :cylc:conf:
+                    `flow.cylc[cylc][mail]task event batch interval`.
                 '''
             )
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -101,11 +101,6 @@ with Conf('global.cylc', desc='''
         Conf('UTC mode', VDR.V_BOOLEAN, False, desc='''
                 Default for :cylc:conf:`flow.cylc[cylc]UTC mode`.
         ''')
-        Conf('task event mail interval', VDR.V_INTERVAL, DurationFloat(300),
-             desc='''
-                Default for
-                :cylc:conf:`flow.cylc[cylc]task event mail interval`.
-        ''')
 
         with Conf('events', desc='''
             You can define site defaults for each of the following options,
@@ -115,10 +110,6 @@ with Conf('global.cylc', desc='''
             Conf('handlers', VDR.V_STRING_LIST)
             Conf('handler events', VDR.V_STRING_LIST)
             Conf('mail events', VDR.V_STRING_LIST)
-            Conf('mail from', VDR.V_STRING)
-            Conf('mail smtp', VDR.V_STRING)
-            Conf('mail to', VDR.V_STRING)
-            Conf('mail footer', VDR.V_STRING)
             Conf('startup handler', VDR.V_STRING_LIST)
             Conf('timeout handler', VDR.V_STRING_LIST)
             Conf('inactivity handler', VDR.V_STRING_LIST)
@@ -130,6 +121,23 @@ with Conf('global.cylc', desc='''
             Conf('abort on timeout', VDR.V_BOOLEAN)
             Conf('abort on inactivity', VDR.V_BOOLEAN)
             Conf('abort on stalled', VDR.V_BOOLEAN)
+
+        with Conf('mail', desc='''
+            Options for email handling.
+        '''):
+            Conf('from', VDR.V_STRING)
+            Conf('smtp', VDR.V_STRING)
+            Conf('to', VDR.V_STRING)
+            Conf('footer', VDR.V_STRING)
+            Conf(
+                'task event batch interval',
+                VDR.V_INTERVAL,
+                DurationFloat(300),
+                desc='''
+                    Default for
+                    :cylc:conf:`flow.cylc[cylc]task event mail interval`.
+                '''
+            )
 
         with Conf('main loop', desc='''
             Configuration of the Cylc Scheduler's main loop.
@@ -507,11 +515,17 @@ with Conf('global.cylc', desc='''
         Conf('handler events', VDR.V_STRING_LIST)
         Conf('handler retry delays', VDR.V_INTERVAL_LIST, None)
         Conf('mail events', VDR.V_STRING_LIST)
-        Conf('mail from', VDR.V_STRING)
-        Conf('mail retry delays', VDR.V_INTERVAL_LIST)
-        Conf('mail smtp', VDR.V_STRING)
-        Conf('mail to', VDR.V_STRING)
         Conf('submission timeout', VDR.V_INTERVAL)
+
+    with Conf('task mail', desc='''
+        Global site/user defaults for
+        :cylc:conf:`flow.cylc[runtime][<namespace>][mail]`.
+    '''):
+
+        Conf('from', VDR.V_STRING)
+        Conf('retry delays', VDR.V_INTERVAL_LIST)
+        Conf('smtp', VDR.V_STRING)
+        Conf('to', VDR.V_STRING)
 
     # client
     with Conf('test battery', desc='''

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1341,8 +1341,29 @@ def upg(cfg, descr):
         '8.0.0',
         ['cylc', 'health check interval'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail retry delays'])
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'abort if any task fails'])
+    u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])
+    u.deprecate(
+        '8.0.0',
+        ['cylc', 'task event mail interval'],
+        ['cylc', 'mail', 'task event batch interval']
+    )
+    # Whole workflow task mail settings
+    for mail_setting in ['to', 'from', 'smtp', 'footer']:
+        u.deprecate(
+            '8.0.0',
+            ['cylc', f'mail {mail_setting}'],
+            ['cylc', 'mail', mail_setting]
+        )
+    # Task mail settings in [runtime][TASK]
+    for mail_setting in ['to', 'from', 'smtp']:
+        u.deprecate(
+            '8.0.0',
+            ['runtime', '__MANY__', 'events', f'mail {mail_setting}'],
+            ['runtime', '__MANY__', 'mail', mail_setting]
+        )
     u.deprecate(
         '8.0.0',
         ['scheduling', 'max active cycle points'],

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -201,7 +201,6 @@ with Conf(
                (e.g. ``+05:30``), given that the time zone is used as part of
                task output filenames.
         ''')
-        Conf('task event mail interval', VDR.V_INTERVAL)
         Conf('disable automatic shutdown', VDR.V_BOOLEAN, desc='''
             This has the same effect as the ``--no-auto-shutdown`` flag for
             the suite run commands: it prevents the suite server program from
@@ -285,10 +284,13 @@ with Conf(
             Conf('abort on timeout', VDR.V_BOOLEAN)
             Conf('abort on inactivity', VDR.V_BOOLEAN)
             Conf('mail events', VDR.V_STRING_LIST, None)
-            Conf('mail from', VDR.V_STRING)
-            Conf('mail smtp', VDR.V_STRING)
-            Conf('mail to', VDR.V_STRING)
-            Conf('mail footer', VDR.V_STRING)
+
+        with Conf('mail'):
+            Conf('from', VDR.V_STRING)
+            Conf('smtp', VDR.V_STRING)
+            Conf('to', VDR.V_STRING)
+            Conf('footer', VDR.V_STRING)
+            Conf('task event batch interval', VDR.V_INTERVAL)
 
         with Conf('reference test'):
             Conf('expected task failures', VDR.V_STRING_LIST)
@@ -1094,29 +1096,6 @@ with Conf(
 
                        ``submission failed, failed``
                 ''')
-                Conf('mail from', VDR.V_STRING, desc='''
-                    Specify an alternate ``from:`` email address for event
-                    notifications.
-                ''')
-                Conf('mail retry delays', VDR.V_INTERVAL_LIST, None, desc='''
-                    Specify an initial delay before running the mail
-                    notification command and any retry delays in case the
-                    command returns a non-zero code. The default behaviour is
-                    to run the mail notification command once without any
-                    delay.
-                ''')
-                Conf('mail smtp', VDR.V_STRING, desc='''
-                    Specify the SMTP server for sending email notifications.
-
-                    Example:
-
-                       ``smtp.yourorg``
-                ''')
-                Conf('mail to', VDR.V_STRING, desc='''
-                    A list of email addresses to send task event
-                    notifications. The list can be anything accepted by the
-                    ``mail`` command.
-                ''')
                 Conf('submission timeout', VDR.V_INTERVAL, desc='''
                     If a task has not started after the specified ISO 8601
                     duration/interval, the *submission timeout* event
@@ -1137,6 +1116,26 @@ with Conf(
                 Conf('execution timeout handler', VDR.V_STRING_LIST, None)
                 Conf('submission timeout handler', VDR.V_STRING_LIST, None)
                 Conf('custom handler', VDR.V_STRING_LIST, None)
+
+            with Conf('mail', desc='''
+                Settings for mail events.
+            '''):
+                Conf('from', VDR.V_STRING, desc='''
+                    Specify an alternate ``from:`` email address for event
+                    notifications.
+                ''')
+                Conf('smtp', VDR.V_STRING, desc='''
+                    Specify the SMTP server for sending email notifications.
+
+                    Example:
+
+                       ``smtp.yourorg``
+                ''')
+                Conf('to', VDR.V_STRING, desc='''
+                    A list of email addresses to send task event
+                    notifications. The list can be anything accepted by the
+                    ``mail`` command.
+                ''')
 
             with Conf('suite state polling', desc='''
                 Configure automatic suite polling tasks as described in

--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -136,11 +136,10 @@
         <keyword>number of cycle points</keyword>
         <keyword>members</keyword>
         <keyword>max-polls</keyword>
-        <keyword>mail to</keyword>
-        <keyword>mail smtp</keyword>
-        <keyword>mail retry delays</keyword>
-        <keyword>mail from</keyword>
-        <keyword>mail events</keyword>
+        <keyword>to</keyword>
+        <keyword>smtp</keyword>
+        <keyword>from</keyword>
+        <keyword>events</keyword>
         <keyword>limit</keyword>
         <keyword>interval</keyword>
         <keyword>initial cycle point constraints</keyword>

--- a/cylc/flow/etc/syntax/cylc.xml
+++ b/cylc/flow/etc/syntax/cylc.xml
@@ -62,10 +62,9 @@
         <RegExpr attribute='Keyword' String=' number of cycle points '/>
         <RegExpr attribute='Keyword' String=' members '/>
         <RegExpr attribute='Keyword' String=' max-polls '/>
-        <RegExpr attribute='Keyword' String=' mail to '/>
-        <RegExpr attribute='Keyword' String=' mail smtp '/>
-        <RegExpr attribute='Keyword' String=' mail retry delays '/>
-        <RegExpr attribute='Keyword' String=' mail from '/>
+        <RegExpr attribute='Keyword' String=' to '/>
+        <RegExpr attribute='Keyword' String=' smtp '/>
+        <RegExpr attribute='Keyword' String=' from '/>
         <RegExpr attribute='Keyword' String=' mail events '/>
         <RegExpr attribute='Keyword' String=' limit '/>
         <RegExpr attribute='Keyword' String=' interval '/>

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -456,10 +456,10 @@ class Scheduler:
 
         self.broadcast_mgr.linearized_ancestors.update(
             self.config.get_linearized_ancestors())
-        self.task_events_mgr.mail_interval = self.cylc_config[
-            "task event mail interval"]
+        self.task_events_mgr.mail_interval = self.cylc_config['mail'][
+            "task event batch interval"]
         self.task_events_mgr.mail_footer = self._get_events_conf(
-            "mail footer")
+            "footer")
         self.task_events_mgr.suite_url = self.config.cfg['meta']['URL']
         self.task_events_mgr.suite_cfg = self.config.cfg['meta']
         if self.options.genref:
@@ -989,9 +989,9 @@ class Scheduler:
         self.broadcast_mgr.linearized_ancestors = (
             self.config.get_linearized_ancestors())
         self.pool.set_do_reload(self.config)
-        self.task_events_mgr.mail_interval = self.cylc_config[
-            'task event mail interval']
-        self.task_events_mgr.mail_footer = self._get_events_conf("mail footer")
+        self.task_events_mgr.mail_interval = self.cylc_config['mail'][
+            'task event batch interval']
+        self.task_events_mgr.mail_footer = self._get_events_conf("footer")
 
         # Log tasks that have been added by the reload, removed tasks are
         # logged by the TaskPool.

--- a/cylc/flow/suite_events.py
+++ b/cylc/flow/suite_events.py
@@ -69,8 +69,6 @@ class SuiteEventHandler():
         for getter in getters:
             if key in getter:
                 value = getter[key]
-            elif key.replace('mail ', '') in getter:
-                value = getter[key.replace('mail ', '')]
             if value is not None:
                 return value
         return default

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -295,7 +295,7 @@ class TaskEventsManager():
         flag=FLAG_INTERNAL,
         submit_num=None,
     ):
-        """Parse an task message and update task state.
+        """Parse a task message and update task state.
 
         Incoming, e.g. "succeeded at <TIME>", may be from task job or polling.
 
@@ -627,8 +627,11 @@ class TaskEventsManager():
         """Return an events setting from suite then global configuration."""
         for getter in [
                 self.broadcast_mgr.get_broadcast(itask.identity).get("events"),
+                itask.tdef.rtconfig["mail"],
                 itask.tdef.rtconfig["events"],
-                glbl_cfg().get()["task events"]]:
+                glbl_cfg().get()["task mail"],
+                glbl_cfg().get()["task events"],
+        ]:
             try:
                 value = getter.get(key)
             except (AttributeError, ItemNotFoundError, KeyError):
@@ -972,22 +975,20 @@ class TaskEventsManager():
         if (id_key in self.event_timers or
                 event not in self._get_events_conf(itask, "mail events", [])):
             return
-        retry_delays = self._get_events_conf(itask, "mail retry delays")
-        if not retry_delays:
-            retry_delays = [0]
+
         self.event_timers[id_key] = TaskActionTimer(
             TaskEventMailContext(
                 self.HANDLER_MAIL,  # key
                 self.HANDLER_MAIL,  # ctx_type
                 self._get_events_conf(  # mail_from
                     itask,
-                    "mail from",
+                    "from",
                     "notifications@" + get_host(),
                 ),
-                self._get_events_conf(itask, "mail to", get_user()),  # mail_to
-                self._get_events_conf(itask, "mail smtp"),  # mail_smtp
+                self._get_events_conf(itask, "to", get_user()),  # mail_to
+                self._get_events_conf(itask, "smtp"),  # mail_smtp
             ),
-            retry_delays)
+        )
 
     def _setup_custom_event_handlers(self, itask, event, message):
         """Set up custom task event handlers."""

--- a/tests/functional/cylc-get-config/00-simple/section2.stdout
+++ b/tests/functional/cylc-get-config/00-simple/section2.stdout
@@ -1,1037 +1,1037 @@
-[[var_p2]]
-    platform = 
-    script = echo "RUN: run-var.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = VAR, PARALLEL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = parallel
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[OPS]]
-    platform = 
-    script = echo "RUN: run-ops.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = 
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[ops_s1]]
-    platform = 
-    script = echo "RUN: run-ops.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = OPS, SERIAL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = serial
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[ops_s2]]
-    platform = 
-    script = echo "RUN: run-ops.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = OPS, SERIAL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = serial
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[ops_p1]]
-    platform = 
-    script = echo "RUN: run-ops.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = OPS, PARALLEL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = parallel
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[ops_p2]]
-    platform = 
-    script = echo "RUN: run-ops.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = OPS, PARALLEL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = parallel
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[var_p1]]
-    platform = 
-    script = echo "RUN: run-var.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = VAR, PARALLEL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = parallel
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[VAR]]
-    platform = 
-    script = echo "RUN: run-var.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = 
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[var_s1]]
-    platform = 
-    script = echo "RUN: run-var.sh"
-    env-script = 
-    err-script = 
-    exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = VAR, SERIAL
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = serial
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[SERIAL]]
-    platform = 
-    env-script = 
-    err-script = 
-    exit-script = 
-    script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = 
-    [[[meta]]]
-        title = 
-        description = 
-        URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = serial
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
-    [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
-        default run length = PT10S
-        time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
-    [[[remote]]]
-        owner = 
-        suite definition directory = 
-        host = 
-        retrieve job logs = 
-        retrieve job logs max size = 
-        retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
 [[root]]
     platform = 
+    inherit = 
+    init-script = 
     env-script = 
     err-script = 
     exit-script = 
+    pre-script = 
     script = 
+    post-script = 
     extra log files = 
     work sub-directory = 
-    init-script = 
-    pre-script = 
-    post-script = 
-    inherit = 
     [[[meta]]]
         title = 
         description = 
         URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
     [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
         default run length = PT10S
+        speedup factor = 
         time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
     [[[remote]]]
+        host = 
         owner = 
         suite definition directory = 
-        host = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[PARALLEL]]
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[directives]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[OPS]]
+    script = echo "RUN: run-ops.sh"
     platform = 
+    inherit = 
+    init-script = 
     env-script = 
     err-script = 
     exit-script = 
-    script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
     pre-script = 
     post-script = 
-    inherit = 
+    extra log files = 
+    work sub-directory = 
     [[[meta]]]
         title = 
         description = 
         URL = 
-    [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
-        execution timeout = 
-        submission timeout = 
-        submission timeout handler = 
-        submitted handler = 
-        started handler = 
-        execution timeout handler = 
-        expired handler = 
-        submission failed handler = 
-        submission retry handler = 
-        warning handler = 
-        critical handler = 
-        custom handler = 
-        succeeded handler = 
-        retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
-    [[[environment]]]
-    [[[parameter environment templates]]]
-    [[[directives]]]
-        job_type = parallel
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
     [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
         default run length = PT10S
+        speedup factor = 
         time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
     [[[remote]]]
+        host = 
         owner = 
         suite definition directory = 
-        host = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
-    [[[job]]]
-        batch submit command template = 
-        batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
-        execution polling intervals = 
-        execution time limit = 
-[[var_s2]]
-    platform = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[directives]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[VAR]]
     script = echo "RUN: run-var.sh"
+    platform = 
+    inherit = 
+    init-script = 
     env-script = 
     err-script = 
     exit-script = 
-    extra log files = 
-    work sub-directory = 
-    init-script = 
     pre-script = 
     post-script = 
-    inherit = VAR, SERIAL
+    extra log files = 
+    work sub-directory = 
     [[[meta]]]
         title = 
         description = 
         URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
     [[[events]]]
-        handler events = 
-        mail smtp = 
-        handlers = 
-        mail events = 
-        mail retry delays = 
-        handler retry delays = 
-        mail to = 
-        mail from = 
         execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
         submission timeout = 
-        submission timeout handler = 
+        expired handler = 
+        late offset = 
+        late handler = 
         submitted handler = 
         started handler = 
-        execution timeout handler = 
-        expired handler = 
+        succeeded handler = 
+        failed handler = 
         submission failed handler = 
-        submission retry handler = 
         warning handler = 
         critical handler = 
-        custom handler = 
-        succeeded handler = 
         retry handler = 
-        failed handler = 
-        late handler = 
-        late offset = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
     [[[environment]]]
+    [[[directives]]]
+    [[[outputs]]]
     [[[parameter environment templates]]]
+[[SERIAL]]
+    platform = 
+    inherit = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
     [[[directives]]]
         job_type = serial
-    [[[environment filter]]]
-        exclude = 
-        include = 
-    [[[outputs]]]
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
     [[[simulation]]]
-        fail try 1 only = True
-        fail cycle points = 
-        speedup factor = 
-        disable task event handlers = True
         default run length = PT10S
+        speedup factor = 
         time limit buffer = PT30S
-    [[[suite state polling]]]
-        interval = 
-        host = 
-        max-polls = 
-        message = 
-        run-dir = 
-        user = 
-        verbose mode = 
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
     [[[remote]]]
+        host = 
         owner = 
         suite definition directory = 
-        host = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[PARALLEL]]
+    platform = 
+    inherit = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = parallel
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
     [[[job]]]
-        batch submit command template = 
         batch system = 
-        submission retry delays = 
-        execution retry delays = 
-        submission polling intervals = 
+        batch submit command template = 
         execution polling intervals = 
+        execution retry delays = 
         execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[ops_s1]]
+    script = echo "RUN: run-ops.sh"
+    inherit = OPS, SERIAL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = serial
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[ops_s2]]
+    script = echo "RUN: run-ops.sh"
+    inherit = OPS, SERIAL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = serial
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[ops_p1]]
+    script = echo "RUN: run-ops.sh"
+    inherit = OPS, PARALLEL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = parallel
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[ops_p2]]
+    script = echo "RUN: run-ops.sh"
+    inherit = OPS, PARALLEL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = parallel
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[var_s1]]
+    script = echo "RUN: run-var.sh"
+    inherit = VAR, SERIAL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = serial
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[var_s2]]
+    script = echo "RUN: run-var.sh"
+    inherit = VAR, SERIAL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = serial
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[var_p1]]
+    script = echo "RUN: run-var.sh"
+    inherit = VAR, PARALLEL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = parallel
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]
+[[var_p2]]
+    script = echo "RUN: run-var.sh"
+    inherit = VAR, PARALLEL
+    platform = 
+    init-script = 
+    env-script = 
+    err-script = 
+    exit-script = 
+    pre-script = 
+    post-script = 
+    extra log files = 
+    work sub-directory = 
+    [[[directives]]]
+        job_type = parallel
+    [[[meta]]]
+        title = 
+        description = 
+        URL = 
+    [[[simulation]]]
+        default run length = PT10S
+        speedup factor = 
+        time limit buffer = PT30S
+        fail cycle points = 
+        fail try 1 only = True
+        disable task event handlers = True
+    [[[environment filter]]]
+        include = 
+        exclude = 
+    [[[job]]]
+        batch system = 
+        batch submit command template = 
+        execution polling intervals = 
+        execution retry delays = 
+        execution time limit = 
+        submission polling intervals = 
+        submission retry delays = 
+    [[[remote]]]
+        host = 
+        owner = 
+        suite definition directory = 
+        retrieve job logs = 
+        retrieve job logs max size = 
+        retrieve job logs retry delays = 
+    [[[events]]]
+        execution timeout = 
+        handlers = 
+        handler events = 
+        handler retry delays = 
+        mail events = 
+        submission timeout = 
+        expired handler = 
+        late offset = 
+        late handler = 
+        submitted handler = 
+        started handler = 
+        succeeded handler = 
+        failed handler = 
+        submission failed handler = 
+        warning handler = 
+        critical handler = 
+        retry handler = 
+        submission retry handler = 
+        execution timeout handler = 
+        submission timeout handler = 
+        custom handler = 
+    [[[mail]]]
+        from = 
+        smtp = 
+        to = 
+    [[[suite state polling]]]
+        user = 
+        host = 
+        interval = 
+        max-polls = 
+        message = 
+        run-dir = 
+        verbose mode = 
+    [[[environment]]]
+    [[[outputs]]]
+    [[[parameter environment templates]]]

--- a/tests/functional/deprecations/01-cylc8-basic.t
+++ b/tests/functional/deprecations/01-cylc8-basic.t
@@ -26,23 +26,7 @@ TEST_NAME="${TEST_NAME_BASE}-val"
 run_ok "${TEST_NAME}" cylc validate -v "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-cmp"
-cylc validate -v "${SUITE_NAME}" 2>&1 \
-    | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
-cmp_ok val.out <<__END__
- * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][allow task failures] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][live mode suite timeout] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][dummy mode suite timeout] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][dummy-local mode suite timeout] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][simulation mode suite timeout] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][required run mode] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
- * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
- * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
- * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
-__END__
+cylc validate "${SUITE_NAME}" 2> 'val.out'
+cmp_ok val.out "$TEST_SOURCE_DIR/${TEST_NAME_BASE}/validation.stderr"
 
 purge_suite "${SUITE_NAME}"

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -7,6 +7,11 @@
     authentication =
     required run mode =
     force run mode =
+    task event mail interval = 
+    mail to = 
+    mail from = 
+    mail smtp = 
+    mail footer = 
     [[reference test]]
         allow task failures =
         live mode suite timeout =
@@ -28,5 +33,10 @@
     [[foo, cat, dog]]
         [[[job]]]
             shell = fish
+        [[[events]]]
+            mail from = 
+            mail to = 
+            mail smtp = 
+            mail retry delays = 
 
 

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -1,0 +1,24 @@
+WARNING - deprecated items were automatically upgraded in "suite definition"
+WARNING -  * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][allow task failures] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][live mode suite timeout] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][dummy mode suite timeout] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][dummy-local mode suite timeout] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][simulation mode suite timeout] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][required run mode] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail retry delays] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
+WARNING -  * (8.0.0) [cylc][mail to] -> [cylc][mail][to] - value unchanged
+WARNING -  * (8.0.0) [cylc][mail from] -> [cylc][mail][from] - value unchanged
+WARNING -  * (8.0.0) [cylc][mail smtp] -> [cylc][mail][smtp] - value unchanged
+WARNING -  * (8.0.0) [cylc][mail footer] -> [cylc][mail][footer] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] -> [runtime][foo, cat, dog][mail][smtp] - value unchanged
+WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"

--- a/tests/functional/events/09-task-event-mail.t
+++ b/tests/functional/events/09-task-event-mail.t
@@ -26,11 +26,12 @@ OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_global_config "" "
 [cylc]
-    [[events]]
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 [task events]
     mail events = failed, retry, succeeded
-    mail smtp = ${TEST_SMTPD_HOST}"
+[task mail]
+    smtp = ${TEST_SMTPD_HOST}"
     OPT_SET='-s GLOBALCFG=True'
 else
     OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"

--- a/tests/functional/events/09-task-event-mail/flow.cylc
+++ b/tests/functional/events/09-task-event-mail/flow.cylc
@@ -4,8 +4,8 @@
 
 [cylc]
 {% if GLOBALCFG is not defined %}
-    [[events]]
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 {% endif %}{# not GLOBALCFG is not defined #}
 
 [scheduling]
@@ -20,5 +20,6 @@
 {% if GLOBALCFG is not defined %}
         [[[events]]]
             mail events = failed, retry, succeeded
-            mail smtp = {{MAIL_SMTP}}
+        [[[mail]]]
+            smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/functional/events/18-suite-event-mail.t
+++ b/tests/functional/events/18-suite-event-mail.t
@@ -28,8 +28,9 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 [cylc]
     [[events]]
         mail events = startup, shutdown
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
-        mail smtp = ${TEST_SMTPD_HOST}"
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = ${TEST_SMTPD_HOST}"
     OPT_SET='-s GLOBALCFG=True'
 else
     OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"

--- a/tests/functional/events/18-suite-event-mail/flow.cylc
+++ b/tests/functional/events/18-suite-event-mail/flow.cylc
@@ -3,12 +3,14 @@
     title=Suite Event Mail
 
 [cylc]
-    [[events]]
 {% if GLOBALCFG is not defined %}
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = {{MAIL_SMTP}}
+    [[events]]
         mail events = startup, shutdown
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
-        mail smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}
+    [[events]]
         abort on stalled = True
         abort on inactivity = True
         inactivity = PT3M

--- a/tests/functional/events/29-task-event-mail-1/flow.cylc
+++ b/tests/functional/events/29-task-event-mail-1/flow.cylc
@@ -3,8 +3,8 @@
     title=Task Event Mail
 
 [cylc]
-    [[events]]
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 
 [scheduling]
     [[graph]]
@@ -17,4 +17,5 @@
             execution retry delays = PT1S
         [[[events]]]
             mail events = failed, retry
-            mail smtp = {{MAIL_SMTP}}
+        [[[mail]]]
+            smtp = {{MAIL_SMTP}}

--- a/tests/functional/events/30-task-event-mail-2.t
+++ b/tests/functional/events/30-task-event-mail-2.t
@@ -26,11 +26,12 @@ OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_global_config "" "
 [cylc]
-    [[events]]
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
 [task events]
     mail events = failed, retry, succeeded
-    mail smtp = ${TEST_SMTPD_HOST}"
+[task mail]
+    smtp = ${TEST_SMTPD_HOST}"
     OPT_SET='-s GLOBALCFG=True'
 else
     OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"

--- a/tests/functional/events/30-task-event-mail-2/flow.cylc
+++ b/tests/functional/events/30-task-event-mail-2/flow.cylc
@@ -3,11 +3,12 @@
     title=Task Event Mail
 
 [cylc]
-    task event mail interval = PT15S
     [[events]]
         abort on timeout = True
-        mail footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
         timeout = PT20S
+    [[mail]]
+        footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        task event batch interval = PT15S
     [[reference test]]
         expected task failures = t1.1, t2.1, t3.1, t4.1, t5.1
 
@@ -22,4 +23,5 @@
             execution retry delays = 2*PT20S
         [[[events]]]
             mail events = failed, retry
-            mail smtp = {{MAIL_SMTP}}
+        [[[mail]]]
+            smtp = {{MAIL_SMTP}}

--- a/tests/unit/test_suite_events.py
+++ b/tests/unit/test_suite_events.py
@@ -30,7 +30,6 @@ from cylc.flow.suite_events import SuiteEventHandler
         ('handlers', ['stalled'], True),
         ('hotel', None, True),
         ('from', 'highway@mixture', True),
-        ('mail from', 'highway@mixture', True),
         ('abort on timeout', True, True),
         ('handlers', ['stalled'], False),
         ('hotel', None, False),

--- a/tests/unit/test_suite_events.py
+++ b/tests/unit/test_suite_events.py
@@ -1,0 +1,73 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+tests for functions in cylc.flow.suite_events.py
+"""
+
+import pytest
+
+from types import SimpleNamespace
+
+from cylc.flow.suite_events import SuiteEventHandler
+
+
+@pytest.mark.parametrize(
+    'key, expected, scheduler_mail_defined',
+    [
+        ('handlers', ['stalled'], True),
+        ('hotel', None, True),
+        ('from', 'highway@mixture', True),
+        ('mail from', 'highway@mixture', True),
+        ('abort on timeout', True, True),
+        ('handlers', ['stalled'], False),
+        ('hotel', None, False),
+        ('abort on timeout', True, False),
+    ]
+)
+def test_get_events_handler(
+    mock_glbl_cfg, key, expected, scheduler_mail_defined
+):
+    # It checks that method returns sensible answers.
+    if scheduler_mail_defined is True:
+        mock_glbl_cfg(
+            'cylc.flow.suite_events.glbl_cfg',
+            '''
+            [cylc]
+                [[mail]]
+                    from = highway@mixture
+                [[events]]
+                    abort on timeout = True
+            '''
+        )
+    else:
+        mock_glbl_cfg(
+            'cylc.flow.suite_events.glbl_cfg',
+            '''
+            [cylc]
+                [[events]]
+                    abort on timeout = True
+            '''
+        )
+
+    config = SimpleNamespace()
+    config.cfg = {
+        'cylc': {
+            'events': {
+                'handlers': ['stalled']
+            },
+        }
+    }
+    assert SuiteEventHandler.get_events_conf(config, key) == expected


### PR DESCRIPTION
Closes #3691 

These changes partially address issue described in [the config changes summary](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-config-changes.md#cylceventsmail----schedulermail)

[cylc][events]mail * -> [scheduler][mail]

mail from, mail smtp, mail to and mail footer can apply to both scheduler and task events so move them to a separate section and remove mail from the name. 

[cylc]task event mail interval -> [scheduler][mail]task event batch interval

#### Bonus
I got rid of the `mail retry delays` config item too.

reference [discussion](https://github.com/cylc/cylc-flow/pull/3348#discussion_r333229597)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No dependency changes.