### PR TITLE
templatevars: parse CLI opts with literal_eval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,11 @@ symlink to `DIR` (see #3884).
 
 ### Enhancements
 
+[#3974](https://github.com/cylc/cylc-flow/pull/3974) - Template variables,
+both in set files and provided via the -s/--set command line options are
+now parsed using ast.literal_eval. This permits non-string data types,
+strings must now be quoted.
+
 [#3811](https://github.com/cylc/cylc-flow/pull/3811) - Move from cycle based
 to `n` distance dependency graph window node generation and pruning of the
 data-store (API/visual backing data). Ability to modify distance of live

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1486,7 +1486,7 @@ class Reload(Mutation):
             running at reload time.
 
             If the suite was started with Jinja2 template variables set on the
-            command line (cylc run --set FOO=bar REG) the same template
+            command line (cylc run --set "FOO='bar'" REG) the same template
             settings apply to the reload (only changes to the flow.cylc
             file itself are reloaded).
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -172,12 +172,16 @@ TASK_GLOB matches task or family names at a given cycle point.
             self.add_std_option(
                 "-s", "--set", metavar="NAME=VALUE",
                 help=(
-                    "Set the value of a Jinja2 template variable in the "
-                    "suite definition. This option can be used multiple "
-                    "times on the command line. "
-                    "NOTE: these settings persist across suite restarts, "
-                    "but can be set again on the \"cylc restart\" "
-                    "command line if they need to be overridden."
+                    "Set the value of a Jinja2 template variable in the"
+                    " suite definition."
+                    " Values should be valid Python literals so strings"
+                    " must be quoted"
+                    " e.g. 'STR=\"string\"', INT=43, BOOL=True."
+                    " This option can be used multiple "
+                    " times on the command line."
+                    " NOTE: these settings persist across suite restarts,"
+                    " but can be set again on the \"cylc restart\""
+                    " command line if they need to be overridden."
                 ),
                 action="append", default=[], dest="templatevars")
 
@@ -187,6 +191,8 @@ TASK_GLOB matches task or family names at a given cycle point.
                     "Set the value of Jinja2 template variables in the "
                     "suite definition from a file containing NAME=VALUE "
                     "pairs (one per line). "
+                    "As with --set values should be valid Python literals "
+                    "so strings must be quoted e.g. STR='string'. "
                     "NOTE: these settings persist across suite restarts, "
                     "but can be set again on the \"cylc restart\" "
                     "command line if they need to be overridden."

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -26,7 +26,7 @@ reload. Changes to task definitions take effect immediately, unless a task is
 already running at reload time.
 
 If the suite was started with Jinja2 template variables set on the command line
-(cylc run --set FOO=bar REG) the same template settings apply to the reload
+(cylc run --set 'FOO="bar"' REG) the same template settings apply to the reload
 (only changes to the flow.cylc file itself are reloaded).
 
 If the modified suite definition does not parse, failure to reload will

--- a/tests/flakyfunctional/cylc-show/00-simple.t
+++ b/tests/flakyfunctional/cylc-show/00-simple.t
@@ -27,11 +27,11 @@ TEST_SHOW_OUTPUT_PATH="${PWD}/${TEST_NAME_BASE}-show"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_OUTPUT_PATH="${TEST_SHOW_OUTPUT_PATH}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${TEST_SHOW_OUTPUT_PATH}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_OUTPUT_PATH="${TEST_SHOW_OUTPUT_PATH}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${TEST_SHOW_OUTPUT_PATH}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-show"
 cmp_ok "${TEST_NAME}-suite" <<'__SHOW_OUTPUT__'

--- a/tests/flakyfunctional/restart/19-checkpoint/flow.cylc
+++ b/tests/flakyfunctional/restart/19-checkpoint/flow.cylc
@@ -20,7 +20,7 @@ if [[ "${CYLC_TASK_CYCLE_POINT}" == '2017' ]]; then
     cylc__job__poll_grep_suite_log -F \
         '[t1.2017] status=submitted: (received)started'
     sleep 2  # make sure status change recorded in DB
-    cylc broadcast "${CYLC_SUITE_NAME}" -p '2017' -n 't1' --set='script=true'
+    cylc broadcast "${CYLC_SUITE_NAME}" -p '2017' -n 't1' --set='script="true"'
     cylc hold "${CYLC_SUITE_NAME}"
     cylc__job__poll_grep_suite_log -F \
         'INFO - Command succeeded: hold()'

--- a/tests/flakyfunctional/special/04-clock-triggered.t
+++ b/tests/flakyfunctional/special/04-clock-triggered.t
@@ -23,37 +23,37 @@ set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "START=$(date '+%Y%m%dT%H')" \
-    -s "HOUR=$(date '+%H')" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(date '+%Y%m%dT%H')'" \
+    -s "HOUR='$(date '+%H')'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-run-now" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(date '+%Y%m%dT%H')" \
-    -s "HOUR=$(date '+%H')" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(date '+%Y%m%dT%H')'" \
+    -s "HOUR='$(date '+%H')'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 NOW="$(date '+%Y%m%dT%H')"
 run_ok "${TEST_NAME_BASE}-run-past" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='-10')" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT1M'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='-10')'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT1M"'
 #-------------------------------------------------------------------------------
 NOW="$(date '+%Y%m%dT%H')"
 run_fail "${TEST_NAME_BASE}-run-later" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='10')" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='10')'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 purge
 exit

--- a/tests/flakyfunctional/special/05-clock-triggered-utc.t
+++ b/tests/flakyfunctional/special/05-clock-triggered-utc.t
@@ -23,37 +23,37 @@ set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "START=$(date -u '+%Y%m%dT%H00')Z" \
-    -s "HOUR=$(date -u '+%H')" \
-    -s 'UTC_MODE=True' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(date -u '+%Y%m%dT%H00')Z'" \
+    -s "HOUR='$(date -u '+%H')'" \
+    -s 'UTC_MODE="True"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-run-now" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(date -u '+%Y%m%dT%H00')Z" \
-    -s "HOUR=$(date -u '+%H')" \
-    -s 'UTC_MODE=True' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT1M'
+    -s "START='$(date -u '+%Y%m%dT%H00')Z'" \
+    -s "HOUR='$(date -u '+%H')'" \
+    -s 'UTC_MODE="True"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT1M"'
 #-------------------------------------------------------------------------------
 NOW="$(date -u '+%Y%m%dT%H00')Z"
 run_ok "${TEST_NAME_BASE}-run-past" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='-10')" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)" \
-    -s 'UTC_MODE=True' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='-10')'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)'" \
+    -s 'UTC_MODE="True"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 NOW="$(date -u '+%Y%m%dT%H00')Z"
 run_fail "${TEST_NAME_BASE}-run-later" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='10')" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)" \
-    -s 'UTC_MODE=True' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='10')'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)'" \
+    -s 'UTC_MODE="True"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 purge
 exit

--- a/tests/flakyfunctional/special/06-clock-triggered-iso.t
+++ b/tests/flakyfunctional/special/06-clock-triggered-iso.t
@@ -23,38 +23,38 @@ set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "START=$(date '+%Y%m%dT%H%z')" \
-    -s "HOUR=$(date '+%H')" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(date '+%Y%m%dT%H%z')'" \
+    -s "HOUR='$(date '+%H')'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-run-now" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(date '+%Y%m%dT%H%z')" \
-    -s "HOUR=$(date '+%H')" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(date '+%Y%m%dT%H%z')'" \
+    -s "HOUR='$(date '+%H')'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 TZSTR="$(date '+%z')"
 NOW="$(date '+%Y%m%dT%H')"
 run_ok "${TEST_NAME_BASE}-run-past" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='-10')${TZSTR}" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT1M'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='-10')${TZSTR}'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT1M"'
 #-------------------------------------------------------------------------------
 NOW="$(date '+%Y%m%dT%H')"
 run_fail "${TEST_NAME_BASE}-run-later" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s "START=$(cylc cycle-point "${NOW}" --offset-hour='10')${TZSTR}" \
-    -s "HOUR=$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)" \
-    -s 'UTC_MODE=False' \
-    -s 'OFFSET=PT0S' \
-    -s 'TIMEOUT=PT12S'
+    -s "START='$(cylc cycle-point "${NOW}" --offset-hour='10')${TZSTR}'" \
+    -s "HOUR='$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)'" \
+    -s 'UTC_MODE="False"' \
+    -s 'OFFSET="PT0S"' \
+    -s 'TIMEOUT="PT12S"'
 #-------------------------------------------------------------------------------
 purge
 exit

--- a/tests/flakyfunctional/special/08-clock-triggered-0.t
+++ b/tests/flakyfunctional/special/08-clock-triggered-0.t
@@ -24,27 +24,27 @@ set_test_number 4
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s START="$(date '+%Y%m%dT%H%z')" \
-    -s HOUR="$(date '+%H')" -s 'UTC_MODE=False' -s 'TIMEOUT=PT0.2M'
+    cylc validate "${SUITE_NAME}" -s "START='$(date '+%Y%m%dT%H%z')'" \
+    -s "HOUR='$(date '+%H')'" -s 'UTC_MODE="False"' -s 'TIMEOUT="PT0.2M"'
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-run-now" \
     cylc run --debug --no-detach "${SUITE_NAME}" \
-    -s START="$(date '+%Y%m%dT%H%z')" \
-    -s HOUR="$(date '+%H')" -s 'UTC_MODE=False' -s 'TIMEOUT=PT0.2M'
+    -s "START='$(date '+%Y%m%dT%H%z')'" \
+    -s "HOUR='$(date '+%H')'" -s 'UTC_MODE="False"' -s 'TIMEOUT="PT0.2M"'
 #-------------------------------------------------------------------------------
 NOW="$(date '+%Y%m%dT%H')"
 START="$(cylc cycle-point "${NOW}" --offset-hour='-10')$(date '+%z')"
 HOUR="$(cylc cycle-point "${NOW}" --offset-hour='-10' --print-hour)"
 run_ok "${TEST_NAME_BASE}-run-past" \
-    cylc run --debug --no-detach "${SUITE_NAME}" -s START="${START}" \
-    -s HOUR="${HOUR}" -s 'UTC_MODE=False' -s 'TIMEOUT=PT1M'
+    cylc run --debug --no-detach "${SUITE_NAME}" -s "START='${START}'" \
+    -s "HOUR='${HOUR}'" -s 'UTC_MODE="False"' -s 'TIMEOUT="PT1M"'
 #-------------------------------------------------------------------------------
 NOW="$(date '+%Y%m%dT%H')"
 START="$(cylc cycle-point "${NOW}" --offset-hour='10')$(date '+%z')"
 HOUR="$(cylc cycle-point "${NOW}" --offset-hour='10' --print-hour)"
 run_fail "${TEST_NAME_BASE}-run-later" \
     cylc run --debug --no-detach "${SUITE_NAME}" -s START="${START}" \
-    -s HOUR="${HOUR}" -s 'UTC_MODE=False' -s 'TIMEOUT=PT0.2M'
+    -s "HOUR='${HOUR}'" -s 'UTC_MODE="False"' -s 'TIMEOUT="PT0.2M"'
 #-------------------------------------------------------------------------------
 purge
 exit

--- a/tests/flakyfunctional/xtriggers/00-wall_clock.t
+++ b/tests/flakyfunctional/xtriggers/00-wall_clock.t
@@ -19,7 +19,8 @@
 . "$(dirname "$0")/test_header"
 
 run_suite() {
-  cylc run --no-detach --debug "$1" -s "START=$2" -s "HOUR=$3" -s "OFFSET=$4"
+  cylc run --no-detach --debug "$1" \
+    -s "START='$2'" -s "HOUR='$3'" -s "OFFSET='$4'"
 }
 
 set_test_number 5
@@ -33,7 +34,7 @@ HOUR="$(date +%H)"
 OFFSET="PT0S"
 
 run_ok "${TEST_NAME_BASE}-val" cylc validate "${SUITE_NAME}" \
-   -s "START=${START}" -s "HOUR=${HOUR}" -s "OFFSET=${OFFSET}"
+   -s "START='${START}'" -s "HOUR='${HOUR}'" -s "OFFSET='${OFFSET}'"
 
 TEST_NAME="${TEST_NAME_BASE}-now"
 run_ok "${TEST_NAME}" run_suite "${SUITE_NAME}" "${START}" "${HOUR}" "${OFFSET}"

--- a/tests/flakyfunctional/xtriggers/01-suite_state.t
+++ b/tests/flakyfunctional/xtriggers/01-suite_state.t
@@ -31,7 +31,7 @@ run_ok "${TEST_NAME_BASE}-val-up" cylc val --debug "${SUITE_NAME_UPSTREAM}"
 
 # Validate the downstream test suite.
 run_ok "${TEST_NAME_BASE}-val" \
-    cylc val --debug --set="UPSTREAM=${SUITE_NAME_UPSTREAM}" "${SUITE_NAME}"
+    cylc val --debug --set="UPSTREAM='${SUITE_NAME_UPSTREAM}'" "${SUITE_NAME}"
 
 # Run the upstream suite and detach (not a test).
 cylc run "${SUITE_NAME_UPSTREAM}"
@@ -39,7 +39,7 @@ cylc run "${SUITE_NAME_UPSTREAM}"
 # Run the test suite - it should fail after inactivity ...
 TEST_NAME="${TEST_NAME_BASE}-run-fail"
 suite_run_fail "${TEST_NAME}" \
-   cylc run --set="UPSTREAM=${SUITE_NAME_UPSTREAM}" --no-detach "${SUITE_NAME}"
+   cylc run --set="UPSTREAM='${SUITE_NAME_UPSTREAM}'" --no-detach "${SUITE_NAME}"
 
 SUITE_LOG="$(cylc cat-log -m 'p' "${SUITE_NAME}")"
 grep_ok 'WARNING - suite timed out after inactivity for PT10S' "${SUITE_LOG}"

--- a/tests/functional/cylc-cat-log/editor/bin/run_tests.sh
+++ b/tests/functional/cylc-cat-log/editor/bin/run_tests.sh
@@ -27,12 +27,12 @@ function run_tests {
     PLATFORM=$1
 
     TEST_NAME="${TEST_NAME_BASE}-validate"
-    run_ok "${TEST_NAME}" cylc validate --set="PLATFORM=$PLATFORM" \
+    run_ok "${TEST_NAME}" cylc validate --set="PLATFORM='$PLATFORM'" \
         "${SUITE_NAME}"
 
     # Run the suite to generate some log files.
     TEST_NAME="${TEST_NAME_BASE}-suite-run"
-    run_ok "${TEST_NAME}" cylc run --set="PLATFORM=$PLATFORM" \
+    run_ok "${TEST_NAME}" cylc run --set="PLATFORM='$PLATFORM'" \
         --no-detach "${SUITE_NAME}"
 
     LOG_DIR="$RUN_DIR/${SUITE_NAME}"

--- a/tests/functional/cylc-kill/00-multi-hosts-compat.t
+++ b/tests/functional/cylc-kill/00-multi-hosts-compat.t
@@ -22,11 +22,11 @@ set_test_number 3
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 
 RUN_DIR="$RUN_DIR/${SUITE_NAME}"
 LOG="${RUN_DIR}/log/suite/log"

--- a/tests/functional/cylc-kill/01-multi-hosts.t
+++ b/tests/functional/cylc-kill/01-multi-hosts.t
@@ -23,11 +23,11 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 
 RUN_DIR="$RUN_DIR/${SUITE_NAME}"
 LOG="${RUN_DIR}/log/suite/log"

--- a/tests/functional/cylc-message/00-ssh/flow.cylc
+++ b/tests/functional/cylc-message/00-ssh/flow.cylc
@@ -9,7 +9,7 @@
 [runtime]
     [[t0]]
         script = """
-            cylc broadcast "${CYLC_SUITE_NAME}" '--name=t1' '--set=script=true'
+            cylc broadcast "${CYLC_SUITE_NAME}" '--name=t1' '--set=script="true"'
         """
         platform = {{ environ['CYLC_TEST_PLATFORM'] }}
     [[t1]]

--- a/tests/functional/cylc-ping/04-check-keys-remote.t
+++ b/tests/functional/cylc-ping/04-check-keys-remote.t
@@ -35,9 +35,9 @@ init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 __FLOW_CONFIG__
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 RRUND="cylc-run/${SUITE_NAME}"
 RSRVD="${RRUND}/.service"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'

--- a/tests/functional/cylc-ping/05-check-keys-sharedfs.t
+++ b/tests/functional/cylc-ping/05-check-keys-sharedfs.t
@@ -36,9 +36,9 @@ init_suite "${TEST_NAME_BASE}" <<'__FLOW_CYLC__'
 __FLOW_CYLC__
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 RRUND="cylc-run/${SUITE_NAME}"
 RSRVD="${RRUND}/.service"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'

--- a/tests/functional/cylc-show/01-clock-triggered.t
+++ b/tests/functional/cylc-show/01-clock-triggered.t
@@ -26,11 +26,11 @@ TEST_SHOW_OUTPUT_PATH="$PWD/${TEST_NAME_BASE}-show.stdout"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-show
 contains_ok "${TEST_NAME}.stdout" <<__SHOW_OUTPUT__

--- a/tests/functional/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/functional/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -36,14 +36,14 @@ fi
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_SHOW_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH" \
-    --set=TZ_OFFSET_BASIC="$TZ_OFFSET_BASIC" "${SUITE_NAME}"
+    --set="TEST_SHOW_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'" \
+    --set="TZ_OFFSET_BASIC='$TZ_OFFSET_BASIC'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 sed "s/\$TZ_OFFSET_BASIC/$TZ_OFFSET_BASIC/g" reference-untz.log >reference.log
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_SHOW_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH" \
-    --set=TZ_OFFSET_BASIC="$TZ_OFFSET_BASIC" "${SUITE_NAME}"
+    --set="TEST_SHOW_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'" \
+    --set="TZ_OFFSET_BASIC='$TZ_OFFSET_BASIC'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-show
 contains_ok "${TEST_NAME}.stdout" <<__SHOW_OUTPUT__

--- a/tests/functional/cylc-show/05-complex.t
+++ b/tests/functional/cylc-show/05-complex.t
@@ -25,11 +25,11 @@ TEST_SHOW_OUTPUT_PATH="$PWD/${TEST_NAME_BASE}-show.stdout"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-   --set=TEST_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH"  "${SUITE_NAME}"
+   --set="TEST_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'"  "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 run_ok "${TEST_NAME}" cylc run \
-   --no-detach --set=TEST_OUTPUT_PATH="$TEST_SHOW_OUTPUT_PATH" "${SUITE_NAME}"
+   --no-detach --set="TEST_OUTPUT_PATH='$TEST_SHOW_OUTPUT_PATH'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-show"
 contains_ok "${TEST_SHOW_OUTPUT_PATH}" << '__OUT__'

--- a/tests/functional/events/10-task-event-job-logs-retrieve.t
+++ b/tests/functional/events/10-task-event-job-logs-retrieve.t
@@ -34,11 +34,11 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate ${OPT_SET} \
-    -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 # shellcheck disable=SC2086
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach ${OPT_SET} \
-       -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+       -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 sed "/'job-logs-retrieve'/!d" \
     "${SUITE_RUN_DIR}/log/job/1/t1/"{01,02,03}"/job-activity.log" \

--- a/tests/functional/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/functional/events/11-cycle-task-event-job-logs-retrieve.t
@@ -24,7 +24,7 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate -s "HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+    cylc validate -s "HOST='${CYLC_TEST_HOST}'" "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}"
 

--- a/tests/functional/events/17-task-event-job-logs-retrieve-command.t
+++ b/tests/functional/events/17-task-event-job-logs-retrieve-command.t
@@ -42,11 +42,11 @@ chmod +x "${TEST_DIR}/${SUITE_NAME}/bin/my-rsync"
 
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate ${OPT_SET} -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    cylc validate ${OPT_SET} -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 # shellcheck disable=SC2086
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach ${OPT_SET} \
-       -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+       -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 SUITE_LOG_D="$RUN_DIR/${SUITE_NAME}/log"
 sed 's/^.* -v //' "${SUITE_LOG_D}/suite/my-rsync.log" >'my-rsync.log.edited'

--- a/tests/functional/events/32-task-event-job-logs-retrieve-2.t
+++ b/tests/functional/events/32-task-event-job-logs-retrieve-2.t
@@ -23,9 +23,10 @@ set_test_number 5
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    cylc validate -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --reference-test --debug --no-detach -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    cylc run --reference-test --debug --no-detach \
+        -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 sed "/'job-logs-retrieve'/!d" \
     "${SUITE_RUN_DIR}/log/job/1/t1/01/job-activity.log" \

--- a/tests/functional/events/33-task-event-job-logs-retrieve-3.t
+++ b/tests/functional/events/33-task-event-job-logs-retrieve-3.t
@@ -23,10 +23,10 @@ set_test_number 5
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    cylc validate -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach \
-    -s "PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    -s "PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 sed "/'job-logs-retrieve'/!d" \
     "${SUITE_RUN_DIR}/log/job/1/t1/01/job-activity.log" \

--- a/tests/functional/events/37-suite-event-bad-custom-template.t
+++ b/tests/functional/events/37-suite-event-bad-custom-template.t
@@ -28,7 +28,8 @@ LOG="${SUITE_RUN_DIR}/log/suite/log"
 MESSAGE="('suite-event-handler-00', 'startup') bad template: 'rubbish'"
 run_ok "${TEST_NAME_BASE}-run1-log" grep -q -F "ERROR - ${MESSAGE}" "${LOG}"
 suite_run_fail "${TEST_NAME_BASE}-run2" \
-    cylc run --reference-test --debug --no-detach -s 'ABORT=True' "${SUITE_NAME}"
+    cylc run --reference-test --debug --no-detach \
+        -s 'ABORT="True"' "${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-run2-err" \
     grep -q -F "Suite shutting down - ${MESSAGE}" \
     "${TEST_NAME_BASE}-run2.stderr"

--- a/tests/functional/graph-equivalence/00-oneline.t
+++ b/tests/functional/graph-equivalence/00-oneline.t
@@ -26,11 +26,11 @@ install_suite "${TEST_NAME_BASE}" test1
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-check-a"
 cmp_ok "${TEST_SOURCE_DIR}/splitline_refs/a-ref" 'a-prereqs'

--- a/tests/functional/graph-equivalence/01-twolines.t
+++ b/tests/functional/graph-equivalence/01-twolines.t
@@ -26,11 +26,11 @@ install_suite "${TEST_NAME_BASE}" test2
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-check-a"
 cmp_ok "${TEST_SOURCE_DIR}/splitline_refs/a-ref" 'a-prereqs'

--- a/tests/functional/graph-equivalence/02-splitline.t
+++ b/tests/functional/graph-equivalence/02-splitline.t
@@ -27,11 +27,11 @@ install_suite "${TEST_NAME_BASE}" test3
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
-    --set=TEST_OUTPUT_PATH="${PWD}" "${SUITE_NAME}"
+    --set="TEST_OUTPUT_PATH='${PWD}'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-check-a"
 cmp_ok "${TEST_SOURCE_DIR}/splitline_refs/a-ref" 'a-prereqs'

--- a/tests/functional/graphing/02-icp-task-missing.t
+++ b/tests/functional/graphing/02-icp-task-missing.t
@@ -26,11 +26,11 @@ TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-r1"
-graph_suite "${SUITE_NAME}" 'r1.graph.plain.test' --set='INCLUDE_R1=true'
+graph_suite "${SUITE_NAME}" 'r1.graph.plain.test' --set='INCLUDE_R1="true"'
 cmp_ok 'r1.graph.plain.test' "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph.plain.ref"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-no-r1"
-graph_suite "${SUITE_NAME}" 'no-r1.graph.plain.test' --set='INCLUDE_R1=true'
+graph_suite "${SUITE_NAME}" 'no-r1.graph.plain.test' --set='INCLUDE_R1="true"'
 cmp_ok 'no-r1.graph.plain.test' "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph.plain.ref"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/graphing/07-stop-at-final-point.t
+++ b/tests/functional/graphing/07-stop-at-final-point.t
@@ -26,11 +26,11 @@ TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-graph-npoints"
-graph_suite "${SUITE_NAME}" 'graph.plain.test1' --set="STOP_CRITERION=number of cycle points = 6"
+graph_suite "${SUITE_NAME}" 'graph.plain.test1' --set="STOP_CRITERION='number of cycle points = 6'"
 cmp_ok 'graph.plain.test1' "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph.plain.ref"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-graph-final-point"
-graph_suite "${SUITE_NAME}" 'graph.plain.test2' --set="STOP_CRITERION=final cycle point = 2015-01-05"
+graph_suite "${SUITE_NAME}" 'graph.plain.test2' --set="STOP_CRITERION='final cycle point = 2015-01-05'"
 cmp_ok 'graph.plain.test2' "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/graph.plain.ref"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/jinja2/05-commandline.t
+++ b/tests/functional/jinja2/05-commandline.t
@@ -23,7 +23,7 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" commandline-set
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-validate1
-run_ok "${TEST_NAME}" cylc validate --set=TASKNAME=foo --set=STEP=2 "${SUITE_NAME}"
+run_ok "${TEST_NAME}" cylc validate --set="TASKNAME='foo'" --set="STEP='2'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-validate2
 run_ok "${TEST_NAME}" cylc validate \

--- a/tests/functional/jinja2/10-builtin-functions.t
+++ b/tests/functional/jinja2/10-builtin-functions.t
@@ -23,14 +23,16 @@ set_test_number 5
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}"-pass
-run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}" -s 'FOO=True' \
-    -s 'ANSWER=42'
+run_ok "${TEST_NAME}" cylc validate "${SUITE_NAME}" \
+    -s 'FOO="True"' \
+    -s 'ANSWER="42"'
 TEST_NAME="${TEST_NAME_BASE}"-fail-assert
-run_fail "${TEST_NAME}" cylc validate "${SUITE_NAME}" -s 'FOO=True' \
-    -s 'ANSWER=43'
+run_fail "${TEST_NAME}" cylc validate "${SUITE_NAME}" \
+    -s 'FOO="True"' \
+    -s 'ANSWER="43"'
 grep_ok 'Jinja2 Assertation Error: Universal' "${TEST_NAME}.stderr"
 TEST_NAME="${TEST_NAME_BASE}"-fail-raise
-run_fail "${TEST_NAME}" cylc validate "${SUITE_NAME}" -s 'ANSWER=42'
+run_fail "${TEST_NAME}" cylc validate "${SUITE_NAME}" -s 'ANSWER="42"'
 grep_ok 'Jinja2 Error: FOO must be defined' "${TEST_NAME}.stderr"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/jinja2/commandline-set/vars.txt
+++ b/tests/functional/jinja2/commandline-set/vars.txt
@@ -1,2 +1,2 @@
-TASKNAME=foo
-STEP=2
+TASKNAME="foo"
+STEP="2"

--- a/tests/functional/job-submission/02-job-nn-remote-host.t
+++ b/tests/functional/job-submission/02-job-nn-remote-host.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 sqlite3 "${SUITE_RUN_DIR}/.service/db" <'db.sqlite3'
 suite_run_ok "${TEST_NAME_BASE}-restart" \
     cylc restart --reference-test --debug --no-detach  \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 purge
 exit

--- a/tests/functional/job-submission/07-multi.t
+++ b/tests/functional/job-submission/07-multi.t
@@ -23,9 +23,10 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --debug --no-detach --reference-test -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" \
+    cylc run --debug --no-detach --reference-test \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
     "${SUITE_NAME}"
 
 RUN_DIR="$RUN_DIR/${SUITE_NAME}"

--- a/tests/functional/job-submission/08-activity-log-host.t
+++ b/tests/functional/job-submission/08-activity-log-host.t
@@ -23,10 +23,12 @@ set_test_number 2
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    cylc validate "${SUITE_NAME}" \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" \
-    cylc run --debug --no-detach --reference-test -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" \
-    "${SUITE_NAME}"
+    cylc run --debug --no-detach --reference-test \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
+        "${SUITE_NAME}"
 
 purge
 exit

--- a/tests/functional/job-submission/09-activity-log-host-bad-submit.t
+++ b/tests/functional/job-submission/09-activity-log-host-bad-submit.t
@@ -32,12 +32,12 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-       -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" \
-       -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+       -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
+       -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test \
-    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'" \
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 
 purge
 exit

--- a/tests/functional/job-submission/13-tidy-submits-of-prev-run-remote-host.t
+++ b/tests/functional/job-submission/13-tidy-submits-of-prev-run-remote-host.t
@@ -22,10 +22,11 @@ set_test_number 11
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    cylc validate "${SUITE_NAME}" \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 RLOGD1="cylc-run/${SUITE_NAME}/log/job/1/t1/01"
 RLOGD2="cylc-run/${SUITE_NAME}/log/job/1/t1/02"
 LOGD1="$RUN_DIR/${SUITE_NAME}/log/job/1/t1/01"
@@ -42,7 +43,7 @@ sed -i 's/script =.*$/script = true/' "flow.cylc"
 sed -i -n '1,/triggered off/p' "reference.log"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 # shellcheck disable=SC2086
 run_ok "exists-rlogd1" ${SSH} "${CYLC_TEST_HOST}" test -e "${RLOGD1}"
 # shellcheck disable=SC2086

--- a/tests/functional/job-submission/14-tidy-submits-of-prev-run-remote-host-with-shared-fs.t
+++ b/tests/functional/job-submission/14-tidy-submits-of-prev-run-remote-host-with-shared-fs.t
@@ -23,10 +23,10 @@ set_test_number 7
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 LOGD1="$RUN_DIR/${SUITE_NAME}/log/job/1/t1/01"
 LOGD2="$RUN_DIR/${SUITE_NAME}/log/job/1/t1/02"
 exists_ok "${LOGD1}"
@@ -35,7 +35,7 @@ sed -i 's/script =.*$/script = true/' "flow.cylc"
 sed -i -n '1,/triggered off/p' "reference.log"
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 exists_ok "${LOGD1}"
 exists_fail "${LOGD2}"
 #-------------------------------------------------------------------------------

--- a/tests/functional/platforms/02-host-to-platform-upgrade.t
+++ b/tests/functional/platforms/02-host-to-platform-upgrade.t
@@ -38,7 +38,7 @@ run_fail "${TEST_NAME_BASE}-validate-fail" \
 # Ensure that you can validate suite
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-        -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+        -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'"
 
 # Check that the cfgspec/suite.py has issued a warning about upgrades.
 grep_ok "\[upgradeable_cylc7_settings\]\[remote\]host = ${CYLC_TEST_HOST}"\
@@ -56,7 +56,7 @@ grep_ok "\[upgradeable_cylc7_settings\]\[remote\]host = ${CYLC_TEST_HOST}"\
 # Run the suite
 #suite_run_ok "${TEST_NAME_BASE}-run" \
 #    cylc run --debug --no-detach \
-#    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+#    -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'" "${SUITE_NAME}"
 
 ## Check that the upgradeable config has been run on a sensible host.
 #grep_ok \

--- a/tests/functional/platforms/04-host-to-platform-upgrade-fail-inherit.t
+++ b/tests/functional/platforms/04-host-to-platform-upgrade-fail-inherit.t
@@ -34,12 +34,12 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 # Both of these cases should validate ok.
 run_ok "${TEST_NAME_BASE}-validate" \
   cylc validate "${SUITE_NAME}" \
-     -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+     -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'"
 
 # Run the suite
 suite_run_fail "${TEST_NAME_BASE}-run" \
   cylc run --debug --no-detach \
-  -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+  -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'" "${SUITE_NAME}"
 
 # Grep for inherit-fail to fail later at submit time
 grep_ok "SuiteConfigError:.*non-valid-child.1"\

--- a/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
+++ b/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
@@ -32,7 +32,7 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 # Both of these cases should validate ok.
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-         -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}"
+         -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'"
 
 # Check that the cfgspec/suite.py has issued a warning about upgrades.
 grep_ok "\[not_upgradable_cylc7_settings\]\[remote\]host = parasite"\
@@ -41,7 +41,7 @@ grep_ok "\[not_upgradable_cylc7_settings\]\[remote\]host = parasite"\
 # Run the suite
 suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach \
-    -s "CYLC_TEST_HOST=${CYLC_TEST_HOST}" "${SUITE_NAME}"
+    -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'" "${SUITE_NAME}"
 
 # Check that the suite failed because no matching platfrom could be found.
 grep_ok "\[jobs-submit err\] No platform found matching your task"\

--- a/tests/functional/queues/00-queuesize-3.t
+++ b/tests/functional/queues/00-queuesize-3.t
@@ -23,9 +23,10 @@ set_test_number 2
 install_suite "${TEST_NAME_BASE}" qsize
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_ok "${TEST_NAME}" cylc validate -s q_size=3 "${SUITE_NAME}"
+run_ok "${TEST_NAME}" cylc validate -s 'q_size="3"' "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach -s q_size=3 "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
+     -s "q_size='3'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/queues/01-queuesize-5.t
+++ b/tests/functional/queues/01-queuesize-5.t
@@ -23,9 +23,10 @@ set_test_number 2
 install_suite "${TEST_NAME_BASE}" qsize
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_ok "${TEST_NAME}" cylc validate -s q_size=5 "${SUITE_NAME}"
+run_ok "${TEST_NAME}" cylc validate -s 'q_size="5"' "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach -s q_size=5 "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME}" cylc run --reference-test --debug --no-detach \
+    -s 'q_size="5"' "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/reload/19-remote-kill.t
+++ b/tests/functional/reload/19-remote-kill.t
@@ -22,10 +22,10 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate --set="CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" "${SUITE_NAME}"
+    cylc validate --set="CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${SUITE_NAME}"
 suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach --reference-test \
-    --set="CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" \
+    --set="CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
      "${SUITE_NAME}"
 sqlite3 "${SUITE_RUN_DIR}/.service/db" \
     'SELECT cycle,name,run_status FROM task_jobs' >'db.out'

--- a/tests/functional/remote/01-file-install.t
+++ b/tests/functional/remote/01-file-install.t
@@ -23,9 +23,9 @@ set_test_number 6
 install_suite "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run1" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 RRUND="cylc-run/${SUITE_NAME}"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'
 SSH="$(cylc get-global-config -i "[platforms][$CYLC_TEST_PLATFORM]ssh command")"
@@ -45,9 +45,11 @@ install_suite "${TEST_NAME_BASE}"
 
 export SECOND_RUN="dir1/, dir2/, file1, file2"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" -s "SECOND_RUN=${SECOND_RUN}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
+    -s "SECOND_RUN='${SECOND_RUN}'"
 suite_run_ok "${TEST_NAME_BASE}-run2" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}" -s "SECOND_RUN=${SECOND_RUN}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" \
+    -s "SECOND_RUN='${SECOND_RUN}'"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'
 ${SSH} "${CYLC_TEST_PLATFORM}" \
 find "${RRUND}/"{app,bin,dir1,dir2,file1,file2,etc,lib} -type f | sort > 'find.out'

--- a/tests/functional/remote/02-install-target.t
+++ b/tests/functional/remote/02-install-target.t
@@ -37,9 +37,9 @@ init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 __FLOW_CONFIG__
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug \
-     "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+     "${SUITE_NAME}" -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 CYLC_SUITE_RUN_DIR="$RUN_DIR/${SUITE_NAME}"
 poll_grep_suite_log 'Suite held'
 grep_ok "REMOTE INIT NOT REQUIRED for localhost" "${CYLC_SUITE_RUN_DIR}/log/suite/log"

--- a/tests/functional/remote/04-symlink-dirs.t
+++ b/tests/functional/remote/04-symlink-dirs.t
@@ -45,9 +45,9 @@ create_test_global_config "" "
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run-ok" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM=${CYLC_TEST_PLATFORM}"
+    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 poll_grep_suite_log 'File installation complete.'
 TEST_SYM="${TEST_NAME_BASE}-run-symlink-exists-ok"
 if [[ $(readlink "$HOME/cylc-run/${SUITE_NAME}") == \

--- a/tests/functional/restart/16-template-vars.t
+++ b/tests/functional/restart/16-template-vars.t
@@ -24,11 +24,11 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-    --set='FINAL_CYCLE_POINT=2020' --set='COMMAND=true'
+    --set='FINAL_CYCLE_POINT="2020"' --set='COMMAND="true"'
 
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run "${SUITE_NAME}" \
-    --set='FINAL_CYCLE_POINT=2020' --set='COMMAND=true' \
+    --set='FINAL_CYCLE_POINT="2020"' --set='COMMAND="true"' \
     --stop-point=2018 --debug --no-detach
 
 suite_run_ok "${TEST_NAME_BASE}-restart" \

--- a/tests/functional/restart/17-template-vars-file.t
+++ b/tests/functional/restart/17-template-vars-file.t
@@ -23,8 +23,8 @@ set_test_number 3
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 cat >'template-vars.list' <<'__LIST__'
-COMMAND=true
-FINAL_CYCLE_POINT=2020
+COMMAND="true"
+FINAL_CYCLE_POINT="2020"
 __LIST__
 
 run_ok "${TEST_NAME_BASE}-validate" \

--- a/tests/functional/restart/18-template-vars-override.t
+++ b/tests/functional/restart/18-template-vars-override.t
@@ -24,16 +24,16 @@ install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${SUITE_NAME}" \
-    --set='FINAL_CYCLE_POINT=2020' --set='COMMAND=true'
+    --set='FINAL_CYCLE_POINT="2020"' --set='COMMAND="true"'
 
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run "${SUITE_NAME}" \
-    --set='FINAL_CYCLE_POINT=2020' --set='COMMAND=true' \
+    --set='FINAL_CYCLE_POINT="2020"' --set='COMMAND="true"' \
     --stop-point=2018 --debug --no-detach
 
 suite_run_ok "${TEST_NAME_BASE}-restart" \
     cylc restart "${SUITE_NAME}" --debug --no-detach --reference-test \
-    --set='FINAL_CYCLE_POINT=2022'
+    --set='FINAL_CYCLE_POINT="2022"'
 
 purge
 exit

--- a/tests/functional/restart/34-auto-restart-basic.t
+++ b/tests/functional/restart/34-auto-restart-basic.t
@@ -49,7 +49,7 @@ __FLOW_CONFIG__
 # run suite on localhost normally
 create_test_global_config '' "${BASE_GLOBAL_CONFIG}"
 run_ok "${TEST_NAME}-suite-start" \
-    cylc run "${SUITE_NAME}" --host=localhost -s 'FOO=foo' -v
+    cylc run "${SUITE_NAME}" --host=localhost -s 'FOO="foo"' -v
 cylc suite-state "${SUITE_NAME}" --task='task_foo01' \
     --status='succeeded' --point=1 --interval=1 --max-polls=20 >& $ERR
 

--- a/tests/functional/runahead/03-check-default-future.t
+++ b/tests/functional/runahead/03-check-default-future.t
@@ -23,11 +23,11 @@ set_test_number 5
 install_suite "${TEST_NAME_BASE}" default-future
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_ok "${TEST_NAME}" cylc validate -v --set=FUTURE_TRIGGER_START_POINT=T04 \
+run_ok "${TEST_NAME}" cylc validate -v --set="FUTURE_TRIGGER_START_POINT='T04'" \
     "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-run_fail "${TEST_NAME}" cylc run --debug --no-detach --set=FUTURE_TRIGGER_START_POINT=T04 \
+run_fail "${TEST_NAME}" cylc run --debug --no-detach --set="FUTURE_TRIGGER_START_POINT='T04'" \
     "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-max-cycle

--- a/tests/functional/runahead/05-check-default-future-2.t
+++ b/tests/functional/runahead/05-check-default-future-2.t
@@ -23,11 +23,13 @@ set_test_number 5
 install_suite "${TEST_NAME_BASE}" default-future
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_ok "${TEST_NAME}" cylc validate -v --set=FUTURE_TRIGGER_START_POINT=T02 \
+run_ok "${TEST_NAME}" cylc validate -v \
+    --set="FUTURE_TRIGGER_START_POINT='T02'" \
     "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-run_fail "${TEST_NAME}" cylc run --debug --no-detach --set=FUTURE_TRIGGER_START_POINT=T02 \
+run_fail "${TEST_NAME}" cylc run --debug --no-detach \
+    --set="FUTURE_TRIGGER_START_POINT='T02'" \
     "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-max-cycle

--- a/tests/functional/startup/01-log-flow-config.t
+++ b/tests/functional/startup/01-log-flow-config.t
@@ -39,11 +39,11 @@ __FLOW_CONFIG__
 
 run_ok "${TEST_NAME_BASE}-val-1" cylc validate "${SUITE_NAME}"
 run_ok "${TEST_NAME_BASE}-val-2" \
-    cylc validate --set 'WEATHER=good' "${SUITE_NAME}"
+    cylc validate --set 'WEATHER="good"' "${SUITE_NAME}"
 
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --no-detach "${SUITE_NAME}"
 suite_run_ok "${TEST_NAME_BASE}-restart" \
-    cylc restart --set 'WEATHER=good' --no-detach "${SUITE_NAME}"
+    cylc restart --set 'WEATHER="good"' --no-detach "${SUITE_NAME}"
 
 # Check for 3 generated *.cylc files
 LOGD="${RUN_DIR}/${SUITE_NAME}/log/flow-config"

--- a/tests/functional/suite-host-self-id/00-address.t
+++ b/tests/functional/suite-host-self-id/00-address.t
@@ -35,7 +35,7 @@ MY_INET_TARGET=$( \
 MY_HOST_IP="$(get_local_ip_address "${MY_INET_TARGET}")"
 
 run_ok "${TEST_NAME_BASE}-validate" \
-    cylc validate "${SUITE_NAME}" "--set=MY_HOST_IP=${MY_HOST_IP}"
+    cylc validate "${SUITE_NAME}" --set="MY_HOST_IP='${MY_HOST_IP}'"
 
 create_test_global_config '' '
 [scheduler]
@@ -43,7 +43,7 @@ create_test_global_config '' '
         method = address'
 suite_run_ok "${TEST_NAME_BASE}-run" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}" \
-    "--set=MY_HOST_IP=${MY_HOST_IP}"
+    --set="MY_HOST_IP='${MY_HOST_IP}'"
 #-------------------------------------------------------------------------------
 
 purge

--- a/tests/functional/suite-state/00-polling.t
+++ b/tests/functional/suite-state/00-polling.t
@@ -36,7 +36,7 @@ run_ok "${TEST_NAME}" cylc val --debug "${UPSTREAM}"
 
 TEST_NAME=${TEST_NAME_BASE}-validate-polling
 run_ok "${TEST_NAME}" \
-    cylc val --debug --set="UPSTREAM=${UPSTREAM}" "${SUITE_NAME}"
+    cylc val --debug --set="UPSTREAM='${UPSTREAM}'" "${SUITE_NAME}"
 
 #-------------------------------------------------------------------------------
 # run the upstream suite and detach (not a test)
@@ -45,7 +45,7 @@ cylc run "${UPSTREAM}"
 #-------------------------------------------------------------------------------
 # check auto-generated task script for lbad
 cylc get-config \
-    --set="UPSTREAM=${UPSTREAM}" -i '[runtime][lbad]script' "${SUITE_NAME}" \
+    --set="UPSTREAM='${UPSTREAM}'" -i '[runtime][lbad]script' "${SUITE_NAME}" \
     >'lbad.script'
 cmp_ok 'lbad.script' << __END__
 echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail ${UPSTREAM}
@@ -54,7 +54,7 @@ __END__
 
 # check auto-generated task script for l-good
 cylc get-config \
-    --set="UPSTREAM=${UPSTREAM}" -i '[runtime][l-good]script' "${SUITE_NAME}" \
+    --set="UPSTREAM='${UPSTREAM}'" -i '[runtime][l-good]script' "${SUITE_NAME}" \
     >'l-good.script'
 cmp_ok 'l-good.script' << __END__
 echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed ${UPSTREAM}
@@ -66,7 +66,7 @@ __END__
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" \
     cylc run --reference-test --debug --no-detach \
-    --set="UPSTREAM=${UPSTREAM}" "${SUITE_NAME}"
+    --set="UPSTREAM='${UPSTREAM}'" "${SUITE_NAME}"
 
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/suite-state/01-polling.t
+++ b/tests/functional/suite-state/01-polling.t
@@ -36,12 +36,12 @@ run_ok "${TEST_NAME}" cylc val --debug "${UPSTREAM}"
 
 TEST_NAME="${TEST_NAME_BASE}-validate-polling"
 run_ok "${TEST_NAME}" \
-    cylc val --debug --set="UPSTREAM=${UPSTREAM}" "${SUITE_NAME}"
+    cylc val --debug --set="UPSTREAM='${UPSTREAM}'" "${SUITE_NAME}"
 
 #-------------------------------------------------------------------------------
 # check auto-generated task script for lbad
 cylc get-config \
-    --set="UPSTREAM=${UPSTREAM}" \
+    --set="UPSTREAM='${UPSTREAM}'" \
     -i '[runtime][lbad]script' "${SUITE_NAME}" >'lbad.script'
 cmp_ok 'lbad.script' << __END__
 echo cylc suite-state --task=bad --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=fail ${UPSTREAM}
@@ -50,7 +50,7 @@ __END__
 
 # check auto-generated task script for l-good
 cylc get-config \
-    --set="UPSTREAM=${UPSTREAM}" \
+    --set="UPSTREAM='${UPSTREAM}'" \
     -i '[runtime][l-good]script' "${SUITE_NAME}" >'l-good.script'
 cmp_ok 'l-good.script' << __END__
 echo cylc suite-state --task=good-stuff --point=\$CYLC_TASK_CYCLE_POINT --interval=2 --max-polls=20 --status=succeed ${UPSTREAM}
@@ -65,7 +65,7 @@ cylc run "${UPSTREAM}" 1>'upstream.out' 2>&1
 # run the suite-state polling test suite
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" \
-    cylc run --reference-test --debug --no-detach --set="UPSTREAM=${UPSTREAM}" \
+    cylc run --reference-test --debug --no-detach --set="UPSTREAM='${UPSTREAM}'" \
     "${SUITE_NAME}"
 
 #-------------------------------------------------------------------------------

--- a/tests/functional/suite-state/04-template.t
+++ b/tests/functional/suite-state/04-template.t
@@ -37,7 +37,7 @@ TEST_NAME="${TEST_NAME_BASE}-runtime"
 #-------------------------------------------------------------------------------
 suite_run_ok "${TEST_NAME}" \
     cylc run --reference-test --debug --no-detach "${SUITE_NAME}" \
-    --set="REF_SUITE=${SUITE_NAME_REF}"
+    --set="REF_SUITE='${SUITE_NAME_REF}'"
 #-------------------------------------------------------------------------------
 purge "${SUITE_NAME_REF}"
 purge

--- a/tests/functional/triggering/16-fam-expansion.t
+++ b/tests/functional/triggering/16-fam-expansion.t
@@ -24,11 +24,11 @@ install_suite "${TEST_NAME_BASE}" fam-expansion
 SHOW_OUT="$PWD/show.out"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_ok "${TEST_NAME}" cylc validate --set="SHOW_OUT=$SHOW_OUT" "${SUITE_NAME}"
+run_ok "${TEST_NAME}" cylc validate --set="SHOW_OUT='$SHOW_OUT'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" \
-    cylc run --debug --no-detach --set="SHOW_OUT=$SHOW_OUT" "${SUITE_NAME}"
+    cylc run --debug --no-detach --set="SHOW_OUT='$SHOW_OUT'" "${SUITE_NAME}"
 #-------------------------------------------------------------------------------
 contains_ok "$SHOW_OUT" <<'__SHOW_DUMP__'
   + (((1 | 0) & (3 | 2) & (5 | 4)) & (0 | 2 | 4))

--- a/tests/functional/validate/74-templatevar-types.t
+++ b/tests/functional/validate/74-templatevar-types.t
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test validating xtrigger names in suite.
+. "$(dirname "$0")/test_header"
+
+set_test_number 5
+
+TEST_NAME="${TEST_NAME_BASE}-val"
+
+# test a valid xtrigger
+cat >'flow.cylc' <<'__FLOW_CONFIG__'
+#!Jinja2
+[scheduling]
+    initial cycle point = {{ ICP - 1 }}
+    cycling mode = integer
+    [[graph]]
+        R1 = foo
+__FLOW_CONFIG__
+run_fail "${TEST_NAME}-valid" cylc validate flow.cylc
+run_fail "${TEST_NAME}-valid" cylc validate flow.cylc -s 'ICP="2000"'
+run_ok "${TEST_NAME}-valid" cylc validate flow.cylc -s 'ICP=2000'
+
+cat >'template' <<'__TEMPLATE__'
+ICP=2000
+__TEMPLATE__
+run_fail "${TEST_NAME}-valid" cylc validate flow.cylc
+run_ok "${TEST_NAME}-valid" cylc validate flow.cylc --set-file=template
+
+exit

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -81,6 +81,24 @@ class TestTemplatevars(unittest.TestCase):
                 expected, load_template_vars(template_vars=pairs,
                                              template_vars_file=tf.name))
 
+    def test_load_template_vars_from_string_and_file(self):
+        """Text pair variables take precedence over file."""
+        pairs = [
+            "str='str'",
+            "int=12",
+            "float=12.3",
+            "bool=True",
+            "none=None"
+        ]
+        expected = {
+            'str': 'str',
+            'int': 12,
+            'float': 12.3,
+            'bool': True,
+            'none': None
+        }
+        self.assertEqual(expected, load_template_vars(template_vars=pairs))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -27,9 +27,9 @@ class TestTemplatevars(unittest.TestCase):
 
     def test_load_template_vars_from_string(self):
         pairs = [
-            "name=John",
-            "type=Human",
-            "age=12"
+            "name='John'",
+            "type='Human'",
+            "age='12'"
         ]
         expected = {
             "name": "John",
@@ -41,11 +41,11 @@ class TestTemplatevars(unittest.TestCase):
     def test_load_template_vars_from_file(self):
         with tempfile.NamedTemporaryFile() as tf:
             tf.write("""
-            name=John
-            type=Human
+            name='John'
+            type='Human'
             # a comment
             # type=Test
-            age=12
+            age='12'
             """.encode())
             tf.flush()
             expected = {
@@ -60,16 +60,16 @@ class TestTemplatevars(unittest.TestCase):
     def test_load_template_vars_from_string_and_file(self):
         """Text pair variables take precedence over file."""
         pairs = [
-            "name=John",
-            "age=12"
+            "name='John'",
+            "age='12'"
         ]
         with tempfile.NamedTemporaryFile() as tf:
             tf.write("""
-            name=Mariah
-            type=Human
+            name='Mariah'
+            type='Human'
             # a comment
             # type=Test
-            age=70
+            age='70'
             """.encode())
             tf.flush()
             expected = {


### PR DESCRIPTION
Apologies, oversight on my part, it turned out to be a three line change rather than the two lines predicted.

For this PR I have upgraded the set-file logic along with the CLI option (hence the unexpected third line), can revert though it would be somewhat inconsistent. If it is a problem then we could potentially use a different CLI opt for specifying type variables.

> **Rationale (discussed at meeting)**
> * We would expect the `-s`, `--set` option to be used interactively so the change shouldn't impact user scripts.
> * And if it does the CLI has changed anyway.
> * Set-files may be more controversial, however, I don't think these are very widely used.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No dependency changes.
