### PR TITLE
templatevars: support listrange()

### DIFF
--- a/lib/parsec/jinja2support.py
+++ b/lib/parsec/jinja2support.py
@@ -34,6 +34,21 @@ from jinja2 import (
 from parsec import LOG
 
 
+def listrange(*args):
+    """Return a range as a list.
+
+    Python equivalent to the Jinja2:
+        range() | list
+
+        >>> listrange(5)
+        [0, 1, 2, 3, 4]
+        >>> listrange(0, 5, 2)
+        [0, 2, 4]
+
+    """
+    return list(range(*args))
+
+
 class PyModuleLoader(BaseLoader):
     """Load python module as Jinja2 template.
 
@@ -130,6 +145,7 @@ def jinja2environment(dir_=None):
     env.globals['environ'] = os.environ
     env.globals['raise'] = raise_helper
     env.globals['assert'] = assert_helper
+    env.globals['listrange'] = listrange
     return env
 
 

--- a/tests/jinja2/10-builtin-functions/suite.rc
+++ b/tests/jinja2/10-builtin-functions/suite.rc
@@ -6,6 +6,8 @@
 
 {{ assert(ANSWER | int == 42, 'Universal constant incorrectly set.') }}
 
+{{ assert(listrange(2) == [0, 1], 'issue with listrange') }}
+
 [scheduling]
     [[dependencies]]
         graph = foo


### PR DESCRIPTION
Back-support for #3979 to allow writing Rose configs that are dual-compativle with Cylc7/Cylc8.

> **Pending decision:** Merge or close.
>
> If we need to support `range()` we will need to sneek this into a Cylc7 release along with the matchign
> Rose2019 change.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [x] No dependency changes.
