### PR TITLE
Update cylc wrapper.

### DIFF
--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -121,15 +121,15 @@ if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
     # Conda
     if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
         # A conda pack installation
-        . ${CYLC_HOME}/bin/activate || exit 1
+        . "${CYLC_HOME}/bin/activate" || exit 1
     else
         # A normal conda environment
-        . $(dirname ${CYLC_HOME})/../etc/profile.d/conda.sh
+        . "$(dirname ${CYLC_HOME})/../etc/profile.d/conda.sh"
         conda activate "$(basename ${CYLC_HOME})" || exit 1
     fi
 elif [[ -f "${CYLC_HOME}/bin/activate" ]]; then
     # Python venv
-    . ${CYLC_HOME}/bin/activate || exit 1
+    . "${CYLC_HOME}/bin/activate" || exit 1
 else
     echo 1>&2 "ERROR: cylc installation not found in ${CYLC_HOME}"
     exit 1

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -16,54 +16,123 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Wrapper for selection between installed versions of cylc.
-# Author: Matt Shin (Met Office).
-
-#_____________________________
-# INSTALLATION: 
+#------------------------------------------------------------------------------
+# Wrapper script to support multiple Cylc versions installed on the same host.
+# Currently handles Conda and Python virtual environments.
 #
-#  1. Install this script as "cylc" in $PATH for normal users.
+# INSTALL AND CONFIGURE THE WRAPPER
+#----------------------------------
+# Copy this script as "cylc" into the default $PATH on scheduler and job hosts,
+# and modify CYLC_HOME_ROOT(_ALT) below (see "EDIT ME") to point to the parent
+# directory of all installed versions.
 #
-#  2. Install cylc versions as described in the INSTALL file, e.g.:
-#     /opt/cylc-7.6.1/
-#     /opt/cylc-7.7.0/
-#     /opt/cylc -> cylc-7.7.0/  # symlink DEFAULT version
+# HOW IT WORKS
+#-------------
+# Intercept `cylc` commands and re-invoke them with the appropriate cylc-flow
+# version, according to location or version information in the environment:
+# - 1) $CYLC_HOME if defined, or
+# - 2) $CYLC_HOME_ROOT(_ALT)/$CYLC_VERSION
 #
-# Environment variables:
-#  $CYLC_HOME_ROOT: top installation directory, e.g. /opt/
-#  $CYLC_HOME:   a specific version, e.g. /opt/cylc-7.7.0/
-#  $CYLC_VERSION: a specific version string, e.g. 7.7.0
-#
-#  3. Set $CYLC_HOME_ROOT for your site - see "!!! EDIT ME !!! below.
-
-#_____________________________
-# ACTION IN ORDER OF PRIORITY:
+# USERS SHOULD:
+# - Set CYLC_VERSION to select a specific installed version under the ROOT
+# - Set CYLC_HOME in .bashrc (scheduler and job hosts) to select a single
+#   version outside of the ROOT location.
 # 
-# 1) If $CYLC_HOME is defined and exists it will be selected. If it does
-#   not exist the command will fail.
+# The scheduler writes cylc.flow.__version__ to CYLC_VERSION in task job
+# scripts so that jobs see the right version. __version__ only increments with
+# releases so CYLC_VERSION cannot be used for fine-grained selection. Git
+# branches between releases, for example, all have the same version. Use
+# CYLC_HOME to select a venv in your cylc-flow git clone.
 #
-# 2) If $CYLC_VERSION is defined and exists it will be selected. If it
-#   does not exist the default under $CYLC_HOME_ROOT will be selected.
+# CYLC_HOME must be set in .bashrc so that task jobs also see it - otherwise
+# they will try to select their CYLC_VERSION.
+#
+# If USERS set a default CYLC_VERSION in .bashrc it should take an existing
+# value first to avoid overiding task job version selection:
+# - export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
+#
+# INSTALLING CYLC RELEASES WITH CONDA
+#------------------------------------
+# Create environments named cylc-$CYLC_VERSION or cylc-flow-$CYLC_VERSION under
+# a root location such as /opt/cylc:
+#
+# $ conda create -p /opt/cylc/cylc-8.2.0 cylc=8.2.0
 # 
-# 3) If $CYLC_HOME and $CYLC_VERSION are both undefined, the default
-#   under $CYLC_HOME_ROOT will be selected.
+# $ ls /opt/cylc
+# cylc-8.1.0/
+# cylc-8.2.0/
+#
+# Note you can `pip install` cylc-flow from a git clone into a conda
+# environment and then select it by CYLC_VERSION but that will be misleading
+# (the code won't actually be the release version). It is better to use Python
+# venvs and CYLC_HOME for cylc-flow development and testing.
+#
+# INSTALLING CYLC-FLOW RELEASES WITH PIP FOR DEVELOPMENT AND TESTING
+#-------------------------------------------------------------------
+# Create Python virtual environments in-place in your cylc-flow git
+# clones and select them using CYLC_HOME in your .bashrc.
+#
+# Create a new venv and install cylc-flow:
+#   $ cd <my-cylc-flow-clone>
+#   $ python -m venv venv
+#   $ . venv/bin/activate
+#   $ pip install -e . 
+#
+# Set CYLC_HOME in .bashrc to select this venv (see explanation above):
+#   $ echo "export CYLC_HOME=$PWD/venv" >> .bashrc
+#   $ . .bashrc
+#
+# You can also `pip install` cylc-flow releases under a common root location
+# for CYLC_VERSION based selection, like for conda:
+#
+#   $ CYLC_HOME_ROOT=$HOME/cylc-flow/releases  # (set in this wrapper too)
+#   $ python -m venv $CYLC_HOME_ROOT/cylc-flow-8.0a2
+#   $ . $CYLC_HOME_ROOT/cylc-flow-8.0a2/bin/activate
+#   $ python -m pip install cylc-flow==8.0a2
+# 
+# (But there is no need to do this if you have full system releases - i.e. not
+# just cylc-flow - installed via conda anyway.)
  
-#_____________________________
-# NOTES:
-# * Users will typically accept the default or set $CYLC_VERSION, but
-#   they may set $CYLC_HOME to pick up a private cylc installation.
-# * Developers may set $CYLC_HOME to pick up their own repository clone.
-# * Running suites export $CYLC_VERSION to task environments, so that
-#    task messaging commands etc. pick up the compatible cylc version.
-# * Note that $CYLC_ROOT_HOME can be overridden in the environment too.
+##############################!!! EDIT ME !!!##################################
+# Central Cylc conda releases:
+CYLC_HOME_ROOT=${CYLC_HOME_ROOT:-/opt}
+# User Conda releases:
+CYLC_HOME_ROOT_ALT=${CYLC_HOME_ROOT_ALT:-/home/$USER/miniconda3/envs}
+# NOTE: users can set CYLC_HOME in their .bashrc to select a non-release conda
+# or pip virtual environment (located in a cylc-flow git clone, for example).
+###############################################################################
 
-CYLC_HOME_ROOT=${CYLC_HOME_ROOT:-/opt} # !!! EDIT ME !!!
-
+# If CYLC_HOME is not defined, find it using {ROOT} and {VERSION}.
 if [[ -z ${CYLC_HOME:-} ]]; then
-    if [[ -n ${CYLC_VERSION:-} && -d $CYLC_HOME_ROOT/cylc-$CYLC_VERSION ]]; then
-        CYLC_HOME=$CYLC_HOME_ROOT/cylc-$CYLC_VERSION
-    else
-        CYLC_HOME=$CYLC_HOME_ROOT/cylc
+    CYLC_HOME=$CYLC_HOME_ROOT/cylc  # default symlinked version
+    if [[ -n ${CYLC_VERSION:-} ]]; then
+        # Look for matching version in root locations
+        for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
+            for NAME in "cylc" "cylc-flow"; do
+                if [[ -d $ROOT/${NAME}-$CYLC_VERSION ]]; then
+                    CYLC_HOME=$ROOT/${NAME}-$CYLC_VERSION
+                    break 2
+                fi
+            done
+         done
     fi
 fi
-exec "$CYLC_HOME/bin/$(basename "$0")" "$@"
+if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
+    # Conda
+    if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
+        # A conda pack installation
+        . ${CYLC_HOME}/bin/activate || exit 1
+    else
+        # A normal conda environment
+        . $(dirname ${CYLC_HOME})/../etc/profile.d/conda.sh
+        conda activate "$(basename ${CYLC_HOME})" || exit 1
+    fi
+elif [[ -f "${CYLC_HOME}/bin/activate" ]]; then
+    # Python venv
+    . ${CYLC_HOME}/bin/activate || exit 1
+else
+    echo 1>&2 "ERROR: cylc installation not found in ${CYLC_HOME}"
+    exit 1
+fi
+# The selected Cylc should now be first in $PATH
+exec "$(basename "$0")" "$@"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -130,15 +130,15 @@ if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
         . "${CYLC_HOME}/bin/activate" || exit 1
     else
         # A normal conda environment
-        . "$(dirname ${CYLC_HOME})/../etc/profile.d/conda.sh"
-        conda activate "$(basename ${CYLC_HOME})" || exit 1
+        . "$(dirname "${CYLC_HOME}")"/../etc/profile.d/conda.sh
+        conda activate "$(basename "${CYLC_HOME}")" || exit 1
     fi
 elif [[ -f "${CYLC_HOME}/bin/activate" ]]; then
     # A Cylc 8 Python venv
     . "${CYLC_HOME}/bin/activate" || exit 1
 elif [[ -x "${CYLC_HOME}/bin/cylc" ]]; then
     # A Cylc 7 installation
-    exec $CYLC_HOME/bin/$(basename $0) "$@"
+    exec "${CYLC_HOME}"/bin/"$(basename "$0")" "$@"
 else
     echo 1>&2 "ERROR: cylc not found in ${CYLC_HOME}"
     exit 1

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -18,10 +18,10 @@
 
 #------------------------------------------------------------------------------
 # Wrapper script to support multiple Cylc versions installed on the same host.
-# Currently handles Conda and Python virtual environments.
+# Handles Cylc 8 Conda and Python virtual envs, and plain Cylc 7 installations.
 #
-# INSTALL AND CONFIGURE THE WRAPPER
-#----------------------------------
+# WRAPPER INSTALLATION AND CONFIGURATION
+#---------------------------------------
 # Copy this script as "cylc" into the default $PATH on scheduler and job hosts,
 # and modify CYLC_HOME_ROOT(_ALT) below (see "EDIT ME") to point to the parent
 # directory of all installed versions.
@@ -31,44 +31,47 @@
 # Intercept `cylc` commands and re-invoke them with the appropriate cylc-flow
 # version, according to location or version information in the environment:
 # - 1) $CYLC_HOME if defined, or
-# - 2) $CYLC_HOME_ROOT(_ALT)/$CYLC_VERSION
+# - 2) $CYLC[7]_HOME_ROOT[_ALT]/$CYLC_VERSION
 #
-# USERS SHOULD:
-# - Set CYLC_VERSION to select a specific installed version under the ROOT
-# - Set CYLC_HOME in .bashrc (scheduler and job hosts) to select a single
-#   version outside of the ROOT location.
+# USER INSTRUCTIONS
+#------------------
+# - Set CYLC_VERSION to select an installed version under the ROOT
+#   - this is just the version string, e.g. "8.0.0"
+# - Set CYLC_HOME in .bashrc (scheduler and job hosts) to select a
+#     specific version outside of the ROOT location
+#   - CYLC_HOME should point to a Cylc 8 venv, or a Cylc 7 installation
+#     directory, for a specific Cylc version. It must be set in .bashrc so that
+#     task jobs see it (otherwise they will try to select via CYLC_VERSION)
+# - Do not explicitly select the default "cylc" symlink version.
 # 
 # The scheduler writes cylc.flow.__version__ to CYLC_VERSION in task job
-# scripts so that jobs see the right version. __version__ only increments with
-# releases so CYLC_VERSION cannot be used for fine-grained selection. Git
-# branches between releases, for example, all have the same version. Use
-# CYLC_HOME to select a venv in your cylc-flow git clone.
+# scripts so that jobs pick up the same Cylc version as their parent scheduler.
+# The__version__ string only increments with releases so CYLC_VERSION cannot be
+# used for fine-grained selection between e.g. git working copies between
+# releases. Use CYLC_HOME to select a venv in your cylc-flow git clone.
 #
-# CYLC_HOME must be set in .bashrc so that task jobs also see it - otherwise
-# they will try to select their CYLC_VERSION.
-#
-# If USERS set a default CYLC_VERSION in .bashrc it should take an existing
-# value first to avoid overiding task job version selection:
+# If USERS set CYLC_VERSION in their .bashrc it default to an existing value to
+# avoid overiding task job version selection:
 # - export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
 #
 # INSTALLING CYLC RELEASES WITH CONDA
 #------------------------------------
 # Create environments named cylc-$CYLC_VERSION or cylc-flow-$CYLC_VERSION under
-# a root location such as /opt/cylc:
+# a root location such as /opt:
+#   $ conda create -p /opt/cylc-8.2.0 cylc=8.2.0
+# and create a default version symlink "cylc" to the latest version:
+#   $ ls /opt/cylc*
+#   cylc-8.1.0
+#   cylc-8.2.0
+#   cylc
 #
-# $ conda create -p /opt/cylc/cylc-8.2.0 cylc=8.2.0
-# 
-# $ ls /opt/cylc
-# cylc-8.1.0/
-# cylc-8.2.0/
-#
-# Note you can `pip install` cylc-flow from a git clone into a conda
+# Note you can `pip install` cylc-flow from a git clone into a Conda
 # environment and then select it by CYLC_VERSION but that will be misleading
-# (the code won't actually be the release version). It is better to use Python
+# if the code is not the true release version. It may be better to use Python
 # venvs and CYLC_HOME for cylc-flow development and testing.
 #
-# INSTALLING CYLC-FLOW RELEASES WITH PIP FOR DEVELOPMENT AND TESTING
-#-------------------------------------------------------------------
+# INSTALLING CYLC-FLOW WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
+#-------------------------------------------------------------------------
 # Create Python virtual environments in-place in your cylc-flow git
 # clones and select them using CYLC_HOME in your .bashrc.
 #
@@ -79,46 +82,49 @@
 #   $ pip install -e . 
 #
 # Set CYLC_HOME in .bashrc to select this venv (see explanation above):
-#   $ echo "export CYLC_HOME=$PWD/venv" >> .bashrc
-#   $ . .bashrc
+#   $ echo "export CYLC_HOME=$PWD/venv" >> ~/.bashrc
+#   $ . ~/.bashrc
 #
-# You can also `pip install` cylc-flow releases under a common root location
-# for CYLC_VERSION based selection, like for conda:
-#
+# Note you can also `pip install` cylc-flow releases under a common root
+# location for CYLC_VERSION based selection, like for Conda:
 #   $ CYLC_HOME_ROOT=$HOME/cylc-flow/releases  # (set in this wrapper too)
 #   $ python -m venv $CYLC_HOME_ROOT/cylc-flow-8.0a2
 #   $ . $CYLC_HOME_ROOT/cylc-flow-8.0a2/bin/activate
 #   $ python -m pip install cylc-flow==8.0a2
-# 
-# (But there is no need to do this if you have full system releases - i.e. not
-# just cylc-flow - installed via conda anyway.)
+# But there is no need to do this if you have full system releases - not just
+# cylc-flow - installed via Conda anyway.
  
 ##############################!!! EDIT ME !!!##################################
-# Central Cylc conda releases:
-CYLC_HOME_ROOT=${CYLC_HOME_ROOT:-/opt}
+# Central Cylc Conda releases:
+CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
 # User Conda releases:
-CYLC_HOME_ROOT_ALT=${CYLC_HOME_ROOT_ALT:-/home/$USER/miniconda3/envs}
-# NOTE: users can set CYLC_HOME in their .bashrc to select a non-release conda
-# or pip virtual environment (located in a cylc-flow git clone, for example).
+CYLC_HOME_ROOT_ALT="${CYLC_HOME_ROOT_ALT:-$HOME/miniconda3/envs}"
+
+# Legacy Cylc 7 locations if needed:
+CYLC7_HOME_ROOT="${CYLC7_HOME_ROOT_ALT:-/opt}" 
+CYLC7_HOME_ROOT_ALT="${CYLC7_HOME_ROOT_ALT:-$HOME/cylc/cylc-7}" 
 ###############################################################################
 
-# If CYLC_HOME is not defined, find it using {ROOT} and {VERSION}.
-if [[ -z ${CYLC_HOME:-} ]]; then
-    CYLC_HOME=$CYLC_HOME_ROOT/cylc  # default symlinked version
+if [[ -z "${CYLC_HOME:-}" ]]; then
+    # If CYLC_HOME is not defined find it with CYLC_HOME_ROOT and CYLC_VERSION.
     if [[ -n ${CYLC_VERSION:-} ]]; then
         # Look for matching version in root locations
-        for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
+        for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}" \
+                "${CYLC7_HOME_ROOT}" "${CYLC7_HOME_ROOT_ALT}"; do
             for NAME in "cylc" "cylc-flow"; do
-                if [[ -d $ROOT/${NAME}-$CYLC_VERSION ]]; then
-                    CYLC_HOME=$ROOT/${NAME}-$CYLC_VERSION
+                if [[ -d "${ROOT}/${NAME}-${CYLC_VERSION}" ]]; then
+                    CYLC_HOME="${ROOT}/${NAME}-${CYLC_VERSION}"
                     break 2
                 fi
             done
-         done
+        done
+    else
+        echo 1>&2 "ERROR: CYLC_HOME not defined or found"
+        exit 1
     fi
 fi
 if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
-    # Conda
+    # A Cylc 8 Conda environment
     if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
         # A conda pack installation
         . "${CYLC_HOME}/bin/activate" || exit 1
@@ -128,11 +134,14 @@ if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
         conda activate "$(basename ${CYLC_HOME})" || exit 1
     fi
 elif [[ -f "${CYLC_HOME}/bin/activate" ]]; then
-    # Python venv
+    # A Cylc 8 Python venv
     . "${CYLC_HOME}/bin/activate" || exit 1
+elif [[ -x "${CYLC_HOME}/bin/cylc" ]]; then
+    # A Cylc 7 installation
+    exec $CYLC_HOME/bin/$(basename $0) "$@"
 else
-    echo 1>&2 "ERROR: cylc installation not found in ${CYLC_HOME}"
+    echo 1>&2 "ERROR: cylc not found in ${CYLC_HOME}"
     exit 1
 fi
-# The selected Cylc should now be first in $PATH
+# The selected Cylc 8 should now be first in $PATH
 exec "$(basename "$0")" "$@"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -56,8 +56,7 @@
 #
 # INSTALLING CYLC RELEASES WITH CONDA
 #------------------------------------
-# Create environments named cylc-$CYLC_VERSION or cylc-flow-$CYLC_VERSION under
-# a root location such as /opt:
+# Create environments named cylc-$CYLC_VERSION under a root location such as /opt:
 #   $ conda create -p /opt/cylc-8.2.0 cylc=8.2.0
 # and create a default version symlink "cylc" to the latest version:
 #   $ ls /opt/cylc*
@@ -88,11 +87,11 @@
 # Note you can also `pip install` cylc-flow releases under a common root
 # location for CYLC_VERSION based selection, like for Conda:
 #   $ CYLC_HOME_ROOT=$HOME/cylc-flow/releases  # (set in this wrapper too)
-#   $ python -m venv $CYLC_HOME_ROOT/cylc-flow-8.0a2
-#   $ . $CYLC_HOME_ROOT/cylc-flow-8.0a2/bin/activate
+#   $ python -m venv $CYLC_HOME_ROOT/cylc-8.0a2
+#   $ . $CYLC_HOME_ROOT/cylc-8.0a2/bin/activate
 #   $ python -m pip install cylc-flow==8.0a2
-# But there is no need to do this if you have full system releases - not just
-# cylc-flow - installed via Conda anyway.
+# But there is no need to do this if you also have full system releases (as
+# opposed to cylc-flow only) installed by Conda.
  
 ##############################!!! EDIT ME !!!##################################
 # Central Cylc Conda releases:
@@ -111,12 +110,10 @@ if [[ -z "${CYLC_HOME:-}" ]]; then
         # Look for matching version in root locations
         for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}" \
                 "${CYLC7_HOME_ROOT}" "${CYLC7_HOME_ROOT_ALT}"; do
-            for NAME in "cylc" "cylc-flow"; do
-                if [[ -d "${ROOT}/${NAME}-${CYLC_VERSION}" ]]; then
-                    CYLC_HOME="${ROOT}/${NAME}-${CYLC_VERSION}"
-                    break 2
-                fi
-            done
+            if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
+                CYLC_HOME="${ROOT}/cylc-${CYLC_VERSION}"
+                break 2
+            fi
         done
     else
         echo 1>&2 "ERROR: CYLC_HOME not defined or found"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -23,15 +23,25 @@
 # WRAPPER INSTALLATION AND CONFIGURATION
 #---------------------------------------
 # Copy this script as "cylc" into the default $PATH on scheduler and job hosts,
-# and modify CYLC_HOME_ROOT(_ALT) below (see "EDIT ME") to point to the parent
+# and modify CYLC_HOME_ROOT (see "EDIT ME" below) to point to the parent
 # directory of all installed versions.
 #
 # HOW IT WORKS
 #-------------
 # Intercept "cylc" commands and re-invoke them with the appropriate cylc-flow
-# version, according to location or version information in the environment:
-# + 1) $CYLC_HOME if defined, or
-# + 2) $CYLC_HOME_ROOT[_ALT]/$CYLC_VERSION
+# version selected by, in order of priority:
+#  1) $CYLC_HOME if defined, or
+#  2) $CYLC_HOME_ROOT/$CYLC_VERSION, or
+#  3) $CYLC_HOME_ROOT_ALT/$CYLC_VERSION
+#
+# CYLC_HOME_ROOT should default to the central release location, in this
+# wrapper (see "EDIT ME" below). This must also be done on job hosts.
+#
+# CYLC_HOME_ROOT_ALT can be set by users, e.g. to their own release location.
+#
+# CYLC_HOME can be set by users to a specific version outside of the HOME_ROOT
+# locations, e.g. for a venv in a git working copy. CYLC_HOME must be set in
+# .bashrc so that task jobs see the same version as the parent scheduler.
 #
 # In Cylc 8+ the scheduler sets CYLC_VERSION=cylc.flow.__version__ in task
 # job environments so jobs get the same version as their parent scheduler.
@@ -39,34 +49,18 @@
 # used for fine-grained selection among (e.g.) git working copies between
 # releases. Use CYLC_HOME to select a venv in your cylc-flow git clone.
 #
-# INSTRUCTIONS FOR USERS
-#-----------------------
-# + Set CYLC_VERSION to select an installed version under the root location
-#   - this is just the version string, e.g. "8.0.0"
-#   - if setting it in .bashrc, be sure to default to an existing value to
-#       avoid overiding task job version selection, e.g.:
-#     $ export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
-#   - do not explicitly select the default "cylc" symlink as a version
-# + Set CYLC_HOME in .bashrc (on scheduler and job hosts) to select a specific
-#     version outside of the ROOT location
-#   - this should point to a Cylc 8 venv, or a Cylc 7 installation directory.
-#     It must be set in .bashrc so that task jobs see it (otherwise they will
-#     select CYLC_VERSION as set by the parent scheduler)
-#
 # INSTALLING cylc 8+ RELEASES WITH CONDA
 #---------------------------------------
 # Create environments named cylc-$CYLC_VERSION under a root location such as /opt:
 #   $ conda create -p /opt/cylc-8.2.0 cylc=8.2.0
-# and create a default version symlink "cylc" to the latest version:
-#   $ ls /opt/cylc*
-#   cylc-8.1.0
-#   cylc-8.2.0
-#   cylc
 #
-# Note you can `pip install` cylc-flow from a git clone into a Conda
-# environment and then select it by CYLC_VERSION but that will be misleading
-# if the code is not the true release version. It may be better to use Python
-# venvs and CYLC_HOME for cylc-flow development and testing.
+# And create a default version symlink "cylc" to the latest version:
+#   $ ln -s cylc-8.2.0 cylc
+#
+# Note you can `pip install` from a cylc-flow git clone into a Conda
+# environment and then select it by CYLC_VERSION but that may be misleading
+# if the code is not the true release version. Better to use Python venvs and
+# CYLC_HOME for development and testing.
 #
 # INSTALLING cylc-flow 8+ WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
 #----------------------------------------------------------------------------
@@ -80,8 +74,6 @@
 #   $ pip install -e . 
 #
 # Set CYLC_HOME in .bashrc to select this venv (see explanation above):
-#   $ echo "export CYLC_HOME=$PWD/venv" >> ~/.bashrc
-#   $ . ~/.bashrc
 #
 # Note you can also `pip install` cylc-flow releases under a common root
 # location for CYLC_VERSION based selection, like for Conda:
@@ -94,17 +86,33 @@
 #
 # INSTALLING LEGACY cylc 7 RELEASE TARBALLS BY HAND
 #--------------------------------------------------
-# The Cylc project was split into multiple repositories when Cylc 8 development
-# started. The scheduler component is now called "cylc-flow" instead of "cylc".
-# To work with this wrapper unpacked Cylc 7 release tarballs must be renamed
-# from (e.g.) "cylc-flow-7.9.1" to "cylc-7.9.1". Then follow version-specific
-# installation instructions. Running "make" should create a file called VERSION
-# that contains just the version string (e.g.) "7.9.1".
+# cylc-flow release tarballs now unpack to (e.g.) cylc-flow-7.9.1. To work with
+# this wrapper the directory should be renamed to "cylc-7.9.1". Then follow
+# version-specific installation instructions. Running "make" should create a
+# file called VERSION that contains just the version string (e.g.) "7.9.1".
+#
+# INSTRUCTIONS FOR USERS
+#-----------------------
+# + Set CYLC_HOME_ROOT_ALT in your .bashrc to point to your local conda
+#   environments location if you have releases not available centrally, e.g.:
+#     $ export CYLC_HOME_ROOT_ALT=$HOME/miniconda3/envs
+#   Environments must be named for the cylc version, e.g. "cylc-8.0.2"
+# + Set CYLC_VERSION e.g. "8.0.0" to select a version in the root locations
+#   - CYLC_VERSION is propagated to task job environments by the scheduler.
+#     If you set it in .bashrc, be sure to default to an existing value to
+#     to avoid overiding jobs and to allow only-the fly selection
+#       $ export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
+#   - do not explicitly select the default "cylc" symlink as a version
+# + Set CYLC_HOME in .bashrc (on scheduler and job hosts) to select a specific
+#     version outside of the ROOT location
+#   - CYLC_HOME should point to a Cylc 8 venv, or a Cylc 7 directory. It must
+#     be set in .bashrc so that task jobs see it too
+# + Any of these settings in .bashrc must be replicated on job hosts.
 #
 ##############################!!! EDIT ME !!!##################################
 # Centrally installed Cylc releases:
 CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
-# For an alternate location set CYLC_HOME_ROOT_ALT.
+# Note users can set CYLC_HOME_ROOT_ALT as well (see above), e.g.:
 # CYLC_HOME_ROOT_ALT=${HOME}/miniconda3/envs
 ###############################################################################
 
@@ -119,7 +127,7 @@ if [[ -z "${CYLC_HOME}" && -n ${CYLC_VERSION} ]]; then
     done
 fi
 if [[ -z "${CYLC_HOME}" ]]; then
-    echo 1>&2 "ERROR: CYLC_HOME not defined or found"
+    echo 1>&2 "ERROR: CYLC_HOME not defined or found in CYLC_HOME_ROOT[_ALT]"
     exit 1
 fi
 

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -17,35 +17,39 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #------------------------------------------------------------------------------
-# Wrapper script to support multiple Cylc versions installed on the same host.
-# Handles Conda and Python virtual envs, and plain Cylc 7 installations.
+# Wrapper script to support multiple installed Cylc versions. Handles Conda and
+# Python virtual environments, and legacy plain Cylc 7 installations.
 #
 # WRAPPER INSTALLATION AND CONFIGURATION
 #---------------------------------------
-# Copy this script as "cylc" into the default $PATH on scheduler and job hosts,
-# and modify CYLC_HOME_ROOT (see "EDIT ME" below) to point to the parent
-# directory of all installed versions.
+# - Copy this script as "cylc" into default $PATH, on scheduler and job hosts
+# - Set CYLC_HOME_ROOT ("EDIT ME" below) to default to the parent directory of
+#   installed versions
 #
 # HOW IT WORKS
 #-------------
-# Intercept "cylc" commands and re-invoke them with the appropriate cylc-flow
-# version selected by, in order of priority:
+# Intercept "cylc" commands and re-invoke them with the cylc-flow version
+# selected, in order of priority, by:
 #  1) $CYLC_HOME if defined, or
-#  2) $CYLC_HOME_ROOT/$CYLC_VERSION, or
-#  3) $CYLC_HOME_ROOT_ALT/$CYLC_VERSION
+#  2) $CYLC_HOME_ROOT/$CYLC_VERSION if found, or
+#  3) $CYLC_HOME_ROOT_ALT/$CYLC_VERSION, if found
 #
 # CYLC_HOME_ROOT should default to the central release location, in this
 # wrapper (see "EDIT ME" below). This must also be done on job hosts.
 #
-# CYLC_HOME_ROOT_ALT can be set by users, e.g. to their own release location.
+# CYLC_HOME_ROOT_ALT can be set by users to their own release location.
 #
-# CYLC_HOME can be set by users to a specific version outside of the HOME_ROOT
-# locations, e.g. for a venv in a git working copy. CYLC_HOME must be set in
-# .bashrc so that task jobs see the same version as the parent scheduler.
+# CYLC_HOME can be set by users to a specific version outside of the root
+# location(s), e.g. for a venv in a git working copy. This must be set in
+# .bashrc so that task jobs see CYLC_HOME too.
 #
-# In Cylc 8+ the scheduler sets CYLC_VERSION=cylc.flow.__version__ in task
-# job environments so jobs get the same version as their parent scheduler.
-# The__version__ string increments with releases so CYLC_VERSION cannot be
+# CYLC_VERSION does not have to be set by users in their .bashrc because the
+# scheduler propagates its own version to task job scripts. If users do specify 
+# a version in .bashrc they should make sure it defaults to an existing version
+# to avoid overriding task job version selection (see User Instructions below).
+#
+# In Cylc 8+ the scheduler sets CYLC_VERSION=cylc.flow.__version__ in task job
+# scripts. __version__ only increments with releases so CYLC_VERSION cannot be
 # used for fine-grained selection among (e.g.) git working copies between
 # releases. Use CYLC_HOME to select a venv in your cylc-flow git clone.
 #
@@ -64,8 +68,8 @@
 #
 # INSTALLING cylc-flow 8+ WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
 #----------------------------------------------------------------------------
-# Create Python virtual environments in-place in your cylc-flow git
-# clones and select them using CYLC_HOME in your .bashrc.
+# Create Python virtual environments in-place in your cylc-flow git clones and
+# select them using CYLC_HOME in your .bashrc.
 #
 # Create a new venv and install cylc-flow:
 #   $ cd <my-cylc-flow-clone>
@@ -93,25 +97,24 @@
 #
 # INSTRUCTIONS FOR USERS
 #-----------------------
-# + Set CYLC_HOME_ROOT_ALT in your .bashrc to point to your local conda
-#   environments location if you have releases not available centrally, e.g.:
+# + Set CYLC_HOME_ROOT_ALT in .bashrc to point any local conda releases, e.g.:
 #     $ export CYLC_HOME_ROOT_ALT=$HOME/miniconda3/envs
-#   Environments must be named for the cylc version, e.g. "cylc-8.0.2"
+#   (Environments must be named for the cylc version, e.g. "cylc-8.0.2")
 # + Set CYLC_VERSION e.g. "8.0.0" to select a version in the root locations
-#   - CYLC_VERSION is propagated to task job environments by the scheduler.
-#     If you set it in .bashrc, be sure to default to an existing value to
-#     to avoid overiding jobs and to allow only-the fly selection
+#   - CYLC_VERSION is propagated to task jobs by the scheduler. If you set it
+#   in .bashrc it must default to an existing value to avoid overiding jobs:
 #       $ export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
-#   - do not explicitly select the default "cylc" symlink as a version
+#   - Do not explicitly select the default "cylc" symlink as a version
 # + Set CYLC_HOME in .bashrc (on scheduler and job hosts) to select a specific
-#     version outside of the ROOT location
-#   - CYLC_HOME should point to a Cylc 8 venv, or a Cylc 7 directory. It must
-#     be set in .bashrc so that task jobs see it too
+#   version outside of the ROOT location
+#   - CYLC_HOME should point to a Cylc 8 venv, or a plain Cylc 7 directory. It
+#     must be set in .bashrc so that task jobs see it too
 # + Any of these settings in .bashrc must be replicated on job hosts.
 #
 ##############################!!! EDIT ME !!!##################################
 # Centrally installed Cylc releases:
 CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
+
 # Note users can set CYLC_HOME_ROOT_ALT as well (see above), e.g.:
 # CYLC_HOME_ROOT_ALT=${HOME}/miniconda3/envs
 ###############################################################################

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -140,6 +140,13 @@ elif [[ -d "${CYLC_HOME}"/conda-meta && \
         -f "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh ]]; then
     # A normal Conda environment
     . "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh
+    # Unset CONDA_SHLVL in case CONDA_* was inherited from the scheduler
+    # environment (this has no effect in a clean job submission shell). Doing
+    # this avoids an apparent bug where conda.py:reactivate() does not put the
+    # target environment in front of PATH. If bashrc has since prepended the
+    # wrapper location to PATH in the job environment this results in the
+    # wrapper invoking itself again (repeatedly... fork bomb).
+    unset CONDA_SHLVL
     conda activate "${CYLC_HOME##*/}" || exit 1
 elif [[ -x "${CYLC_HOME}/bin/cylc" ]]; then
     # A Cylc 7 installation

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -53,8 +53,8 @@
 #     It must be set in .bashrc so that task jobs see it (otherwise they will
 #     select CYLC_VERSION as set by the parent scheduler)
 #
-# INSTALLING CYLC RELEASES WITH CONDA
-#------------------------------------
+# INSTALLING cylc 8+ RELEASES WITH CONDA
+#---------------------------------------
 # Create environments named cylc-$CYLC_VERSION under a root location such as /opt:
 #   $ conda create -p /opt/cylc-8.2.0 cylc=8.2.0
 # and create a default version symlink "cylc" to the latest version:
@@ -68,8 +68,8 @@
 # if the code is not the true release version. It may be better to use Python
 # venvs and CYLC_HOME for cylc-flow development and testing.
 #
-# INSTALLING CYLC-FLOW WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
-#-------------------------------------------------------------------------
+# INSTALLING cylc-flow 8+ WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
+#----------------------------------------------------------------------------
 # Create Python virtual environments in-place in your cylc-flow git
 # clones and select them using CYLC_HOME in your .bashrc.
 #
@@ -91,7 +91,16 @@
 #   $ python -m pip install cylc-flow==8.0a2
 # But there is no need to do this if you also have full system releases (as
 # opposed to cylc-flow only) installed by Conda.
- 
+#
+# INSTALLING LEGACY cylc 7 RELEASE TARBALLS BY HAND
+#--------------------------------------------------
+# The Cylc project was split into multiple repositories when Cylc 8 development
+# started. The scheduler component is now called "cylc-flow" instead of "cylc".
+# To work with this wrapper unpacked Cylc 7 release tarballs must be renamed
+# from (e.g.) "cylc-flow-7.9.1" to "cylc-7.9.1". Then follow version-specific
+# installation instructions. Running "make" should create a file called VERSION
+# that contains just the version string (e.g.) "7.9.1".
+#
 ##############################!!! EDIT ME !!!##################################
 # Centrally installed Cylc releases:
 CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -121,7 +121,7 @@ CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
 
 # If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
 if [[ -z "${CYLC_HOME}" ]]; then
-    if [[ -z ${CYLC_VERSION} ]]; then
+    if [[ -z "${CYLC_VERSION}" ]]; then
         echo 1>&2 "ERROR: CYLC_HOME or CYLC_VERSION must be defined"
         exit 1
     fi     
@@ -142,30 +142,25 @@ if [[ -z "${CYLC_HOME}" ]]; then
     exit 1
 fi
 
-# Find and activate the virtual env, or find the Cylc 7 bin directory.
-BASENAME_PREFIX=""
+# Note "conda activate" fails to prepend the environment bin dir to PATH if
+# local jobs inherit the scheduler environment and bashrc has prepended other
+# paths here. We don't actually rely on PATH to find "cylc" below, but just in
+# case, this makes "conda activate" do the right thing:
+unset CONDA_SHLVL
+
+# If selecting a virtual environment, activate it
 if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
     # A Python venv or Conda pack installation
     . "${CYLC_HOME}/bin/activate" || exit 1
-elif [[ -d "${CYLC_HOME}"/conda-meta && \
-        -f "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh ]]; then
+elif [[ -d "${CYLC_HOME}/conda-meta" && \
+        -f "${CYLC_HOME%/*/*}/etc/profile.d/conda.sh" ]]; then
     # A normal Conda environment
-    . "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh
-    # Unset CONDA_SHLVL in case CONDA_* was inherited from the scheduler
-    # environment (this has no effect in a clean job submission shell). Doing
-    # this avoids an apparent bug where conda.py:reactivate() does not put the
-    # target environment in front of PATH. If bashrc has since prepended the
-    # wrapper location to PATH in the job environment this results in the
-    # wrapper invoking itself again (repeatedly... fork bomb).
-    unset CONDA_SHLVL
+    . "${CYLC_HOME%/*/*}/etc/profile.d/conda.sh"
     conda activate "${CYLC_HOME##*/}" || exit 1
-elif [[ -x "${CYLC_HOME}/bin/cylc" ]]; then
-    # A Cylc 7 installation
-    BASENAME_PREFIX="${CYLC_HOME}"/bin/
-else
+fi
+if [[ ! -x "${CYLC_HOME}/bin/cylc" ]]; then
     echo 1>&2 "ERROR: cylc not found in ${CYLC_HOME}"
     exit 1
 fi
-
-# Execute the command via the selected Cylc installation.
-exec "${BASENAME_PREFIX}${0##*/}" "$@"
+# Execute the command in the selected installation.
+exec "${CYLC_HOME}/bin/${0##*/}" "$@"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -18,7 +18,7 @@
 
 #------------------------------------------------------------------------------
 # Wrapper script to support multiple Cylc versions installed on the same host.
-# Handles Cylc 8 Conda and Python virtual envs, and plain Cylc 7 installations.
+# Handles Conda and Python virtual envs, and plain Cylc 7 installations.
 #
 # WRAPPER INSTALLATION AND CONFIGURATION
 #---------------------------------------
@@ -28,31 +28,30 @@
 #
 # HOW IT WORKS
 #-------------
-# Intercept `cylc` commands and re-invoke them with the appropriate cylc-flow
+# Intercept "cylc" commands and re-invoke them with the appropriate cylc-flow
 # version, according to location or version information in the environment:
-# - 1) $CYLC_HOME if defined, or
-# - 2) $CYLC[7]_HOME_ROOT[_ALT]/$CYLC_VERSION
+# + 1) $CYLC_HOME if defined, or
+# + 2) $CYLC_HOME_ROOT[_ALT]/$CYLC_VERSION
 #
-# USER INSTRUCTIONS
-#------------------
-# - Set CYLC_VERSION to select an installed version under the ROOT
-#   - this is just the version string, e.g. "8.0.0"
-# - Set CYLC_HOME in .bashrc (scheduler and job hosts) to select a
-#     specific version outside of the ROOT location
-#   - CYLC_HOME should point to a Cylc 8 venv, or a Cylc 7 installation
-#     directory, for a specific Cylc version. It must be set in .bashrc so that
-#     task jobs see it (otherwise they will try to select via CYLC_VERSION)
-# - Do not explicitly select the default "cylc" symlink version.
-# 
-# The scheduler writes cylc.flow.__version__ to CYLC_VERSION in task job
-# scripts so that jobs pick up the same Cylc version as their parent scheduler.
-# The__version__ string only increments with releases so CYLC_VERSION cannot be
-# used for fine-grained selection between e.g. git working copies between
+# In Cylc 8+ the scheduler sets CYLC_VERSION=cylc.flow.__version__ in task
+# job environments so jobs get the same version as their parent scheduler.
+# The__version__ string increments with releases so CYLC_VERSION cannot be
+# used for fine-grained selection among (e.g.) git working copies between
 # releases. Use CYLC_HOME to select a venv in your cylc-flow git clone.
 #
-# If USERS set CYLC_VERSION in their .bashrc it default to an existing value to
-# avoid overiding task job version selection:
-# - export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
+# INSTRUCTIONS FOR USERS
+#-----------------------
+# + Set CYLC_VERSION to select an installed version under the root location
+#   - this is just the version string, e.g. "8.0.0"
+#   - if setting it in .bashrc, be sure to default to an existing value to
+#       avoid overiding task job version selection, e.g.:
+#     $ export CYLC_VERSION=${CYLC_VERSION:-8.0.0}
+#   - do not explicitly select the default "cylc" symlink as a version
+# + Set CYLC_HOME in .bashrc (on scheduler and job hosts) to select a specific
+#     version outside of the ROOT location
+#   - this should point to a Cylc 8 venv, or a Cylc 7 installation directory.
+#     It must be set in .bashrc so that task jobs see it (otherwise they will
+#     select CYLC_VERSION as set by the parent scheduler)
 #
 # INSTALLING CYLC RELEASES WITH CONDA
 #------------------------------------
@@ -94,32 +93,28 @@
 # opposed to cylc-flow only) installed by Conda.
  
 ##############################!!! EDIT ME !!!##################################
-# Central Cylc Conda releases:
+# Centrally installed Cylc releases:
 CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
-# User Conda releases:
-CYLC_HOME_ROOT_ALT="${CYLC_HOME_ROOT_ALT:-$HOME/miniconda3/envs}"
-
-# Legacy Cylc 7 locations if needed:
-CYLC7_HOME_ROOT="${CYLC7_HOME_ROOT_ALT:-/opt}" 
-CYLC7_HOME_ROOT_ALT="${CYLC7_HOME_ROOT_ALT:-$HOME/cylc/cylc-7}" 
+# For an alternate location set CYLC_HOME_ROOT_ALT.
+# CYLC_HOME_ROOT_ALT=${HOME}/miniconda3/envs
 ###############################################################################
 
-if [[ -z "${CYLC_HOME:-}" ]]; then
-    # If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
-    if [[ -n ${CYLC_VERSION:-} ]]; then
-        # Look for matching version in root locations
-        for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}" \
-                "${CYLC7_HOME_ROOT}" "${CYLC7_HOME_ROOT_ALT}"; do
-            if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
-                CYLC_HOME="${ROOT}/cylc-${CYLC_VERSION}"
-                break
-            fi
-        done
-    else
-        echo 1>&2 "ERROR: CYLC_HOME not defined or found"
-        exit 1
-    fi
+# If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
+if [[ -z "${CYLC_HOME}" && -n ${CYLC_VERSION} ]]; then
+    # Look for matching version in root locations
+    for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
+        if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
+            CYLC_HOME="${ROOT}/cylc-${CYLC_VERSION}"
+            break
+        fi
+    done
 fi
+if [[ -z "${CYLC_HOME}" ]]; then
+    echo 1>&2 "ERROR: CYLC_HOME not defined or found"
+    exit 1
+fi
+
+# Find and activate the virtual env, or find the Cylc 7 bin directory.
 BASENAME_PREFIX=""
 if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
     # A Python venv or Conda pack installation
@@ -136,4 +131,6 @@ else
     echo 1>&2 "ERROR: cylc not found in ${CYLC_HOME}"
     exit 1
 fi
-exec "${BASENAME_PREFIX}$(basename "$0")" "$@"
+
+# Execute the command via the selected Cylc installation.
+exec "${BASENAME_PREFIX}${0##*/}" "$@"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -105,14 +105,14 @@ CYLC7_HOME_ROOT_ALT="${CYLC7_HOME_ROOT_ALT:-$HOME/cylc/cylc-7}"
 ###############################################################################
 
 if [[ -z "${CYLC_HOME:-}" ]]; then
-    # If CYLC_HOME is not defined find it with CYLC_HOME_ROOT and CYLC_VERSION.
+    # If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
     if [[ -n ${CYLC_VERSION:-} ]]; then
         # Look for matching version in root locations
         for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}" \
                 "${CYLC7_HOME_ROOT}" "${CYLC7_HOME_ROOT_ALT}"; do
             if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
                 CYLC_HOME="${ROOT}/cylc-${CYLC_VERSION}"
-                break 2
+                break
             fi
         done
     else
@@ -120,25 +120,20 @@ if [[ -z "${CYLC_HOME:-}" ]]; then
         exit 1
     fi
 fi
-if [[ -d "${CYLC_HOME}/conda-meta" ]]; then
-    # A Cylc 8 Conda environment
-    if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
-        # A conda pack installation
-        . "${CYLC_HOME}/bin/activate" || exit 1
-    else
-        # A normal conda environment
-        . "$(dirname "${CYLC_HOME}")"/../etc/profile.d/conda.sh
-        conda activate "$(basename "${CYLC_HOME}")" || exit 1
-    fi
-elif [[ -f "${CYLC_HOME}/bin/activate" ]]; then
-    # A Cylc 8 Python venv
+BASENAME_PREFIX=""
+if [[ -f "${CYLC_HOME}/bin/activate" ]]; then
+    # A Python venv or Conda pack installation
     . "${CYLC_HOME}/bin/activate" || exit 1
+elif [[ -d "${CYLC_HOME}"/conda-meta && \
+        -f "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh ]]; then
+    # A normal Conda environment
+    . "${CYLC_HOME%/*/*}"/etc/profile.d/conda.sh
+    conda activate "${CYLC_HOME##*/}" || exit 1
 elif [[ -x "${CYLC_HOME}/bin/cylc" ]]; then
     # A Cylc 7 installation
-    exec "${CYLC_HOME}"/bin/"$(basename "$0")" "$@"
+    BASENAME_PREFIX="${CYLC_HOME}"/bin/
 else
     echo 1>&2 "ERROR: cylc not found in ${CYLC_HOME}"
     exit 1
 fi
-# The selected Cylc 8 should now be first in $PATH
-exec "$(basename "$0")" "$@"
+exec "${BASENAME_PREFIX}$(basename "$0")" "$@"

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -119,22 +119,23 @@ CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
 # CYLC_HOME_ROOT_ALT=${HOME}/miniconda3/envs
 ###############################################################################
 
-# If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
 if [[ -z "${CYLC_HOME}" ]]; then
-    if [[ -z "${CYLC_VERSION}" ]]; then
-        echo 1>&2 "ERROR: CYLC_HOME or CYLC_VERSION must be defined"
-        exit 1
-    fi     
-    # Look for matching version in root locations
+    # Look for specified or default version under the root locations
+    if [[ -n "${CYLC_VERSION}" ]]; then
+        CYLC_NAME="cylc-$CYLC_VERSION"
+    else
+        # Default version symlink
+        CYLC_NAME="cylc"
+    fi
     for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
-        if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
-            CYLC_HOME="${ROOT}/cylc-${CYLC_VERSION}"
+        if [[ -d "${ROOT}/${CYLC_NAME}" ]]; then
+            CYLC_HOME="${ROOT}/${CYLC_NAME}"
             break
         fi
     done
 fi
 if [[ -z "${CYLC_HOME}" ]]; then
-    MSG="ERROR: cylc-$CYLC_VERSION not found in $CYLC_HOME_ROOT"
+    MSG="ERROR: $CYLC_NAME not found in $CYLC_HOME_ROOT"
     if [[ -n "${CYLC_HOME_ROOT_ALT}" ]]; then
         MSG="${MSG} or ${CYLC_HOME_ROOT_ALT}"
     fi

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -117,7 +117,11 @@ CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
 ###############################################################################
 
 # If CYLC_HOME is not defined try CYLC_HOME_ROOT/cylc-CYLC_VERSION
-if [[ -z "${CYLC_HOME}" && -n ${CYLC_VERSION} ]]; then
+if [[ -z "${CYLC_HOME}" ]]; then
+    if [[ -z ${CYLC_VERSION} ]]; then
+        echo 1>&2 "ERROR: CYLC_HOME or CYLC_VERSION must be defined"
+        exit 1
+    fi     
     # Look for matching version in root locations
     for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
         if [[ -d "${ROOT}/cylc-${CYLC_VERSION}" ]]; then
@@ -127,7 +131,11 @@ if [[ -z "${CYLC_HOME}" && -n ${CYLC_VERSION} ]]; then
     done
 fi
 if [[ -z "${CYLC_HOME}" ]]; then
-    echo 1>&2 "ERROR: CYLC_HOME not defined or found in CYLC_HOME_ROOT[_ALT]"
+    MSG="ERROR: cylc-$CYLC_VERSION not found in $CYLC_HOME_ROOT"
+    if [[ -n "${CYLC_HOME_ROOT_ALT}" ]]; then
+        MSG="${MSG} or ${CYLC_HOME_ROOT_ALT}"
+    fi
+    echo 1>&2 "$MSG"
     exit 1
 fi
 


### PR DESCRIPTION
New `cylc` wrapper for Cylc 8 conda and pip virtual envs.

Based on @dpmatthews original, tweaked a bit.

With this installed in `$PATH`:
- no need to activate venvs manually, the wrapper does it for you
- select versions via `CYLC_VERSION` (releases) or `CYLC_HOME` (between-release venvs in a git clone, e.g.)
- jobs can automatically see the same cylc as their parent scheduler, without hardwiring a single version in your environment
- supports release-version venvs name `cylc-$CYLC_VERSION` ~~and `cylc-flow-$CYLC_VERSION`~~

Need upcoming PR to divorce jobs from scheduler environment (later today...) to test this properly (currently on master local jobs inherit the scheduler's venv, which get in front of the wrapper in `$PATH`).

Documented in comments in the file, for now (explaining it concisely was the hardest part of this PR :grimacing: ).
In due course, some version of this documentation will need to go in the User Guide.
  
Note that we can't use CYLC_VERSION based selection for between-release versions (e.g. in git clones) in Cylc 8, because `cylc.flow.__version__` is now hardwired rather than determined by`git describe`. (Have to use CYLC_HOME  for that).