### PR TITLE
Fix docstring broken WRT config changes

### DIFF
--- a/cylc/flow/main_loop/auto_restart.py
+++ b/cylc/flow/main_loop/auto_restart.py
@@ -16,7 +16,7 @@
 """Automatically restart suites if they are running on bad servers.
 
 Loads in the global configuration to check if the server a suite is running
-on is listed in :cylc:conf:`global.cylc[scheduler]condemned hosts`.
+on is listed in :cylc:conf:`global.cylc[scheduler][run hosts]condemned`.
 
 This is useful if a host needs to be taken off-line e.g. for scheduled
 maintenance.
@@ -36,13 +36,15 @@ The auto stop-restart feature has two modes:
 
 - [Normal Mode]
 
-  - When a host is added to the :cylc:conf:`condemned hosts` list, any suites
+  - When a host is added to the
+    :cylc:conf:`global.cylc[scheduler][run hosts]condemned` list, any suites
     running on that host will automatically shutdown then restart selecting a
-    new host from :cylc:conf:`run hosts`.
+    new host from :cylc:conf:`global.cylc[scheduler][run hosts]available`.
   - For safety, before attempting to stop the suite cylc will first wait
     for any jobs running locally (under background or at) to complete.
   - *In order for Cylc to be able to successfully restart suites the
-    :cylc:conf:`run hosts` must all be on a shared filesystem.*
+    :cylc:conf:`global.cylc[scheduler][run hosts]available` must all be on a
+    shared filesystem.*
 
 - [Force Mode]
 
@@ -58,21 +60,22 @@ running on ``bar`` will stop immediately, making no attempt to restart.
 
    [scheduler]
         [[run hosts]]
-       available = pub
-       condemned = foo, bar!
+            available = pub
+            condemned = foo, bar!
 
 .. warning::
 
    Cylc will reject hosts with ambiguous names such as ``localhost`` or
-   ``127.0.0.1`` for this configuration as `:cylc:conf:`condemned hosts`
+   ``127.0.0.1`` for this configuration as
+   `:cylc:conf:`[scheduler][run hosts]condemned`
    are evaluated on the suite host server.
 
 To prevent large numbers of suites attempting to restart simultaneously the
-:cylc:conf:`[scheduler]auto restart delay` setting defines a period of time in
-seconds.
+:cylc:conf:`global.cylc[scheduler]auto restart delay` setting defines a period
+of time in seconds.
 Suites will wait for a random period of time between zero and
-:cylc:conf:`[scheduler]auto restart delay` seconds before attempting to stop
-and restart.
+:cylc:conf:`global.cylc[scheduler]auto restart delay` seconds before
+attempting to stop and restart.
 
 Suites that are started up in no-detach mode cannot auto stop-restart on a
 different host - as it will still end up attached to the condemned host.


### PR DESCRIPTION
These changes partially address #3696 

- [x] Does not need tests - documentation change which causes failure in cylc-docs.
- [x] No change log entry required: Not a feature.
- [x] This PR is itself a documentation update.

@oliver-sanders  - I think this is a 1-person review. Tag someone if you disagree.