### PR TITLE
Disallow nested run directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,10 @@ task outputs/message triggers are now validated.
 [#3614](https://github.com/cylc/cylc-flow/pull/3795) - Fix error when running
 `cylc ping --verbose $SUITE`.
 
+[#3852](https://github.com/cylc/cylc-flow/pull/3852) - Prevents registering a
+workflow in a sub-directory of a run directory (as `cylc scan` would not be
+able to find it).
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -67,7 +67,8 @@ from cylc.flow.suite_files import (
     ContactFileFields,
     SuiteFiles,
     get_suite_title,
-    load_contact_file_async
+    load_contact_file_async,
+    MAX_SCAN_DEPTH
 )
 
 
@@ -103,7 +104,7 @@ def dir_is_flow(listing):
 
 
 @pipe
-async def scan(run_dir=None, scan_dir=None, max_depth=4):
+async def scan(run_dir=None, scan_dir=None, max_depth=MAX_SCAN_DEPTH):
     """List flows installed on the filesystem.
 
     Args:

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -345,8 +345,7 @@ def get_contact_file(reg):
 def get_flow_file(reg, suite_owner=None):
     """Return the path of a suite's flow.cylc file."""
     return os.path.join(
-        get_suite_source_dir(reg, suite_owner),
-        SuiteFiles.FLOW_FILE)
+        get_suite_source_dir(reg, suite_owner), SuiteFiles.FLOW_FILE)
 
 
 def get_suite_source_dir(reg, suite_owner=None):
@@ -488,13 +487,11 @@ def register(reg=None, source=None, redirect=False, rundir=None):
 
     is_valid, message = SuiteNameValidator.validate(reg)
     if not is_valid:
-        raise SuiteServiceFileError(
-            f'invalid suite name - {message}'
-        )
+        raise SuiteServiceFileError(f'invalid suite name - {message}')
 
     if os.path.isabs(reg):
         raise SuiteServiceFileError(
-            "suite name cannot be an absolute path: %s" % reg)
+            f'suite name cannot be an absolute path: {reg}')
 
     check_nested_run_dirs(reg)
 
@@ -556,14 +553,12 @@ def register(reg=None, source=None, redirect=False, rundir=None):
     if orig_source is not None and source != orig_source:
         if not redirect:
             raise SuiteServiceFileError(
-                "the name '%s' already points to %s.\nUse "
-                "--redirect to re-use an existing name and run "
-                "directory." % (reg, orig_source))
+                f"the name '{reg}' already points to {orig_source}.\nUse "
+                "--redirect to re-use an existing name and run directory.")
         LOG.warning(
-            "the name '%(reg)s' points to %(old)s.\nIt will now"
-            " be redirected to %(new)s.\nFiles in the existing %(reg)s run"
-            " directory will be overwritten.\n",
-            {'reg': reg, 'old': orig_source, 'new': source})
+            f"the name '{reg}' points to {orig_source}.\nIt will now be "
+            f"redirected to {source}.\nFiles in the existing {reg} run "
+            "directory will be overwritten.\n")
         # Remove symlink to the original suite.
         os.unlink(os.path.join(srv_d, SuiteFiles.Service.SOURCE))
 
@@ -579,7 +574,7 @@ def register(reg=None, source=None, redirect=False, rundir=None):
             source_str = source
         os.symlink(source_str, target)
 
-    print('REGISTERED %s -> %s' % (reg, source))
+    print(f'REGISTERED {reg} -> {source}')
     return reg
 
 

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -696,8 +696,6 @@ def _is_valid_run_dir(path):
     if not os.path.isabs(path):
         cylc_run_dir = os.path.expandvars(get_platform()['run directory'])
         path = os.path.join(cylc_run_dir, path)
-    if (os.path.isfile(os.path.join(path, SuiteFiles.FLOW_FILE)) or
-            os.path.isdir(os.path.join(path, SuiteFiles.Service.DIRNAME)) or
-            os.path.isfile(os.path.join(path, SuiteFiles.SUITE_RC))):
+    if os.path.isdir(os.path.join(path, SuiteFiles.Service.DIRNAME)):
         return True
     return False

--- a/tests/unit/test_suite_files.py
+++ b/tests/unit/test_suite_files.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 import unittest
 
 from unittest import mock
 
+import os.path
 from cylc.flow import suite_files
 from cylc.flow.exceptions import SuiteServiceFileError
 
@@ -243,3 +245,47 @@ class TestSuiteFiles(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+@pytest.mark.parametrize('abs_path', [False, True])
+def test_is_valid_run_dir(abs_path, monkeypatch):
+    """Test that a directory is correctly identified as a valid suite dir when
+    it contains a flow config file or service dir.
+    """
+    prefix = os.sep if abs_path is True else 'mock_cylc_dir'
+    flow_file = os.path.join(prefix, 'flow', 'file', 'exists', 'flow.cylc')
+    suite_rc_file = os.path.join(prefix, 'suite_rc', 'exists', 'suite.rc')
+    serv_dir = os.path.join(prefix, 'service', 'dir', 'exists', '.service')
+
+    monkeypatch.setattr('os.path.isfile',
+                        lambda x: x in [flow_file, suite_rc_file])
+    monkeypatch.setattr('os.path.isdir',
+                        lambda x: x == serv_dir)
+    monkeypatch.setattr('cylc.flow.suite_files.get_platform',
+                        lambda: {'run directory': 'mock_cylc_dir'})
+
+    for path, expected in [('flow/file/exists', True),
+                           ('suite_rc/exists', True),
+                           ('service/dir/exists', True),
+                           ('nothing/exists', False)]:
+        path = os.path.normpath(path)
+        if abs_path:
+            path = os.path.join(os.sep, path)
+        assert suite_files._is_valid_run_dir(path) is expected, (
+            f'Is "{path}" a valid run dir?')
+
+
+def test_register_nested_run_dirs(monkeypatch):
+    """Test that a suite cannot be registered in a subdir of another suite."""
+    monkeypatch.setattr('cylc.flow.suite_files._is_valid_run_dir',
+                        lambda x: x == os.path.join('bright', 'falls'))
+    # Not nested in suite dir - ok:
+    suite_files.check_nested_run_dirs('alan/wake')
+    # It is itself a suite dir - ok:
+    suite_files.check_nested_run_dirs('bright/falls')
+    # Nested in a suite dir - bad:
+    for func in (suite_files.check_nested_run_dirs, suite_files.register):
+        for path in ('bright/falls/light', 'bright/falls/light/and/power'):
+            with pytest.raises(SuiteServiceFileError) as exc:
+                func(path)
+            assert 'Nested run directories not allowed' in str(exc.value)


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3835

This PR prevents registering a suite in a subdirectory of another run directory, or registering a suite in a directory whose children contain a run directory. It does this by checking upwards for the existence of a flow config file or a `.service` dir in successive parent dirs up to the cylc run dir, as well as checking downwards in subdirectories to a depth of 4 (the default `cylc scan` depth).

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [X] Appropriate tests are included (unit).
<!-- choose one: -->
- [X] Appropriate change log entry included.
<!-- choose one: -->
- [X] No documentation update required.
<!-- choose one: -->
- [X] No dependency changes.
