### PR TITLE
Execute through entrypoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,10 @@ config option `[scheduling]stop after cycle point`.
 
 ### Fixes
 
+[#3920](https://github.com/cylc/cylc-flow/pull/3920) - Fixed calls to CLI
+commands so that local cylc commands work correctly if cylc is not found in the
+$PATH environment variable.
+
 [#3879](https://github.com/cylc/cylc-flow/pull/3879) - Removed Google
 Groups e-mail from pip packaging metadata. Users browsing PYPI will have
 to visit our website to find out how to reach us (we are using Discourse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ requests_).
  - Gilliano Menezes
  - Mel Hall
  - Ronnie Dutta
+ - John Haiducek
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/cylc/__main__.py
+++ b/cylc/__main__.py
@@ -1,0 +1,4 @@
+if __name__=='__main__':
+    from cylc.flow.scripts.cylc import main
+    import sys
+    sys.exit(main())

--- a/cylc/__main__.py
+++ b/cylc/__main__.py
@@ -1,4 +1,4 @@
-if __name__=='__main__':
+if __name__ == '__main__':
     from cylc.flow.scripts.cylc import main
     import sys
     sys.exit(main())

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -526,7 +526,8 @@ def _get_metrics(hosts, metrics, data=None):
         if is_remote_host(host):
             proc_map[host] = remote_cylc_cmd(cmd, host=host, **kwargs)
         else:
-            proc_map[host] = run_cmd(['cylc'] + cmd, **kwargs)
+            import sys
+            proc_map[host] = run_cmd([sys.executable,'-m','cylc']+cmd, **kwargs)
 
     # Collect results from commands
     while proc_map:

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -527,7 +527,8 @@ def _get_metrics(hosts, metrics, data=None):
             proc_map[host] = remote_cylc_cmd(cmd, host=host, **kwargs)
         else:
             import sys
-            proc_map[host] = run_cmd([sys.executable,'-m','cylc']+cmd, **kwargs)
+            proc_map[host] = run_cmd(
+                [sys.executable, '-m', 'cylc'] + cmd, **kwargs)
 
     # Collect results from commands
     while proc_map:

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -214,7 +214,7 @@ TASK_GLOB matches task or family names at a given cycle point.
                 dest="icp",
             )
 
-    def parse_args(self, remove_opts=None):
+    def parse_args(self, args=None, remove_opts=None):
         """Parse options and arguments, overrides OptionParser.parse_args."""
         if self.auto_add:
             # Add common options after command-specific options.
@@ -227,7 +227,7 @@ TASK_GLOB matches task or family names at a given cycle point.
                 except ValueError:
                     pass
 
-        (options, args) = OptionParser.parse_args(self)
+        (options, args) = OptionParser.parse_args(self, args)
 
         if len(args) < self.n_compulsory_args:
             self.error("Wrong number of arguments (too few)")

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -48,16 +48,15 @@ category_list = [
 
 
 def execute_cmd(cmd, *args):
-    # Replace the current process with that of the sub-command.
+    # Call a sub-command entrypoint
     try:
-        os.execvp(cmd, [cmd] + list(args))  # nosec
+        from pkg_resources import load_entry_point
+        fun=load_entry_point('cylc-flow','console_scripts',cmd)
+        sys.exit(fun(list(args)))
     except OSError as exc:
         if exc.filename is None:
             exc.filename = cmd
         raise click.ClickException(exc)
-    else:
-        sys.exit()
-
 
 CONTEXT_SETTINGS = dict(ignore_unknown_options=True)
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -51,12 +51,13 @@ def execute_cmd(cmd, *args):
     # Call a sub-command entrypoint
     try:
         from pkg_resources import load_entry_point
-        fun=load_entry_point('cylc-flow','console_scripts',cmd)
+        fun = load_entry_point('cylc-flow', 'console_scripts', cmd)
         sys.exit(fun(list(args)))
     except OSError as exc:
         if exc.filename is None:
             exc.filename = cmd
         raise click.ClickException(exc)
+
 
 CONTEXT_SETTINGS = dict(ignore_unknown_options=True)
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc main entry point"""
-import os
 import sys
 
 import click

--- a/cylc/flow/scripts/cylc_help.py
+++ b/cylc/flow/scripts/cylc_help.py
@@ -462,7 +462,7 @@ class ArgumentParser:
         return cls
 
     @staticmethod
-    def parse_args():
+    def parse_args(args):
         help_func()
         return (None, None)
 

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -161,7 +161,8 @@ def cli_function(parser_function=None, **parser_kwargs):
             # should we use colour?
             if parser_function:
                 parser = parser_function()
-                opts, args = parser_function().parse_args(args,**parser_kwargs)
+                opts, args = parser_function().parse_args(
+                    args, **parser_kwargs)
                 use_color = (
                     hasattr(opts, 'color')
                     and (

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -155,13 +155,13 @@ def cli_function(parser_function=None, **parser_kwargs):
     """
     def inner(wrapped_function):
         @wraps(wrapped_function)
-        def wrapper():
+        def wrapper(args=None):
             use_color = False
             wrapped_args, wrapped_kwargs = tuple(), {}
             # should we use colour?
             if parser_function:
                 parser = parser_function()
-                opts, args = parser_function().parse_args(**parser_kwargs)
+                opts, args = parser_function().parse_args(args,**parser_kwargs)
                 use_color = (
                     hasattr(opts, 'color')
                     and (


### PR DESCRIPTION
Most of the cylc CLI commands fail if cylc is not in the $PATH environment variable. This PR addresses this by invoking sub-commands by calling their entrypoint functions directly rather than running them as a shell command in a subprocess. It also makes the main 'cylc' command accessible via 'python -m cylc'.

Remote commands will probably still require cylc being in $PATH.

These changes partially address #3915.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
