### PR TITLE
Fix OrderedDictWithDefault comparison mistake

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -307,7 +307,7 @@ def platform_from_job_info(platforms, job, remote):
         # Handle all the items requiring an exact match.
         for task_section in [job, remote]:
             shared_items = set(
-                task_section).intersection(set(platform_spec.keys()))
+                task_section).intersection(set(platform_spec))
             generic_items_match = all((
                 platform_spec[item] == task_section[item]
                 for item in shared_items

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -17,6 +17,7 @@
 # Tests for the platform lookup.
 
 import pytest
+from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.platforms import platform_from_name, platform_from_job_info
 from cylc.flow.exceptions import PlatformLookupError
 
@@ -199,6 +200,20 @@ def test_similar_but_not_exact_match():
 )
 def test_platform_from_job_info_basic(job, remote, returns):
     assert platform_from_job_info(PLATFORMS, job, remote) == returns
+
+
+def test_platform_from_job_info_ordered_dict_comparison():
+    """Check that we are only comparing set items in OrderedDictWithDefaults.
+    """
+    job = {'batch system': 'background', 'Made up key': 'Zaphod'}
+    remote = {'host': 'hpc1', 'Made up key': 'Arthur'}
+    # Set up a fake OrderedDictWith a fake unset default.
+    platform = OrderedDictWithDefaults()
+    platform.defaults_ = {k: None for k in PLATFORMS['hpc1-bg'].keys()}
+    platform.defaults_['Made up key'] = {}
+    platform.update(PLATFORMS['hpc1-bg'])
+    platforms = {'hpc1-bg': platform, 'dobbie': PLATFORMS['sugar']}
+    assert platform_from_job_info(platforms, job, remote) == 'hpc1-bg'
 
 
 # Cases where the error ought to be raised because no matching platform should


### PR DESCRIPTION
These changes close #3812 

### Cause of bug
From `cylc/flow/parsec/OrderedDictWithDefaults.py`:
```
    def keys(self):
        """Include the default keys, after the list of actually-set ones."""
```

Thus in my code `set(OrderedDictA) ≠ set(OrderedDictA.keys())`. When I originally wrote this code I had not realized that this was the case, and had failed to notice the divergence from standard dict behavior. I had done much of my testing using dicts in plact of OrderedDictWithDefault. In most cases this is fine, but here is an example of a bug which slipped through as a result.

### Checklist

- [x] Unit test added.
- [x] No change log entry required - Fixes a change I hope users will never encounter in anger.
- [x] No documentation update required. Fixes a breakage.
