### PR TITLE
Add Python 3.9 for unit tests in CI (experimental, do not stop other builds if it fails)

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Build Docker container
         run: |
-          docker build -t bash:test dockerfiles/bash/
-          docker run --name bash -v $(pwd -P):/root/cylc-flow --rm -t -d bash:test /bin/bash
+          docker build -t bash:test  -m 1G --memory-swap 1G dockerfiles/bash/
+          docker run --name bash -v $(pwd -P):/root/cylc-flow --rm -t -d -m 1G --memory-swap 1G bash:test /bin/bash
           docker ps -a
 
       - name: Install Cylc dependencies in the container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,15 @@ on: [pull_request]
 jobs:
   fast-tests:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.7', '3.8']
+        experimental: [false]
+        include:
+          - python-version: 3.9
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a small change with no associated Issue.

This is how GH actions handles experimental [Java](https://github.com/apache/commons-imaging/blob/752c546f711a6f27ab71ef7e720de1a9b8826a4d/.github/workflows/maven.yml) versions. I guess it should work with [Python](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run) versions too…

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
