### PR TITLE
Remove unused code in cylc.flow.config (template keys)

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -132,10 +132,6 @@ class SuiteConfig:
     """Class for suite configuration items and derived quantities."""
 
     Q_DEFAULT = 'default'
-    TASK_EVENT_TMPL_KEYS = (
-        'event', 'suite', 'suite_uuid', 'point', 'name', 'submit_num', 'id',
-        'message', 'batch_sys_name', 'batch_sys_job_id', 'submit_time',
-        'start_time', 'finish_time', 'platform_name', 'try_num')
 
     def __init__(
         self,


### PR DESCRIPTION
This is a small change with no associated Issue.

I had submitted a pull request to Cylc UI Server for upgrading JupyterHub & Tornado, and also ran the IDE linter to make sure there was nothing else that needed changing after upgrading. Did not find anything, and last step was running `vulture`, which also did not find anything.

Then just for curiosity ran it against Cylc Flow, and it found many possible unused variables/code. I checked just this one and quickly prepared a PR before going back to deltas in the UI, but there might be others 👍 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
