### PR TITLE
Pool size limit

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1469,6 +1469,8 @@ class Scheduler:
             self.suite_db_mgr.put_task_event_timers(self.task_events_mgr)
             has_updated = await self.update_data_structure()
 
+            self.pool.remove_spent_tasks()
+
             self.process_suite_db_queue()
 
             # If public database is stuck, blast it away by copying the content

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -477,6 +477,7 @@ def restart(parser, options, *args):
 @cli_function(partial(get_option_parser, is_restart=False))
 def run(parser, options, *args):
     """Implement cylc run."""
+    #from cylc.flow import patch_pudb; import pudb; pudb.set_trace()
     if not args:
         _auto_register()
     if options.startcp:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1098,12 +1098,27 @@ class TaskPool:
                 LOG.warning(f'[{c_task}] -suiciding while active')
             self.remove(c_task, 'SUICIDE')
 
+        # TODO - event-driven finished task removal (needs datastore update):
         # Remove the parent task if finished.
-        if (output in [TASK_OUTPUT_SUCCEEDED, TASK_OUTPUT_EXPIRED]
-                or output == TASK_OUTPUT_FAILED and itask.failure_handled):
-            if itask.identity == self.stop_task_id:
-                self.stop_task_finished = True
-            self.remove(itask, 'finished')
+        # if (output in [TASK_OUTPUT_SUCCEEDED, TASK_OUTPUT_EXPIRED]
+        #         or output == TASK_OUTPUT_FAILED and itask.failure_handled):
+        #     if itask.identity == self.stop_task_id:
+        #         self.stop_task_finished = True
+        #     self.remove(itask, 'finished')
+
+    def remove_spent_tasks(self):
+        """Remove finished tasks from the task pool.
+
+        TODO - event-driven finished task removal, once we have event-driven
+        datastore updates (see commented-out block in spawn_on_output above).
+        """
+        for itask in self.get_tasks():
+            if (itask.state(TASK_STATUS_SUCCEEDED, TASK_STATUS_EXPIRED) or
+                    itask.state(TASK_STATUS_FAILED) and itask.failure_handled):
+                print(f'REMOVING {itask.identity}')
+                if itask.identity == self.stop_task_id:
+                    self.stop_task_finished = True
+                self.remove(itask, 'finished')
 
     def get_or_spawn_task(self, name, point, flow_label=None, reflow=True,
                           parent_id=None):


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->


<!-- Significant PRs should address an existing Issue. Choose one: -->

Pool size limit, with preferential release of older cycle points, as an alternative to cycle point based runahead limiting.

Experimental.

- currently has a hardwired limit.
- built on #3861 (iterative task removal - to better see what's happen in the UIs)
- incorporates #3823 (keeps partial waiting tasks out of the main pool, to avoid causing a stall)

How it works:
- active tasks spawn on demand, into the runahead pool which is not size-limited
   - (under SoD all tasks in the runahead pool are ready to run once released)
- tasks in the runahead pool are released, earliest cycle points first, until the main pool reaches its size limit

This would not work under SoS, but under SoD it doesn't cause race-condition stalls because every task in the runahead pool is ready to run so it doesn't matter which of them get released to keep the flow running.  The runahead pool is not size-limited - it takes all children that get spawned by the active task pool - but the smaller the active pool the fewer children they spawn and hence the smaller the runahead pool.

Results so far:
- successfully runs the old "complex" flow with a max pool size of 10 and very little load on the VM.

These changes partially address #xxx
These changes close #xxxx
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
<!-- choose one: -->
- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
- [ ] No dependency changes.
