### PR TITLE
Config.remove old deprecations

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -660,34 +660,6 @@ with Conf('global.cylc', desc='''
 def upg(cfg, descr):
     """Upgrader."""
     u = upgrader(cfg, descr)
-
-    u.obsolete('6.4.1', ['test battery', 'directives'])
-    u.obsolete('6.11.0', ['state dump rolling archive length'])
-    # Roll over is always done.
-    u.obsolete('7.8.0', ['suite logging', 'roll over at start-up'])
-    u.obsolete('7.8.1', ['documentation', 'local index'])
-    u.obsolete('7.8.1', ['documentation', 'files', 'pdf user guide'])
-    u.obsolete('7.8.1', ['documentation', 'files',
-                         'single-page html user guide'])
-    u.deprecate('7.8.1',
-                ['documentation', 'files', 'multi-page html user guide'],
-                ['documentation', 'local'])
-    u.deprecate('8.0.0',
-                ['documentation', 'files', 'html index'],
-                ['documentation', 'local'])
-    u.deprecate('8.0.0',
-                ['documentation', 'urls', 'internet homepage'],
-                ['documentation', 'cylc homepage'])
-    u.obsolete('8.0.0', ['suite servers', 'scan hosts'])
-    u.obsolete('8.0.0', ['suite servers', 'scan ports'])
-    u.obsolete('8.0.0', ['communication'])
-    u.obsolete('8.0.0', ['temporary directory'])
-    u.obsolete('8.0.0', ['task host select command timeout'])
-    u.obsolete('8.0.0', ['xtrigger function timeout'])
-    u.obsolete('8.0.0', ['enable run directory housekeeping'])
-    u.obsolete('8.0.0', ['task messaging'])
-    u.obsolete('8.0.0', ['disable interactive command prompts'])
-
     u.upgrade()
 
 

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1339,12 +1339,6 @@ with Conf(
 def upg(cfg, descr):
     """Upgrade old suite configuration."""
     u = upgrader(cfg, descr)
-    u.obsolete('6.1.3', ['visualization', 'enable live graph movie'])
-    u.obsolete('7.2.2', ['cylc', 'dummy mode'])
-    u.obsolete('7.2.2', ['cylc', 'simulation mode'])
-    u.obsolete('7.2.2', ['runtime', '__MANY__', 'dummy mode'])
-    u.obsolete('7.2.2', ['runtime', '__MANY__', 'simulation mode'])
-    u.obsolete('7.6.0', ['runtime', '__MANY__', 'enable resurrection'])
     u.obsolete(
         '7.8.0',
         ['runtime', '__MANY__', 'suite state polling', 'template'])

--- a/tests/functional/deprecations/00-pre-cylc8.t
+++ b/tests/functional/deprecations/00-pre-cylc8.t
@@ -29,12 +29,6 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${SUITE_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
- * (6.1.3) [visualization][enable live graph movie] - DELETED (OBSOLETE)
- * (7.2.2) [cylc][dummy mode] - DELETED (OBSOLETE)
- * (7.2.2) [cylc][simulation mode] - DELETED (OBSOLETE)
- * (7.2.2) [runtime][foo, cat, dog][dummy mode] - DELETED (OBSOLETE)
- * (7.2.2) [runtime][foo, cat, dog][simulation mode] - DELETED (OBSOLETE)
- * (7.6.0) [runtime][foo, cat, dog][enable resurrection] - DELETED (OBSOLETE)
  * (7.8.0) [runtime][foo, cat, dog][suite state polling][template] - DELETED (OBSOLETE)
  * (7.8.1) [cylc][events][reset timer] - DELETED (OBSOLETE)
  * (7.8.1) [cylc][events][reset inactivity timer] - DELETED (OBSOLETE)

--- a/tests/functional/deprecations/00-pre-cylc8/flow.cylc
+++ b/tests/functional/deprecations/00-pre-cylc8/flow.cylc
@@ -2,8 +2,6 @@
 # in cylc/flow/cfgspec/suite.py.
 
 [cylc]
-    [[dummy mode]]
-    [[simulation mode]]
     [[events]]
         reset timer = 10
         reset inactivity timer = 15
@@ -16,14 +14,7 @@
         external-trigger = cat("meow available") # deprecated name
 [runtime]
     [[foo, cat, dog]]
-        [[[simulation mode]]]
-            script = "echo script" # deprecate
-        [[[dummy mode]]]
-            script = "echo script" # deprecate
-        [[[enable resurrection]]]
         [[[suite state polling]]]
             template = ""
         [[[events]]]
             reset timer = 20
-[visualization]
-    enable live graph movie = True # obsolete


### PR DESCRIPTION
These changes probably close #3690 

- I'm happy about the items I have removed from `cylc/flow/cfgspec/suite.py`.
- I'm happy that I have removed items from `tests/functional/deprecations/01...`
- I'm more uncertain about how I've dealt with the global config deprecation items - I don't think that the config object can do without an upgrader, and I was loathe to remove too much infrastructure, because I imagine that after the clean break between Cylc7 and Cylc8 we might want to be able to carry out upgrades to `global.cylc` and `user.cylc` in future.

