### PR TITLE
tests: correct purge logic for local platforms

### DIFF
--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -518,7 +518,7 @@ purge () {
     '
 
     # remove the suite run directory on the platform if remote
-    if [[ -n "$PLATFORM" && "${PLATFORM}" != local* ]]; then
+    if [[ -n "$PLATFORM" && "${PLATFORM}" != _local* ]]; then
         local HOST
         HOST="$(get_host_from_platform "$PLATFORM")"
         # shellcheck disable=SC2029


### PR DESCRIPTION
Typo, missing `_` means that it is attempting to purge local platforms (i.e. ssh'ing when not necessary).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
