### PR TITLE
Move items from [task][job] to [task]

### DIFF
--- a/cylc/flow/batch_sys_handlers/loadleveler.py
+++ b/cylc/flow/batch_sys_handlers/loadleveler.py
@@ -23,9 +23,9 @@ Loadleveler directives can be provided in the flow.cylc file:
 
    [runtime]
        [[my_task]]
+           execution time limit = PT10M
            [[[job]]]
                batch system = loadleveler
-               execution time limit = PT10M
            [[[directives]]]
                foo = bar
                baz = qux

--- a/cylc/flow/batch_sys_handlers/lsf.py
+++ b/cylc/flow/batch_sys_handlers/lsf.py
@@ -23,9 +23,9 @@ LSF directives can be provided in the flow.cylc file:
 
    [runtime]
        [[my_task]]
+           execution time limit = PT10M
            [[[job]]]
                batch system = lsf
-               execution time limit = PT10M
            [[[directives]]]
                -q = foo
 

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -801,6 +801,11 @@ with Conf(
 
                    ``$CYLC_TASK_CYCLE_POINT/shared/``
             ''')
+            Conf('execution polling intervals', VDR.V_INTERVAL_LIST, None)
+            Conf('execution retry delays', VDR.V_INTERVAL_LIST, None)
+            Conf('execution time limit', VDR.V_INTERVAL)
+            Conf('submission polling intervals', VDR.V_INTERVAL_LIST, None)
+            Conf('submission retry delays', VDR.V_INTERVAL_LIST, None)
 
             with Conf('meta', desc=r'''
                 Section containing metadata items for this task or family
@@ -947,14 +952,6 @@ with Conf(
             '''):
                 Conf('batch system', VDR.V_STRING)
                 Conf('batch submit command template', VDR.V_STRING)
-                # TODO All the remaining items to be moved to top level of
-                # TASK when platforms work is completed.
-                Conf('execution polling intervals', VDR.V_INTERVAL_LIST, None)
-                Conf('execution retry delays', VDR.V_INTERVAL_LIST, None)
-                Conf('execution time limit', VDR.V_INTERVAL)
-                Conf('submission polling intervals', VDR.V_INTERVAL_LIST,
-                     None)
-                Conf('submission retry delays', VDR.V_INTERVAL_LIST, None)
 
             with Conf('remote'):
                 Conf('host', VDR.V_STRING)
@@ -1364,22 +1361,20 @@ def upg(cfg, descr):
         ['scheduling', 'hold after point'],
         ['scheduling', 'hold after cycle point']
     )
-    # TODO uncomment these deprecations when ready - see todo in
-    # [runtime][__MANY__] section.
-    # for job_setting in [
-    #     'execution polling intervals',
-    #     'execution retry delays',
-    #     'execution time limit',
-    #     'submission polling intervals',
-    #     'submission retry delays'
-    # ]:
-    #     u.deprecate(
-    #         '8.0.0',
-    #         ['runtime', '__MANY__', 'job', job_setting],
-    #         ['runtime', '__MANY__', job_setting]
-    #     )
-    # TODO - there are some simple changes to the config (items from [remote]
-    # and [job] moved up 1 level for example) which should be upgraded here.
+
+    for job_setting in [
+        'execution polling intervals',
+        'execution retry delays',
+        'execution time limit',
+        'submission polling intervals',
+        'submission retry delays'
+    ]:
+        u.deprecate(
+            '8.0.0',
+            ['runtime', '__MANY__', 'job', job_setting],
+            ['runtime', '__MANY__', job_setting]
+        )
+
     u.deprecate('8.0.0', ['cylc'], ['scheduler'])
     u.upgrade()
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1318,7 +1318,7 @@ class SuiteConfig:
         for tdef in self.taskdefs.values():
             # Compute simulated run time by scaling the execution limit.
             rtc = tdef.rtconfig
-            limit = rtc['job']['execution time limit']
+            limit = rtc['execution time limit']
             speedup = rtc['simulation']['speedup factor']
             if limit and speedup:
                 sleep_sec = (DurationParser().parse(
@@ -1327,7 +1327,7 @@ class SuiteConfig:
                 sleep_sec = DurationParser().parse(
                     str(rtc['simulation']['default run length'])
                 ).get_seconds()
-            rtc['job']['execution time limit'] = (
+            rtc['execution time limit'] = (
                 sleep_sec + DurationParser().parse(str(
                     rtc['simulation']['time limit buffer'])).get_seconds()
             )

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -155,7 +155,7 @@ def task_mean_elapsed_time(tdef):
     """Calculate task mean elapsed time."""
     if tdef.elapsed_times:
         return sum(tdef.elapsed_times) / len(tdef.elapsed_times)
-    return tdef.rtconfig['job'].get('execution time limit', None)
+    return tdef.rtconfig.get('execution time limit', None)
 
 
 def apply_delta(key, delta, data):

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -713,8 +713,8 @@ class TaskJobManager:
             retry = False
 
         if retry:
-            if rtconfig['job']['submission retry delays']:
-                submit_delays = rtconfig['job']['submission retry delays']
+            if rtconfig['submission retry delays']:
+                submit_delays = rtconfig['submission retry delays']
             else:
                 submit_delays = itask.platform['submission retry delays']
             # TODO: same for execution delays?
@@ -727,7 +727,7 @@ class TaskJobManager:
                     ),
                     (
                         TimerFlags.EXECUTION_RETRY,
-                        rtconfig['job']['execution retry delays']
+                        rtconfig['execution retry delays']
                     )
             ]:
                 if delays is None:
@@ -950,7 +950,7 @@ class TaskJobManager:
             batch_sys_conf = {}
         try:
             itask.summary[self.KEY_EXECUTE_TIME_LIMIT] = float(
-                rtconfig['job']['execution time limit'])
+                rtconfig['execution time limit'])
         except TypeError:
             pass
 

--- a/tests/functional/cylc-get-config/00-simple/section2.stdout
+++ b/tests/functional/cylc-get-config/00-simple/section2.stdout
@@ -9,6 +9,11 @@
     script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[meta]]]
         title = 
         description = 
@@ -26,11 +31,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -86,6 +86,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[meta]]]
         title = 
         description = 
@@ -103,11 +108,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -163,6 +163,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[meta]]]
         title = 
         description = 
@@ -180,11 +185,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -240,6 +240,11 @@
     script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = serial
     [[[meta]]]
@@ -259,11 +264,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -318,6 +318,11 @@
     script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = parallel
     [[[meta]]]
@@ -337,11 +342,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -396,6 +396,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = serial
     [[[meta]]]
@@ -415,11 +420,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -474,6 +474,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = serial
     [[[meta]]]
@@ -493,11 +498,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -552,6 +552,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = parallel
     [[[meta]]]
@@ -571,11 +576,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -630,6 +630,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = parallel
     [[[meta]]]
@@ -649,11 +654,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -708,6 +708,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = serial
     [[[meta]]]
@@ -727,11 +732,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -786,6 +786,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = serial
     [[[meta]]]
@@ -805,11 +810,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -864,6 +864,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = parallel
     [[[meta]]]
@@ -883,11 +888,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 
@@ -942,6 +942,11 @@
     pre-script = 
     post-script = 
     work sub-directory = 
+    execution polling intervals = 
+    execution retry delays = 
+    execution time limit = 
+    submission polling intervals = 
+    submission retry delays = 
     [[[directives]]]
         job_type = parallel
     [[[meta]]]
@@ -961,11 +966,6 @@
     [[[job]]]
         batch system = 
         batch submit command template = 
-        execution polling intervals = 
-        execution retry delays = 
-        execution time limit = 
-        submission polling intervals = 
-        submission retry delays = 
     [[[remote]]]
         host = 
         owner = 

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -41,6 +41,11 @@
         extra log files =
         [[[job]]]
             shell = fish
+            execution polling intervals =
+            execution retry delays =
+            execution time limit =
+            submission polling intervals =
+            submission retry delays =
         [[[events]]]
             mail from =
             mail to =

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -22,4 +22,9 @@ WARNING -  * (8.0.0) [cylc][events][mail smtp] - DELETED (OBSOLETE) - use "globa
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
 WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
 WARNING -  * (8.0.0) [scheduling][hold after point] -> [scheduling][hold after cycle point] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution polling intervals] -> [runtime][foo, cat, dog][execution polling intervals] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution retry delays] -> [runtime][foo, cat, dog][execution retry delays] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution time limit] -> [runtime][foo, cat, dog][execution time limit] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission polling intervals] -> [runtime][foo, cat, dog][submission polling intervals] - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission retry delays] -> [runtime][foo, cat, dog][submission retry delays] - value unchanged
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged

--- a/tests/functional/validate/23-fail-old-syntax-7/flow.cylc
+++ b/tests/functional/validate/23-fail-old-syntax-7/flow.cylc
@@ -9,5 +9,4 @@
 [runtime]
     [[A]]
         script = "sleep 10"
-        [[[job]]]
-            execution retry delays = 2*PT30M, PT60M
+        execution retry delays = 2*PT30M, PT60M


### PR DESCRIPTION
These changes partially address #3696 
These five items needed to be moved from `[scheduling][TASK][job]` to `[scheduling][TASK]`:
* execution polling intervals
* execution retry delays
* execution time limit
* submission polling intervals
* submission retry delays

- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required: All changes to be logged at the end of issue #3696 
- [x] Docs: All changes to be logged at the end of issue #3696 