### PR TITLE
tests: fix disabled batch sys tests

### DIFF
--- a/tests/flakyfunctional/execution-time-limit/00-background.t
+++ b/tests/flakyfunctional/execution-time-limit/00-background.t
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution time limit, background/at job
-CYLC_TEST_BATCH_SYS=${TEST_NAME_BASE##??-}
-export REQUIRE_PLATFORM="batch:$CYLC_TEST_BATCH_SYS"
+BATCH_SYS="${0##*\/??-}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS%%.t}"
 . "$(dirname "$0")/test_header"
 set_test_number 4
 

--- a/tests/functional/cylc-poll/06-loadleveler.t
+++ b/tests/functional/cylc-poll/06-loadleveler.t
@@ -17,8 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test "cylc poll" for loadleveler, slurm, or pbs jobs.
 # TODO Check this test on a dockerized system or VM.
-BATCH_SYS_NAME="$(sed 's/.*\/...\(.*\)\.t/\1/' <<< "$0")"
-export REQUIRE_PLATFORM="batch:$BATCH_SYS_NAME comms:tcp"
+BATCH_SYS="${0##*\/??-}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS%%.t} comms:tcp"
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/functional/directives/00-loadleveler.t
+++ b/tests/functional/directives/00-loadleveler.t
@@ -19,8 +19,9 @@
 #     This test requires an e.g. [test battery][batch systems][loadleveler]host
 #     entry in site/user config in order to run 'loadleveler' tests (same for
 #     slurm, pbs, etc), otherwise it will be bypassed.
-BATCH_SYS_NAME="$(sed 's/.*\/...\(.*\)\.t/\1/' <<< "$0")"
-export REQUIRE_PLATFORM="batch:$BATCH_SYS_NAME comms:tcp"
+BATCH_SYS="${0##*\/??-}"
+BATCH_SYS_NAME="${BATCH_SYS%%.t}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS_NAME} comms:tcp"
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2

--- a/tests/functional/execution-time-limit/02-slurm.t
+++ b/tests/functional/execution-time-limit/02-slurm.t
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution time limit setting, slurm job
-CYLC_TEST_BATCH_SYS="${TEST_NAME_BASE##??-}"
-export REQUIRE_PLATFORM="batch:$CYLC_TEST_BATCH_SYS"
+BATCH_SYS="${0##*\/??-}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS%%.t}"
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/functional/execution-time-limit/03-pbs.t
+++ b/tests/functional/execution-time-limit/03-pbs.t
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Test execution time limit setting, PBS job
-CYLC_TEST_BATCH_SYS="${TEST_NAME_BASE##??-}"
-export REQUIRE_PLATFORM="batch:$CYLC_TEST_BATCH_SYS"
+BATCH_SYS="${0##*\/??-}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS%%.t}"
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 3

--- a/tests/functional/job-kill/02-loadleveler.t
+++ b/tests/functional/job-kill/02-loadleveler.t
@@ -17,8 +17,8 @@
 #-------------------------------------------------------------------------------
 # Test killing of jobs submitted to loadleveler, slurm, pbs...
 # TODO Check this test on a dockerized system or VM.
-BATCH_SYS_NAME="$(sed 's/.*\/...\(.*\)\.t/\1/' <<< "$0")"
-export REQUIRE_PLATFORM="batch:$BATCH_SYS_NAME comms:tcp"
+BATCH_SYS="${0##*\/??-}"
+export REQUIRE_PLATFORM="batch:${BATCH_SYS%%.t} comms:tcp"
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 2


### PR DESCRIPTION
A few batch sys tests were broken, likely a rebase error.

The way tests are skipped is an especially nasty feature of the test framework, will address when converting to pytest whenever that happens.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
