### PR TITLE
Fix reference to batch sys -> job runner

### DIFF
--- a/tests/functional/cylc-run/03-remote-run-host.t
+++ b/tests/functional/cylc-run/03-remote-run-host.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 # Run a workflow with ``cylc run --host=somewhere-else``
-export REQUIRE_PLATFORM='loc:remote fs:shared batch:background'
+export REQUIRE_PLATFORM='loc:remote fs:shared runner:background'
 . "$(dirname "$0")/test_header"
 set_test_number 2
 


### PR DESCRIPTION
Follow up to #3992, this patch partially address #3910 