### PR TITLE
Cylc version: long format

### DIFF
--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+import pathlib
 
 from ansimarkup import parse as cparse
 import click
@@ -339,20 +340,26 @@ def cli_help():
     sys.exit(0)
 
 
-def cli_version():
+def cli_version(short=False):
     """Display the Cylc Flow version."""
-    click.echo(__version__)
+    version = f"{__version__}"
+    if not short:
+        version += f" ({pathlib.Path(__file__).parent.parent.parent})"
+    click.echo(version)
     sys.exit(0)
 
 
 @click.command(context_settings={'ignore_unknown_options': True})
 @click.option("--help", "-h", "help_", is_flag=True, is_eager=True)
 @click.option("--version", "-V", is_flag=True, is_eager=True)
+@click.option("--version-short", is_flag=True, is_eager=True)
 @click.argument("cmd-args", nargs=-1)
-def main(cmd_args, version, help_):
+def main(cmd_args, version, version_short, help_):
     if not cmd_args:
         if version:
-            cli_version()
+            cli_version(short=False)
+        elif version_short:
+            cli_version(short=True)
         else:
             cli_help()
     else:
@@ -360,7 +367,7 @@ def main(cmd_args, version, help_):
         command = cmd_args.pop(0)
 
         if command == "version":
-            cli_version()
+            cli_version(short=("--short" in cmd_args))
 
         if command == "help":
             help_ = True

--- a/tests/flakyfunctional/database/00-simple.t
+++ b/tests/flakyfunctional/database/00-simple.t
@@ -43,7 +43,7 @@ sqlite3 "${DB_FILE}" \
     'SELECT key, value FROM suite_params
     WHERE key != "uuid_str" AND key != "cycle_point_tz" ORDER BY key' \
     >"${NAME}"
-sed -i "s/$(cylc --version)/<SOME-VERSION>/g" "${NAME}"
+sed -i "s/$(cylc --version-short)/<SOME-VERSION>/g" "${NAME}"
 cmp_ok "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/${NAME}" "${NAME}"
 
 NAME='select-task-events.out'

--- a/tests/functional/authentication/01-remote-suite-same-name.t
+++ b/tests/functional/authentication/01-remote-suite-same-name.t
@@ -34,7 +34,7 @@ scp ${SSH_OPTS} -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-register" \
     ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" \
-    CYLC_VERSION="$(cylc version)" cylc register "${SUITE_NAME}" \
+    CYLC_VERSION="$(cylc version --short)" cylc register "${SUITE_NAME}" \
     "cylc-run/${SUITE_NAME}"
 
 suite_run_ok "${TEST_NAME_BASE}" \

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -19,7 +19,7 @@
 
 . "$(dirname "$0")/test_header"
 # Number of tests depends on the number of 'cylc' commands.
-set_test_number $(( 22 + $(find "${CYLC_REPO_DIR}/bin" -name 'cylc-*' | wc -l) ))
+set_test_number $(( 25 + $(find "${CYLC_REPO_DIR}/bin" -name 'cylc-*' | wc -l) ))
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -71,6 +71,10 @@ run_ok "${TEST_NAME_BASE}-version.stdout" \
     test -n "${TEST_NAME_BASE}-version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
+
+run_ok "${TEST_NAME_BASE}-version-short" cylc version --short
+run_ok "${TEST_NAME_BASE}---version-short" cylc --version-short
+cmp_ok "${TEST_NAME_BASE}-version-short.stdout" "${TEST_NAME_BASE}---version-short.stdout"
 
 # --help with no DISPLAY
 while read -r ITEM; do

--- a/tests/functional/cylc-get-cylc-version/00-basic/flow.cylc
+++ b/tests/functional/cylc-get-cylc-version/00-basic/flow.cylc
@@ -10,5 +10,5 @@
 [runtime]
     [[root]]
         script = """
-diff -u <(cylc --version) <(cylc get-cylc-version "${CYLC_SUITE_NAME}")
+diff -u <(cylc version --short) <(cylc get-cylc-version "${CYLC_SUITE_NAME}")
 """

--- a/tests/functional/graphql/01-workflow.t
+++ b/tests/functional/graphql/01-workflow.t
@@ -87,7 +87,7 @@ cat > expected << __HERE__
             "host": "${HOST}",
             "port": ${PORT},
             "owner": "${USER}",
-            "cylcVersion": "$(cylc version)",
+            "cylcVersion": "$(cylc version --short)",
             "meta": {
                 "title": "foo",
                 "description": "bar"

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -702,7 +702,7 @@ create_test_global_config() {
     mkdir 'etc'
     # Suite host self-identification method.
     echo "$PRE" >'etc/global.cylc'
-    USER_TESTS_CONF_FILE="${HOME}/.cylc/flow/$(cylc version)/global-tests.cylc"
+    USER_TESTS_CONF_FILE="${HOME}/.cylc/flow/$(cylc version --short)/global-tests.cylc"
     if [[ -f "${USER_TESTS_CONF_FILE}" ]]; then
         cat "${USER_TESTS_CONF_FILE}" >>'etc/global.cylc'
     fi


### PR DESCRIPTION
This is a small change with no associated Issue.

When working with multiple Cylc 8 installations via the (upcoming) central wrapper, `cylc version` should report the location of the Cylc version that it invokes, as well as the version string.  

Useful for developers too now that we don't use `git describe` for a fine-grained version string (between releases the hardwired and self-reported code `__version__` string stays the same), so playing with multiple git branches at once requires checking out to a different location and changing `$CYLC_HOME` (for the central wrapper) - setting a different `$CYLC_VERSION` for each branch no longer works.

On this branch, `cylc version` prints `VERSION (LOCATION)` with new command options for `VERSION` alone.

I considered requiring `--long` to get the location, but people may not be expecting additional options to a version query, (Also, `rose version` prints the location).

Example for cylc-flow in `/home/oliverh/cylc/cylc-flow` with symlink `cylc-8.0a3.dev -> cylc-flow`:
```
$ cylc version
8.0a3.dev (/home/oliverh/cylc)

$ cylc --version
8.0a3.dev (/home/oliverh/cylc)

$ cylc -V
8.0a3.dev (/home/oliverh/cylc)

$ cylc version --short
8.0a3.dev

$ cylc --version-short
8.0a3.dev
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
