### PR TITLE
poll: remove poll_succ option

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -584,15 +584,12 @@ class Resolvers(BaseResolvers):
         self.schd.command_queue.put(("remove_tasks", (tasks,), {}))
         return (True, 'Command queued')
 
-    def poll_tasks(self, tasks=None, poll_succeeded=False):
+    def poll_tasks(self, tasks=None):
         """Request the suite to poll task jobs.
 
         Args:
             tasks (list, optional):
                 List of identifiers, see `task globs`_
-            poll_succeeded (bool, optional):
-                Allow polling of remote tasks if True.
-
         Returns:
             tuple: (outcome, message)
 
@@ -603,7 +600,7 @@ class Resolvers(BaseResolvers):
 
         """
         self.schd.command_queue.put(
-            ("poll_tasks", (tasks,), {"poll_succ": poll_succeeded}))
+            ("poll_tasks", (tasks,), {}))
         return (True, 'Command queued')
 
     def put_ext_trigger(self, message, id):

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1637,10 +1637,7 @@ class Poll(Mutation, TaskMutation):
         resolver = partial(mutator, command='poll_tasks')
 
     class Arguments(TaskMutation.Arguments):
-        poll_succeeded = Boolean(
-            description='Allow polling of succeeded tasks.',
-            default_value=False
-        )
+        ...
 
 
 class Remove(Mutation, TaskMutation):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -797,7 +797,7 @@ class Scheduler:
             if should_poll:
                 to_poll_tasks.append(itask)
         self.task_job_mgr.poll_task_jobs(
-            self.suite, to_poll_tasks, poll_succ=True)
+            self.suite, to_poll_tasks)
 
     def process_command_queue(self):
         """Process queued commands."""
@@ -910,17 +910,12 @@ class Scheduler:
             return self.pool.release_tasks(ids)
         self.release_suite()
 
-    def command_poll_tasks(self, items=None, poll_succ=False):
-        """Poll pollable tasks or a task/family if options are provided.
-
-        Don't poll succeeded tasks unless poll_succ is True.
-
-        """
+    def command_poll_tasks(self, items=None):
+        """Poll pollable tasks or a task/family if options are provided."""
         if self.config.run_mode('simulation'):
             return
         itasks, bad_items = self.pool.filter_task_proxies(items)
-        self.task_job_mgr.poll_task_jobs(self.suite, itasks,
-                                         poll_succ=poll_succ)
+        self.task_job_mgr.poll_task_jobs(self.suite, itasks)
         return len(bad_items)
 
     def command_kill_tasks(self, items=None):

--- a/cylc/flow/scripts/poll.py
+++ b/cylc/flow/scripts/poll.py
@@ -51,10 +51,6 @@ def get_option_parser():
             ('REG', 'Suite name'),
             ('[TASK_GLOB ...]', 'Task matching patterns')])
 
-    parser.add_option(
-        "-s", "--succeeded", help="Allow polling of succeeded tasks.",
-        action="store_true", default=False, dest="poll_succ")
-
     return parser
 
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -95,11 +95,9 @@ from cylc.flow.task_remote_mgr import (
     TaskRemoteMgr
 )
 from cylc.flow.task_state import (
-    TASK_STATUS_FAILED,
     TASK_STATUS_READY,
     TASK_STATUS_RUNNING,
     TASK_STATUS_SUBMITTED,
-    TASK_STATUS_SUCCEEDED,
     TASK_STATUSES_ACTIVE
 )
 from cylc.flow.wallclock import (
@@ -174,35 +172,19 @@ class TaskJobManager:
             self.JOBS_KILL, suite, to_kill_tasks,
             self._kill_task_jobs_callback)
 
-    def poll_task_jobs(self, suite, itasks, poll_succ=True, msg=None):
+    def poll_task_jobs(self, suite, itasks, msg=None):
         """Poll jobs of specified tasks.
-
-        Any job that is or was submitted or running can be polled, except for
-        retrying tasks - which would poll (correctly) as failed. And don't poll
-        succeeded tasks by default.
 
         This method uses _poll_task_jobs_callback() and
         _manip_task_jobs_callback() as help/callback methods.
 
         _poll_task_job_callback() executes one specific job.
         """
-        to_poll_tasks = []
-        pollable_statuses = {
-            TASK_STATUS_SUBMITTED, TASK_STATUS_RUNNING, TASK_STATUS_FAILED
-        }
-        if poll_succ:
-            pollable_statuses.add(TASK_STATUS_SUCCEEDED)
-        for itask in itasks:
-            if itask.state(*pollable_statuses):
-                to_poll_tasks.append(itask)
-            else:
-                LOG.debug("skipping %s: not pollable, "
-                          "or skipping 'succeeded' tasks" % itask.identity)
-        if to_poll_tasks:
+        if itasks:
             if msg is not None:
                 LOG.info(msg)
             self._run_job_cmd(
-                self.JOBS_POLL, suite, to_poll_tasks,
+                self.JOBS_POLL, suite, itasks,
                 self._poll_task_jobs_callback)
 
     def prep_submit_task_jobs(self, suite, itasks, check_syntax=True):


### PR DESCRIPTION
Remove the (inactive) `--succeeded` option to `cylc poll`.

This does not make sense post-SoD since there aren't any succeeded tasks in the pool anyway.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
