### PR TITLE
pre_configure: capture plugin error

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -27,6 +27,21 @@ class CylcError(Exception):
     """
 
 
+class PluginError(CylcError):
+    """Represents an error arising from a Cylc plugin."""
+
+    def __init__(self, entry_point, plugin_name, exc):
+        self.entry_point = entry_point
+        self.plugin_name = plugin_name
+        self.exc = exc
+
+    def __str__(self):
+        return (
+            f'Error in plugin {self.entry_point}.{self.plugin_name}'
+            f'\n{self.exc}'
+        )
+
+
 class UserInputError(CylcError):
     """Exception covering erroneous user input to a Cylc interface.
 


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-rose/issues/9

Catch errors from plugins and wrap them in a Cylc error with plugin context. Should be good enough for now.

*Example `rose-suite.conf`*:

```ini
[jinja2:suite.rc]
Y=X
```

*Output:*

```console
$ cylc install .
PluginError: Error in plugin cylc.post_configure.rose
jinja2:suite.rc=Y=X: Invalid template variable: X
Must be a valid Python or Jinja2 literal (note strings "must be quoted").
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
