### PR TITLE
Fix trailing slash in reg (workflow name) bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,10 @@ issue when mixing offset and conditional (e.g. foo<m-1> & baz => foo<m>).
 workflow from shutting down properly on a keyboard interrupt (Ctrl+C) in
 Python 3.8+.
 
+[#4011](https://github.com/cylc/cylc-flow/pull/4011) - Fix bug where including
+a trailing slash in the suite/workflow name would cause `cylc stop`
+(and possibly other commands) to silently fail.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -314,7 +314,7 @@ def scheduler_cli(parser, options, args, is_restart=False):
     functionality.
 
     """
-    reg = args[0]
+    reg = os.path.normpath(args[0])
     # Check suite is not already running before start of host selection.
     try:
         suite_files.detect_old_contact_file(reg)

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -74,12 +74,11 @@ from standard input.
 Broadcast cannot change [runtime] inheritance.
 
 See also 'cylc reload' - reload a modified suite definition at run time."""
+
+import os.path
 import sys
-
 import re
-
 from tempfile import NamedTemporaryFile
-
 from ansimarkup import parse as cparse
 
 from cylc.flow import ID_DELIM
@@ -296,6 +295,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(_, options, suite):
     """Implement cylc broadcast."""
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/ext_trigger.py
+++ b/cylc/flow/scripts/ext_trigger.py
@@ -34,6 +34,7 @@ Use the retry options in case the target suite is down or out of contact.
 
 Note: to manually trigger a task use 'cylc trigger', not this command."""
 
+import os.path
 from time import sleep
 
 from cylc.flow import LOG
@@ -89,6 +90,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, event_msg, event_id):
+    suite = os.path.normpath(suite)
     LOG.info('Send to suite %s: "%s" (%s)', suite, event_msg, event_id)
 
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -29,6 +29,8 @@ Held tasks do not submit their jobs even if ready to run.
 See also 'cylc release'.
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -67,6 +69,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/kill.py
+++ b/cylc/flow/scripts/kill.py
@@ -25,6 +25,8 @@ Examples:
   $ cylc kill REG TASK_GLOB ...  # kill one or more active tasks
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -57,6 +59,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
     """CLI of "cylc kill"."""
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/poll.py
+++ b/cylc/flow/scripts/poll.py
@@ -25,6 +25,8 @@ Examples:
   $ cylc poll REG TASK_GLOB  # poll multiple active tasks or families
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -56,6 +58,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -29,6 +29,8 @@ Held tasks do not submit their jobs even if ready to run.
 See also 'cylc hold'.
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -60,6 +62,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -32,6 +32,8 @@ If the suite was started with Jinja2 template variables set on the command line
 If the modified suite definition does not parse, failure to reload will
 be reported but no harm will be done to the running suite."""
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -57,6 +59,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -22,6 +22,8 @@ Remove task instances from the scheduler task pool.
 
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -53,6 +55,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -30,6 +30,8 @@ The --output=OUTPUT option can be used multiple times on the command line.
 
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -66,6 +68,7 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/set_verbosity.py
+++ b/cylc/flow/scripts/set_verbosity.py
@@ -25,6 +25,8 @@ example, if you choose WARNING, only warnings and critical messages will be
 logged.
 """
 
+import os.path
+
 from cylc.flow import LOG_LEVELS
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
@@ -64,6 +66,7 @@ def main(parser, options, suite, severity_str):
     except KeyError:
         parser.error("Illegal logging level, %s" % severity_str)
 
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -38,6 +38,7 @@ poll and kill commands, however, will be executed prior to shutdown, unless
 This command exits immediately unless --max-polls is greater than zero, in
 which case it polls to wait for suite shutdown."""
 
+import os.path
 import sys
 
 from cylc.flow.command_polling import Poller
@@ -151,6 +152,7 @@ def main(parser, options, suite, shutdown_arg=None):
     if options.flow_label and int(options.max_polls) > 0:
         parser.error("ERROR: --flow is not compatible with --max-polls")
 
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     if int(options.max_polls) > 0:

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -30,6 +30,8 @@ need to trigger a queue-limited task twice to get it to submit immediately).
 
 """
 
+import os.path
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.network.client import SuiteRuntimeClient
 from cylc.flow.terminal import cli_function
@@ -69,6 +71,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options, suite, *task_globs):
     """CLI for "cylc trigger"."""
+    suite = os.path.normpath(suite)
     pclient = SuiteRuntimeClient(suite, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -91,6 +91,7 @@ def record_messages(suite, task_job, messages):
     # Write to job.status
     _append_job_status_file(suite, task_job, event_time, messages)
     # Send messages
+    suite = os.path.normpath(suite)
     try:
         pclient = SuiteRuntimeClient(suite)
     except SuiteStopped:


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4010 

It seems that passing a reg with a trailing slash to the `mutations_kwargs` dict was the reason for this bug. As such I've fixed it everywhere I found a `mutations_kwargs` dict.

Does this need a functional test?

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [ ] Appropriate tests are included (functional).
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
<!-- choose one: -->
- [x] No dependency changes.
