### PR TITLE
schema: separate task and job mutations

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -930,20 +930,20 @@ class Scheduler:
         """
         if self.config.run_mode('simulation'):
             return
-        itasks, bad_items = self.pool.filter_task_proxies(items)
-        self.task_job_mgr.poll_task_jobs(self.suite, itasks,
+        task_jobs, bad_items = self.pool.filter_task_proxies(items)
+        self.task_job_mgr.poll_task_jobs(self.suite, task_jobs,
                                          poll_succ=poll_succ)
         return len(bad_items)
 
     def command_kill_tasks(self, items=None):
         """Kill all tasks or a task/family if options are provided."""
-        itasks, bad_items = self.pool.filter_task_proxies(items)
+        task_jobs, bad_items = self.pool.filter_task_proxies(items)
         if self.config.run_mode('simulation'):
-            for itask in itasks:
+            for itask in task_jobs:
                 if itask.state(*TASK_STATUSES_ACTIVE):
                     itask.state.reset(TASK_STATUS_FAILED)
             return len(bad_items)
-        self.task_job_mgr.kill_task_jobs(self.suite, itasks)
+        self.task_job_mgr.kill_task_jobs(self.suite, task_jobs)
         return len(bad_items)
 
     def command_hold(self, tasks=None, time=None):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -939,7 +939,7 @@ class Scheduler:
         """Kill all tasks or a task/family if options are provided."""
         task_jobs, bad_items = self.pool.filter_task_proxies(items)
         if self.config.run_mode('simulation'):
-            for itask in task_jobs:
+            for itask, _ in task_jobs:
                 if itask.state(*TASK_STATUSES_ACTIVE):
                     itask.state.reset(TASK_STATUS_FAILED)
             return len(bad_items)

--- a/cylc/flow/task_id.py
+++ b/cylc/flow/task_id.py
@@ -22,6 +22,58 @@ from cylc.flow.cycling.loader import get_point, standardise_point_string
 from cylc.flow.exceptions import PointParsingError
 
 
+SEP_PATTERN = r'[^\.\:\#\/]+'
+
+TASK_GLOB_DOT = re.compile(
+    rf'''
+        ^
+        (?P<namespace>{SEP_PATTERN})
+        (?:\.(?P<point>{SEP_PATTERN}))?
+        (?:\:(?P<state>{SEP_PATTERN}))?
+        (?:\#(?P<job>{SEP_PATTERN}))?
+        $
+    ''',
+    re.X
+)
+TASK_GLOB_PATH = re.compile(
+    rf'''
+        ^
+        (?P<point>{SEP_PATTERN})
+        \/
+        (?P<namespace>{SEP_PATTERN})
+        (?:\:(?P<state>{SEP_PATTERN}))?
+        (?:\#(?P<job>{SEP_PATTERN}))?
+        $
+    ''',
+    re.X
+)
+
+
+def parse_reference(string):
+    """Parse a cycle/namespace/state/job reference string.
+
+    Supports both formats:
+
+    * namespace[.cycle][:status][#job]
+    * cycle[/namespace][:status][#job]
+
+    Returns:
+        dict - Dictionary containing the keys:
+
+        * point
+        * namespace
+        * state
+        * job
+
+    """
+    match = TASK_GLOB_DOT.match(string)
+    if match:
+        return match.groupdict()
+    match = TASK_GLOB_PATH.match(string)
+    if match:
+        return match.groupdict()
+
+
 class TaskID:
     """Task ID utilities."""
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1406,7 +1406,10 @@ class TaskPool:
         task_jobs = []
         bad_items = []
         if not items:
-            task_jobs += self.get_all_tasks()
+            task_jobs += [
+                (itask, None)
+                for itask in self.get_all_tasks()
+            ]
         else:
             for item in items:
                 tokens = parse_reference(item)


### PR DESCRIPTION
Separate task and job mutations in the schema.

* This means you can now selectively kill/poll specific jobs by explicitly providing the submit number.
* However, for regular use there is no interface change.
* This allows the UI to perform mutations on jobs (e.g. right click on running job icon, select kill) (see https://github.com/cylc/cylc-ui/pull/504).

At present there isn't much value to being able to specify a particular job submit number since it would be considered an error for two jobs to run at the same time.

Here's an example specifying the job submit num on the CLI:

```console
$ # cylc kill <flow> '<namespace>.<point>#<job>'
$ cylc kill abc 'foo.1#1'
```

And here via GraphQL:

```graphql
mutation () {
    kill ("abc", "foo.1#1") {
        result
    }
}
```

Obviously `#` isn't ideal for use on the CLI, we could consider something else, see also #3592.

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
<!-- choose one: -->
- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
- [ ] No dependency changes.
