### PR TITLE
Define a local "at" platform

### DIFF
--- a/etc/conf/global.cylc
+++ b/etc/conf/global.cylc
@@ -5,6 +5,10 @@
     [[_local_background_indep_tcp]]
         hosts = localhost
         install target = localhost
+    [[_local_at_indep_tcp]]
+        hosts = localhost
+        install target = localhost
+        batch system = at
     [[_remote_background_indep_tcp]]
         hosts = _remote_background_indep_tcp
     [[_remote_at_indep_tcp]]

--- a/etc/conf/global.cylc
+++ b/etc/conf/global.cylc
@@ -5,10 +5,6 @@
     [[_local_background_indep_tcp]]
         hosts = localhost
         install target = localhost
-    [[_local_at_indep_tcp]]
-        hosts = localhost
-        install target = localhost
-        batch system = at
     [[_remote_background_indep_tcp]]
         hosts = _remote_background_indep_tcp
     [[_remote_at_indep_tcp]]
@@ -27,6 +23,10 @@
         communication method = poll
         execution polling intervals = 5*PT1S, PT5S
         submission polling intervals = PT1S
+    # [[_local_at_indep_tcp]]
+    #     hosts = localhost
+    #     install target = localhost
+    #     batch system = at
     # [[_remote_background_shared_tcp]]
     #     hosts = _remote_background_shared_tcp
     # [[_remote_background_shared_poll]]


### PR DESCRIPTION
This is a small change with no associated Issue.

Some local tests were being skipped with `requires batch:at`

One review should do @oliver-sanders 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
