### PR TITLE
remote: clarify platform/host commands

### DIFF
--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -29,7 +29,7 @@ from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import HostSelectException
 from cylc.flow.hostuserutil import get_fqdn_by_host, is_remote_host
-from cylc.flow.remote import remote_cylc_cmd, run_cmd
+from cylc.flow.remote import _remote_cylc_cmd, run_cmd
 from cylc.flow.terminal import parse_dirty_json
 
 
@@ -524,7 +524,7 @@ def _get_metrics(hosts, metrics, data=None):
     }
     for host in hosts:
         if is_remote_host(host):
-            proc_map[host] = remote_cylc_cmd(cmd, host=host, **kwargs)
+            proc_map[host] = _remote_cylc_cmd(cmd, host=host, **kwargs)
         else:
             proc_map[host] = run_cmd(['cylc'] + cmd, **kwargs)
 

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -35,7 +35,7 @@ from cylc.flow.pathutil import (
     get_suite_run_dir,
     get_suite_run_log_name,
     get_suite_file_install_log_name, make_localhost_symlinks)
-from cylc.flow.remote import remote_cylc_cmd
+from cylc.flow.remote import _remote_cylc_cmd
 from cylc.flow.scheduler import Scheduler, SchedulerError
 from cylc.flow.scripts import cylc_header
 from cylc.flow import suite_files
@@ -384,7 +384,7 @@ def _distribute(host, is_restart):
         # Prevent recursive host selection
         cmd = sys.argv[1:]
         cmd.append("--host=localhost")
-        remote_cylc_cmd(cmd, host=host)
+        _remote_cylc_cmd(cmd, host=host)
         sys.exit(0)
 
 

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -82,7 +82,7 @@ from cylc.flow.task_id import TaskID
 from cylc.flow.task_job_logs import (
     JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_OPTS, NN, JOB_LOG_ACTIVITY)
 from cylc.flow.terminal import cli_function
-from cylc.flow.platforms import get_platform, get_host_from_platform
+from cylc.flow.platforms import get_platform
 
 
 # Immortal tail-follow processes on job hosts can be cleaned up by killing
@@ -440,10 +440,12 @@ def main(parser, options, *args, color=False):
             cmd.append(suite_name)
             is_edit_mode = (mode == 'edit')
             try:
-                host = get_host_from_platform(platform)
                 proc = remote_cylc_cmd(
-                    cmd, host, capture_process=is_edit_mode,
-                    manage=(mode == 'tail'))
+                    cmd,
+                    platform,
+                    capture_process=is_edit_mode,
+                    manage=(mode == 'tail')
+                )
             except KeyboardInterrupt:
                 # Ctrl-C while tailing.
                 pass

--- a/cylc/flow/scripts/check_versions.py
+++ b/cylc/flow/scripts/check_versions.py
@@ -41,7 +41,7 @@ from cylc.flow.cylc_subproc import procopen, PIPE, DEVNULL
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.config import SuiteConfig
 from cylc.flow.platforms import get_platform
-from cylc.flow.remote import construct_platform_ssh_cmd
+from cylc.flow.remote import construct_ssh_cmd
 from cylc.flow.suite_files import parse_suite_arg
 from cylc.flow.templatevars import load_template_vars
 from cylc.flow.terminal import cli_function
@@ -88,7 +88,7 @@ def main(_, options, *args):
     versions = {}
     for platform_name in sorted(platforms):
         platform = get_platform(platform_name)
-        cmd = construct_platform_ssh_cmd(['version'], platform)
+        cmd = construct_ssh_cmd(['version'], platform)
         if verbose:
             print(cmd)
         proc = procopen(cmd, stdin=DEVNULL, stdout=PIPE, stderr=PIPE)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -67,7 +67,7 @@ from cylc.flow.task_state import (
 )
 from cylc.flow.task_action_timer import TimerFlags
 from cylc.flow.wallclock import get_current_time_string, get_utc_mode
-from cylc.flow.remote import construct_platform_ssh_cmd
+from cylc.flow.remote import construct_ssh_cmd
 from cylc.flow.exceptions import (
     PlatformLookupError, SuiteConfigError, TaskRemoteMgmtError
 )
@@ -314,7 +314,7 @@ class TaskJobManager:
                 cmd, [len(b) for b in itasks_batches])
 
             if remote_mode:
-                cmd = construct_platform_ssh_cmd(cmd, platform)
+                cmd = construct_ssh_cmd(cmd, platform)
             else:
                 cmd = ['cylc'] + cmd
 
@@ -693,7 +693,7 @@ class TaskJobManager:
             cmd.append(get_remote_suite_run_job_dir(platform, suite))
             job_log_dirs = []
             if remote_mode:
-                cmd = construct_platform_ssh_cmd(cmd, platform)
+                cmd = construct_ssh_cmd(cmd, platform)
             for itask in sorted(itasks, key=lambda itask: itask.identity):
                 job_log_dirs.append(get_task_job_id(
                     itask.point, itask.tdef.name, itask.submit_num))

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -53,7 +53,7 @@ from cylc.flow.platforms import (
     get_platform,
     get_host_from_platform,
     get_install_target_from_platform)
-from cylc.flow.remote import construct_platform_ssh_cmd
+from cylc.flow.remote import construct_ssh_cmd
 REMOTE_INIT_FAILED = 'REMOTE INIT FAILED'
 
 
@@ -226,7 +226,7 @@ class TaskRemoteMgr:
         if comm_meth in ['ssh']:
             cmd.append('--indirect-comm=%s' % comm_meth)
         # Create the ssh command
-        cmd = construct_platform_ssh_cmd(cmd, platform)
+        cmd = construct_ssh_cmd(cmd, platform)
         self.proc_pool.put_command(
             SubProcContext(
                 'remote-init',
@@ -261,7 +261,7 @@ class TaskRemoteMgr:
             cmd.append(str(f'{self.install_target}'))
             cmd.append(get_remote_suite_run_dir(platform, self.suite))
             if is_remote_platform(platform):
-                cmd = construct_platform_ssh_cmd(cmd, platform, timeout='10s')
+                cmd = construct_ssh_cmd(cmd, platform, timeout='10s')
             else:
                 cmd = ['cylc'] + cmd
             procs[(host, owner)] = (


### PR DESCRIPTION
* Make the default way of constructing / running ssh stuff platform orientated.
* Prefix the underlying primitive "host" commands with `_` to make the danger (no platform conf) clear.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
