### PR TITLE
actions: run tests on macos

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -8,7 +8,12 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
+        os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9']
+        include:
+          - os: 'macos-latest'
+            python-version: '3.7'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +23,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Apt-Get
+      - name: Brew Install
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew update
+          brew install shellcheck sqlite3
+
+      - name: Apt-Get Install
+        if: endsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck sqlite3

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -30,7 +30,7 @@ jobs:
           brew install shellcheck sqlite3
 
       - name: Apt-Get Install
-        if: endsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck sqlite3

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -5,10 +5,11 @@ on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
+        os: ['ubuntu-latest']
         python-version: ['3.7']
         tests: [
           # local tests
@@ -23,11 +24,17 @@ jobs:
           ['tests/f tests/k', '1/1',
            '_remote_background_indep_tcp _remote_at_indep_tcp']
         ]
+        include:
+          - os: 'macos-latest'
+            python-version: '3.7'
+            tests: ['tests/f', '1/4', '_local_background*']
+
     env:
       BASE: ${{ matrix.tests[0] }}
       CHUNK: ${{ matrix.tests[1] }}
       CYLC_TEST_PLATFORMS: ${{ matrix.tests[2] }}
       CYLC_COVERAGE: 1
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -37,7 +44,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Apt-Get
+      - name: Brew Install
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          # apply DNS patch
+          patch cylc/flow/hostuserutil.py < etc/conf/macos-patch
+
+          # install system deps
+          brew update
+          brew install bash coreutils gnu-sed
+
+          # add GNU coreutils and sed to the user PATH
+          # (see instructions in brew install output)
+          cat >> "$HOME/.bashrc" <<__HERE__
+          PATH="$(brew --prefix)/opt/coreutils/libexec/gnubin:$PATH"
+          PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+          __HERE__
+
+      - name: Apt-Get Install
+        if: endsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y sqlite3 tree
@@ -54,7 +79,7 @@ jobs:
           mkdir "$HOME/cylc-run"
 
       - name: Configure Atrun
-        if: matrix.tests[2] == '_local_background* _local_at*'
+        if: contains(matrix.tests[2], '_local_at')
         run: |
           PTH="$HOME/.cylc/flow/$(cylc version)"
           mkdir -p "${PTH}"
@@ -69,7 +94,7 @@ jobs:
           etc/bin/swarm --yes --debug configure
 
       - name: Swarm Build
-        if: matrix.tests[2] != '_local_background* _local_at*'
+        if: contains(matrix.tests[2], '_remote')
         run: |
           # `swarm configure` seems to get ignored so override the user config
           cp etc/conf/ssh_config $HOME/.ssh/config
@@ -125,25 +150,25 @@ jobs:
           path: cylc-run
 
       - name: Fetch Remote Coverage
+        if: contains(matrix.tests[2], '_remote')
         run: |
-          if [[ "${{ matrix.tests[2] }}" = _remote* ]]; then
-            host="$(cut -d ' ' -f 1 <<< "${{ matrix.tests[2] }}")"
-            # copy back the remote coverage files
-            rsync -av \
-              "${host}:/cylc/" \
-              '.' \
-              --include='.coverage*' \
-              --exclude='*' \
-              >rsyncout
-            cat rsyncout
-            # fiddle the python source location to match the local system
-            for db in $(grep --color=never '.coverage\.' rsyncout); do
-              sqlite3 "$db" "
-                UPDATE file
-                SET path = REPLACE(path, '/cylc/cylc/', '$PWD/cylc/')
-              "
-            done
-          fi
+          # pick the first host in the list
+          host="$(cut -d ' ' -f 1 <<< "${{ matrix.tests[2] }}")"
+          # copy back the remote coverage files
+          rsync -av \
+            "${host}:/cylc/" \
+            '.' \
+            --include='.coverage*' \
+            --exclude='*' \
+            >rsyncout
+          cat rsyncout
+          # fiddle the python source location to match the local system
+          for db in $(grep --color=never '.coverage\.' rsyncout); do
+            sqlite3 "$db" "
+              UPDATE file
+              SET path = REPLACE(path, '/cylc/cylc/', '$PWD/cylc/')
+            "
+          done
 
       - name: Shutdown
         if: always()

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -62,7 +62,7 @@ jobs:
           __HERE__
 
       - name: Apt-Get Install
-        if: endsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y sqlite3 tree

--- a/etc/conf/macos-patch
+++ b/etc/conf/macos-patch
@@ -1,0 +1,13 @@
+diff --git a/cylc/flow/hostuserutil.py b/cylc/flow/hostuserutil.py
+index 21e51735e..17917b8fc 100644
+--- a/cylc/flow/hostuserutil.py
++++ b/cylc/flow/hostuserutil.py
+@@ -113,7 +113,7 @@ class HostUtil:
+         """Return the extended info of the current host."""
+         if target not in self._host_exs:
+             if target is None:
+-                target = socket.getfqdn()
++                target = socket.gethostname()
+             try:
+                 self._host_exs[target] = socket.gethostbyname_ex(target)
+             except IOError as exc:


### PR DESCRIPTION
Bar the outstanding DNS issue and after a spate of portability changes Cylc Flow now supports MacOS nicely.

Add `macos-latest` into the CI tests:

* All unit and integration tests
  * Some of these required fixing for MacOS
  * Recent example of a portability test fix - https://github.com/cylc/cylc-flow/pull/3917
* The first 1/4 of functional tests
  * Running the whole test battery would be a bit much.

To sidestep the DNS issue this PR applies the [`cylc.flow.hostuserutil`](https://github.com/cylc/cylc-flow/issues/2689#issuecomment-715161888) I've been using for local development over the last year.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
