### PR TITLE
docs: fix link to external triggers

### DIFF
--- a/doc/src/suite-config.rst
+++ b/doc/src/suite-config.rst
@@ -1862,8 +1862,8 @@ workflow is skipped, if it is more than one day behind the wall-clock (see also
                  copy:expired => !proc"""
 
 
-External Triggers
-"""""""""""""""""
+External Event Triggers
+"""""""""""""""""""""""
 
 This is a substantial topic, documented in :ref:`External Triggers`.
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Because Sphinx turns every heading into a reference within the scope of the current document this link was referencing the section it is contained in.

> **Cylc7 doc reminder:** `cd doc; make html; <browser> build/build/html/index.html`

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
