### PR TITLE
Remove author_email from our Python packaging metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,11 @@ hierarchy and ability to set site config directory.
 
 ### Fixes
 
+[#3879](https://github.com/cylc/cylc-flow/pull/3879) - Removed Google
+Groups e-mail from pip packaging metadata. Users browsing PYPI will have
+to visit our website to find out how to reach us (we are using Discourse
+and it does not offer an e-mail address).
+
 [#3859](https://github.com/cylc/cylc-flow/pull/3859) - Fixes the query of
 broadcast states to retrieve only the data for the requested ID, instead
 of returning all the broadcast states in the database.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@
 [metadata]
 name = cylc-flow
 author = Hilary Oliver
-author_email = cylc@googlegroups.com
 url=https://cylc.github.io/
 description = A workflow engine for cycling systems
 keywords =


### PR DESCRIPTION
These changes close #3713 

`author_email` is one of the keys available for `pip`'s packaging metadata. But it is not mandatory (see https://github.com/pypa/pip/blob/50aca38eafde71ac0314d14246f7ebf043695f5e/src/pip/_vendor/distlib/metadata.py#L620 for the mandatory ones—couldn't find in their docs, had to locate in the code :cry: )

The `author_email` requires a valid [RFC-822](https://packaging.python.org/specifications/core-metadata/#author-email) address. Since we are not using Google Groups, and Discourse does not offer an e-mail address, I think the best option is to simply remove it.

If users want to get in contact, they will need to visit our project URL (which is in the packaging metadata) and find how to reach us.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why? packaging only).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes. (checked the conda recipe, no mention of google groups :+1: )
