### PR TITLE
validate: do not check for circular/cyclic graph if size is above limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,7 +151,7 @@ to control the job submission environment.
 
 [#4020](https://github.com/cylc/cylc-flow/pull/4020) - `cylc validate` will no
 longer check for a cyclic/circular graph if there are more than 100 tasks,
-unless the option  `--check-circular` is used. This is to improved performance.
+unless the option  `--check-circular` is used. This is to improve performance.
 
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,6 +149,10 @@ parse ``rose-suite.conf`` files in repository "cylc-rose".
 [#3955](https://github.com/cylc/cylc-flow/pull/3955) - Global config options
 to control the job submission environment.
 
+[#4020](https://github.com/cylc/cylc-flow/pull/4020) - `cylc validate` will no
+longer check for a cyclic/circular graph if there are more than 100 tasks,
+unless the option  `--check-circular` is used. This is to improved performance.
+
 
 ### Fixes
 

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -57,7 +57,8 @@ def get_option_parser():
     parser.add_option(
         "--check-circular",
         help="Check for circular dependencies in graphs when the number of "
-             "tasks is greater than 100. This can be slow when the number of "
+             "tasks is greater than 100 (smaller graphs are always checked). "
+             "This can be slow when the number of "
              "tasks is high.",
         action="store_true", default=False, dest="check_circular")
 

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -55,6 +55,13 @@ def get_option_parser():
         action="store_true", default=False, dest="strict")
 
     parser.add_option(
+        "--check-circular",
+        help="Check for circular dependencies in graphs when the number of "
+             "tasks is greater than 100. This can be slow when the number of "
+             "tasks is high.",
+        action="store_true", default=False, dest="check_circular")
+
+    parser.add_option(
         "--output", "-o",
         help="Specify a file name to dump the processed flow.cylc.",
         metavar="FILENAME", action="store", dest="output")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import pytest
 import logging
 from unittest.mock import Mock
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.config import SuiteConfig
@@ -92,7 +90,7 @@ def get_test_inheritance_quotes():
 class TestSuiteConfig:
     """Test class for the Cylc SuiteConfig object."""
 
-    def test_xfunction_imports(self, mock_glbl_cfg):
+    def test_xfunction_imports(self, mock_glbl_cfg, tmp_path):
         """Test for a suite configuration with valid xtriggers"""
         mock_glbl_cfg(
             'cylc.flow.platforms.glbl_cfg',
@@ -102,30 +100,25 @@ class TestSuiteConfig:
                     hosts = localhost
             '''
         )
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            name_a_tree_file = python_dir / "name_a_tree.py"
-            with name_a_tree_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""name_a_tree = lambda: 'jacaranda'""")
-                f.flush()
-            flow_file = Path(temp_dir, "flow.cylc")
-            with flow_file.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            tree = name_a_tree()
-        [[graph]]
-            R1 = '@tree => qux'
-                """)
-                f.flush()
-                suite_config = SuiteConfig(suite="name_a_tree", fpath=f.name)
-                config = suite_config
-                assert 'tree' in config.xtrigger_mgr.functx_map
+        python_dir = tmp_path / "lib" / "python"
+        python_dir.mkdir(parents=True)
+        name_a_tree_file = python_dir / "name_a_tree.py"
+        # NB: we are not returning a lambda, instead we have a scalar
+        name_a_tree_file.write_text("""name_a_tree = lambda: 'jacaranda'""")
+        flow_file = tmp_path / SuiteFiles.FLOW_FILE
+        flow_config = """
+        [scheduling]
+            initial cycle point = 2018-01-01
+            [[xtriggers]]
+                tree = name_a_tree()
+            [[graph]]
+                R1 = '@tree => qux'
+        """
+        flow_file.write_text(flow_config)
+        suite_config = SuiteConfig(suite="name_a_tree", fpath=flow_file)
+        assert 'tree' in suite_config.xtrigger_mgr.functx_map
 
-    def test_xfunction_import_error(self, mock_glbl_cfg):
+    def test_xfunction_import_error(self, mock_glbl_cfg, tmp_path):
         """Test for error when a xtrigger function cannot be imported."""
         mock_glbl_cfg(
             'cylc.flow.platforms.glbl_cfg',
@@ -135,30 +128,26 @@ class TestSuiteConfig:
                     hosts = localhost
             '''
         )
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            caiman_file = python_dir / "caiman.py"
-            with caiman_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""caiman = lambda: True""")
-                f.flush()
-            flow_file = Path(temp_dir, "flow.cylc")
-            with flow_file.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = piranha()
-        [[graph]]
-            R1 = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(ImportError) as excinfo:
-                    SuiteConfig(suite="caiman_suite", fpath=f.name)
-                assert "not found" in str(excinfo.value)
+        python_dir = tmp_path / "lib" / "python"
+        python_dir.mkdir(parents=True)
+        caiman_file = python_dir / "caiman.py"
+        # NB: we are not returning a lambda, instead we have a scalar
+        caiman_file.write_text("""caiman = lambda: True""")
+        flow_file = tmp_path / SuiteFiles.FLOW_FILE
+        flow_config = """
+        [scheduling]
+            initial cycle point = 2018-01-01
+            [[xtriggers]]
+                oopsie = piranha()
+            [[graph]]
+                R1 = '@oopsie => qux'
+        """
+        flow_file.write_text(flow_config)
+        with pytest.raises(ImportError) as excinfo:
+            SuiteConfig(suite="caiman_suite", fpath=flow_file)
+        assert "not found" in str(excinfo.value)
 
-    def test_xfunction_attribute_error(self, mock_glbl_cfg):
+    def test_xfunction_attribute_error(self, mock_glbl_cfg, tmp_path):
         """Test for error when a xtrigger function cannot be imported."""
         mock_glbl_cfg(
             'cylc.flow.platforms.glbl_cfg',
@@ -168,30 +157,26 @@ class TestSuiteConfig:
                     hosts = localhost
             '''
         )
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            capybara_file = python_dir / "capybara.py"
-            with capybara_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""toucan = lambda: True""")
-                f.flush()
-            flow_file = Path(temp_dir, "flow.cylc")
-            with flow_file.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = capybara()
-        [[graph]]
-            R1 = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(AttributeError) as excinfo:
-                    SuiteConfig(suite="capybara_suite", fpath=f.name)
-                assert "not found" in str(excinfo.value)
+        python_dir = tmp_path / "lib" / "python"
+        python_dir.mkdir(parents=True)
+        capybara_file = python_dir / "capybara.py"
+        # NB: we are not returning a lambda, instead we have a scalar
+        capybara_file.write_text("""toucan = lambda: True""")
+        flow_file = tmp_path / SuiteFiles.FLOW_FILE
+        flow_config = """
+        [scheduling]
+            initial cycle point = 2018-01-01
+            [[xtriggers]]
+                oopsie = capybara()
+            [[graph]]
+                R1 = '@oopsie => qux'
+        """
+        flow_file.write_text(flow_config)
+        with pytest.raises(AttributeError) as excinfo:
+            SuiteConfig(suite="capybara_suite", fpath=flow_file)
+        assert "not found" in str(excinfo.value)
 
-    def test_xfunction_not_callable(self, mock_glbl_cfg):
+    def test_xfunction_not_callable(self, mock_glbl_cfg, tmp_path):
         """Test for error when a xtrigger function is not callable."""
         mock_glbl_cfg(
             'cylc.flow.platforms.glbl_cfg',
@@ -201,28 +186,24 @@ class TestSuiteConfig:
                     hosts = localhost
             '''
         )
-        with TemporaryDirectory() as temp_dir:
-            python_dir = Path(os.path.join(temp_dir, "lib", "python"))
-            python_dir.mkdir(parents=True)
-            not_callable_file = python_dir / "not_callable.py"
-            with not_callable_file.open(mode="w") as f:
-                # NB: we are not returning a lambda, instead we have a scalar
-                f.write("""not_callable = 42""")
-                f.flush()
-            flow_file = Path(temp_dir, "flow.cylc")
-            with flow_file.open(mode="w") as f:
-                f.write("""
-    [scheduling]
-        initial cycle point = 2018-01-01
-        [[xtriggers]]
-            oopsie = not_callable()
-        [[graph]]
-            R1 = '@oopsie => qux'
-                """)
-                f.flush()
-                with pytest.raises(ValueError) as excinfo:
-                    SuiteConfig(suite="suite_with_not_callable", fpath=f.name)
-                assert "callable" in str(excinfo.value)
+        python_dir = tmp_path / "lib" / "python"
+        python_dir.mkdir(parents=True)
+        not_callable_file = python_dir / "not_callable.py"
+        # NB: we are not returning a lambda, instead we have a scalar
+        not_callable_file.write_text("""not_callable = 42""")
+        flow_file = tmp_path / SuiteFiles.FLOW_FILE
+        flow_config = """
+        [scheduling]
+            initial cycle point = 2018-01-01
+            [[xtriggers]]
+                oopsie = not_callable()
+            [[graph]]
+                R1 = '@oopsie => qux'
+        """
+        flow_file.write_text(flow_config)
+        with pytest.raises(ValueError) as excinfo:
+            SuiteConfig(suite="suite_with_not_callable", fpath=flow_file)
+        assert "callable" in str(excinfo.value)
 
     def test_family_inheritance_and_quotes(self, mock_glbl_cfg):
         """Test that inheritance does not ignore items, if not all quoted.
@@ -276,7 +257,7 @@ def test_queue_config_repeated(caplog, tmp_path):
        inherit = A, B
    [[y]]
     """
-    flow_file = tmp_path / "flow.cylc"
+    flow_file = tmp_path / SuiteFiles.FLOW_FILE
     flow_file.write_text(flow_file_content)
     SuiteConfig(suite="qtest", fpath=flow_file.absolute())
     log = caplog.messages[0].split('\n')
@@ -302,7 +283,7 @@ def test_queue_config_not_used_not_defined(caplog, tmp_path):
    [[foo]]
    # bar not even defined
     """
-    flow_file = tmp_path / "flow.cylc"
+    flow_file = tmp_path / SuiteFiles.FLOW_FILE
     flow_file.write_text(flow_file_content)
     SuiteConfig(suite="qtest", fpath=flow_file.absolute())
     log = caplog.messages[0].split('\n')
@@ -456,7 +437,7 @@ def test_cycle_point_tz(caplog, monkeypatch):
         _test(**case)
 
 
-def test_rsync_includes_will_not_accept_sub_directories():
+def test_rsync_includes_will_not_accept_sub_directories(tmp_path):
 
     flow_cylc_content = """
     [scheduling]
@@ -465,19 +446,16 @@ def test_rsync_includes_will_not_accept_sub_directories():
             graph = "blah => deeblah"
     [scheduler]
         install = dir/, dir2/subdir2/, file1, file2
-        """
-    with TemporaryDirectory() as temp_dir:
-        flow_cylc = Path(temp_dir, "flow.cylc")
-        with flow_cylc.open(mode="w") as f:
-            f.write(flow_cylc_content)
-            f.flush()
+    """
+    flow_cylc = tmp_path.joinpath(SuiteFiles.FLOW_FILE)
+    flow_cylc.write_text(flow_cylc_content)
 
-        with pytest.raises(SuiteConfigError) as exc:
-            SuiteConfig(suite="rsynctest", fpath=flow_cylc)
-        assert "Directories can only be from the top level" in str(exc.value)
+    with pytest.raises(SuiteConfigError) as exc:
+        SuiteConfig(suite="rsynctest", fpath=flow_cylc)
+    assert "Directories can only be from the top level" in str(exc.value)
 
 
-def test_valid_rsync_includes_returns_correct_list():
+def test_valid_rsync_includes_returns_correct_list(tmp_path):
     """Test that the rsync includes in the correct """
 
     flow_cylc_content = """
@@ -487,17 +465,14 @@ def test_valid_rsync_includes_returns_correct_list():
             graph = "blah => deeblah"
     [scheduler]
         install = dir/, dir2/, file1, file2
-        """
-    with TemporaryDirectory() as temp_dir:
-        flow_cylc = Path(temp_dir, "flow.cylc")
-        with flow_cylc.open(mode="w") as f:
-            f.write(flow_cylc_content)
-            f.flush()
+    """
+    flow_cylc = tmp_path.joinpath(SuiteFiles.FLOW_FILE)
+    flow_cylc.write_text(flow_cylc_content)
 
-        config = SuiteConfig(suite="rsynctest", fpath=flow_cylc)
+    config = SuiteConfig(suite="rsynctest", fpath=flow_cylc)
 
-        rsync_includes = SuiteConfig.get_validated_rsync_includes(config)
-        assert rsync_includes == ['dir/', 'dir2/', 'file1', 'file2']
+    rsync_includes = SuiteConfig.get_validated_rsync_includes(config)
+    assert rsync_includes == ['dir/', 'dir2/', 'file1', 'file2']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #3869

> Cyclic graph validation can be quite slow and is currently included as part of `--strict`

This PR (last one of 2020!) introduces an option `--check-circular` to `cylc validate`. If the number of tasks is less than the limit (100), checking for circular graph will always happen. If the number is above the limit, the check will be skipped (with a warning) unless `--check-circular` is used.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit).
- [x] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No dependency changes.
