### PR TITLE
tests/u: add note about ISP DNS meddling

### DIFF
--- a/tests/unit/test_hostuserutil.py
+++ b/tests/unit/test_hostuserutil.py
@@ -15,48 +15,60 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import unittest
+import re
+
+import pytest
 
 from cylc.flow.hostuserutil import (
-    get_fqdn_by_host, get_host, get_user, get_user_home, is_remote_host,
-    is_remote_user)
+    get_fqdn_by_host,
+    get_host,
+    get_user,
+    get_user_home,
+    is_remote_host,
+    is_remote_user
+)
 
 
-class TestHostUserUtil(unittest.TestCase):
-    """Test aspects of "cylc.flow.hostuserutil"."""
-
-    def test_is_remote_user_on_current_user(self):
-        """is_remote_user with current user."""
-        self.assertFalse(is_remote_user(None))
-        self.assertFalse(is_remote_user(os.getenv('USER')))
-
-    def test_is_remote_host_on_localhost(self):
-        """is_remote_host with localhost."""
-        self.assertFalse(is_remote_host(None))
-        self.assertFalse(is_remote_host('localhost'))
-        self.assertFalse(is_remote_host(os.getenv('HOSTNAME')))
-        self.assertFalse(is_remote_host(get_host()))
-
-    def test_get_fqdn_by_host_on_bad_host(self):
-        """get_fqdn_by_host bad host."""
-        bad_host = 'nosuchhost.nosuchdomain.org'
-        with self.assertRaisesRegex(
-                IOError,
-                r"(\[Errno -2\] Name or service|"
-                r"\[Errno 8\] nodename nor servname provided, or)"
-                r" not known: '{}'".format(bad_host)) as ctx:
-            get_fqdn_by_host(bad_host)
-
-        self.assertEqual(ctx.exception.filename, bad_host)
-
-    def test_get_user(self):
-        """get_user."""
-        self.assertEqual(os.getenv('USER'), get_user())
-
-    def test_get_user_home(self):
-        """get_user_home."""
-        self.assertEqual(os.getenv('HOME'), get_user_home())
+def test_is_remote_user_on_current_user():
+    """is_remote_user with current user."""
+    assert not is_remote_user(None)
+    assert not is_remote_user(os.getenv('USER'))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_is_remote_host_on_localhost():
+    """is_remote_host with localhost."""
+    assert not is_remote_host(None)
+    assert not is_remote_host('localhost')
+    assert not is_remote_host(os.getenv('HOSTNAME'))
+    assert not is_remote_host(get_host())
+
+
+def test_get_fqdn_by_host_on_bad_host():
+    """get_fqdn_by_host bad host.
+
+    Warning:
+        This test can fail due to ISP/network configuration
+        (for example ISP may reroute failed DNS to custom search page)
+        e.g: https://www.virginmedia.com/help/advanced-network-error-search
+
+    """
+    bad_host = 'nosuchhost.nosuchdomain.org'
+    with pytest.raises(IOError) as exc:
+        get_fqdn_by_host(bad_host)
+    assert re.match(
+        r"(\[Errno -2\] Name or service|"
+        r"\[Errno 8\] nodename nor servname provided, or)"
+        r" not known: '{}'".format(bad_host),
+        str(exc.value)
+    )
+    assert exc.value.filename == bad_host
+
+
+def test_get_user():
+    """get_user."""
+    assert os.getenv('USER') == get_user()
+
+
+def test_get_user_home():
+    """get_user_home."""
+    assert os.getenv('HOME') == get_user_home()


### PR DESCRIPTION
Had much fun debugging my network to find out that my ISP was very helpfully redirecting all failed DNS requests to an IPA in Ireland that is listed on malicious IP databases as being associated with DNS spoofing, thanks ISP!

To save others going though this I've added a note to the unit test where the problem is likely to be spotted first.

Converted unittest => pytest in the process.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.