### PR TITLE
Remove last vestiges of the runahead task state.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@ compatibility, the `cylc run` command will automatically symlink an existing
 
 ### Enhancements
 
+[#3857](https://github.com/cylc/cylc-flow/pull/3857) - removed the obsolete
+"runahead" task state (not used since spawn-on-demand implementation).
+
 [#3816](https://github.com/cylc/cylc-flow/pull/3816) - change `cylc spawn`
 command name to `cylc set-outputs` to better reflect its role in Cylc 8.
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -35,7 +35,6 @@ from cylc.flow.broadcast_mgr import ALL_CYCLE_POINTS_STRS, addict
 from cylc.flow.task_state import (
     TASK_STATUSES_ORDERED,
     TASK_STATUS_DESC,
-    # TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING,
     TASK_STATUS_QUEUED,
     TASK_STATUS_EXPIRED,
@@ -1226,8 +1225,6 @@ class TaskStatus(Enum):
     # NOTE: this is an enumeration purely for the GraphQL schema
     # TODO: the task statuses should be formally declared in a Python
     #       enumeration rendering this class unnecessary
-    # NOTE: runahead purposefully omitted to hide users from the task pool
-    # Runahead = TASK_STATUS_RUNAHEAD
     Waiting = TASK_STATUS_WAITING
     Queued = TASK_STATUS_QUEUED
     Expired = TASK_STATUS_EXPIRED

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -28,8 +28,6 @@ from cylc.flow.wallclock import get_current_time_string
 
 
 # Task status names and meanings.
-# Held back from dependency matching, in the runahead pool:
-TASK_STATUS_RUNAHEAD = "runahead"
 # Held back from job submission due to un-met prerequisites:
 TASK_STATUS_WAITING = "waiting"
 # Prerequisites met, but held back in a limited internal queue:
@@ -54,8 +52,6 @@ TASK_STATUS_FAILED = "failed"
 TASK_STATUS_RETRYING = "retrying"
 
 TASK_STATUS_DESC = {
-    TASK_STATUS_RUNAHEAD:
-        'Waiting for dependencies to be satisfied.',
     TASK_STATUS_WAITING:
         'Waiting for dependencies to be satisfied.',
     TASK_STATUS_QUEUED:
@@ -82,7 +78,6 @@ TASK_STATUS_DESC = {
 
 # Task statuses ordered according to task runtime progression.
 TASK_STATUSES_ORDERED = [
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING,
     TASK_STATUS_QUEUED,
     TASK_STATUS_EXPIRED,
@@ -109,7 +104,6 @@ TASK_STATUS_DISPLAY_ORDER = [
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_QUEUED,
     TASK_STATUS_WAITING,
-    TASK_STATUS_RUNAHEAD
 ]
 
 TASK_STATUSES_ALL = set(TASK_STATUSES_ORDERED)
@@ -127,7 +121,6 @@ TASK_STATUSES_RESTRICTED = set([
 
 # Tasks statuses to show in restricted monitoring mode.
 TASK_STATUSES_NO_JOB_FILE = set([
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING,
     TASK_STATUS_READY,
     TASK_STATUS_EXPIRED,
@@ -161,7 +154,6 @@ TASK_STATUSES_FINAL = TASK_STATUSES_SUCCESS | TASK_STATUSES_FAILURE
 # - expired: which is effectively the "succeeded" final state.
 # - held: which is placeholder state, not a real state.
 TASK_STATUSES_NEVER_ACTIVE = set([
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING,
     TASK_STATUS_QUEUED,
     TASK_STATUS_READY,

--- a/cylc/flow/task_state_prop.py
+++ b/cylc/flow/task_state_prop.py
@@ -16,7 +16,6 @@
 """Task state properties for display."""
 
 from cylc.flow.task_state import (
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING,
     TASK_STATUS_QUEUED,
     TASK_STATUS_READY,
@@ -33,9 +32,6 @@ from colorama import Style, Fore, Back
 
 
 _STATUS_MAP = {
-    TASK_STATUS_RUNAHEAD: {
-        "ascii_ctrl": Style.BRIGHT + Fore.WHITE + Back.BLUE
-    },
     TASK_STATUS_WAITING: {
         "ascii_ctrl": Style.BRIGHT + Fore.CYAN + Back.RESET
     },
@@ -79,16 +75,14 @@ def extract_group_state(child_states, is_stopped=False):
                       TASK_STATUS_RETRYING, TASK_STATUS_RUNNING,
                       TASK_STATUS_SUBMITTED, TASK_STATUS_READY,
                       TASK_STATUS_QUEUED, TASK_STATUS_WAITING,
-                      TASK_STATUS_SUCCEEDED,
-                      TASK_STATUS_RUNAHEAD]
+                      TASK_STATUS_SUCCEEDED]
     if is_stopped:
         ordered_states = [TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED,
                           TASK_STATUS_RUNNING, TASK_STATUS_SUBMITTED,
                           TASK_STATUS_EXPIRED, TASK_STATUS_READY,
                           TASK_STATUS_SUBMIT_RETRYING, TASK_STATUS_RETRYING,
                           TASK_STATUS_SUCCEEDED, TASK_STATUS_QUEUED,
-                          TASK_STATUS_WAITING,
-                          TASK_STATUS_RUNAHEAD]
+                          TASK_STATUS_WAITING]
     for state in ordered_states:
         if state in child_states:
             return state

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -30,7 +30,6 @@ from cylc.flow.exceptions import (
 )
 from cylc.flow.task_state import (
     TASK_STATUSES_ORDERED,
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_RUNNING,
     TASK_STATUS_FAILED,
@@ -250,7 +249,6 @@ class TuiApp:
         self.filter_states = {
             state: True
             for state in TASK_STATUSES_ORDERED
-            if state is not TASK_STATUS_RUNAHEAD
         }
         if isinstance(screen, html_fragment.HtmlGenerator):
             # the HtmlGenerator only captures one frame

--- a/cylc/flow/tui/overlay.py
+++ b/cylc/flow/tui/overlay.py
@@ -43,7 +43,6 @@ import urwid
 
 from cylc.flow.task_state import (
     TASK_STATUSES_ORDERED,
-    TASK_STATUS_RUNAHEAD,
     TASK_STATUS_WAITING
 )
 from cylc.flow.tui import (
@@ -153,8 +152,6 @@ def help_info(app):
     items.append(urwid.Divider())
     items.append(urwid.Text('Task Icons:'))
     for state in TASK_STATUSES_ORDERED:
-        if state == TASK_STATUS_RUNAHEAD:
-            continue
         items.append(
             urwid.Text(
                 get_task_icon(state, is_held=False)

--- a/tests/functional/graphql/01-workflow.t
+++ b/tests/functional/graphql/01-workflow.t
@@ -96,7 +96,6 @@ cat > expected << __HERE__
             "reloaded": false,
             "runMode": "live",
             "stateTotals": {
-                "runahead": 0,
                 "waiting": 1,
                 "queued": 0,
                 "expired": 0,

--- a/tests/functional/startup/00-state-summary.t
+++ b/tests/functional/startup/00-state-summary.t
@@ -34,7 +34,7 @@ poll_grep_suite_log -F '[foo.1] status=failed: (polled)failed'
 cylc dump "${SUITE_NAME}" > dump.out
 TEST_NAME=${TEST_NAME_BASE}-grep
 # State summary should not just say "Initializing..."
-grep_ok "state totals={'runahead': 0, 'waiting': 0, 'queued': 0, 'expired': 0, 'ready': 0, 'submit-failed': 0, 'submit-retrying': 0, 'submitted': 0, 'retrying': 0, 'running': 0, 'failed': 1, 'succeeded': 0}" dump.out
+grep_ok "state totals={'waiting': 0, 'queued': 0, 'expired': 0, 'ready': 0, 'submit-failed': 0, 'submit-retrying': 0, 'submitted': 0, 'retrying': 0, 'running': 0, 'failed': 1, 'succeeded': 0}" dump.out
 #-------------------------------------------------------------------------------
 cylc stop --max-polls=10 --interval=2 "${SUITE_NAME}"
 purge_suite "${SUITE_NAME}"


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

Since spawn-on-demand, there is no `runahead` task state anymore - instead, `waiting` tasks hidden in the runahead pool.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation Issue at cylc/cylc-doc#163
- [x] No dependency changes.
