### PR TITLE
Fix remote init by platform

### DIFF
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -45,7 +45,6 @@ from cylc.flow.exceptions import (
 )
 from cylc.flow.hostuserutil import (
     get_host,
-    is_remote_host,
     is_remote_platform
 )
 from cylc.flow.job_file import JobFileWriter
@@ -261,7 +260,7 @@ class TaskJobManager:
                     ri_map[install_target] = (REMOTE_FILE_INSTALL_DONE)
 
                 # Remote init not in progress for target, so start it
-                elif install_target not in ri_map.keys():
+                elif install_target not in ri_map:
                     self.task_remote_mgr.remote_init(
                         platform, curve_auth, client_pub_key_dir)
                     for itask in itasks:

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -256,8 +256,7 @@ class TaskJobManager:
             # Skip to jobs (use .get() to avoid KeyError)
             if (ri_map.get(install_target) != REMOTE_FILE_INSTALL_DONE):
                 # Skip both remote init and remote file install for localhost
-                if (install_target == 'localhost' or
-                        not is_remote_host(get_host_from_platform(platform))):
+                if install_target == 'localhost':
                     LOG.debug(f"REMOTE INIT NOT REQUIRED for {install_target}")
                     ri_map[install_target] = (REMOTE_FILE_INSTALL_DONE)
 

--- a/tests/functional/remote/05-remote-init.t
+++ b/tests/functional/remote/05-remote-init.t
@@ -32,6 +32,7 @@ create_test_global_config "" "
         install target = ${CYLC_TEST_INSTALL_TARGET}
         ssh command = garbage
     "
+
 #-------------------------------------------------------------------------------
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
@@ -58,3 +59,5 @@ grep_ok "WARNING - Suite stalled with unhandled failed tasks:" \
 grep_ok "* b.1 (submit-failed)
 	* a.1 (submit-failed)" \
     "${TEST_NAME_BASE}-run.stderr" 
+purge
+exit

--- a/tests/functional/remote/05-remote-init.t
+++ b/tests/functional/remote/05-remote-init.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test remote initialisation - when remote init fails for an install target,
+# check other platforms with same install target can be initialised.
+
+export REQUIRE_PLATFORM='loc:remote'
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 5
+create_test_global_config "" "
+[platforms]
+    [[ariel]]
+        hosts = ${CYLC_TEST_HOST}
+        install target = ${CYLC_TEST_INSTALL_TARGET}
+    [[belle]]
+        hosts = ${CYLC_TEST_HOST}
+        install target = ${CYLC_TEST_INSTALL_TARGET}
+        ssh command = garbage
+    "
+#-------------------------------------------------------------------------------
+install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+suite_run_fail "${TEST_NAME_BASE}-run" \
+    cylc run --debug --no-detach "${SUITE_NAME}"
+NAME='select-task-jobs.out'
+DB_FILE="${SUITE_RUN_DIR}/log/db"
+sqlite3 "${DB_FILE}" \
+    'SELECT name, submit_status, run_status, platform_name
+     FROM task_jobs ORDER BY name' \
+    >"${NAME}"
+cmp_ok "${NAME}" <<__SELECT__
+a|1||
+b|1||
+e|0|0|ariel
+f|0|0|ariel
+g|0|0|localhost
+__SELECT__
+
+grep_ok "WARNING - Suite stalled with unhandled failed tasks:" \
+    "${TEST_NAME_BASE}-run.stderr" 
+grep_ok "* b.1 (submit-failed)
+	* a.1 (submit-failed)" \
+    "${TEST_NAME_BASE}-run.stderr" 

--- a/tests/functional/remote/05-remote-init/flow.cylc
+++ b/tests/functional/remote/05-remote-init/flow.cylc
@@ -1,0 +1,39 @@
+[scheduler]
+    [[events]]
+        abort on stalled = true
+        abort on inactivity = true
+[scheduling]
+    [[graph]]
+    R1 = """
+a & b & g      
+# a & b setup to submit-fail, g (localhost) does not require remote init
+b:submitted => c
+b:start  => d 
+# c & d should not be triggered
+b:submit-fail => e & f 
+#  e and f on a same install target but with a different platform name - these should execute
+"""
+[runtime]
+    [[task]]
+        script="sleep 1; echo hello"
+    [[a]]
+        inherit=task
+        platform=belle
+    [[b]]
+        inherit=task
+        platform=belle  
+    [[c]]
+        inherit=task
+        platform=belle 
+    [[d]]
+        inherit=task
+        platform= belle
+    [[e]]
+        inherit=task
+        platform=ariel
+    [[f]]
+        inherit=task
+        platform=ariel
+    [[g]]
+        inherit=task
+        platform=localhost

--- a/tests/functional/remote/05-remote-init/reference.log
+++ b/tests/functional/remote/05-remote-init/reference.log
@@ -1,7 +1,0 @@
-Initial point: 1
-Final point: 1
-[a.1] -triggered off []
-[b.1] -triggered off []
-[g.1] -triggered off []
-[e.1] -triggered off ['b.1']
-[f.1] -triggered off ['b.1']

--- a/tests/functional/remote/05-remote-init/reference.log
+++ b/tests/functional/remote/05-remote-init/reference.log
@@ -1,0 +1,7 @@
+Initial point: 1
+Final point: 1
+[a.1] -triggered off []
+[b.1] -triggered off []
+[g.1] -triggered off []
+[e.1] -triggered off ['b.1']
+[f.1] -triggered off ['b.1']


### PR DESCRIPTION
Fixes a bug whereby tasks were being grouped by install target when grouping by platform was required.
Also fixes a bug whereby the database was not being updated correctly. 
This is a small change with no associated Issue.

NOTE: This will be required before beta.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional). - possibly requires more testing to cover various fail cases - e.g. when rsync (for file install) fails
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
