### PR TITLE
Fix failure to shutdown on keyboard interrupt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -164,6 +164,10 @@ task outputs/message triggers are now validated.
 workflow in a sub-directory of a run directory (as `cylc scan` would not be
 able to find it).
 
+[#3982](https://github.com/cylc/cylc-flow/pull/3982) - Fix bug preventing
+workflow from shutting down properly on a keyboard interrupt (Ctrl+C) in
+Python 3.8+.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -611,7 +611,7 @@ class Scheduler:
             await self.shutdown(exc)
             raise exc from None
 
-        except Exception as exc:
+        except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             try:
                 await self.shutdown(exc)
             except Exception as exc2:
@@ -643,7 +643,7 @@ class Scheduler:
             await self.configure()
             await self.start_servers()
             await self.log_start()
-        except Exception as exc:
+        except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             await self.shutdown(exc)
             raise
         else:

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -406,13 +406,7 @@ async def _run(parser, options, reg, is_restart, scheduler):
     # stop cylc stop
     except SchedulerError:
         ret = 1
-    except KeyboardInterrupt as exc:
-        try:
-            await scheduler.shutdown(exc)
-        except Exception as exc2:
-            # In case of exceptions in the shutdown method itself.
-            LOG.exception(exc2)
-            raise exc2 from None
+    except (KeyboardInterrupt, asyncio.CancelledError):
         ret = 2
     except Exception:
         ret = 3


### PR DESCRIPTION
These changes close #3946

<kbd>Ctrl</kbd>+<kbd>C</kbd> was failing to shutdown the scheduler on Python 3.8+ due to the fact that `asyncio.CanclledError` changed from subclassing `Exception` to `BaseException`. See https://stackoverflow.com/a/60167684/3217306 and https://docs.python.org/3.8/library/asyncio-exceptions.html#asyncio.CancelledError

I'm new to asyncio, and there seems to be another way of handling signal interruptions: https://www.roguelynn.com/words/asyncio-graceful-shutdowns/. However, the changes I've made are very simple and seem to work.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (I'm not sure we can test this?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
