### PR TITLE
db: only write task event timers when changed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@ templates in [runtime][X][environment].
 
 ### Fixes
 
+[#3948](https://github.com/cylc/cylc-flow/pull/3948) - Only write task
+event timers to the database when they have changed (reverts behaviour
+change in 7.8.6). This corrects last updated timestamps in cylc review and
+reduces filesystem load.
+
 [#3759](https://github.com/cylc/cylc-flow/pull/3754) - Fix a bug in the GUI
 tree view that could cause tasks to be sorted in the wrong order.
 

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -316,18 +316,21 @@ class SuiteDatabaseManager(object):
 
     def put_task_event_timers(self, task_events_mgr):
         """Put statements to update the task_action_timers table."""
-        self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
-        for key, timer in task_events_mgr.event_timers.items():
-            key1, point, name, submit_num = key
-            self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
-                "name": name,
-                "cycle": point,
-                "ctx_key": json.dumps((key1, submit_num,)),
-                "ctx": self._namedtuple2json(timer.ctx),
-                "delays": json.dumps(timer.delays),
-                "num": timer.num,
-                "delay": timer.delay,
-                "timeout": timer.timeout})
+        if task_events_mgr.event_timers_updated:
+            self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
+            for key, timer in task_events_mgr._event_timers.items():
+                key1, point, name, submit_num = key
+                self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
+                    "name": name,
+                    "cycle": point,
+                    "ctx_key": json.dumps((key1, submit_num,)),
+                    "ctx": self._namedtuple2json(timer.ctx),
+                    "delays": json.dumps(timer.delays),
+                    "num": timer.num,
+                    "delay": timer.delay,
+                    "timeout": timer.timeout
+                })
+            task_events_mgr.event_timers_updated = False
 
     def put_xtriggers(self, sat_xtrig):
         """Put statements to update external triggers table."""

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -948,6 +948,7 @@ class TaskEventsManager(object):
 
         """
         self._event_timers[key] = timer
+        self.event_timers_updated = True
 
     def remove_event_timer(self, key):
         """Remove a new event timer.
@@ -957,6 +958,7 @@ class TaskEventsManager(object):
 
         """
         del self._event_timers[key]
+        self.event_timers_updated = True
 
     def unset_waiting_event_timer(self, key):
         """Invoke unset_waiting on an event timer.
@@ -966,6 +968,7 @@ class TaskEventsManager(object):
 
         """
         self._event_timers[key].unset_waiting()
+        self.event_timers_updated = True
 
     def _reset_job_timers(self, itask):
         """Set up poll timer and timeout for task."""

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -465,8 +465,10 @@ class TaskPool(object):
             if isinstance(key1, list):
                 key1 = tuple(key1)
             key = (key1, cycle, name, submit_num)
-            self.task_events_mgr.event_timers[key] = TaskActionTimer(
-                ctx, delays, num, delay, timeout)
+            self.task_events_mgr.add_event_timer(
+                key,
+                TaskActionTimer(ctx, delays, num, delay, timeout)
+            )
         else:
             LOG.exception(
                 "%(id)s: skip action timer %(ctx_key)s" %
@@ -787,7 +789,7 @@ class TaskPool(object):
             return False
         if stop_mode == self.STOP_REQUEST_NOW_NOW:
             return True
-        if self.task_events_mgr.event_timers:
+        if self.task_events_mgr._event_timers:
             return False
         for itask in self.get_tasks():
             if (stop_mode == self.STOP_REQUEST_CLEAN and
@@ -806,7 +808,9 @@ class TaskPool(object):
             elif itask.state.status in TASK_STATUSES_ACTIVE:
                 LOG.warning("%s: orphaned task (%s)" % (
                     itask.identity, itask.state.status))
-        for key1, point, name, submit_num in self.task_events_mgr.event_timers:
+        for key1, point, name, submit_num in (
+            self.task_events_mgr._event_timers
+        ):
             LOG.warning("%s/%s/%s: incomplete task event handler %s" % (
                 point, name, submit_num, key1))
 


### PR DESCRIPTION
Follow-on from #3597
Close #3818 

Only write task event timers to the database when they have changed.

Currently the entire DB table is rebuilt twice per main loop even when the scheduler is inactive or stalled.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
