### PR TITLE
Revert to iterative finished task removal.

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1469,6 +1469,8 @@ class Scheduler:
             self.suite_db_mgr.put_task_event_timers(self.task_events_mgr)
             has_updated = await self.update_data_structure()
 
+            self.pool.remove_spent_tasks()
+
             self.process_suite_db_queue()
 
             # If public database is stuck, blast it away by copying the content

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1098,12 +1098,27 @@ class TaskPool:
                 LOG.warning(f'[{c_task}] -suiciding while active')
             self.remove(c_task, 'SUICIDE')
 
+        # TODO - event-driven finished task removal (needs datastore update):
         # Remove the parent task if finished.
-        if (output in [TASK_OUTPUT_SUCCEEDED, TASK_OUTPUT_EXPIRED]
-                or output == TASK_OUTPUT_FAILED and itask.failure_handled):
-            if itask.identity == self.stop_task_id:
-                self.stop_task_finished = True
-            self.remove(itask, 'finished')
+        # if (output in [TASK_OUTPUT_SUCCEEDED, TASK_OUTPUT_EXPIRED]
+        #         or output == TASK_OUTPUT_FAILED and itask.failure_handled):
+        #     if itask.identity == self.stop_task_id:
+        #         self.stop_task_finished = True
+        #     self.remove(itask, 'finished')
+
+    def remove_spent_tasks(self):
+        """Remove finished tasks from the task pool.
+
+        TODO - event-driven finished task removal, once we have event-driven
+        datastore updates (see commented-out block in spawn_on_output above).
+        """
+        for itask in self.get_tasks():
+            if (itask.state(TASK_STATUS_SUCCEEDED, TASK_STATUS_EXPIRED) or
+                    itask.state(TASK_STATUS_FAILED) and itask.failure_handled):
+                print(f'REMOVING {itask.identity}')
+                if itask.identity == self.stop_task_id:
+                    self.stop_task_finished = True
+                self.remove(itask, 'finished')
 
     def get_or_spawn_task(self, name, point, flow_label=None, reflow=True,
                           parent_id=None):


### PR DESCRIPTION
This is a small change with no associated Issue.

Temporarily revert to non event-driven removal of finished tasks from the task pool, so that the datastore (and thence the UI and TUI) sees they are finished.

Event-driven removal can be restored once we have event-driven datastore updates.


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
<!-- choose one: -->
- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
- [ ] No dependency changes.