### PR TITLE
Global config changes: process pool, logging

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -90,9 +90,6 @@ with Conf('global.cylc', desc='''
            The default is set quite high to avoid killing important
            processes when the system is under load.
     ''')
-    Conf('run directory rolling archive length', VDR.V_INTEGER, -1, desc='''
-        The number of old run directory trees to retain at start-up.
-    ''')
 
     with Conf('scheduler', desc='''
         Default values for entries in :cylc:conf:`flow.cylc[scheduler]`
@@ -100,7 +97,11 @@ with Conf('global.cylc', desc='''
         ``flow.cylc`` file.
     '''):
         Conf('UTC mode', VDR.V_BOOLEAN, False, desc='''
-                Default for :cylc:conf:`flow.cylc[scheduler]UTC mode`.
+            Default for :cylc:conf:`flow.cylc[scheduler]UTC mode`.
+        ''')
+        Conf('run directory rolling archive length', VDR.V_INTEGER, -1,
+             desc='''
+            The number of old run directory trees to retain at start-up.
         ''')
 
         with Conf('events', desc='''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -75,22 +75,6 @@ with Conf('global.cylc', desc='''
        Prior to Cylc 8, ``global.cylc`` was named ``global.rc``, but that name
        is no longer supported.
 ''') as SPEC:
-
-    # suite
-    Conf('process pool size', VDR.V_INTEGER, 4, desc='''
-        Maximum number of concurrent processes used to execute external job
-        submission, event handlers, and job poll and kill commands - see
-        :ref:`Managing External Command Execution`.
-    ''')
-    Conf('process pool timeout', VDR.V_INTERVAL, DurationFloat(600), desc='''
-        Interval after which long-running commands in the process pool will be
-        killed - see :ref:`Managing External Command Execution`.
-
-        .. note::
-           The default is set quite high to avoid killing important
-           processes when the system is under load.
-    ''')
-
     with Conf('scheduler', desc='''
         Default values for entries in :cylc:conf:`flow.cylc[scheduler]`
         section. This should not be confused with scheduling in the
@@ -98,6 +82,20 @@ with Conf('global.cylc', desc='''
     '''):
         Conf('UTC mode', VDR.V_BOOLEAN, False, desc='''
             Default for :cylc:conf:`flow.cylc[scheduler]UTC mode`.
+        ''')
+        Conf('process pool size', VDR.V_INTEGER, 4, desc='''
+            Maximum number of concurrent processes used to execute external job
+            submission, event handlers, and job poll and kill commands - see
+            :ref:`Managing External Command Execution`.
+        ''')
+        Conf('process pool timeout', VDR.V_INTERVAL, DurationFloat(600),
+             desc='''
+            Interval after which long-running commands in the process pool
+            will be killed - see :ref:`Managing External Command Execution`.
+
+            .. note::
+               The default is set quite high to avoid killing important
+               processes when the system is under load.
         ''')
         Conf('run directory rolling archive length', VDR.V_INTEGER, -1,
              desc='''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -171,17 +171,18 @@ with Conf('global.cylc', desc='''
                     The interval with which this plugin is run.
                 ''')
 
-    with Conf('suite logging', desc='''
-        The suite event log, held under the suite run directory, is maintained
-        as a rolling archive. Logs are rolled over (backed up and started anew)
-        when they reach a configurable limit size.
-    '''):
-        Conf('rolling archive length', VDR.V_INTEGER, 5, desc='''
-            How many rolled logs to retain in the archive.
-        ''')
-        Conf('maximum size in bytes', VDR.V_INTEGER, 1000000, desc='''
-            Suite event logs are rolled over when they reach this file size.
-        ''')
+        with Conf('logging', desc='''
+            The workflow event log, held under the suite run directory, is
+            maintained as a rolling archive. Logs are rolled over (backed up
+            and started anew) when they reach a configurable limit size.
+        '''):
+            Conf('rolling archive length', VDR.V_INTEGER, 5, desc='''
+                How many rolled logs to retain in the archive.
+            ''')
+            Conf('maximum size in bytes', VDR.V_INTEGER, 1000000, desc='''
+                Suite event logs are rolled over when they reach this
+                file size.
+            ''')
 
     with Conf('editors', desc='''
         Choose your favourite text editor for editing suite configurations.

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -114,7 +114,6 @@ class TimestampRotatingFileHandler(logging.FileHandler):
 
     FILE_HEADER_FLAG = 'cylc_log_file_header'
     FILE_NUM = 'cylc_log_num'
-    GLBL_KEY = 'suite logging'
     MIN_BYTES = 1024
 
     def __init__(self, log_file_path, no_detach=False, timestamp=True):
@@ -141,7 +140,8 @@ class TimestampRotatingFileHandler(logging.FileHandler):
         """Should rollover?"""
         if self.stamp is None or self.stream is None:
             return True
-        max_bytes = glbl_cfg().get([self.GLBL_KEY, 'maximum size in bytes'])
+        max_bytes = glbl_cfg().get(
+            ['scheduler', 'logging', 'maximum size in bytes'])
         if max_bytes < self.MIN_BYTES:  # No silly value
             max_bytes = self.MIN_BYTES
         msg = "%s\n" % self.format(record)
@@ -168,7 +168,8 @@ class TimestampRotatingFileHandler(logging.FileHandler):
             os.unlink(self.baseFilename)
         os.symlink(os.path.basename(filename), self.baseFilename)
         # Housekeep log files
-        arch_len = glbl_cfg().get([self.GLBL_KEY, 'rolling archive length'])
+        arch_len = glbl_cfg().get(
+            ['scheduler', 'logging', 'rolling archive length'])
         if arch_len:
             log_files = glob(self.baseFilename + '.*')
             log_files.sort()

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -112,7 +112,7 @@ def make_suite_run_tree(suite):
     """Create all top-level cylc-run output dirs on the suite host."""
     cfg = glbl_cfg().get()
     # Roll archive
-    archlen = cfg['run directory rolling archive length']
+    archlen = cfg['scheduler']['run directory rolling archive length']
     dir_ = os.path.expandvars(get_suite_run_dir(suite))
     for i in range(archlen, -1, -1):  # archlen...0
         if i > 0:

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -120,8 +120,9 @@ class SubProcPool:
     RET_CODE_SUITE_STOPPING = 999
 
     def __init__(self):
-        self.size = glbl_cfg().get(['process pool size'])
-        self.proc_pool_timeout = glbl_cfg().get(['process pool timeout'])
+        self.size = glbl_cfg().get(['scheduler', 'process pool size'])
+        self.proc_pool_timeout = glbl_cfg().get(
+            ['scheduler', 'process pool timeout'])
         self.closed = False  # Close queue
         self.stopping = False  # No more job submit if True
         # .stopping may be set by an API command in a different thread

--- a/etc/bin/run-functional-tests
+++ b/etc/bin/run-functional-tests
@@ -24,7 +24,7 @@ Run the Cylc test battery, in <CYLC_REPO_DIR>/tests.
 
 Options and arguments are appended to "prove -j \$NPROC -s -r \${@:-tests/f}".
 NPROC is the number of concurrent processes to run, which defaults to the
-global config "process pool size" setting.
+global config "[scheduler]process pool size" setting.
 
 The tests ignore normal site/user global config and instead use:
    ~/.cylc/flow/<cylc-version>/global-tests.cylc

--- a/tests/flakyfunctional/events/44-timeout.t
+++ b/tests/flakyfunctional/events/44-timeout.t
@@ -22,7 +22,7 @@
 
 set_test_number 4
 
-create_test_global_config "
+create_test_global_config "" "
 [scheduler]
     process pool timeout = PT10S
 "

--- a/tests/flakyfunctional/events/44-timeout.t
+++ b/tests/flakyfunctional/events/44-timeout.t
@@ -23,7 +23,9 @@
 set_test_number 4
 
 create_test_global_config "
-process pool timeout = PT10S" ""
+[scheduler]
+    process pool timeout = PT10S
+"
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 

--- a/tests/flakyfunctional/job-submission/18-check-chunking.t
+++ b/tests/flakyfunctional/job-submission/18-check-chunking.t
@@ -21,7 +21,8 @@
 set_test_number 3
 
 create_test_global_config '
-process pool size = 1
+[scheduler]
+    process pool size = 1
 ' ''
 
 init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'

--- a/tests/flakyfunctional/job-submission/18-check-chunking.t
+++ b/tests/flakyfunctional/job-submission/18-check-chunking.t
@@ -20,10 +20,10 @@
 . "$(dirname "$0")/test_header"
 set_test_number 3
 
-create_test_global_config '
+create_test_global_config '' '
 [scheduler]
     process pool size = 1
-' ''
+'
 
 init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 [scheduler]
@@ -40,12 +40,12 @@ init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
     [[t1<p>]]
         # Reduce the load on many jobs sending the "started" message
         init-script = """
-sleep $((RANDOM % 10))
-"""
+            sleep $((RANDOM % 10))
+        """
         script = """
-wait
-sleep $((RANDOM % 5))
-"""
+            wait
+            sleep $((RANDOM % 5))
+        """
 __FLOW_CONFIG__
 
 

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -21,7 +21,7 @@ export REQUIRE_PLATFORM='batch:at'
 . "$(dirname "$0")/test_header"
 set_test_number 15
 
-create_test_global_config "
+create_test_global_config "" "
 [scheduler]
     process pool timeout = PT10S
 [platforms]

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -22,7 +22,8 @@ export REQUIRE_PLATFORM='batch:at'
 set_test_number 15
 
 create_test_global_config "
-process pool timeout = PT10S" "
+[scheduler]
+    process pool timeout = PT10S
 [platforms]
     [[$CYLC_TEST_PLATFORM]]
         batch submit command template = talkingnonsense %(job)s

--- a/tests/functional/events/47-long-output.t
+++ b/tests/functional/events/47-long-output.t
@@ -24,10 +24,10 @@ fi
 
 set_test_number 10
 
-create_test_global_config "
+create_test_global_config "" "
 [scheduler]
     process pool timeout = PT10S
-" ""
+"
 
 # Long STDOUT output
 

--- a/tests/functional/events/47-long-output.t
+++ b/tests/functional/events/47-long-output.t
@@ -25,7 +25,9 @@ fi
 set_test_number 10
 
 create_test_global_config "
-process pool timeout = PT10S" ""
+[scheduler]
+    process pool timeout = PT10S
+" ""
 
 # Long STDOUT output
 

--- a/tests/functional/job-submission/16-timeout.t
+++ b/tests/functional/job-submission/16-timeout.t
@@ -20,10 +20,9 @@ export REQUIRE_PLATFORM='batch:at comms:tcp'
 . "$(dirname "$0")/test_header"
 set_test_number 4
 
-create_test_global_config "
+create_test_global_config "" "
 [scheduler]
     process pool timeout = PT10S
-" "
 [platforms]
     [[$CYLC_TEST_PLATFORM]]
         batch submit command template = sleep 30

--- a/tests/functional/job-submission/16-timeout.t
+++ b/tests/functional/job-submission/16-timeout.t
@@ -21,7 +21,8 @@ export REQUIRE_PLATFORM='batch:at comms:tcp'
 set_test_number 4
 
 create_test_global_config "
-process pool timeout = PT10S
+[scheduler]
+    process pool timeout = PT10S
 " "
 [platforms]
     [[$CYLC_TEST_PLATFORM]]

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -121,8 +121,8 @@
 #         Expect 2 OK tests.
 #     create_test_global_config [PRE [POST]]
 #         Create a new global config file $PWD/etc from global-tests.cylc
-#         with PRE and POST pre- and ap-pended (PRE for top level items with no
-#         section heading). PRE and POST are strings.
+#         with PRE and POST pre- and ap-pended (PRE for e.g. jinja2 shebang).
+#         PRE and POST are strings.
 #     localhost_fqdn
 #         Get the FQDN of the current host using the same mechanism Cylc uses.
 #     get_fqdn [TARGET]

--- a/tests/functional/logging/03-roll.t
+++ b/tests/functional/logging/03-roll.t
@@ -38,7 +38,8 @@ create_test_global_config '' '
 [scheduler]
     [[logging]]
         rolling archive length = 8
-        maximum size in bytes = 2048'
+        maximum size in bytes = 2048
+'
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \

--- a/tests/functional/logging/03-roll.t
+++ b/tests/functional/logging/03-roll.t
@@ -35,9 +35,10 @@ init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 __FLOW_CONFIG__
 
 create_test_global_config '' '
-[suite logging]
-    rolling archive length = 8
-    maximum size in bytes = 2048'
+[scheduler]
+    [[logging]]
+        rolling archive length = 8
+        maximum size in bytes = 2048'
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -162,7 +162,8 @@ class TestPathutil(TestCase):
 )
 def test_make_suite_run_tree(caplog, tmpdir, mock_glbl_cfg, subdir):
     glbl_conf_str = f'''
-        run directory rolling archive length = 1
+        [scheduler]
+            run directory rolling archive length = 1
         [platforms]
             [[localhost]]
                 run directory = {tmpdir}


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #3696

- `process pool *` -> `[scheduler]process pool *`
- `[suite logging]` -> `[scheduler][logging]`
- `run directory rolling archive length` -> `[scheduler]run directory rolling archive length`

Also the `test_header` function `create_test_global_config` has been simplified to only arg which is appended to the user's global config, as there are no longer any top-level global config items that would need to be prepended.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No changelog entry needed (entry will be written after #3696 is closed)
- [x] No documentation update required (docs will be updated after #3696 is closed)
- [x] No dependency changes.
