### PR TITLE
Remove redundant _dump_item method

### DIFF
--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -598,28 +598,6 @@ def create_server_keys(keys, suite_srv_dir):
     os.umask(old_umask)
 
 
-def _dump_item(path, item, value):
-    """Dump "value" to a file called "item" in the directory "path".
-
-    1. File permission should already be user-read-write-only on
-       creation by mkstemp.
-    2. The combination of os.fsync and os.rename should guarantee
-       that we don't end up with an incomplete file.
-    """
-    os.makedirs(path, exist_ok=True)
-    from tempfile import NamedTemporaryFile
-    handle = NamedTemporaryFile(prefix=item, dir=path, delete=False)
-    try:
-        handle.write(value.encode())
-    except AttributeError:
-        handle.write(value)
-    os.fsync(handle.fileno())
-    handle.close()
-    fname = os.path.join(path, item)
-    os.rename(handle.name, fname)
-    LOG.debug('Generated %s', fname)
-
-
 def get_suite_title(reg):
     """Return the the suite title without a full file parse
 


### PR DESCRIPTION
This code should probably have been removed in the pr which removed get_auth_items (https://github.com/cylc/cylc-flow/pull/3509)

This is a very small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (only removing unused code).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
