### PR TITLE
remove inline #

### DIFF
--- a/tests/functional/rose-conf/04-opts-set-from-env/opt/rose-suite-Gaelige.conf
+++ b/tests/functional/rose-conf/04-opts-set-from-env/opt/rose-suite-Gaelige.conf
@@ -1,8 +1,8 @@
 [jinja2:suite.rc]
 ICP=1
 FCP=1
-TASK1="cuir" # to put
-TASK2="tog"  # to lift
-TASK3="gabh" # to take
+TASK1="cuir" 
+TASK2="tog"  
+TASK3="gabh" 
 MEMBERS=["control", "aon", "dhà", "trì"]
 SAMUELJOHNSON={"ein": 1, "zwei": 2, "drei": 3}


### PR DESCRIPTION
This is a small change with no associated Issue.

Master currently failing test `tests/functional/rose-conf/04-opts/set-from-env`
This is caused by in-line comment.

This may need to be addressed if it is something we need to support - quick fix for now.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (Fix for test).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
