### PR TITLE
Intel host select.get platform group

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -26,7 +26,7 @@ from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.upgrade import upgrader
 from cylc.flow.parsec.validate import (
     DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_platform_group
 
 # Regex to check whether a string is a command
 REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
@@ -1359,8 +1359,8 @@ def upg(cfg, descr):
 
     if 'runtime' in cfg:
         for task_name, task_cfg in cfg['runtime'].items():
-            platform = get_platform(task_cfg, task_name, warn_only=True)
-            if type(platform) == str:
+            platform = get_platform_group(task_cfg, task_name, warn_only=True)
+            if isinstance(platform, str):
                 LOG.warning(platform)
 
 

--- a/cylc/flow/job_pool.py
+++ b/cylc/flow/job_pool.py
@@ -34,7 +34,9 @@ from cylc.flow.task_state import (
     TASK_STATUS_RUNNING, TASK_STATUS_SUCCEEDED,
     TASK_STATUS_FAILED)
 from cylc.flow.data_messages_pb2 import PbJob, JDeltas
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import (
+    get_platform_group, get_host_from_platform_group
+)
 
 JOB_STATUSES_ALL = [
     TASK_STATUS_READY,
@@ -128,8 +130,8 @@ class JobPool:
             tdef = self.schd.config.get_taskdef(name)
             j_owner = self.schd.owner
             if platform_name:
-                j_host = get_host_from_platform(
-                    get_platform(platform_name)
+                j_host = get_host_from_platform_group(
+                    get_platform_group(platform_name)
                 )
             else:
                 j_host = self.schd.host

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -61,7 +61,7 @@ from cylc.flow.async_util import (
 )
 from cylc.flow.network.client import (
     SuiteRuntimeClient, ClientError, ClientTimeout)
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 from cylc.flow.exceptions import SuiteStopped
 from cylc.flow.suite_files import (
     ContactFileFields,
@@ -128,7 +128,7 @@ async def scan(run_dir=None, scan_dir=None, max_depth=4):
     """
     if not run_dir:
         run_dir = Path(
-            get_platform()['run directory'].replace('$HOME', '~')
+            get_localhost_platform()['run directory'].replace('$HOME', '~')
         ).expanduser()
     if not scan_dir:
         scan_dir = run_dir

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -22,7 +22,7 @@ from shutil import rmtree
 
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 
 
 def get_remote_suite_run_dir(platform, suite, *args):
@@ -50,7 +50,7 @@ def get_suite_run_dir(suite, *args):
     """Return local suite run directory, join any extra args."""
     return expandvars(
         os.path.join(
-            get_platform()['run directory'], suite, *args
+            get_localhost_platform()['run directory'], suite, *args
         )
     )
 
@@ -92,14 +92,14 @@ def get_suite_run_pub_db_name(suite):
 def get_suite_run_share_dir(suite, *args):
     """Return local suite work/share directory, join any extra args."""
     return expandvars(os.path.join(
-        get_platform()['work directory'], suite, 'share', *args
+        get_localhost_platform()['work directory'], suite, 'share', *args
     ))
 
 
 def get_suite_run_work_dir(suite, *args):
     """Return local suite work/work directory, join any extra args."""
     return expandvars(os.path.join(
-        get_platform()['work directory'], suite, 'work', *args
+        get_localhost_platform()['work directory'], suite, 'work', *args
     ))
 
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -36,6 +36,11 @@ HOST_REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 PLATFORM_REC_COMMAND = re.compile(r'(\$\()\s*(.*)\s*([)])$')
 
 
+def get_localhost_platform():
+    # Convienence wrapper to get_platform_group
+    return get_platform_group()['platforms'][0]
+
+
 def get_platform_group(
     task_conf=None, task_id='unknown task', warn_only=False
 ):
@@ -351,6 +356,12 @@ def platform_from_job_info(platforms, job, remote):
             return task_host
 
     raise PlatformLookupError('No platform found matching your task')
+
+
+def get_host_from_platform_group(platform_group, method=None):
+    # Wrapper for get_host_from_platform
+    platform = random.choice(platform_group['platforms'])
+    return get_host_from_platform(platform, method)
 
 
 def get_host_from_platform(platform, method=None):

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -31,7 +31,7 @@ from time import sleep
 import cylc.flow.flags
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow import LOG
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import get_localhost_platform, get_host_from_platform
 
 
 def get_proc_ancestors():
@@ -255,7 +255,7 @@ def construct_ssh_cmd(
     """
     # If ssh cmd isn't given use the default from localhost settings.
     if ssh_cmd is None:
-        command = shlex.split(get_platform()['ssh command'])
+        command = shlex.split(get_localhost_platform()['ssh command'])
     else:
         command = shlex.split(ssh_cmd)
 
@@ -284,7 +284,7 @@ def construct_ssh_cmd(
 
     # Use bash -l?
     if ssh_login_shell is None:
-        ssh_login_shell = get_platform()['use login shell']
+        ssh_login_shell = get_localhost_platform()['use login shell']
     if ssh_login_shell:
         # A login shell will always source /etc/profile and the user's bash
         # profile file. To avoid having to quote the entire remote command
@@ -298,7 +298,7 @@ def construct_ssh_cmd(
     if ssh_cylc:
         command.append(ssh_cylc)
     else:
-        ssh_cylc = get_platform()['cylc executable']
+        ssh_cylc = get_localhost_platform()['cylc executable']
         if ssh_cylc.endswith('cylc'):
             command.append(ssh_cylc)
         else:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -74,7 +74,7 @@ from cylc.flow.pathutil import (
 )
 from cylc.flow.platforms import (
     get_install_target_from_platform,
-    get_platform,
+    get_localhost_platform,
     is_platform_with_target_in_list)
 from cylc.flow.profiler import Profiler
 from cylc.flow.resources import extract_resources
@@ -1065,7 +1065,7 @@ class Scheduler:
             fields.PUBLISH_PORT:
                 str(self.publisher.port),
             fields.SSH_USE_LOGIN_SHELL:
-                str(get_platform()['use login shell']),
+                str(get_localhost_platform()['use login shell']),
             fields.SUITE_RUN_DIR_ON_SUITE_HOST:
                 self.suite_run_dir,
             fields.UUID:

--- a/cylc/flow/scripts/cylc_cat_log.py
+++ b/cylc/flow/scripts/cylc_cat_log.py
@@ -53,6 +53,7 @@ import sys
 from cylc.flow.remote import remote_cylc_cmd, watch_and_kill
 
 import os
+import random
 import shlex
 from contextlib import suppress
 from getpass import getuser
@@ -77,7 +78,9 @@ from cylc.flow.task_id import TaskID
 from cylc.flow.task_job_logs import (
     JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_OPTS, NN, JOB_LOG_ACTIVITY)
 from cylc.flow.terminal import cli_function
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import (
+    get_localhost_platform, get_platform_group, get_host_from_platform
+)
 
 
 # Immortal tail-follow processes on job hosts can be cleaned up by killing
@@ -354,7 +357,7 @@ def main(parser, options, *args, color=False):
                 raise UserInputError(
                     "max rotation %d" % (len(logs) - 1))
         tail_tmpl = os.path.expandvars(
-            get_platform()["tail command template"]
+            get_localhost_platform()["tail command template"]
         )
         out = view_log(logpath, mode, tail_tmpl, color=color)
         if out == 1:
@@ -389,7 +392,10 @@ def main(parser, options, *args, color=False):
                 pass
         platform_name, batch_sys_name, live_job_id = get_task_job_attrs(
             suite_name, point, task, options.submit_num)
-        platform = get_platform(platform_name)
+        # TODO - use intelligent platform/host selection
+        platform = random.choice(
+            get_platform_group(platform_name)['platforms']
+        )
         batchview_cmd = None
         if live_job_id is not None:
             # Job is currently running. Get special batch system log view

--- a/cylc/flow/scripts/cylc_check_versions.py
+++ b/cylc/flow/scripts/cylc_check_versions.py
@@ -41,7 +41,7 @@ from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.cylc_subproc import procopen, PIPE, DEVNULL
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.config import SuiteConfig
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_platform_group
 from cylc.flow.remote import construct_platform_ssh_cmd
 from cylc.flow.suite_files import parse_suite_arg
 from cylc.flow.templatevars import load_template_vars
@@ -88,8 +88,8 @@ def main(_, options, *args):
     # get the cylc version on each platform
     versions = {}
     for platform_name in sorted(platforms):
-        platform = get_platform(platform_name)
-        cmd = construct_platform_ssh_cmd(['version'], platform)
+        platform_group = get_platform_group(platform_name)
+        cmd = construct_platform_ssh_cmd(['version'], platform_group)
         if verbose:
             print(cmd)
         proc = procopen(cmd, stdin=DEVNULL, stdout=PIPE, stderr=PIPE)

--- a/cylc/flow/scripts/cylc_get_site_config.py
+++ b/cylc/flow/scripts/cylc_get_site_config.py
@@ -28,7 +28,7 @@ Multiple items can be specified at once."""
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 
 
 def get_option_parser():
@@ -60,7 +60,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options):
     if options.run_dir:
-        print(get_platform()['run directory'])
+        print(get_localhost_platform()['run directory'])
     else:
         glbl_cfg().idump(
             options.item, sparse=options.sparse, pnative=options.pnative)

--- a/cylc/flow/scripts/cylc_suite_state.py
+++ b/cylc/flow/scripts/cylc_suite_state.py
@@ -58,7 +58,7 @@ from cylc.flow.command_polling import Poller
 from cylc.flow.task_state import TASK_STATUSES_ORDERED
 from cylc.flow.terminal import cli_function
 from cylc.flow.cycling.util import add_offset
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 
 from metomi.isodatetime.parsers import TimePointParser
 
@@ -217,7 +217,7 @@ def main(parser, options, suite):
     # this only runs locally
     run_dir = os.path.expandvars(
         os.path.expanduser(
-            options.run_dir or get_platform()['run directory']
+            options.run_dir or get_localhost_platform()['run directory']
         )
     )
 

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -30,7 +30,7 @@ import aiofiles
 from cylc.flow import LOG
 from cylc.flow.exceptions import SuiteServiceFileError
 from cylc.flow.pathutil import get_suite_run_dir
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 from cylc.flow.hostuserutil import (
     get_user,
     is_remote_host,
@@ -279,7 +279,7 @@ def detect_old_contact_file(reg, check_host_port=None):
     cmd = ["timeout", "10", "ps", PS_OPTS, str(old_pid_str)]
     if is_remote_host(old_host):
         import shlex
-        ssh_str = get_platform()["ssh command"]
+        ssh_str = get_localhost_platform()["ssh command"]
         cmd = shlex.split(ssh_str) + ["-n", old_host] + cmd
     from subprocess import Popen, PIPE, DEVNULL  # nosec
     from time import sleep, time

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -45,7 +45,7 @@ from cylc.flow.task_action_timer import (
     TaskActionTimer,
     TimerFlags
 )
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import get_platform_group, get_host_from_platform
 from cylc.flow.task_job_logs import (
     get_task_job_id, get_task_job_log, get_task_job_activity_log,
     JOB_LOG_OUT, JOB_LOG_ERR)
@@ -640,7 +640,7 @@ class TaskEventsManager():
 
     def _process_job_logs_retrieval(self, schd_ctx, ctx, id_keys):
         """Process retrieval of task job logs from remote user@host."""
-        platform = get_platform(ctx.platform_n)
+        platform = get_platform_group(ctx.platform_n)
         ssh_str = str(platform["ssh command"])
         rsync_str = str(platform["retrieve job logs command"])
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -27,6 +27,7 @@ This module provides logic to:
 import json
 from logging import DEBUG, CRITICAL, INFO, WARNING
 import os
+import random
 from shutil import rmtree
 from time import time
 from copy import deepcopy
@@ -41,7 +42,8 @@ from cylc.flow.hostuserutil import (
 from cylc.flow.job_file import JobFileWriter
 from cylc.flow.pathutil import get_remote_suite_run_job_dir
 from cylc.flow.platforms import (
-    get_platform, get_host_from_platform, get_install_target_from_platform,
+    get_platform_group, get_host_from_platform,
+    get_install_target_from_platform,
     HOST_REC_COMMAND, PLATFORM_REC_COMMAND
 )
 from cylc.flow.subprocpool import SubProcPool
@@ -680,7 +682,9 @@ class TaskJobManager:
 
         # Go through each list of itasks and carry out commands as required.
         for platform_n, itasks in sorted(auth_itasks.items()):
-            platform = get_platform(platform_n)
+            platform = random.choice(
+                get_platform_group(platform_n)['platforms']
+            )
             if is_remote_platform(platform):
                 remote_mode = True
                 cmd = [cmd_key]
@@ -874,7 +878,9 @@ class TaskJobManager:
                 rtconfig['remote']['host'] = host_n
 
             try:
-                platform = get_platform(rtconfig)
+                platform = random.choice(
+                    get_platform_group(rtconfig)['platforms']
+                )
             except PlatformLookupError as exc:
                 # Submit number not yet incremented
                 itask.submit_num += 1

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -21,6 +21,7 @@
 from fnmatch import fnmatchcase
 from string import ascii_letters
 import json
+import random
 from time import time
 
 from cylc.flow.parsec.OrderedDict import OrderedDict
@@ -52,7 +53,7 @@ from cylc.flow.task_state import (
     TASK_OUTPUT_SUCCEEDED,
 )
 from cylc.flow.wallclock import get_current_time_string
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_platform_group
 
 
 class FlowLabelMgr:
@@ -380,7 +381,9 @@ class TaskPool:
                     TASK_STATUS_RUNNING
             ):
                 # update the task proxy with user@host
-                itask.platform = get_platform(platform_name)
+                itask.platform = random.choice(
+                    get_platform_group(platform_name)['platforms']
+                )
 
                 if time_submit:
                     itask.set_summary_time('submitted', time_submit)

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -21,7 +21,7 @@ from time import time
 from metomi.isodatetime.timezone import get_local_time_zone
 
 import cylc.flow.cycling.iso8601
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 from cylc.flow.task_id import TaskID
 from cylc.flow.task_action_timer import TimerFlags
 from cylc.flow.task_state import (
@@ -213,7 +213,7 @@ class TaskProxy:
 
         self.local_job_file_path = None
 
-        self.platform = get_platform()
+        self.platform = get_localhost_platform()
         self.task_owner = None
 
         self.job_vacated = False

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -25,6 +25,7 @@ This module provides logic to:
 from cylc.flow.cylc_subproc import procopen
 import os
 from shlex import quote
+import random
 import re
 from subprocess import Popen, PIPE, DEVNULL
 import tarfile
@@ -49,7 +50,7 @@ from cylc.flow.suite_files import (
 from cylc.flow.task_remote_cmd import (
     REMOTE_INIT_DONE, REMOTE_INIT_NOT_REQUIRED)
 from cylc.flow.platforms import (
-    get_platform,
+    get_platform_group,
     get_host_from_platform,
     get_install_target_from_platform)
 from cylc.flow.remote import construct_platform_ssh_cmd
@@ -246,7 +247,7 @@ class TaskRemoteMgr:
         # Issue all SSH commands in parallel
         procs = {}
         for platform, init_with_contact in self.remote_init_map.items():
-            platform = get_platform(platform)
+            platform = random.choice(get_platform_group(platform)['platforms'])
             host = get_host_from_platform(platform)
             owner = platform['owner']
             self.install_target = get_install_target_from_platform(platform)

--- a/cylc/flow/xtriggers/suite_state.py
+++ b/cylc/flow/xtriggers/suite_state.py
@@ -19,7 +19,7 @@ import sqlite3
 
 from cylc.flow.cycling.util import add_offset
 from cylc.flow.dbstatecheck import CylcSuiteDBChecker
-from cylc.flow.platforms import get_platform
+from cylc.flow.platforms import get_localhost_platform
 from metomi.isodatetime.parsers import TimePointParser
 
 
@@ -70,7 +70,7 @@ def suite_state(suite, task, point, offset=None, status='succeeded',
     """
     cylc_run_dir = os.path.expandvars(
         os.path.expanduser(
-            cylc_run_dir or get_platform()['run directory']
+            cylc_run_dir or get_localhost_platform()['run directory']
         )
     )
     if offset is not None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ import pytest
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.wallclock import get_current_time_string
-from cylc.flow.platforms import platform_from_name
+from cylc.flow.platforms import get_localhost_platform
 
 from .utils import (
     _expanduser,
@@ -80,7 +80,7 @@ def _pytest_passed(request):
 def run_dir(request):
     """The cylc run directory for this host."""
     path = _expanduser(
-        platform_from_name()['run directory']
+        get_localhost_platform()['run directory']
     )
     path.mkdir(exist_ok=True)
     yield path

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -26,7 +26,7 @@ from unittest import mock
 from cylc.flow import __version__
 import cylc.flow.flags
 from cylc.flow.job_file import JobFileWriter
-from cylc.flow.platforms import platform_from_name
+from cylc.flow.platforms import get_localhost_platform
 
 
 @pytest.mark.parametrize(
@@ -60,7 +60,7 @@ def fixture_get_platform():
         platforms dictionary.
     """
     def inner_func(custom_settings=None):
-        platform = platform_from_name()
+        platform = get_localhost_platform()
         if custom_settings is not None:
             platform.update(custom_settings)
         return platform
@@ -250,7 +250,7 @@ def test_write_directives(fixture_get_platform, job_conf: dict, expected: str):
     ["at", "background", "loadleveler", "pbs", "sge", "slurm"])
 def test_traps_for_each_batch_system(batch_sys: str):
     """Test traps for each batch system"""
-    platform = platform_from_name()
+    platform = get_localhost_platform()
     platform.update({
         "batch system": f"{batch_sys}",
         "owner": "me"

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -92,7 +92,7 @@ class TestPathutil(TestCase):
           that the tester can more easily see which function ha
           failed.
     """
-    @patch('cylc.flow.pathutil.get_platform')
+    @patch('cylc.flow.pathutil.get_localhost_platform')
     def test_get_suite_run_dirs(self, mocked_platform):
         """Usage of get_suite_run_*dir."""
         homedir = os.getenv("HOME")
@@ -123,7 +123,7 @@ class TestPathutil(TestCase):
                 mocked_platform.assert_called_with()
                 mocked.get_host_item.reset_mock()
 
-    @patch('cylc.flow.pathutil.get_platform')
+    @patch('cylc.flow.pathutil.get_localhost_platform')
     def test_get_suite_run_names(self, mocked_platform):
         """Usage of get_suite_run_*name."""
         homedir = os.getenv("HOME")

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -17,7 +17,7 @@
 # Tests for the platform lookup.
 
 import pytest
-from cylc.flow.platforms import platform_from_name, platform_from_job_info
+from cylc.flow.platforms import platforms_from_name, platform_from_job_info
 from cylc.flow.exceptions import PlatformLookupError
 
 PLATFORMS = {
@@ -74,7 +74,7 @@ PLATFORMS_WITH_RE = {
 
 
 # ----------------------------------------------------------------------------
-# Tests of platform_from_name
+# Tests of platforms_from_name
 # ----------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "PLATFORMS, platform, expected",
@@ -124,7 +124,8 @@ PLATFORMS_WITH_RE = {
 def test_basic(PLATFORMS, platform, expected):
     # n.b. The name field of the platform is set in the Globalconfig object
     # if the name is 'localhost', so we don't test for it here.
-    platform = platform_from_name(platform_name=platform, platforms=PLATFORMS)
+    platform_group = platforms_from_name(platform_name=platform, platforms=PLATFORMS)
+    platform = platform_group['platforms'][0]
     if isinstance(expected, dict):
         assert platform == expected
     else:
@@ -133,12 +134,12 @@ def test_basic(PLATFORMS, platform, expected):
 
 def test_platform_not_there():
     with pytest.raises(PlatformLookupError):
-        platform_from_name('moooo', PLATFORMS)
+        platforms_from_name('moooo', PLATFORMS)
 
 
 def test_similar_but_not_exact_match():
     with pytest.raises(PlatformLookupError):
-        platform_from_name('vld1', PLATFORMS_WITH_RE)
+        platforms_from_name('vld1', PLATFORMS_WITH_RE)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -124,7 +124,9 @@ PLATFORMS_WITH_RE = {
 def test_basic(PLATFORMS, platform, expected):
     # n.b. The name field of the platform is set in the Globalconfig object
     # if the name is 'localhost', so we don't test for it here.
-    platform_group = platforms_from_name(platform_name=platform, platforms=PLATFORMS)
+    platform_group = platforms_from_name(
+        platform_name=platform, platforms=PLATFORMS
+    )
     platform = platform_group['platforms'][0]
     if isinstance(expected, dict):
         assert platform == expected


### PR DESCRIPTION
These changes are a pre-requisite to addressing #3827 
To carry out intelligent host selection the code needs to have access not to platforms but to platform groups.

To this end this PR
- Replaces `platforms.get_platform` with `platforms.get_platform_group` and  `platforms.get_platform_from_name` to `get_platforms_from_name`, so that code calling it has information about the whole group of platforms. If regex only matches a single platform rather than a platform group then a dummy platform group dictionary containing that single platform is returned. Question: Should this have selection method set to "first" to save time?
- Adds function `platforms.get_localhost_platform` - in many places in the code `get_platform()` is called. This function replaces that one, and makes it easier to differentiate cases where we just want info about the localhost platform with cases where something more complex is happening.
- Adds a function `platforms.get_host_from_platform_group`. As with `platforms.get_host_from_platform` this is a placeholder for more sophisticated logic. At the moment it simply picks a random platform from the platform_group and calls `get_host_from_platform`.
