### PR TITLE
Upload cylc-run artifact on test fail.

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -46,3 +46,15 @@ jobs:
             tests/functional/shutdown/09-now2.t \
             tests/functional/shutdown/13-no-port-file-check.t \
             tests/functional/shutdown/14-no-dir-check.t
+
+      - name: Copy cylc-run out of container
+        if: failure()
+        run: |
+          docker cp bash:/root/cylc-run .
+
+      - name: Upload
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Upload cylc-run artifact
+          path: cylc-run

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -114,9 +114,14 @@ jobs:
           find "${TMPDIR:-/tmp}/${USER}/cylctb-"* -type f \
               -exec echo '==== {} ====' \; -exec cat '{}' \;
 
+      - name: Copy cylc-run out of container
+        if: failure()
+        run: |
+          docker cp bash:/root/cylc-run .
+
       - name: Upload
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: cylc-run
+          name: Upload cylc-run artifact
           path: cylc-run


### PR DESCRIPTION
@oliver-sanders this just adds an artifact upload section to the bash test config.  Hoping it'll allow us to diagnose the `broadcast/00-simple` test problem.  See comments from here: https://github.com/cylc/cylc-flow/pull/3933#issuecomment-725800905  The change looks simple but all I did was copy your section from the other file, so you'd best check it.

[UPDATE: now for bash and main functional test actions]