### PR TITLE
Fix bad host test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,8 @@ config option `[scheduling]stop after cycle point`.
 
 ### Fixes
 
+[#3917](https://github.com/cylc/cylc-flow/pull/3917) - Fix a bug that caused one of the hostname resolution tests to fail in certain environments.
+
 [#3879](https://github.com/cylc/cylc-flow/pull/3879) - Removed Google
 Groups e-mail from pip packaging metadata. Users browsing PYPI will have
 to visit our website to find out how to reach us (we are using Discourse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ requests_).
  - Gilliano Menezes
  - Mel Hall
  - Ronnie Dutta
+ - John Haiducek
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/tests/unit/test_hostuserutil.py
+++ b/tests/unit/test_hostuserutil.py
@@ -40,13 +40,12 @@ class TestHostUserUtil(unittest.TestCase):
     def test_get_fqdn_by_host_on_bad_host(self):
         """get_fqdn_by_host bad host."""
         bad_host = 'nosuchhost.nosuchdomain.org'
-        try:  # Future: Replace with assertRaises context manager syntax
+        with self.assertRaisesRegex(
+                IOError,
+                "(\[Errno -2\] Name or service|\[Errno 8\] nodename nor servname provided, or) not known: '{}'".format(bad_host)) as ctx:
             get_fqdn_by_host(bad_host)
-        except IOError as exc:
-            self.assertEqual(exc.filename, bad_host)
-            self.assertEqual(
-                "[Errno -2] Name or service not known: '%s'" % bad_host,
-                str(exc))
+
+        self.assertEqual(ctx.exception.filename, bad_host)
 
     def test_get_user(self):
         """get_user."""

--- a/tests/unit/test_hostuserutil.py
+++ b/tests/unit/test_hostuserutil.py
@@ -42,7 +42,9 @@ class TestHostUserUtil(unittest.TestCase):
         bad_host = 'nosuchhost.nosuchdomain.org'
         with self.assertRaisesRegex(
                 IOError,
-                "(\[Errno -2\] Name or service|\[Errno 8\] nodename nor servname provided, or) not known: '{}'".format(bad_host)) as ctx:
+                r"(\[Errno -2\] Name or service|"
+                r"\[Errno 8\] nodename nor servname provided, or)"
+                r" not known: '{}'".format(bad_host)) as ctx:
             get_fqdn_by_host(bad_host)
 
         self.assertEqual(ctx.exception.filename, bad_host)


### PR DESCRIPTION
Changed the test test_get_fqdn_by_host_on_bad_host to check the exception thrown by socket.gethostbyname_ex using a regex to account for variations in error message returned in different environments.

Also changed the test to use a context manager to test whether an exception is raised. This should prevent the test from incorrectly passing if no exception is thrown.

These changes close #3916.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
