### PR TITLE
Cylc version long take 2

### DIFF
--- a/cylc/flow/scripts/__init__.py
+++ b/cylc/flow/scripts/__init__.py
@@ -78,7 +78,7 @@ LOGO_LINES = [
 ]
 
 LICENCE = dedent(f"""
-    The Cylc Suite Engine [{__version__}]
+    The Cylc Workflow Engine [{__version__}]
     Copyright (C) 2008-2020 NIWA
     & British Crown (Met Office) & Contributors.
 """)

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -35,15 +35,16 @@ from cylc.flow.terminal import (
 
 
 def get_version(long=False):
-    """Return the Cylc Flow version and top level installation path.
+    """Return version string, and (if long is True) install location.
 
-    Path reports correctly for normal pip and conda installations
+    The install location returned is the top directory of the virtual
+    environment. This works for normal pip and conda installations
     but not for "pip install -e ." because of the source links.
     """
     version = f"{__version__}"
     if long:
-        parents = Path(__file__).parent.parent.parent
-        version += f" ({parents.parent.parent.parent.parent})"
+        path = Path(__file__).parent.parent.parent.parent.parent.parent.parent
+        version += f" ({path})"
     return version
 
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 from ansimarkup import parse as cparse
 import click
@@ -33,14 +34,29 @@ from cylc.flow.terminal import (
 )
 
 
+def get_version(long=False):
+    """Return the Cylc Flow version and top level installation path.
+
+    Path reports correctly for normal pip and conda installations
+    but not for "pip install -e ." because of the source links.
+    """
+    version = f"{__version__}"
+    if long:
+        parents = Path(__file__).parent.parent.parent
+        version += f" ({parents.parent.parent.parent.parent})"
+    return version
+
+
 DESC = '''
-Cylc ("silk") is a workflow engine for orchestrating complex *suites* of
-inter-dependent distributed cycling (repeating) tasks, as well as ordinary
-non-cycling workflows.
+Cylc ("silk") orchestrates complex cycling (and non-cycling) workflows.
 '''
 
 USAGE = f"""{cylc_header()}
 {centered(DESC)}
+
+Version:
+  $ cylc version --long           # print cylc-flow version and install path
+    {get_version(True)}
 
 Usage:
   $ cylc help all                 # list all commands
@@ -339,9 +355,9 @@ def cli_help():
     sys.exit(0)
 
 
-def cli_version():
-    """Display the Cylc Flow version."""
-    click.echo(__version__)
+def cli_version(long=False):
+    """Wrapper for get_version."""
+    click.echo(get_version(long))
     sys.exit(0)
 
 
@@ -360,7 +376,7 @@ def main(cmd_args, version, help_):
         command = cmd_args.pop(0)
 
         if command == "version":
-            cli_version()
+            cli_version("--long" in cmd_args)
 
         if command == "help":
             help_ = True

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -38,8 +38,9 @@ def get_version(long=False):
     """Return version string, and (if long is True) install location.
 
     The install location returned is the top directory of the virtual
-    environment. This works for normal pip and conda installations
-    but not for "pip install -e ." because of the source links.
+    environment, obtained from the Python executable path. (cylc-flow file
+    locations are buried deep in the library and don't always give the right
+    result, e.g. if installed with `pip install -e .`).
     """
     version = f"{__version__}"
     if long:

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -43,8 +43,7 @@ def get_version(long=False):
     """
     version = f"{__version__}"
     if long:
-        path = Path(__file__).parent.parent.parent.parent.parent.parent.parent
-        version += f" ({path})"
+        version += f" ({Path(sys.executable).parent.parent})"
     return version
 
 

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -72,8 +72,14 @@ run_ok "${TEST_NAME_BASE}-version.stdout" \
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
 
+# Check "cylc version --long" output is correct.
 cylc version --long > long1
-echo "$(cylc version) ($(dirname $(dirname $(which cylc))))" > long2
+WHICH="$(which cylc)"
+PARENT1="$(dirname "${WHICH}")"
+PARENT2="$(dirname "${PARENT1}")"
+echo "$(cylc version) (${PARENT2})" > long2
+# the concise version of the above is a shellcheck quoting nightmare:
+# echo "$(cylc version) ($(dirname $(dirname $(which cylc))))" > long2
 cmp_ok long1 long2
 
 # --help with no DISPLAY

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -19,7 +19,7 @@
 
 . "$(dirname "$0")/test_header"
 # Number of tests depends on the number of 'cylc' commands.
-set_test_number $(( 22 + $(find "${CYLC_REPO_DIR}/bin" -name 'cylc-*' | wc -l) ))
+set_test_number $(( 23 + $(find "${CYLC_REPO_DIR}/bin" -name 'cylc-*' | wc -l) ))
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -71,6 +71,10 @@ run_ok "${TEST_NAME_BASE}-version.stdout" \
     test -n "${TEST_NAME_BASE}-version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
+
+cylc version --long > long1
+echo "$(cylc version) ($(dirname $(dirname $(which cylc))))" > long2
+cmp_ok long1 long2
 
 # --help with no DISPLAY
 while read -r ITEM; do


### PR DESCRIPTION
Supersedes #3950 

```
$ cylc --version
8.0a3.dev

$ cylc version
8.0a3.dev

$ cylc version --long  # conda environment
8.0a2 (/home/oliverh/miniconda3/envs/cylc-8.0a2)

$ cylc version --long  # "pip install ." with venv in git clone
8.0a3.dev (/home/oliverh/cylc/cylc-flow.git/venv)
```

Path reported is the top level of the virtual environment, for both conda and Python venv.

@kinow - you might want a quick re-review since I've gone back to the more conventional `--long` option. 
