### PR TITLE
Cli setting of rose opts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,13 @@ to control the job submission environment.
 longer check for a cyclic/circular graph if there are more than 100 tasks,
 unless the option  `--check-circular` is used. This is to improve performance.
 
+[#4023](https://github.com/cylc/cylc-flow/pull/4023) - Add ability to use
+post-install entry point from rose-cylc to use Rose style CLI settings of
+configurations in Cylc install. If Cylc-rose is installed three new CLI
+options will be available:
+- `--opt_conf_keys="foo, bar"`
+- `--defines="[env]FOO=BAR"`
+- `--suite-defines="FOO=BAR"
 
 ### Fixes
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -165,7 +165,11 @@ def main(parser, opts, flow_name=None, src=None):
         'cylc.pre_configure'
     ):
         try:
-            entry_point.resolve()(dir_=opts.source, opts=opts)
+            if opts.source:
+                entry_point.resolve()(dir_=opts.source, opts=opts)
+            else:
+                from pathlib import Path
+                entry_point.resolve()(dir_=Path().cwd(), opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -113,6 +113,44 @@ def get_option_parser():
         default=False,
         dest="no_symlinks")
 
+    # If cylc-rose plugin is available ad the --option/-O config
+    try:
+        __import__('cylc.rose')
+        parser.add_option(
+            "--opt-conf-key", "-O",
+            help=(
+                "Use optional Rose Config Setting"
+                "(If Cylc-Rose is installed)"
+            ),
+            action="append",
+            default=[],
+            dest="opt_conf_keys"
+        )
+        parser.add_option(
+            "--define", '-D',
+            help=(
+                "Each of these overrides the `[SECTION]KEY` setting in a "
+                "`rose-suite.conf` file. "
+                "Can be used to disable a setting using the syntax "
+                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
+            ),
+            action="append",
+            default=[],
+            dest="defines"
+        )
+        parser.add_option(
+            "--define-suite", "--define-flow", '-S',
+            help=(
+                "As `--define`, but with an implicit `[SECTION]` for "
+                "workflow variables."
+            ),
+            action="append",
+            default=[],
+            dest="define_suites"
+        )
+    except ImportError:
+        pass
+
     return parser
 
 
@@ -127,7 +165,7 @@ def main(parser, opts, flow_name=None, src=None):
         'cylc.pre_configure'
     ):
         try:
-            entry_point.resolve()(opts.source)
+            entry_point.resolve()(dir_=opts.source, opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors

--- a/tests/functional/cylc-clean/00-basic.t
+++ b/tests/functional/cylc-clean/00-basic.t
@@ -58,6 +58,15 @@ cmp_ok "${TEST_NAME}.stdout" <<< "${TEST_DIR}/${SYM_NAME}-run/cylc-run/${SUITE_N
 INSTALL_LOG_FILE=$(ls "${TEST_DIR}/${SYM_NAME}-log/cylc-run/${SUITE_NAME}/log/install")
 TEST_NAME="test-dir-tree-pre-clean"
 tree --noreport --charset=ascii "${TEST_DIR}/${SYM_NAME}-"* > "${TEST_NAME}.stdout"
+
+# If rose-cylc plugin is installed add install files to tree.
+export ROSE_FILES=''
+python -c "import cylc.rose" > /dev/null 2>&1 &&
+    export ROSE_FILES="
+                    |-- opt
+                    |   \`-- rose-suite-cylc-install.conf
+                    |-- rose-suite.conf"
+
 # Note: backticks need to be escaped in the heredoc
 cmp_ok "${TEST_NAME}.stdout" << __TREE__
 ${TEST_DIR}/${SYM_NAME}-cycle
@@ -87,7 +96,7 @@ ${TEST_DIR}/${SYM_NAME}-run
                     |-- _cylc-install
                     |   \`-- source -> ${TEST_DIR}/${SUITE_NAME}
                     |-- flow.cylc
-                    |-- log -> ${TEST_DIR}/${SYM_NAME}-log/cylc-run/${SUITE_NAME}/log
+                    |-- log -> ${TEST_DIR}/${SYM_NAME}-log/cylc-run/${SUITE_NAME}/log${ROSE_FILES}
                     |-- share -> ${TEST_DIR}/${SYM_NAME}-share/cylc-run/${SUITE_NAME}/share
                     \`-- work -> ${TEST_DIR}/${SYM_NAME}-work/cylc-run/${SUITE_NAME}/work
 ${TEST_DIR}/${SYM_NAME}-share

--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -52,7 +52,15 @@ mkdir .git .svn dir1 dir2
 touch .git/file1 .svn/file1 dir1/file1 dir2/file1 file1 file2
 run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
-tree -a -v -I '*.log|03-file-transfer*' "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
+# If rose-cylc plugin is installed add install files to tree.
+export ROSE_FILES=''
+python -c "import cylc.rose" > /dev/null 2>&1 &&
+    export ROSE_FILES="
+                    |-- opt
+                    |   \`-- rose-suite-cylc-install.conf
+                    |-- rose-suite.conf"
+
+tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
 cmp_ok 'basic-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service
@@ -65,10 +73,13 @@ ${RND_SUITE_RUNDIR}/
 ├── file1
 ├── file2
 ├── flow.cylc
-└── log
-    └── install
+├── log
+│   └── install
+├── opt
+│   └── rose-suite-cylc-install.conf
+└── rose-suite.conf
 
-7 directories, 5 files
+8 directories, 7 files
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
@@ -92,7 +103,7 @@ __END__
 
 run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
-tree -a -v -I '*.log|03-file-transfer*' "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
+tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
 cmp_ok 'cylc-ignore-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service
@@ -100,10 +111,13 @@ ${RND_SUITE_RUNDIR}/
 │   └── source -> ${RND_SUITE_SOURCE}
 ├── file1
 ├── flow.cylc
-└── log
-    └── install
+├── log
+│   └── install
+├── opt
+│   └── rose-suite-cylc-install.conf
+└── rose-suite.conf
 
-5 directories, 2 files
+6 directories, 4 files
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__

--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -54,13 +54,18 @@ run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
 # If rose-cylc plugin is installed add install files to tree.
 export ROSE_FILES=''
-python -c "import cylc.rose" > /dev/null 2>&1 &&
-    export ROSE_FILES="
-                    |-- opt
-                    |   \`-- rose-suite-cylc-install.conf
-                    |-- rose-suite.conf"
+if python -c "import cylc.rose" > /dev/null 2>&1; then
+    export ROSE_FILES="""├── log
+│   └── install
+├── opt
+│   └── rose-suite-cylc-install.conf
+└── rose-suite.conf"""
+else
+    export ROSE_FILES="""└── log
+    └── install"""
+fi
 
-tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
+tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
 cmp_ok 'basic-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service
@@ -73,13 +78,7 @@ ${RND_SUITE_RUNDIR}/
 ├── file1
 ├── file2
 ├── flow.cylc
-├── log
-│   └── install
-├── opt
-│   └── rose-suite-cylc-install.conf
-└── rose-suite.conf
-
-8 directories, 7 files
+${ROSE_FILES}
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
@@ -103,7 +102,7 @@ __END__
 
 run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
-tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
+tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
 cmp_ok 'cylc-ignore-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service
@@ -111,13 +110,7 @@ ${RND_SUITE_RUNDIR}/
 │   └── source -> ${RND_SUITE_SOURCE}
 ├── file1
 ├── flow.cylc
-├── log
-│   └── install
-├── opt
-│   └── rose-suite-cylc-install.conf
-└── rose-suite.conf
-
-6 directories, 4 files
+${ROSE_FILES}
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__

--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -55,14 +55,14 @@ run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 # If rose-cylc plugin is installed add install files to tree.
 export ROSE_FILES=''
 if python -c "import cylc.rose" > /dev/null 2>&1; then
-    export ROSE_FILES="""├── log
+    export ROSE_FILES="├── log
 │   └── install
 ├── opt
 │   └── rose-suite-cylc-install.conf
-└── rose-suite.conf"""
+└── rose-suite.conf"
 else
-    export ROSE_FILES="""└── log
-    └── install"""
+    export ROSE_FILES="└── log
+    └── install"
 fi
 
 tree -a -v -I '*.log|03-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'


### PR DESCRIPTION
built on: https://github.com/cylc/cylc-flow/pull/4000
sibling: [cylc-rose PR20](https://github.com/cylc/cylc-rose/pull/20)

### Summary
These changes partially address #3819 
These changes are downstream of changes in (cylc-rose:#20)[https://github.com/cylc/cylc-rose/pull/20]. The PR attempts to add command line options similar to the following `rose suite-run` options:
- `--opt-conf-key`
- `--defines`
- `--suite-defines`

### Checklist
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] Documentation written as part of CLI, but not in Cylc docs. Is this OK for now?  
