### PR TITLE
BACK COMPAT: remove old compat and update comments

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -719,13 +719,25 @@ class SuiteConfig:
         # Replace suite and task name in suite and task URLs.
         self.cfg['meta']['URL'] = self.cfg['meta']['URL'] % {
             'suite_name': self.suite}
-        # back-compat $CYLC_SUITE_NAME:
+        # BACK_COMPAT: CYLC_SUITE_NAME
+        # from:
+        #     Cylc7
+        # to:
+        #     Cylc8
+        # remove at:
+        #     Cylc9
         self.cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(
             self.suite, self.cfg['meta']['URL'])
         for name, cfg in self.cfg['runtime'].items():
             cfg['meta']['URL'] = cfg['meta']['URL'] % {
                 'suite_name': self.suite, 'task_name': name}
-            # back-compat $CYLC_SUITE_NAME and $CYLC_TASK_NAME:
+            # BACK_COMPAT: CYLC_SUITE_NAME, CYLC_TASK_NAME
+            # from:
+            #     Cylc7
+            # to:
+            #     Cylc8
+            # remove at:
+            #     Cylc9
             cfg['meta']['URL'] = RE_SUITE_NAME_VAR.sub(
                 self.suite, cfg['meta']['URL'])
             cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(

--- a/cylc/flow/job_pool.py
+++ b/cylc/flow/job_pool.py
@@ -261,10 +261,26 @@ class JobPool:
 
     @staticmethod
     def parse_job_item(item):
-        """Parse internal id
-        point/name/submit_num
-        or name.point.submit_num syntax (back compat).
+        """Parse internal id.
+
+        Args:
+            item (str):
+                point/name/submit_num
+                OR name.point.submit_num syntax.
+
+        Returns:
+            tuple - (point_str: str, name_str: str, submit_num: [int, None])
+
         """
+        # BACK COMPAT: name.point.submit_num
+        # url:
+        #     https://github.com/cylc/cylc-admin/pull/115
+        # from:
+        #     Cylc7
+        # to:
+        #     Cylc8
+        # remove at:
+        #     Cylc9
         submit_num = None
         if item.count('/') > 1:
             point_str, name_str, submit_num = item.split('/', 2)

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -146,7 +146,16 @@ def addict(cfig, key, val, parents, index):
         # this item already exists
         if (
             parents[0:2] == ['scheduling', 'graph'] or
-            parents[0:2] == ['scheduling', 'dependencies']  # back compat <=7.X
+            # BACK COMPAT: [scheduling][dependencies]
+            # url:
+            #     https://github.com/cylc/cylc-flow/pull/3191
+            # from:
+            #     Cylc<=7
+            # to:
+            #     Cylc8
+            # remove at:
+            #     Cylc9
+            parents[0:2] == ['scheduling', 'dependencies']
         ):
             # append the new graph string to the existing one
             if not isinstance(cfig, list):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1133,7 +1133,6 @@ class Scheduler:
                 self.options.icp = value
                 LOG.info('+ initial point = %s' % value)
         elif key in self.suite_db_mgr.KEY_START_CYCLE_POINT_COMPATS:
-            # 'warm_point' for back compat <= 7.6.X
             if self.is_restart and self.options.ignore_startcp:
                 LOG.debug('- start point = %s (ignored)' % value)
             elif self.options.startcp is None:

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -105,7 +105,12 @@ def main(parser, options, *args):
         return parser.error('No message supplied')
     cylc.flow.flags.verbose = os.getenv('CYLC_VERBOSE') == 'true'
     cylc.flow.flags.debug = os.getenv('CYLC_DEBUG') == 'true'
-    if len(args) <= 2:  # compat
+    if len(args) <= 2:
+        # BACK COMPAT: args <= 2
+        # from:
+        #     ????
+        # remove at:
+        #     ????
         suite = os.getenv('CYLC_SUITE_NAME')
         task_job = os.getenv('CYLC_TASK_JOB')
         message_strs = list(args)

--- a/cylc/flow/suite_db_mgr.py
+++ b/cylc/flow/suite_db_mgr.py
@@ -46,7 +46,7 @@ class SuiteDatabaseManager:
         KEY_INITIAL_CYCLE_POINT, 'initial_point')
     KEY_START_CYCLE_POINT = 'startcp'
     KEY_START_CYCLE_POINT_COMPATS = (
-        KEY_START_CYCLE_POINT, 'start_point', 'warm_point')
+        KEY_START_CYCLE_POINT, 'start_point')
     KEY_FINAL_CYCLE_POINT = 'fcp'
     KEY_FINAL_CYCLE_POINT_COMPATS = (KEY_FINAL_CYCLE_POINT, 'final_point')
     KEY_STOP_CYCLE_POINT = 'stopcp'

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -526,7 +526,7 @@ class TaskEventsManager():
                 itask, ("message %s" % str(severity).lower()), message)
         lseverity = str(severity).lower()
         if lseverity in self.NON_UNIQUE_EVENTS:
-            itask.non_unique_events.update(lseverity)
+            itask.non_unique_events.update({lseverity: 1})
             self.setup_event_handlers(itask, lseverity, message)
 
     def _process_message_check(

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -526,8 +526,7 @@ class TaskEventsManager():
                 itask, ("message %s" % str(severity).lower()), message)
         lseverity = str(severity).lower()
         if lseverity in self.NON_UNIQUE_EVENTS:
-            itask.non_unique_events.setdefault(lseverity, 0)
-            itask.non_unique_events[lseverity] += 1
+            itask.non_unique_events.update(lseverity)
             self.setup_event_handlers(itask, lseverity, message)
 
     def _process_message_check(
@@ -1036,7 +1035,8 @@ class TaskEventsManager():
         if event in self.NON_UNIQUE_EVENTS:
             key1 = (
                 self.HANDLER_MAIL,
-                '%s-%d' % (event, itask.non_unique_events.get(event, 1)))
+                '%s-%d' % (event, itask.non_unique_events[event] or 1)
+            )
         else:
             key1 = (self.HANDLER_MAIL, event)
         id_key = (key1, str(itask.point), itask.tdef.name, itask.submit_num)
@@ -1079,7 +1079,8 @@ class TaskEventsManager():
             if event in self.NON_UNIQUE_EVENTS:
                 key1 = (
                     f'{self.HANDLER_CUSTOM}-{i:02d}',
-                    f'{event}-{itask.non_unique_events.get(event, 1):d}')
+                    f'{event}-{itask.non_unique_events[event] or 1:d}'
+                )
             else:
                 key1 = (f'{self.HANDLER_CUSTOM}-{i:02d}', event)
             id_key = (
@@ -1127,10 +1128,13 @@ class TaskEventsManager():
                         quote(str(self.uuid_str)),
                     EventData.TryNum.value:
                         itask.get_try_num(),
-                    # BACK COMPAT
-                    # For: Cylc < 8
-                    # Remove at: Cylc9 - pending announcement of deprecation
-                    # https://github.com/cylc/cylc-flow/pull/3992
+                    # BACK COMPAT: JobID_old, JobRunnerName_old
+                    # url:
+                    #     https://github.com/cylc/cylc-flow/pull/3992
+                    # from:
+                    #     Cylc < 8
+                    # remove at:
+                    #     Cylc9 - pending announcement of deprecation
                     # next 2 (JobID_old, JobRunnerName_old) are deprecated
                     EventData.JobID_old.value:
                         quote(str(itask.summary['submit_method_id'])),

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -635,19 +635,10 @@ class TaskJobManager:
             ctx.cmd = cmd_ctx.cmd  # print original command on failure
             return
         except ValueError:
-            # back compat for cylc 7.7.1 and previous
-            try:
-                values = line.split('|')
-                items = dict(  # done this way to ensure IndexError is raised
-                    (key, values[x]) for
-                    x, key in enumerate(JobPollContext.CONTEXT_ATTRIBUTES))
-                job_log_dir = items.pop('job_log_dir')
-                jp_ctx = JobPollContext(job_log_dir, **items)
-            except (ValueError, IndexError):
-                itask.set_summary_message(self.POLL_FAIL)
-                self.job_pool.add_job_msg(job_d, self.POLL_FAIL)
-                ctx.cmd = cmd_ctx.cmd  # print original command on failure
-                return
+            itask.set_summary_message(self.POLL_FAIL)
+            self.job_pool.add_job_msg(job_d, self.POLL_FAIL)
+            ctx.cmd = cmd_ctx.cmd  # print original command on failure
+            return
         finally:
             log_task_job_activity(ctx, suite, itask.point, itask.tdef.name)
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -418,22 +418,8 @@ class TaskPool:
                     TASK_STATUS_FAILED,
                     TASK_STATUS_SUCCEEDED
             ):
-                try:
-                    for message in json.loads(outputs_str).values():
-                        itask.state.outputs.set_completion(message, True)
-                except (AttributeError, TypeError, ValueError):
-                    # BACK COMPAT: outputs in separate lines
-                    # (as "trigger=message")
-                    # from:
-                    #     <=7.6.X
-                    # remove at:
-                    #     ???
-                    try:
-                        for output in outputs_str.splitlines():
-                            itask.state.outputs.set_completion(
-                                output.split("=", 1)[1], True)
-                    except AttributeError:
-                        pass
+                for message in json.loads(outputs_str).values():
+                    itask.state.outputs.set_completion(message, True)
 
             if platform_name:
                 itask.summary['platforms_used'][

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -422,8 +422,12 @@ class TaskPool:
                     for message in json.loads(outputs_str).values():
                         itask.state.outputs.set_completion(message, True)
                 except (AttributeError, TypeError, ValueError):
-                    # Back compat for <=7.6.X
-                    # Each output in separate line as "trigger=message"
+                    # BACK COMPAT: outputs in separate lines
+                    # (as "trigger=message")
+                    # from:
+                    #     <=7.6.X
+                    # remove at:
+                    #     ???
                     try:
                         for output in outputs_str.splitlines():
                             itask.state.outputs.set_completion(
@@ -481,8 +485,7 @@ class TaskPool:
                 {"id": id_, "ctx_key": ctx_key_raw})
             return
         LOG.info("+ %s.%s %s" % (name, cycle, ctx_key))
-        if ctx_key == "poll_timer" or ctx_key[0] == "poll_timers":
-            # "poll_timers" for back compat with <=7.6.X
+        if ctx_key == "poll_timer":
             itask = self.get_task_by_id(id_)
             if itask is None:
                 LOG.warning("%(id)s: task not found, skip" % {"id": id_})

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -16,6 +16,7 @@
 
 """Provide a class to represent a task proxy in a running suite."""
 
+from collections import Counter
 from time import time
 
 from metomi.isodatetime.timezone import get_local_time_zone
@@ -59,7 +60,7 @@ class TaskProxy:
         .manual_trigger (boolean):
             Has this task received a manual trigger command? This flag is reset
             on trigger.
-        .non_unique_events (dict):
+        .non_unique_events (collections.Counter):
             Count non-unique events (e.g. critical, warning, custom).
         .point (cylc.flow.cycling.PointBase):
             Cycle point of the task.
@@ -221,9 +222,7 @@ class TaskProxy:
         self.poll_timer = None
         self.timeout = None
         self.try_timers = {}
-        # Use dict here for Python 2.6 compat.
-        # Should use collections.Counter in Python 2.7+
-        self.non_unique_events = {}
+        self.non_unique_events = Counter()
 
         self.clock_trigger_time = None
         self.expire_time = None


### PR DESCRIPTION
Follow on from: https://github.com/cylc/cylc-flow/pull/3992#discussion_r542490192

Use a standard marker for indicating backwards compatibility in code. Its a totally arbitrary marker, all that matters is that we standardise and record the important information to avoid some of the issues weve had in the past with back-compat lasting longer than inteded.

In the process fix a few cases of back-compat which *should* have been removed already but was missed!

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
