### PR TITLE
job runner: mop up: mop up

### DIFF
--- a/cylc/flow/job_runner_handlers/slurm.py
+++ b/cylc/flow/job_runner_handlers/slurm.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Submits task job scripts to Simple Linux Utility for Resource Management.
 
-# TODO: rewrite the following for platforms:
-
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
 Uses the ``sbatch`` command. SLURM directives can be provided in the flow.cylc
@@ -95,8 +93,8 @@ The resulting formatted directives are:
 .. note::
 
    For older Slurm versions with *packjob* instead of *hetjob*, use
-   :cylc:conf:`[platforms][<platform name>]job runner = slurm_packjob` and
-   directive prefixes ``packjob_0_`` etc.
+   :cylc:conf:`global.cylc[platforms][<platform name>]job runner =
+   slurm_packjob` and directive prefixes ``packjob_0_`` etc.
 
 .. cylc-scope::
 


### PR DESCRIPTION
Follow up to #4004, this fix allows the docs to build
