### PR TITLE
Fix database platforms bug

### DIFF
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -308,7 +308,7 @@ class TaskJobManager:
                     'is_manual_submit': itask.is_manual_submit,
                     'try_num': itask.get_try_num(),
                     'time_submit': now_str,
-                    'platform_name': platform['name'],
+                    'platform_name': itask.platform['name'],
                     'job_runner_name': itask.summary['job_runner_name'],
                 })
                 itask.is_manual_submit = False

--- a/tests/functional/platforms/03-platform-db.t
+++ b/tests/functional/platforms/03-platform-db.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Check db stores correct platform
+export REQUIRE_PLATFORM='loc:remote'
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+create_test_global_config '' "
+[platforms]
+    [[elsa]]
+        hosts = ${CYLC_TEST_HOST}
+        install target = ${CYLC_TEST_INSTALL_TARGET}        
+    [[olaf]]
+        hosts = ${CYLC_TEST_HOST}
+        install target = ${CYLC_TEST_INSTALL_TARGET}
+"
+
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+suite_run_ok "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+
+DB_FILE="${SUITE_RUN_DIR}/log/db"
+NAME='select-name-platform.out'
+
+sqlite3 "${DB_FILE}" 'SELECT name, platform_name FROM task_jobs ORDER BY name' \
+    >"${NAME}"
+
+cmp_ok "${NAME}" <<__SELECT__
+disney|olaf
+frozen|elsa
+__SELECT__
+
+purge
+exit

--- a/tests/functional/platforms/03-platform-db/flow.cylc
+++ b/tests/functional/platforms/03-platform-db/flow.cylc
@@ -1,0 +1,10 @@
+[scheduling]
+    [[graph]]
+        R1 = frozen & disney
+[runtime]
+    [[frozen]]
+        script = "echo let it go"
+        platform = elsa
+    [[disney]]
+        script = "echo cant hold it back anymore"
+        platform = olaf


### PR DESCRIPTION
Fixes a bug where there incorrect platform is stored in the database.
To recreate the bug - run the functional test included in PR without the fix: i.e. line 311 in `task_job_mgr.py`  :  `'platform_name': platform['name']`.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
