### PR TITLE
Use message not label for API task outputs

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -915,8 +915,8 @@ class DataStoreMgr:
                     prereq_list.append(prereq_obj)
             tp_delta.prerequisites.extend(prereq_list)
             tp_delta.outputs = json.dumps({
-                trigger: is_completed
-                for trigger, _, is_completed in itask.state.outputs.get_all()
+                message: received
+                for _, message, received in itask.state.outputs.get_all()
             })
             extras = {}
             if itask.tdef.clocktrigger_offset is not None:


### PR DESCRIPTION
Small change to use the output message instead of the graph label, as the key to the task outputs:
```
    [[wiz]]
        pre-script = sleep 2
        post-script = sleep 2; cylc message "B I N G O"
        [[[meta]]]
            description = "first task wig"
        [[[environment]]]
            GREETING = "Hello from wig!"
        [[[outputs]]]
            bingo = "B I N G O"
```
![image](https://user-images.githubusercontent.com/11400777/98318783-2bd24e80-2044-11eb-8a4a-f5767443d605.png)



**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (not released).
- [x] No documentation update required.
- [x] No dependency changes.
