### PR TITLE
Clean job submission environment.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,11 +138,10 @@ hierarchy and ability to set site config directory.
 [#3883](https://github.com/cylc/cylc-flow/pull/3883) - Added a new workflow
 config option `[scheduling]stop after cycle point`.
 
-
 [#3961](https://github.com/cylc/cylc-flow/pull/3961) - Added a new command:
 `cylc clean`.
 
-[#XXXX](https://github.com/cylc/cylc-flow/pull/3712) - Global config options
+[#3955](https://github.com/cylc/cylc-flow/pull/3955) - Global config options
 to control the job submission environment.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,8 +138,13 @@ hierarchy and ability to set site config directory.
 [#3883](https://github.com/cylc/cylc-flow/pull/3883) - Added a new workflow
 config option `[scheduling]stop after cycle point`.
 
+
 [#3961](https://github.com/cylc/cylc-flow/pull/3961) - Added a new command:
 `cylc clean`.
+
+[#XXXX](https://github.com/cylc/cylc-flow/pull/3712) - Global config options
+to control the job submission environment.
+
 
 ### Fixes
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -33,6 +33,18 @@ from cylc.flow.parsec.validate import (
 # - value_type: value type (compulsory).
 # - default: the default value (optional).
 # - allowed_2, ...: the only other allowed values of this setting (optional).
+
+# Standard executable search paths to pass to job submission subprocesses.
+SYSPATH = [
+    '/bin',
+    '/usr/bin',
+    '/usr/local/bin',
+    '/sbin',
+    '/usr/sbin',
+    '/usr/local/sbin'
+]
+
+
 with Conf('global.cylc', desc='''
     The global configuration which defines default Cylc Flow settings
     for a user or site.
@@ -548,6 +560,40 @@ with Conf('global.cylc', desc='''
                        install target = localhost
             ''')
 
+            Conf('clean job submission environment', VDR.V_BOOLEAN, False,
+                 desc='''
+                Job submission subprocesses inherit their parent environment by
+                default. So remote job submissions inherit the default
+                non-interactive shell environment, but local ones inherit the
+                scheduler environment. This means local jobs see the scheduler
+                environment unless the local batch system prevents it, which
+                can cause problems - e.g. scheduler ``$PYTHON...`` variables
+                can affect Python programs executed by task job scripts. For
+                consistent handling of local and remote jobs a clean job
+                submission environment is recommended, but it is not the
+                default because it prevents local task jobs from running unless
+                the ``cylc`` version selection wrapper script is installed in
+                ``$PATH`` (a clean environment prevents local jobs from seeing
+                the scheduler's virtual environment).
+
+                Specific environment variables can be singled out to pass
+                through to the clean environment, if necessary.
+
+                A standard set of executable paths is passed through to clean
+                environments, and can be added to if necessary.
+            ''')
+
+            Conf('job submission environment pass-through', VDR.V_STRING_LIST,
+                 desc='''
+                Minimal list of environment variable names to pass through to
+                job submission subprocesses. $HOME is passed automatically.
+                You are unlikely to need this.
+            ''')
+            Conf('job submission executable paths', VDR.V_STRING_LIST, desc='''
+                Additional executable locations to pass to the job
+                submission subprocess beyond the standard locations''' +
+                 ', '.join(SYSPATH) + '''. You are unlikely to need this.
+            ''')
         with Conf('localhost', meta=Platform):
             Conf('hosts', VDR.V_STRING_LIST, ['localhost'])
 

--- a/cylc/flow/job_runner_handlers/background.py
+++ b/cylc/flow/job_runner_handlers/background.py
@@ -75,6 +75,7 @@ class BgCommandHandler:
                      timeout_str),
                     job_file_path,
                 ],
+                env=submit_opts.get('env'),
                 preexec_fn=os.setpgrp,
                 stdin=DEVNULL,
                 stdout=open(os.devnull, "wb"),

--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -218,7 +218,6 @@ class JobRunnerManager():
             if os.path.isdir(suite_py) and suite_py not in sys.path:
                 sys.path.append(suite_py)
 
-
     def __init__(self, clean_env=False, env=None, path=None):
         """Initialise JobRunnerManager."""
         # Job submission environment.

--- a/cylc/flow/scripts/jobs_submit.py
+++ b/cylc/flow/scripts/jobs_submit.py
@@ -24,6 +24,7 @@ On a remote job host, this command reads the job files from STDIN.
 """
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
+from cylc.flow.job_runner_mgr import JobRunnerManager
 
 INTERNAL = True
 

--- a/cylc/flow/scripts/jobs_submit.py
+++ b/cylc/flow/scripts/jobs_submit.py
@@ -50,15 +50,38 @@ def get_option_parser():
         dest="utc_mode",
         default=False,
     )
-
+    parser.add_option(
+        "--clean-env",
+        help="Clean job submission environment.",
+        action="store_true",
+        dest="clean_env",
+        default=False,
+    )
+    parser.add_option(
+        "--env",
+        help="Variable to pass from parent environment to job submit "
+        "environment. This option can be used multiple times.",
+        action="append",
+        metavar="VAR=VALUE",
+        dest="env",
+        default=[]
+    )
+    parser.add_option(
+        "--path",
+        help="Executable location to pass to job submit environment. "
+        "This option can be used multiple times.",
+        action="append",
+        metavar="PATH",
+        dest="path",
+        default=[]
+    )
     return parser
 
 
 @cli_function(get_option_parser)
 def main(parser, opts, job_log_root, *job_log_dirs):
     """CLI main."""
-    from cylc.flow.job_runner_mgr import JobRunnerManager
-    JobRunnerManager().jobs_submit(
+    JobRunnerManager(opts.clean_env, opts.env, opts.path).jobs_submit(
         job_log_root,
         job_log_dirs,
         remote_mode=opts.remote_mode,

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -105,6 +105,7 @@ from cylc.flow.wallclock import (
     get_current_time_string,
     get_utc_mode
 )
+from cylc.flow.cfgspec.globalcfg import SYSPATH
 
 
 class TaskJobManager:
@@ -342,6 +343,15 @@ class TaskJobManager:
                 cmd.append('--remote-mode')
             else:
                 remote_mode = False
+            if itask.platform[
+                    'clean job submission environment']:
+                cmd.append('--clean-env')
+            for var in itask.platform[
+                    'job submission environment pass-through']:
+                cmd.append(f"--env={var}")
+            for path in itask.platform[
+                    'job submission executable paths'] + SYSPATH:
+                cmd.append(f"--path={path}")
             cmd.append('--')
             cmd.append(
                 get_remote_suite_run_job_dir(

--- a/tests/flakyfunctional/events/01-task.t
+++ b/tests/flakyfunctional/events/01-task.t
@@ -27,9 +27,13 @@ create_test_global_config '
         hosts = NOHOST.NODOMAIN
 '
 #-------------------------------------------------------------------------------
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate \
+    --set=SUITE_LOG_DIR=\""${SUITE_RUN_DIR}/log/suite"\" \
+    "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug --no-detach "${SUITE_NAME}"
+    cylc run --reference-test --debug --no-detach \
+    --set=SUITE_LOG_DIR=\""${SUITE_RUN_DIR}/log/suite"\" \
+    "${SUITE_NAME}"
 sort -u 'events.log' >'expected.events.log'
 sed 's/ (after .*)$//' "${SUITE_RUN_DIR}/log/suite/events.log" | sort -u \
     >'actual.events.log'

--- a/tests/flakyfunctional/events/01-task/flow.cylc
+++ b/tests/flakyfunctional/events/01-task/flow.cylc
@@ -56,6 +56,8 @@
             submission retry delays = PT3S
      [[baz]]
         # submitted, submission timeout, started, failed
+        # Delay in init-script to cause submission timeout.
+        # (Note CYLC_SUITE_LOG_DIR is not defined at this point!)
         init-script = """
             while ! grep -q 'submission timeout *baz\.1' "${CYLC_SUITE_LOG_DIR}/events.log"
             do

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -14,19 +14,25 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#-------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Test job submission with a very chatty command.
 # + Simulate "cylc jobs-submit" getting killed half way through.
+
 export REQUIRE_PLATFORM='runner:at'
+
 . "$(dirname "$0")/test_header"
 set_test_number 15
 
-create_test_global_config "" "
-[scheduler]
-    process pool timeout = PT10S
+# This test relies on jobs inheriting the scheduler environment: the job
+# submission command bin/talkingnonsense reads COPYING from $CYLC_REPO_DIR
+# and writes to $CYLC_SUITE_RUN_DIR.
+
+create_test_global_config "
+process pool timeout = PT10S
 [platforms]
     [[$CYLC_TEST_PLATFORM]]
         job runner command template = talkingnonsense %(job)s
+        clean job submission environment = False
 "
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/api-suite-info/00-get-graph-raw-1.t
+++ b/tests/functional/api-suite-info/00-get-graph-raw-1.t
@@ -19,6 +19,13 @@
 . "$(dirname "$0")/test_header"
 set_test_number 3
 
+# This test relies on jobs inheriting the venv python from the scheduler.
+create_test_global_config "
+[platforms]
+    [[localhost]]
+        clean job submission environment = False
+"
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"

--- a/tests/functional/api-suite-info/02-get-graph-raw-3.t
+++ b/tests/functional/api-suite-info/02-get-graph-raw-3.t
@@ -19,6 +19,13 @@
 . "$(dirname "$0")/test_header"
 set_test_number 3
 
+# This test relies on jobs inheriting the venv python from the scheduler.
+create_test_global_config "
+[platforms]
+    [[localhost]]
+        clean job submission environment = False
+"
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"

--- a/tests/functional/api-suite-info/03-get-graph-raw-4.t
+++ b/tests/functional/api-suite-info/03-get-graph-raw-4.t
@@ -19,6 +19,13 @@
 . "$(dirname "$0")/test_header"
 set_test_number 3
 
+# This test relies on jobs inheriting the venv python from the scheduler.
+create_test_global_config "
+[platforms]
+    [[localhost]]
+        clean job submission environment = False
+"
+
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"

--- a/tests/functional/job-submission/07-multi.t
+++ b/tests/functional/job-submission/07-multi.t
@@ -33,19 +33,20 @@ RUN_DIR="$RUN_DIR/${SUITE_NAME}"
 LOG="${RUN_DIR}/log/suite/log"
 sed -n 's/^.*\(cylc jobs-submit\)/\1/p' "${LOG}" | sort -u >'edited-suite-log'
 
+PATHOPTS="--path=/bin --path=/usr/bin --path=/usr/local/bin --path=/sbin --path=/usr/sbin --path=/usr/local/sbin" 
 sort >'edited-suite-log-ref' <<__LOG__
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t0/01 20200101T0000Z/t1/01 20200101T0000Z/t2/01 20200101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t0/01 20210101T0000Z/t1/01 20210101T0000Z/t2/01 20210101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t0/01 20220101T0000Z/t1/01 20220101T0000Z/t2/01 20220101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t0/01 20230101T0000Z/t1/01 20230101T0000Z/t2/01 20230101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t0/01 20240101T0000Z/t1/01 20240101T0000Z/t2/01 20240101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t0/01 20250101T0000Z/t1/01 20250101T0000Z/t2/01 20250101T0000Z/t3/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t4/01 20200101T0000Z/t5/01 20200101T0000Z/t6/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t4/01 20210101T0000Z/t5/01 20210101T0000Z/t6/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t4/01 20220101T0000Z/t5/01 20220101T0000Z/t6/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t4/01 20230101T0000Z/t5/01 20230101T0000Z/t6/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t4/01 20240101T0000Z/t5/01 20240101T0000Z/t6/01
-cylc jobs-submit --debug --utc-mode --remote-mode -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t4/01 20250101T0000Z/t5/01 20250101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t0/01 20200101T0000Z/t1/01 20200101T0000Z/t2/01 20200101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t0/01 20210101T0000Z/t1/01 20210101T0000Z/t2/01 20210101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t0/01 20220101T0000Z/t1/01 20220101T0000Z/t2/01 20220101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t0/01 20230101T0000Z/t1/01 20230101T0000Z/t2/01 20230101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t0/01 20240101T0000Z/t1/01 20240101T0000Z/t2/01 20240101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t0/01 20250101T0000Z/t1/01 20250101T0000Z/t2/01 20250101T0000Z/t3/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20200101T0000Z/t4/01 20200101T0000Z/t5/01 20200101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20210101T0000Z/t4/01 20210101T0000Z/t5/01 20210101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20220101T0000Z/t4/01 20220101T0000Z/t5/01 20220101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20230101T0000Z/t4/01 20230101T0000Z/t5/01 20230101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20240101T0000Z/t4/01 20240101T0000Z/t5/01 20240101T0000Z/t6/01
+cylc jobs-submit --debug --utc-mode --remote-mode $PATHOPTS -- '\$HOME/cylc-run/${SUITE_NAME}/log/job' 20250101T0000Z/t4/01 20250101T0000Z/t5/01 20250101T0000Z/t6/01
 __LOG__
 cmp_ok 'edited-suite-log' 'edited-suite-log-ref'
 

--- a/tests/functional/job-submission/18-clean-env/flow.cylc
+++ b/tests/functional/job-submission/18-clean-env/flow.cylc
@@ -1,0 +1,16 @@
+[cylc]
+    [[events]]
+        timeout = PT30S
+        inactivity = PT30S
+        abort on inactivity = True
+        abort on timeout = True
+        abort on stalled = True
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = """
+            echo "BEEF ${BEEF:-undefined}"
+            echo "CHEESE ${CHEESE:-undefined}"
+                 """

--- a/tests/functional/shutdown/12-bad-port-file-check/flow.cylc
+++ b/tests/functional/shutdown/12-bad-port-file-check/flow.cylc
@@ -19,7 +19,7 @@
         script = """
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 # Corrupt port file and don't report back to suite
-SRVD="$RUN_DIR/${CYLC_SUITE_NAME}/.service"
+SRVD="${CYLC_SUITE_RUN_DIR}/.service"
 echo 'Haha! I have corrupted the port file!' >"${SRVD}/contact"
 trap '' EXIT
 exit

--- a/tests/functional/shutdown/13-no-port-file-check/flow.cylc
+++ b/tests/functional/shutdown/13-no-port-file-check/flow.cylc
@@ -19,8 +19,7 @@
         script = """
 wait "${CYLC_TASK_MESSAGE_STARTED_PID}" 2>/dev/null || true
 # Remove contact file and don't report back to suite
-SRVD="$RUN_DIR/${CYLC_SUITE_NAME}/.service"
-rm -f "${SRVD}/contact"
+rm -f "${CYLC_SUITE_RUN_DIR}/.service/contact"
 trap '' EXIT
 exit
 """


### PR DESCRIPTION
Close #3710 
Close #3487 
Supersede #3712 

Global config platform settings to divorce job submission subprocesses from the parent environment (which for local jobs, means the scheduler environment). 

The "impasse" referred to here https://github.com/cylc/cylc-flow/pull/3712#issuecomment-678092052 was resolved (duh) by having the scheduler read relevant global config and pass the `clean_env` flag and associated environment variable names and executable paths to the job host by new `cylc jobs-submit` command line options.
