### PR TITLE
terminal: hack around stupid emacs stty return value

### DIFF
--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -53,7 +53,7 @@ def get_width(default=80):
         return default
     try:
         return int(proc.communicate()[0].split()[1]) or default
-    except IndexError:
+    except (IndexError, ValueError):
         return default
 
 

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -52,7 +52,7 @@ def get_width(default=80):
     if proc.wait():
         return default
     try:
-        return int(proc.communicate()[0].split()[1])
+        return int(proc.communicate()[0].split()[1]) or default
     except IndexError:
         return default
 


### PR DESCRIPTION
Reported by @dpmatthews, emacs implemets `stty size` but in a broken way:

```console
$ stty size
0 0
```

Return the defined default if we get 0.

Workaround:

`alias emacs=vim`

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
