### PR TITLE
Finish off mail config changes

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -480,10 +480,7 @@ with Conf('global.cylc', desc='''
         Global site/user defaults for
         :cylc:conf:`flow.cylc[runtime][<namespace>][mail]`.
     '''):
-
         Conf('from', VDR.V_STRING)
-        Conf('retry delays', VDR.V_INTERVAL_LIST)
-        Conf('smtp', VDR.V_STRING)
         Conf('to', VDR.V_STRING)
 
     # suite

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1369,7 +1369,6 @@ def upg(cfg, descr):
         ['cylc', 'health check interval'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail retry delays'])
-    u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail smtp'])
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])
@@ -1392,6 +1391,12 @@ def upg(cfg, descr):
             ['runtime', '__MANY__', 'events', f'mail {mail_setting}'],
             ['runtime', '__MANY__', 'mail', mail_setting]
         )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'events', 'mail smtp'],
+        None,  # This is really a .obsolete(), just with a custom message
+        cvtr=converter(lambda x: x,
+                       'DELETED (OBSOLETE) - use "[cylc][mail]smtp" instead'))
     u.deprecate(
         '8.0.0',
         ['scheduling', 'max active cycle points'],

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1381,7 +1381,7 @@ def upg(cfg, descr):
     for mail_setting in ['to', 'from', 'smtp', 'footer']:
         u.deprecate(
             '8.0.0',
-            ['cylc', f'mail {mail_setting}'],
+            ['cylc', 'events', f'mail {mail_setting}'],
             ['cylc', 'mail', mail_setting]
         )
     # Task mail settings in [runtime][TASK]

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -301,9 +301,6 @@ with Conf(
                 ``mail footer = see http://myhost/%(owner)s/notes/%(suite)s``
 
             ''')
-            Conf('smtp', VDR.V_STRING, desc='''
-                Specify the SMTP server for sending suite email notifications.
-            ''')
             Conf('to', VDR.V_STRING, desc='''
                 A string containing a list of addresses which can be accepted
                 by the ``mail`` command.
@@ -1378,7 +1375,7 @@ def upg(cfg, descr):
         ['cylc', 'mail', 'task event batch interval']
     )
     # Whole workflow task mail settings
-    for mail_setting in ['to', 'from', 'smtp', 'footer']:
+    for mail_setting in ['to', 'from', 'footer']:
         u.deprecate(
             '8.0.0',
             ['cylc', 'events', f'mail {mail_setting}'],
@@ -1393,10 +1390,20 @@ def upg(cfg, descr):
         )
     u.deprecate(
         '8.0.0',
-        ['runtime', '__MANY__', 'events', 'mail smtp'],
+        ['cylc', 'events', 'mail smtp'],
         None,  # This is really a .obsolete(), just with a custom message
-        cvtr=converter(lambda x: x,
-                       'DELETED (OBSOLETE) - use "[cylc][mail]smtp" instead'))
+        cvtr=converter(lambda x: x, (
+            'DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" '
+            'instead'))
+    )
+    u.deprecate(
+        '8.0.0',
+        ['runtime', '__MANY__', 'events', 'mail smtp'],
+        None,
+        cvtr=converter(lambda x: x, (
+            'DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" '
+            'instead'))
+    )
     u.deprecate(
         '8.0.0',
         ['scheduling', 'max active cycle points'],

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -303,7 +303,6 @@ with Conf(
             ''')
             Conf('smtp', VDR.V_STRING, desc='''
                 Specify the SMTP server for sending suite email notifications.
-
             ''')
             Conf('to', VDR.V_STRING, desc='''
                 A string containing a list of addresses which can be accepted
@@ -1165,13 +1164,6 @@ with Conf(
                     Specify an alternate ``from:`` email address for event
                     notifications.
                 ''')
-                Conf('smtp', VDR.V_STRING, desc='''
-                    Specify the SMTP server for sending email notifications.
-
-                    Example:
-
-                       ``smtp.yourorg``
-                ''')
                 Conf('to', VDR.V_STRING, desc='''
                     A list of email addresses to send task event
                     notifications. The list can be anything accepted by the
@@ -1377,6 +1369,7 @@ def upg(cfg, descr):
         ['cylc', 'health check interval'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail retry delays'])
+    u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail smtp'])
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])
@@ -1393,7 +1386,7 @@ def upg(cfg, descr):
             ['cylc', 'mail', mail_setting]
         )
     # Task mail settings in [runtime][TASK]
-    for mail_setting in ['to', 'from', 'smtp']:
+    for mail_setting in ['to', 'from']:
         u.deprecate(
             '8.0.0',
             ['runtime', '__MANY__', 'events', f'mail {mail_setting}'],

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -185,14 +185,12 @@ class upgrader:
                         msg = self.show_keys(upg['old'])
                         if upg['new']:
                             msg += ' -> ' + self.show_keys(upg['new'])
-                        else:
-                            upg['new'] = upg['old']
                         msg += " - " + upg['cvt'].describe()
                         if not upg['silent']:
                             warnings.setdefault(vn, [])
                             warnings[vn].append(msg)
                         self.del_item(upg['old'])
-                        if upg['cvt'].describe() != "DELETED (OBSOLETE)":
+                        if upg['new']:
                             # check self.cfg does not already contain a
                             # non-deprecated item matching upg['new']:
                             try:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -452,8 +452,8 @@ class Scheduler:
             self.config.get_linearized_ancestors())
         self.task_events_mgr.mail_interval = self.cylc_config['mail'][
             "task event batch interval"]
-        self.task_events_mgr.mail_footer = self._get_events_conf(
-            "footer")
+        self.task_events_mgr.mail_smtp = self._get_events_conf("smtp")
+        self.task_events_mgr.mail_footer = self._get_events_conf("footer")
         self.task_events_mgr.suite_url = self.config.cfg['meta']['URL']
         self.task_events_mgr.suite_cfg = self.config.cfg
         if self.options.genref:
@@ -982,6 +982,7 @@ class Scheduler:
         self.pool.set_do_reload(self.config)
         self.task_events_mgr.mail_interval = self.cylc_config['mail'][
             'task event batch interval']
+        self.task_events_mgr.mail_smtp = self._get_events_conf("smtp")
         self.task_events_mgr.mail_footer = self._get_events_conf("footer")
 
         # Log tasks that have been added by the reload, removed tasks are

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -77,7 +77,7 @@ CustomTaskEventHandlerContext = namedtuple(
 
 TaskEventMailContext = namedtuple(
     "TaskEventMailContext",
-    ["key", "ctx_type", "mail_from", "mail_to", "mail_smtp"])
+    ["key", "ctx_type", "mail_from", "mail_to"])
 
 
 TaskJobLogsRetrieveContext = namedtuple(
@@ -187,6 +187,7 @@ class TaskEventsManager():
         self.xtrigger_mgr = xtrigger_mgr
         self.job_pool = job_pool
         self.mail_interval = 0.0
+        self.mail_smtp = None
         self.mail_footer = None
         self.next_mail_time = None
         self.event_timers = {}
@@ -646,9 +647,8 @@ class TaskEventsManager():
                 "suite": schd_ctx.suite}
         # SMTP server
         env = dict(os.environ)
-        mail_smtp = ctx.mail_smtp
-        if mail_smtp:
-            env["smtp"] = mail_smtp
+        if self.mail_smtp:
+            env["smtp"] = self.mail_smtp
         self.proc_pool.put_command(
             SubProcContext(
                 ctx, cmd, env=env, stdin_str=stdin_str, id_keys=id_keys,
@@ -1035,14 +1035,13 @@ class TaskEventsManager():
                     "from",
                     "notifications@" + get_host(),
                 ),
-                self._get_events_conf(itask, "to", get_user()),  # mail_to
-                self._get_events_conf(itask, "smtp"),  # mail_smtp
-            ),
+                self._get_events_conf(itask, "to", get_user())  # mail_to
+            )
         )
 
     def _setup_custom_event_handlers(self, itask, event, message):
         """Set up custom task event handlers."""
-        handlers = self._get_events_conf(itask, event + ' handler')
+        handlers = self._get_events_conf(itask, f'{event} handler')
         if (handlers is None and
                 event in self._get_events_conf(itask, 'handler events', [])):
             handlers = self._get_events_conf(itask, 'handlers')

--- a/tests/functional/cylc-get-config/00-simple/section2.stdout
+++ b/tests/functional/cylc-get-config/00-simple/section2.stdout
@@ -63,7 +63,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -142,7 +141,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -221,7 +219,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -302,7 +299,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -382,7 +378,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -462,7 +457,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -542,7 +536,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -622,7 +615,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -702,7 +694,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -782,7 +773,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -862,7 +852,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -942,7 +931,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 
@@ -1022,7 +1010,6 @@
         custom handler = 
     [[[mail]]]
         from = 
-        smtp = 
         to = 
     [[[suite state polling]]]
         user = 

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -8,10 +8,11 @@
     required run mode =
     force run mode =
     task event mail interval = 
-    mail to = 
-    mail from = 
-    mail smtp = 
-    mail footer = 
+    [[events]]
+        mail to = 
+        mail from = 
+        mail smtp = 
+        mail footer = 
     [[reference test]]
         allow task failures =
         live mode suite timeout =

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -16,10 +16,10 @@ WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
 WARNING -  * (8.0.0) [cylc][events][mail to] -> [cylc][mail][to] - value unchanged
 WARNING -  * (8.0.0) [cylc][events][mail from] -> [cylc][mail][from] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][mail smtp] -> [cylc][mail][footer] - value unchanged
 WARNING -  * (8.0.0) [cylc][events][mail footer] -> [cylc][mail][footer] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "[cylc][mail]smtp" instead
+WARNING -  * (8.0.0) [cylc][events][mail smtp] - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
 WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -12,6 +12,7 @@ WARNING -  * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail retry delays] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
 WARNING -  * (8.0.0) [cylc][mail to] -> [cylc][mail][to] - value unchanged
@@ -20,6 +21,5 @@ WARNING -  * (8.0.0) [cylc][mail smtp] -> [cylc][mail][smtp] - value unchanged
 WARNING -  * (8.0.0) [cylc][mail footer] -> [cylc][mail][footer] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] -> [runtime][foo, cat, dog][mail][smtp] - value unchanged
 WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -12,7 +12,6 @@ WARNING -  * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][reference test][suite shutdown event handler] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail retry delays] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
 WARNING -  * (8.0.0) [cylc][mail to] -> [cylc][mail][to] - value unchanged
@@ -21,5 +20,6 @@ WARNING -  * (8.0.0) [cylc][mail smtp] -> [cylc][mail][smtp] - value unchanged
 WARNING -  * (8.0.0) [cylc][mail footer] -> [cylc][mail][footer] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "[cylc][mail]smtp" instead
 WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -14,10 +14,10 @@ WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail retry delays] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
-WARNING -  * (8.0.0) [cylc][mail to] -> [cylc][mail][to] - value unchanged
-WARNING -  * (8.0.0) [cylc][mail from] -> [cylc][mail][from] - value unchanged
-WARNING -  * (8.0.0) [cylc][mail smtp] -> [cylc][mail][smtp] - value unchanged
-WARNING -  * (8.0.0) [cylc][mail footer] -> [cylc][mail][footer] - value unchanged
+WARNING -  * (8.0.0) [cylc][events][mail to] -> [cylc][mail][to] - value unchanged
+WARNING -  * (8.0.0) [cylc][events][mail from] -> [cylc][mail][from] - value unchanged
+WARNING -  * (8.0.0) [cylc][events][mail smtp] -> [cylc][mail][footer] - value unchanged
+WARNING -  * (8.0.0) [cylc][events][mail footer] -> [cylc][mail][footer] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "[cylc][mail]smtp" instead

--- a/tests/functional/events/09-task-event-mail.t
+++ b/tests/functional/events/09-task-event-mail.t
@@ -34,7 +34,11 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 "
     OPT_SET='-s GLOBALCFG=True'
 else
-    OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"
+    create_test_global_config "
+[scheduler]
+    [[mail]]
+        smtp = ${TEST_SMTPD_HOST}
+"
 fi
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/events/09-task-event-mail.t
+++ b/tests/functional/events/09-task-event-mail.t
@@ -28,10 +28,10 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 [scheduler]
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = ${TEST_SMTPD_HOST}
 [task events]
     mail events = failed, retry, succeeded
-[task mail]
-    smtp = ${TEST_SMTPD_HOST}"
+"
     OPT_SET='-s GLOBALCFG=True'
 else
     OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"

--- a/tests/functional/events/09-task-event-mail/flow.cylc
+++ b/tests/functional/events/09-task-event-mail/flow.cylc
@@ -6,6 +6,7 @@
 {% if GLOBALCFG is not defined %}
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}
 
 [scheduling]
@@ -20,6 +21,4 @@
 {% if GLOBALCFG is not defined %}
         [[[events]]]
             mail events = failed, retry, succeeded
-        [[[mail]]]
-            smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/functional/events/09-task-event-mail/flow.cylc
+++ b/tests/functional/events/09-task-event-mail/flow.cylc
@@ -6,7 +6,6 @@
 {% if GLOBALCFG is not defined %}
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
-        smtp = {{MAIL_SMTP}}
 {% endif %}{# not GLOBALCFG is not defined #}
 
 [scheduling]

--- a/tests/functional/events/18-suite-event-mail.t
+++ b/tests/functional/events/18-suite-event-mail.t
@@ -33,7 +33,11 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
         smtp = ${TEST_SMTPD_HOST}"
     OPT_SET='-s GLOBALCFG=True'
 else
-    OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"
+    create_test_global_config "
+[scheduler]
+    [[mail]]
+        smtp = ${TEST_SMTPD_HOST}
+"
 fi
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/events/18-suite-event-mail/flow.cylc
+++ b/tests/functional/events/18-suite-event-mail/flow.cylc
@@ -6,7 +6,6 @@
 {% if GLOBALCFG is not defined %}
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
-        smtp = {{MAIL_SMTP}}
     [[events]]
         mail events = startup, shutdown
 {% endif %}{# not GLOBALCFG is not defined #}

--- a/tests/functional/events/29-task-event-mail-1.t
+++ b/tests/functional/events/29-task-event-mail-1.t
@@ -21,16 +21,21 @@ if ! command -v mail 2>'/dev/null'; then
     skip_all '"mail" command not available'
 fi
 set_test_number 4
+
 mock_smtpd_init
-OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"
+create_test_global_config "
+[scheduler]
+    [[mail]]
+        smtp = ${TEST_SMTPD_HOST}
+"
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate ${OPT_SET} "${SUITE_NAME}"
+    cylc validate "$SUITE_NAME"
 # shellcheck disable=SC2086
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug --no-detach ${OPT_SET} "${SUITE_NAME}"
+    cylc run --reference-test --debug --no-detach "$SUITE_NAME"
 
 contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
 b'retry: 1/t1/01'

--- a/tests/functional/events/29-task-event-mail-1/flow.cylc
+++ b/tests/functional/events/29-task-event-mail-1/flow.cylc
@@ -5,7 +5,6 @@
 [scheduler]
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
-        smtp = {{MAIL_SMTP}}
 
 [scheduling]
     [[graph]]

--- a/tests/functional/events/29-task-event-mail-1/flow.cylc
+++ b/tests/functional/events/29-task-event-mail-1/flow.cylc
@@ -5,6 +5,7 @@
 [scheduler]
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = {{MAIL_SMTP}}
 
 [scheduling]
     [[graph]]
@@ -17,5 +18,3 @@
             execution retry delays = PT1S
         [[[events]]]
             mail events = failed, retry
-        [[[mail]]]
-            smtp = {{MAIL_SMTP}}

--- a/tests/functional/events/30-task-event-mail-2.t
+++ b/tests/functional/events/30-task-event-mail-2.t
@@ -34,7 +34,11 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 "
     OPT_SET='-s GLOBALCFG=True'
 else
-    OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"
+    create_test_global_config "
+[scheduler]
+    [[mail]]
+        smtp = ${TEST_SMTPD_HOST}
+"
 fi
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/events/30-task-event-mail-2.t
+++ b/tests/functional/events/30-task-event-mail-2.t
@@ -28,10 +28,10 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
 [scheduler]
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
+        smtp = ${TEST_SMTPD_HOST}
 [task events]
     mail events = failed, retry, succeeded
-[task mail]
-    smtp = ${TEST_SMTPD_HOST}"
+"
     OPT_SET='-s GLOBALCFG=True'
 else
     OPT_SET="-s MAIL_SMTP=${TEST_SMTPD_HOST}"

--- a/tests/functional/events/30-task-event-mail-2/flow.cylc
+++ b/tests/functional/events/30-task-event-mail-2/flow.cylc
@@ -9,7 +9,6 @@
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
         task event batch interval = PT15S
-        smtp = {{MAIL_SMTP}}
     [[reference test]]
         expected task failures = t1.1, t2.1, t3.1, t4.1, t5.1
 

--- a/tests/functional/events/30-task-event-mail-2/flow.cylc
+++ b/tests/functional/events/30-task-event-mail-2/flow.cylc
@@ -9,6 +9,7 @@
     [[mail]]
         footer = see: http://localhost/stuff/%(owner)s/%(suite)s/
         task event batch interval = PT15S
+        smtp = {{MAIL_SMTP}}
     [[reference test]]
         expected task failures = t1.1, t2.1, t3.1, t4.1, t5.1
 
@@ -23,5 +24,3 @@
             execution retry delays = 2*PT20S
         [[[events]]]
             mail events = failed, retry
-        [[[mail]]]
-            smtp = {{MAIL_SMTP}}

--- a/tests/unit/parsec/test_upgrade.py
+++ b/tests/unit/parsec/test_upgrade.py
@@ -48,7 +48,9 @@ def test_simple():
     upg.deprecate('1.3', ['section A'], ['Heading A'])
     # NOTE change to new item keys here!
     upg.deprecate('1.3', ['Heading A', 'cde'], ['Heading A', 'CDE'])
-    upg.deprecate('1.4', ['Heading A', 'abc'], cvtr=x2, silent=True)
+    upg.deprecate(
+        '1.4', ['Heading A', 'abc'], ['Heading A', 'abc'], cvtr=x2,
+        silent=True)
     upg.deprecate(
         '1.4.1', ['item two'], ['Heading A', 'item two'], silent=True)
     upg.deprecate('1.5', ['hostnames'], ['hosts'])

--- a/tests/unit/parsec/test_upgrade.py
+++ b/tests/unit/parsec/test_upgrade.py
@@ -16,7 +16,9 @@
 
 import unittest
 
-from cylc.flow.parsec.upgrade import *
+from cylc.flow.parsec.upgrade import upgrader, converter
+from cylc.flow.parsec.exceptions import UpgradeError
+from cylc.flow.parsec.OrderedDict import OrderedDict
 
 
 def test_simple():
@@ -27,6 +29,7 @@ def test_simple():
         'section A': {
             'abc': 5,
             'cde': 'foo',
+            'gah': 'bar'
         },
         'hostnames': {
             'host 1': {
@@ -57,6 +60,10 @@ def test_simple():
     upg.deprecate(
         '1.5',
         ['hosts', '__MANY__', 'running dir'], ['hosts', '__MANY__', 'run dir'])
+    # obsolete() but with a custom message - `[Heading A]gah` will be deleted:
+    upg.deprecate(
+        '1.3', ['Heading A', 'gah'], None,
+        cvtr=converter(lambda x: x, 'Yaba daba do'))
 
     upg.upgrade()
 


### PR DESCRIPTION
These changes partially address #3696 

global:
- `[task events]mail smtp` -> obsolete
- `[task events]mail retry delays` -> obsolete

flow:
- `[cylc][events]mail smtp` -> obsolete
- `[runtime][X][events]mail smtp` -> obsolete

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No changelog entry needed (entry will be written after #3696 is closed)
- [x] No documentation update required (docs will be updated after #3696 is closed)
- [x] No dependency changes.

