### PR TITLE
Fix typos and unused imports

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -626,7 +626,7 @@ class DataStoreMgr:
             if not levels:
                 self.n_window_boundary_nodes[active_id][0] = {active_id}
                 levels = (0,)
-            # Only trigger pruning for futhest set of boundary nodes
+            # Only trigger pruning for furthest set of boundary nodes
             for tp_id in self.n_window_boundary_nodes[active_id][max(levels)]:
                 self.prune_trigger_nodes.setdefault(
                     tp_id, set()).add(active_id)

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -141,7 +141,7 @@ ALIASES = {
 }
 
 
-# alises for sub-commands which no longer exist
+# aliases for sub-commands which no longer exist
 # {alias_name: message_to_user}
 DEAD_ENDS = {
     'reset': 'cylc reset has been replaced by cylc set-outputs',

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -645,6 +645,7 @@ class TaskJobManager:
         try:
             job_log_dir, context = line.split('|')[1:3]
             items = json.loads(context)
+            jp_ctx = JobPollContext(job_log_dir, **items)
         except TypeError:
             itask.set_summary_message(self.POLL_FAIL)
             self.job_pool.add_job_msg(job_d, self.POLL_FAIL)
@@ -658,6 +659,7 @@ class TaskJobManager:
                     (key, values[x]) for
                     x, key in enumerate(JobPollContext.CONTEXT_ATTRIBUTES))
                 job_log_dir = items.pop('job_log_dir')
+                jp_ctx = JobPollContext(job_log_dir, **items)
             except (ValueError, IndexError):
                 itask.set_summary_message(self.POLL_FAIL)
                 self.job_pool.add_job_msg(job_d, self.POLL_FAIL)
@@ -665,8 +667,6 @@ class TaskJobManager:
                 return
         finally:
             log_task_job_activity(ctx, suite, itask.point, itask.tdef.name)
-
-        jp_ctx = JobPollContext(job_log_dir, **items)
 
         flag = self.task_events_mgr.FLAG_POLLED
         if jp_ctx.run_status == 1 and jp_ctx.run_signal in ["ERR", "EXIT"]:

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -784,7 +784,6 @@ class TaskJobManager:
                 submit_delays = itask.platform['submission retry delays']
             # TODO: same for execution delays?
 
-        if retry:
             for key, delays in [
                     (
                         TimerFlags.SUBMISSION_RETRY,

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -645,7 +645,6 @@ class TaskJobManager:
         try:
             job_log_dir, context = line.split('|')[1:3]
             items = json.loads(context)
-            jp_ctx = JobPollContext(job_log_dir, **items)
         except TypeError:
             itask.set_summary_message(self.POLL_FAIL)
             self.job_pool.add_job_msg(job_d, self.POLL_FAIL)
@@ -666,6 +665,8 @@ class TaskJobManager:
                 return
         finally:
             log_task_job_activity(ctx, suite, itask.point, itask.tdef.name)
+
+        jp_ctx = JobPollContext(job_log_dir, **items)
 
         flag = self.task_events_mgr.FLAG_POLLED
         if jp_ctx.run_status == 1 and jp_ctx.run_signal in ["ERR", "EXIT"]:

--- a/tests/flakyfunctional/xtriggers/01-suite_state.t
+++ b/tests/flakyfunctional/xtriggers/01-suite_state.t
@@ -68,7 +68,7 @@ __END__
 #
 # Lines are those which should appear after a '<datetimestamp> INFO - Broadcast
 # set' ('+') and later '... INFO - Broadcast cancelled:' ('-') line, where we
-# use as a test case an arbitary task where such setting & cancellation occurs:
+# use as a test case an arbitrary task where such setting & cancellation occurs:
 contains_ok "${SUITE_LOG}" << __LOG_BROADCASTS__
 	+ [f1.2015] [environment]upstream_suite=${SUITE_NAME_UPSTREAM}
 	+ [f1.2015] [environment]upstream_task=foo

--- a/tests/functional/platforms/02-host-to-platform-upgrade.t
+++ b/tests/functional/platforms/02-host-to-platform-upgrade.t
@@ -48,7 +48,7 @@ grep_ok "\[upgradeable_cylc7_settings\]\[remote\]host = ${CYLC_TEST_HOST}"\
 #        for now take the easy road out and just not do it
 #
 #        actual solutions:
-#        * work out why job log retreival isn't working (the best option, dur)
+#        * work out why job log retrieval isn't working (the best option, dur)
 #        * convert to unit test (do we really need a functional test of the
 #          upgrader).
 #        * consider using a local platform (e.g. at job sub)

--- a/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
+++ b/tests/functional/platforms/05-host-to-platform-upgrade-fail.t
@@ -43,7 +43,7 @@ suite_run_fail "${TEST_NAME_BASE}-run" \
     cylc run --debug --no-detach \
     -s "CYLC_TEST_HOST='${CYLC_TEST_HOST}'" "${SUITE_NAME}"
 
-# Check that the suite failed because no matching platfrom could be found.
+# Check that the suite failed because no matching platform could be found.
 grep_ok "\[jobs-submit err\] No platform found matching your task"\
     "${SUITE_RUN_DIR}/log/suite/log"
 

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import pytest
 
-from cylc.flow.cycling.loader import standardise_point_string
 from cylc.flow.data_store_mgr import (
     FAMILY_PROXIES,
     TASKS,

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -88,7 +88,7 @@ def run_dir_with_symlinks():
     tmp_path2.mkdir()
     init_flows(
         tmp_path2,
-        # make it nested to proove that the link is followed
+        # make it nested to prove that the link is followed
         running=('bar/baz',)
     )
     Path(tmp_path, 'bar').symlink_to(Path(tmp_path2, 'bar'))

--- a/tests/unit/main_loop/auto_restart.py
+++ b/tests/unit/main_loop/auto_restart.py
@@ -27,7 +27,6 @@ from cylc.flow.main_loop.auto_restart import (
     _can_auto_restart,
     _set_auto_restart
 )
-from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.suite_status import (
     AutoRestartMode,
     StopMode

--- a/tests/unit/main_loop/main_loop.py
+++ b/tests/unit/main_loop/main_loop.py
@@ -16,9 +16,7 @@
 
 import asyncio
 from collections import deque
-from functools import partial
 import logging
-from time import sleep
 
 import pytest
 

--- a/tests/unit/test_host_select.py
+++ b/tests/unit/test_host_select.py
@@ -37,9 +37,9 @@ localhost, localhost_aliases, _ = socket.gethostbyname_ex('localhost')
 localhost_fqdn = get_fqdn_by_host(localhost)
 
 
-# NOTE: ensure that all localhost aliases are actually alises of localhost,
+# NOTE: ensure that all localhost aliases are actually aliases of localhost,
 #       it would appear that this is not always the case
-#       on Travis-CI on of the alises has a different fqdn from the fqdn
+#       on Travis-CI on of the aliases has a different fqdn from the fqdn
 #       of the host it is an alias of
 localhost_aliases = [
     alias

--- a/tests/unit/test_host_select_remote.py
+++ b/tests/unit/test_host_select_remote.py
@@ -176,7 +176,7 @@ def test_remote_suite_host_rankings(mock_glbl_cfg):
     )
     with pytest.raises(HostSelectException) as excinfo:
         select_suite_host()
-    # ensure that host selection actually evuluated rankings
+    # ensure that host selection actually evaluated rankings
     assert set(excinfo.value.data[remote_platform_fqdn]) == {
         'virtual_memory().available > 123456789123456789',
         'cpu_count() > 512',

--- a/tests/unit/test_loggingutil.py
+++ b/tests/unit/test_loggingutil.py
@@ -20,7 +20,7 @@ import unittest
 
 from unittest import mock
 
-from cylc.flow import LOG, RSYNC_LOG
+from cylc.flow import LOG
 from cylc.flow.loggingutil import TimestampRotatingFileHandler
 
 

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -155,7 +155,7 @@ def test_similar_but_not_exact_match():
             'desktop42'
         ),
 
-        # Basic test where the user hasn't sumbitted anything and the task
+        # Basic test where the user hasn't submitted anything and the task
         # returns to default, i.e. localhost.
         (
             {'batch system': 'background'},

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -28,7 +28,7 @@ def test_get_platform_no_args():
 
 
 def test_get_platform_from_platform_name_str(mock_glbl_cfg):
-    # Check that an arbitary string name returns a sensible platform
+    # Check that an arbitrary string name returns a sensible platform
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
         '''

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test the cylc.flow.remote module."""
 
-from subprocess import PIPE
-
 from cylc.flow.remote import run_cmd
 
 

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for remote initialisation."""
 
-from io import StringIO
 from unittest.mock import patch
 
 from cylc.flow.task_remote_cmd import remote_init

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -57,7 +57,7 @@ class TestTemplatevars(unittest.TestCase):
                 expected, load_template_vars(template_vars=None,
                                              template_vars_file=tf.name))
 
-    def test_load_template_vars_from_string_and_file(self):
+    def test_load_template_vars_from_string_and_file_1(self):
         """Text pair variables take precedence over file."""
         pairs = [
             "name='John'",
@@ -81,7 +81,7 @@ class TestTemplatevars(unittest.TestCase):
                 expected, load_template_vars(template_vars=pairs,
                                              template_vars_file=tf.name))
 
-    def test_load_template_vars_from_string_and_file(self):
+    def test_load_template_vars_from_string_and_file_2(self):
         """Text pair variables take precedence over file."""
         pairs = [
             "str='str'",


### PR DESCRIPTION
This is a small change with no associated Issue.

Yesterday ran the IDE linter against Cylc UI, and started doing the same with Cylc Flow. There are two issues it found that might be bugs, but they require understanding about the task pool (which is great for me learning :grimacing: probably bothering @hjoliver and others soon in Element).

This PR fixes typos, removes unused imports, and also renames two test functions that had duplicated names. They are pretty similar, but not identical, so I left both of them.

If CI passes, I think one review should be enough.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
