### PR TITLE
cli: fix --host reinvocation

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -393,13 +393,10 @@ def _distribute(host, is_restart):
     if not host:
         host = select_suite_host()[0]
     if is_remote_host(host):
-        if is_restart:
-            base_cmd = ["restart"] + sys.argv[1:]
-        else:
-            base_cmd = ["run"] + sys.argv[1:]
         # Prevent recursive host selection
-        base_cmd.append("--host=localhost")
-        remote_cylc_cmd(base_cmd, host=host)
+        cmd = sys.argv[1:]
+        cmd.append("--host=localhost")
+        remote_cylc_cmd(cmd, host=host)
         sys.exit(0)
 
 


### PR DESCRIPTION
Mop up from #3899 

Fix reinvocation of `cylc run|restart` using the `--host` option.

This was broken because we used to use commands like `cylc-run` whereas we now use `cylc run` so the argument list is one shorter than it was before.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Test manually for the moment, bumped automated testing to https://github.com/cylc/cylc-flow/issues/3927.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.