### PR TITLE
conf: remove global-tests.cylc and run at tests in actions

### DIFF
--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -55,10 +55,10 @@ jobs:
         run: |
           PTH="$HOME/.cylc/flow/$(cylc version)"
           mkdir -p "${PTH}"
-          cat > "${PTH}/global-test.cylc" << __HERE__
+          cat > "${PTH}/global.cylc" << __HERE__
             [platforms]
                 [[_local_at_indep_tcp]]
-                    hostname = localhost
+                    hosts = localhost
           __HERE__
 
       - name: Swarm Configure

--- a/cylc/flow/etc/global-tests.cylc.eg
+++ b/cylc/flow/etc/global-tests.cylc.eg
@@ -1,12 +1,5 @@
 #------------------------------------------------------------------------------
 # Global configuration settings for the Cylc functional test battery.
-#------------------------------------------------------------------------------
-# Some functional tests need to modify or ignore installed global configuration
-# values; they therefore ignore the standard site and user global config files
-# and start from a special global-tests.cylc file instead. These should contain
-# the minimal essential settings (e.g. for host names) needed to run at your
-# site.
-#
 # See documentation in global.cylc.eg
 #
 #------------------------------------------------------------------------------

--- a/cylc/flow/resources.py
+++ b/cylc/flow/resources.py
@@ -26,7 +26,6 @@ from cylc.flow import LOG
 
 resource_names = [
     'etc/global.cylc.eg',
-    'etc/global-tests.cylc.eg',
     'etc/syntax/cylc-mode.el',
     'etc/syntax/cylc.lang',
     'etc/syntax/cylc.vim',

--- a/dockerfiles/bash/Dockerfile
+++ b/dockerfiles/bash/Dockerfile
@@ -46,7 +46,6 @@ RUN update-alternatives --install /bin/bash bash /bash/bash-3.2 1 && \
 
 # TODO: remove this hardcoded path after #3689
 COPY global.cylc /root/.cylc/flow/8.0a3.dev/global.cylc
-COPY global.cylc /root/.cylc/flow/8.0a3.dev/global-tests.cylc
 
 # To change the system bash version, use for example:
 # `update-alternatives --set bash /bash/bash-4.2`

--- a/etc/bin/run-functional-tests
+++ b/etc/bin/run-functional-tests
@@ -26,13 +26,9 @@ Options and arguments are appended to "prove -j \$NPROC -s -r \${@:-tests/f}".
 NPROC is the number of concurrent processes to run, which defaults to the
 global config "process pool size" setting.
 
-The tests ignore normal site/user global config and instead use:
-   ~/.cylc/flow/<cylc-version>/global-tests.cylc
-This should specify test platforms under the [test battery] section, plus any
-other critical settings settings, including [platforms] configuration for test
-platforms (and special batchview commands like qcat if available). Additional
-global config items can be added on the fly using the create_test_global_config
-shell function defined in the test_header.
+The global config should specify test platforms under the [platforms] section.
+Additional global config items can be added on the fly using the
+create_test_global_config shell function defined in the test_header.
 
 Suite run directories are only cleaned up for passing tests on the suite host.
 
@@ -59,7 +55,7 @@ Options:
   -p, --platform   Specify one or more platforms to use for running the
                    tests.
 
-                   Platforms should be configured in global-test.cylc.
+                   Platforms should be configured in global.cylc.
 
                    Tests will run on the first compatible platform.
 

--- a/etc/bin/swarm
+++ b/etc/bin/swarm
@@ -145,7 +145,6 @@ YES=false
 SSHD="$HOME/.ssh"
 SSH_CONF="$SSHD/config"
 CYLC_CONF="$HOME/.cylc/flow/$(cylc version)/global.cylc"
-CYLC_TEST_CONF="$HOME/.cylc/flow/$(cylc version)/global-tests.cylc"
 HERE="$(realpath "$PWD")"
 ACTIVE_CONTAINERS="$HERE/.docker-active-containers"
 
@@ -342,16 +341,12 @@ configure () {
     append_config \
         "%include '$HERE/etc/conf/global.cylc'" \
         "${CYLC_CONF}"
-    append_config \
-        "%include '$HERE/etc/conf/global.cylc'" \
-        "${CYLC_TEST_CONF}"
 }
 
 # undo configurations make in configure ()
 deconfigure () {
     sed -i "\|$HERE/etc/conf|d" "${SSH_CONF}"
     sed -i "\|$HERE/etc/conf|d" "${CYLC_CONF}"
-    sed -i "\|$HERE/etc/conf|d" "${CYLC_TEST_CONF}"
 }
 
 # run one container interactively

--- a/etc/conf/global.cylc
+++ b/etc/conf/global.cylc
@@ -1,5 +1,4 @@
 # default configuration for the Cylc "swarm" platforms
-# override configurations in your global.cylc/global-tests.cylc as required
 
 [platforms]
     [[_local_background_indep_tcp]]

--- a/tests/functional/cylc-get-site-config/01-defaults.t
+++ b/tests/functional/cylc-get-site-config/01-defaults.t
@@ -21,7 +21,7 @@
 
 set_test_number 1
 
-# Empty it (of non-default global-tests.cylc items, which would then be retrieved
+# Empty it (of non-default global.cylc items, which would then be retrieved
 # by "cylc get-global-config" below).
 echo '' > "$CYLC_CONF_PATH/global.cylc"
 

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -120,7 +120,7 @@
 #         test on the suite and run the reference suite with `suite_run_ok`.
 #         Expect 2 OK tests.
 #     create_test_global_config [PRE [POST]]
-#         Create a new global config file $PWD/etc from global-tests.cylc
+#         Create a new global config file $PWD/etc from global.cylc
 #         with PRE and POST pre- and ap-pended (PRE for top level items with no
 #         section heading). PRE and POST are strings.
 #     localhost_fqdn
@@ -702,7 +702,7 @@ create_test_global_config() {
     mkdir 'etc'
     # Suite host self-identification method.
     echo "$PRE" >'etc/global.cylc'
-    USER_TESTS_CONF_FILE="${HOME}/.cylc/flow/$(cylc version)/global-tests.cylc"
+    USER_TESTS_CONF_FILE="${HOME}/.cylc/flow/$(cylc version)/global.cylc"
     if [[ -f "${USER_TESTS_CONF_FILE}" ]]; then
         cat "${USER_TESTS_CONF_FILE}" >>'etc/global.cylc'
     fi
@@ -882,9 +882,6 @@ for SKIP in ${CYLC_TEST_SKIP}; do
         break
     fi
 done
-
-# Ignore the normal site/user global config, use global-tests.cylc.
-create_test_global_config "$@"
 
 # get array of test platforms to run tests with
 _expand_test_platforms "${PLATFORMS}"


### PR DESCRIPTION
Since #3808 the `global-tests.cylc` file no longer has any real purpose.

Test platforms should be available for interactive work as well as automated testing so it makes sense to share the same configuration for both, just configuring test platforms separately from production ones.

This also enables "at" tests in GH actions which were skipped before due to a config issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
