### PR TITLE
Fix remote init failures

### DIFF
--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -105,6 +105,7 @@ def remote_init(install_target, rund, *dirs_to_symlink, indirect_comm=None):
         src = os.path.expandvars(val)
         if '$' in src:
             print(REMOTE_INIT_FAILED)
+            return
         make_symlink(src, dst)
     srvd = os.path.join(rund, SuiteFiles.Service.DIRNAME)
     os.makedirs(srvd, exist_ok=True)
@@ -119,6 +120,7 @@ def remote_init(install_target, rund, *dirs_to_symlink, indirect_comm=None):
         if pattern.match(filepath) and f"{install_target}" not in filepath:
             # client key for a different install target exists
             print(REMOTE_INIT_FAILED)
+            return
     try:
         remove_keys_on_client(srvd, install_target)
         create_client_keys(srvd, install_target)

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -16,7 +16,7 @@
 """Tests for remote initialisation."""
 
 from io import StringIO
-from mock import patch
+from unittest.mock import patch
 
 from cylc.flow.task_remote_cmd import remote_init
 

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -1,0 +1,51 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for remote initialisation."""
+
+from io import StringIO
+from mock import patch
+
+from cylc.flow.task_remote_cmd import remote_init
+
+
+@patch('sys.stdout', new_callable=StringIO)
+@patch('os.makedirs')
+@patch('os.listdir')
+@patch('os.path.join')
+@patch('os.path.expandvars')
+def test_existing_key_raises_error(
+        mocked_expandvars, mocked_pathjoin, mocked_listdir,
+        mocked_makedirs, mocked_stdout):
+    """Test .service directory that contains existing incorrect key,
+       results in REMOTE INIT FAILED
+    """
+    mocked_expandvars.return_value = "some/expanded/path"
+    mocked_pathjoin.return_value = "joined.path"
+    mocked_listdir.return_value = ['client_wrong.key']
+
+    remote_init('test_install_target', 'some_rund')
+    assert mocked_stdout.getvalue() == "REMOTE INIT FAILED\n"
+
+
+@patch('sys.stdout', new_callable=StringIO)
+@patch('os.path.expandvars')
+def test_unexpandable_symlink_env_var_returns_failed(
+        mocked_expandvars, mocked_stdout):
+    """Test unexpandable symlinks return REMOTE INIT FAILED"""
+    mocked_expandvars.side_effect = ['some/rund/path', '$blah']
+
+    remote_init('test_install_target', 'some_rund', 'run=$blah')
+    assert mocked_stdout.getvalue() == "REMOTE INIT FAILED\n"


### PR DESCRIPTION
This is a small change with no associated Issue.

While debugging a different issue, I noticed that remote init was not correctly failing. 
It was printing `REMOTE INIT FAILED` but not returning, hence, continuing making keys and also printing `REMOTE INIT DONE`, resulting in the workflow continuing, incorrectly.

To test this bug...
1. On master, create a key in the .service directory of the workflow you will run in step 2, something like `client_wrong.key` would work.
2. Run your workflow (should have a task to run on the remote).

The workflow does not raise an error correctly, and just carries on.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
