### PR TITLE
doc: fix documentation in source files

### DIFF
--- a/cylc/flow/batch_sys_handlers/at.py
+++ b/cylc/flow/batch_sys_handlers/at.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to the rudimentary Unix ``at`` scheduler.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 .. note::
 

--- a/cylc/flow/batch_sys_handlers/background.py
+++ b/cylc/flow/batch_sys_handlers/background.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Runs task job scripts as Unix background processes.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 If an :cylc:conf:`execution time limit` is specified for a task, its job will
 be wrapped by the ``timeout`` command.

--- a/cylc/flow/batch_sys_handlers/loadleveler.py
+++ b/cylc/flow/batch_sys_handlers/loadleveler.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to loadleveler by the ``llsubmit`` command.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 Loadleveler directives can be provided in the flow.cylc file:
 

--- a/cylc/flow/batch_sys_handlers/lsf.py
+++ b/cylc/flow/batch_sys_handlers/lsf.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to IBM Platform LSF by the ``bsub`` command.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 LSF directives can be provided in the flow.cylc file:
 

--- a/cylc/flow/batch_sys_handlers/moab.py
+++ b/cylc/flow/batch_sys_handlers/moab.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to the Moab workload manager with ``msub``.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 Moab directives can be provided in the flow.cylc file; the syntax is
 very similar to PBS:

--- a/cylc/flow/batch_sys_handlers/pbs.py
+++ b/cylc/flow/batch_sys_handlers/pbs.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to PBS (or Torque) by the ``qsub`` command.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 PBS directives can be provided in the flow.cylc file:
 

--- a/cylc/flow/batch_sys_handlers/sge.py
+++ b/cylc/flow/batch_sys_handlers/sge.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to Sun/Oracle Grid Engine with ``qsub``.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 SGE directives can be provided in the flow.cylc file:
 

--- a/cylc/flow/batch_sys_handlers/slurm.py
+++ b/cylc/flow/batch_sys_handlers/slurm.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to Simple Linux Utility for Resource Management.
 
-.. cylc-scope:: flow.cylc[runtime][<namespace>][job]
+.. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 Uses the ``sbatch`` command. SLURM directives can be provided in the flow.cylc
 file:

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -133,48 +133,50 @@ with Conf('global.cylc', desc='''
             Conf('ranking', VDR.V_STRING, desc='''
                 A multiline string containing Python expressions to filter
                 and/or rank hosts. For example:
-                cpu_percent() < 70
-                cpu_percent()
-                to filter by cpu_percent() < 70 then to rank by cpu_percent.
+
+                .. code-block:: none
+
+                   cpu_percent() < 70
+                   cpu_percent()
+
+                To filter by ``cpu_percent() < 70`` then to rank by
+                ``cpu_percent``.
             ''')
 
         with Conf('host self-identification', desc='''
             The suite host's identity must be determined locally by cylc and
             passed to running tasks (via ``$CYLC_SUITE_HOST``) so that task
             messages can target the right suite on the right host.
-
-            .. todo
-            Is it conceivable that different remote task hosts at the same site
-            might see the suite host differently? If so we would need to be
-            able to override the target in suite configurations.
         '''):
+            # TODO
+            # Is it conceivable that different remote task hosts at the same
+            # site might see the suite host differently? If so we would need to
+            # be able to override the target in suite configurations.
             Conf(
                 'method', VDR.V_STRING, 'name',
                 options=['name', 'address', 'hardwired'],
                 desc='''
                     This item determines how cylc finds the identity of the
                     suite host.For the default *name* method cylc asks the
-                    suite host
-                    for its host name. This should resolve on remote task
-                    hosts to
-                    the IP address of the suite host; if it doesn't, adjust
-                    network settings or use one of the other methods. For the
-                    *address* method, cylc attempts to use a special external
-                    "target address" to determine the IP address of the suite
-                    host as seen by remote task hosts.  And finally, as a
-                    last resort, you can choose the *hardwired* method and
-                    manually
-                    specify the host name or IP address of the suite host.
+                    suite host for its host name. This should resolve on remote
+                    task hosts to the IP address of the suite host; if it
+                    doesn't, adjust network settings or use one of the other
+                    methods. For the *address* method, cylc attempts to use a
+                    special external "target address" to determine the IP
+                    address of the suite host as seen by remote task hosts.
+                    And finally, as a last resort, you can choose the
+                    *hardwired* method and manually specify the host name or IP
+                    address of the suite host.
 
                     Options:
 
                     name
-                    Self-identified host name.
+                       Self-identified host name.
                     address
-                    Automatically determined IP address (requires *target*).
+                       Automatically determined IP address (requires *target*).
                     hardwired
-                    Manually specified host name or IP address (requires
-                    *host*).
+                       Manually specified host name or IP address (requires
+                       *host*).
             ''')
             Conf('target', VDR.V_STRING, 'google.com', desc='''
                 This item is required for the *address* self-identification
@@ -287,10 +289,10 @@ with Conf('global.cylc', desc='''
 
             Examples::
 
-                ed
-                emacs -nw
-                nano
-                vi
+               ed
+               emacs -nw
+               nano
+               vi
         ''')
         Conf('gui', VDR.V_STRING, desc='''
             A graphical text editor to be used by cylc.
@@ -307,12 +309,12 @@ with Conf('global.cylc', desc='''
 
             Examples::
 
-                atom --wait
-                code -nw
-                emacs
-                gedit -s
-                gvim -fg
-                nedit
+               atom --wait
+               code -nw
+               emacs
+               gedit -s
+               gvim -fg
+               nedit
         ''')
 
     with Conf('platforms'):
@@ -538,9 +540,9 @@ with Conf('global.cylc', desc='''
 
             .. code-block:: cylc
 
-                [platforms]
-                    [[Platform_A]]
-                        install target = localhost
+               [platforms]
+                   [[Platform_A]]
+                       install target = localhost
             ''')
 
         with Conf('localhost', meta=Platform):
@@ -551,10 +553,10 @@ with Conf('global.cylc', desc='''
         with Conf('<group>'):
             Conf('platforms', VDR.V_STRING_LIST)
     # Symlink Dirs
-    with Conf('symlink dirs', desc="""Define directories to be moved, symlinks
-                from the the original ``$HOME/cylc-run`` directories will be
-                created.
-            """):
+    with Conf('symlink dirs', desc="""
+        Define directories to be moved, symlinks from the the original
+        ``$HOME/cylc-run`` directories will be created.
+    """):
         with Conf('<install target>'):
             Conf('run', VDR.V_STRING, None, desc="""
                 Specifies the directory where the workflow run directories are

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -57,7 +57,7 @@ Main loop plugins can be activated either by:
              plugins = health check, auto restart
 
 Main loop plugins can be individually configured in their
-:cylc:conf:`global.cylc[scheduler][main loop][<plugin>] section e.g:
+:cylc:conf:`global.cylc[scheduler][main loop][<plugin name>]` section e.g:
 
 .. code-block:: cylc
 


### PR DESCRIPTION
Fixes the cylc-flow side of the documentation failures. After this to get the docs building again a small number of references to configurations in cylc-doc need to be updated.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
