### PR TITLE
Use the ID key when querying for broadcast checkpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,10 @@ hierarchy and ability to set site config directory.
 
 ### Fixes
 
+[#3859](https://github.com/cylc/cylc-flow/pull/3859) - Fixes the query of
+broadcast states to retrieve only the data for the requested ID, instead
+of returning all the broadcast states in the database.
+
 [#3815](https://github.com/cylc/cylc-flow/pull/3815) - Fixes a minor bug in the
 auto-restart functionality which caused suites to wait for local jobs running
 on *any* host to complete before restarting.

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -505,7 +505,7 @@ class CylcSuiteDAO:
         select from broadcast_states table if id_key == CHECKPOINT_LATEST_ID.
         Otherwise select from broadcast_states_checkpoints where id == id_key.
         """
-        stmt, stmt_args = self.pre_select_broadcast_states(id_key=None,
+        stmt, stmt_args = self.pre_select_broadcast_states(id_key=id_key,
                                                            order=sort)
         for row_idx, row in enumerate(self.connect().execute(stmt, stmt_args)):
             callback(row_idx, list(row))

--- a/tests/functional/broadcast/14-broadcast-checkpoint.t
+++ b/tests/functional/broadcast/14-broadcast-checkpoint.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test broadcast checkpoint values persisted in the database
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 5
+#-------------------------------------------------------------------------------
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-run-suite
+run_ok "${TEST_NAME}" cylc run --no-detach "${SUITE_NAME}"
+#-------------------------------------------------------------------------------
+# The first broadcast checkpoint must contain only
+# one broadcast state - the first we submitted.
+cylc ls-checkpoint "${SUITE_NAME}" 1 > ls-check-point-output.log
+grep_ok "VERSE" ls-check-point-output.log
+grep_fail "PHRASE" ls-check-point-output.log
+#-------------------------------------------------------------------------------
+# Whereas the second broadcast checkpoint must contain
+# two broadcast states - the first we submitted, and the
+# subsequent one as well.
+cylc ls-checkpoint "${SUITE_NAME}" 2 > ls-check-point-output.log
+grep_ok "VERSE" ls-check-point-output.log
+grep_ok "PHRASE" ls-check-point-output.log
+#-------------------------------------------------------------------------------
+purge_suite "${SUITE_NAME}"
+exit

--- a/tests/functional/broadcast/14-broadcast-checkpoint/flow.cylc
+++ b/tests/functional/broadcast/14-broadcast-checkpoint/flow.cylc
@@ -1,0 +1,16 @@
+[cylc]
+    UTC mode = True
+[scheduling]
+    [[graph]]
+        R1 = "t1 => t2"
+[runtime]
+    [[t1]]
+        script = """
+cylc broadcast -s "[environment]VERSE = the quick brown fox" "${CYLC_SUITE_NAME}"
+cylc checkpoint "${CYLC_SUITE_NAME}" test1
+"""
+    [[t2]]
+        script = """
+cylc broadcast -s "[environment]PHRASE = the quick brown fox" "${CYLC_SUITE_NAME}"
+cylc checkpoint "${CYLC_SUITE_NAME}" test2
+"""


### PR DESCRIPTION
This is a small change with no associated Issue.

Found an issue with IDE about the `id_key` not being used. Looking at the query generated, it was always returning all the broadcast states, regardless of the ID I selected, e.g. `cylc ls-broadcast five 1`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
