### PR TITLE
cat-log: fix probable rebase error

### DIFF
--- a/cylc/flow/scripts/cylc_cat_log.py
+++ b/cylc/flow/scripts/cylc_cat_log.py
@@ -55,7 +55,6 @@ from cylc.flow.remote import remote_cylc_cmd, watch_and_kill
 import os
 import shlex
 from contextlib import suppress
-from getpass import getuser
 from glob import glob
 from shlex import quote
 from stat import S_IRUSR
@@ -436,9 +435,8 @@ def main(parser, options, *args, color=False):
             is_edit_mode = (mode == 'edit')
             try:
                 host = get_host_from_platform(platform)
-                user = getuser()
                 proc = remote_cylc_cmd(
-                    cmd, user, host, capture_process=is_edit_mode,
+                    cmd, host, capture_process=is_edit_mode,
                     manage=(mode == 'tail'))
             except KeyboardInterrupt:
                 # Ctrl-C while tailing.


### PR DESCRIPTION
Fix a bug in `cylc cat-log` detected in remote tests.

Likely a rebase error.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
