### PR TITLE
Platforms.fix generic items match

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -342,15 +342,14 @@ def platform_from_job_info(platforms, job, remote):
 def generic_items_match(platform_spec, job, remote):
     """Checks generic items from job/remote against a platform.
     """
-    generic_items_match = True
     for task_section in [job, remote]:
         shared_items = set(task_section).intersection(set(platform_spec))
         if not all([
             platform_spec[item] == task_section[item]
             for item in shared_items
         ]):
-            generic_items_match = False
-    return generic_items_match
+            return False
+    return True
 
 
 def get_host_from_platform(platform, method='random'):

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -340,13 +340,16 @@ def platform_from_job_info(platforms, job, remote):
 
 
 def generic_items_match(platform_spec, job, remote):
+    """Checks generic items from job/remote against a platform.
+    """
+    generic_items_match = True
     for task_section in [job, remote]:
-        shared_items = set(
-            task_section).intersection(set(platform_spec))
-        generic_items_match = all((
+        shared_items = set(task_section).intersection(set(platform_spec))
+        if not all([
             platform_spec[item] == task_section[item]
             for item in shared_items
-        ))
+        ]):
+            generic_items_match = False
     return generic_items_match
 
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -310,15 +310,8 @@ def platform_from_job_info(platforms, job, remote):
     # before site config platforms.
     for platform_name, platform_spec in reversed(list(platforms.items())):
         # Handle all the items requiring an exact match.
-        for task_section in [job, remote]:
-            shared_items = set(
-                task_section).intersection(set(platform_spec))
-            generic_items_match = all((
-                platform_spec[item] == task_section[item]
-                for item in shared_items
-            ))
         # All items other than batch system and host must be an exact match
-        if not generic_items_match:
+        if not generic_items_match(platform_spec, job, remote):
             continue
         # We have some special logic to identify whether task host and task
         # batch system match the platform in question.
@@ -344,6 +337,17 @@ def platform_from_job_info(platforms, job, remote):
             return task_host
 
     raise PlatformLookupError('No platform found matching your task')
+
+
+def generic_items_match(platform_spec, job, remote):
+    for task_section in [job, remote]:
+        shared_items = set(
+            task_section).intersection(set(platform_spec))
+        generic_items_match = all((
+            platform_spec[item] == task_section[item]
+            for item in shared_items
+        ))
+    return generic_items_match
 
 
 def get_host_from_platform(platform, method='random'):

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -460,6 +460,12 @@ def test_get_install_target_to_platforms_map(
             {'captain': 'Picard'},
             {'ship': 'Defiant'},
             False
+        ),
+        (
+            {'captain': 'Picard', 'ship': 'Enterprise'},
+            {'captain': 'Picard'},
+            {},
+            True
         )
     ]
 )

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -20,7 +20,9 @@ import pytest
 from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.platforms import (
     platform_from_name, platform_from_job_info,
-    get_install_target_from_platform, get_install_target_to_platforms_map)
+    get_install_target_from_platform, get_install_target_to_platforms_map,
+    generic_items_match
+)
 
 from cylc.flow.exceptions import PlatformLookupError
 
@@ -426,3 +428,28 @@ def test_get_install_target_to_platforms_map(
                 _map[install_target] = sorted(_map[install_target],
                                               key=lambda k: k['name'])
         assert result == expected_map
+
+
+@pytest.mark.parametrize(
+    'platform, job, remote, expect',
+    [
+        (
+            # Default, no old settings.
+            {'ship': 'Enterprise'}, {}, {}, True
+        ),
+        (
+            {'captain': 'Kirk'},
+            {'captain': 'Picard'},
+            {},
+            False
+        ),
+        (
+            {'captain': 'Sisko'},
+            {},
+            {'captain': 'Janeway'},
+            False
+        )
+    ]
+)
+def test_generic_items_match(platform, job, remote, expect):
+    assert generic_items_match(platform, job, remote) == expect

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -448,6 +448,18 @@ def test_get_install_target_to_platforms_map(
             {},
             {'captain': 'Janeway'},
             False
+        ),
+        (
+            {'captain': 'Picard', 'ship': 'Enterprise'},
+            {'captain': 'Picard'},
+            {'ship': 'Enterprise'},
+            True
+        ),
+        (
+            {'captain': 'Picard', 'ship': 'Enterprise'},
+            {'captain': 'Picard'},
+            {'ship': 'Defiant'},
+            False
         )
     ]
 )

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -32,9 +32,15 @@ PLATFORMS = {
         'hosts': 'localhost',
         'job runner': 'slurm',
     },
-    'hpc': {
+    'hpc-no-logs': {
         'hosts': ['hpc1', 'hpc2'],
         'job runner': 'pbs',
+        'retrieve job logs': False
+    },
+    'hpc-logs': {
+        'hosts': ['hpc1', 'hpc2'],
+        'job runner': 'pbs',
+        'retrieve job logs': True
     },
     'hpc1-bg': {
         'hosts': 'hpc1',
@@ -196,7 +202,7 @@ def test_similar_but_not_exact_match():
         (
             {'batch system': 'pbs'},
             {'host': 'hpc1'},
-            'hpc'
+            'hpc-logs'
         ),
         # When the user asks for hpc1 without specifying pbs user gets platform
         # hpc bg1
@@ -216,7 +222,13 @@ def test_similar_but_not_exact_match():
             {'batch system': None},
             {'host': None},
             'localhost'
-        )
+        ),
+        (
+            # Check that all generic items are matched
+            {'batch system': 'pbs'},
+            {'host': 'hpc1', 'retrieve job logs': False},
+            'hpc-no-logs'
+        ),
     ]
 )
 def test_platform_from_job_info_basic(job, remote, returns):


### PR DESCRIPTION
This is a small change with no associated Issue.

It was noted by @MetRonnie that the function `get_platform_from_job_info`: Logic checking that items in the job section of the old style config weren't being checked for a match/mismatch against platform spec.

- [x] Appropriate tests are included: I refactored part of the existing code into a more easily tested unit.
- [x] No change log entry required: Small features that should be non-user facing.
- [x] No documentation update required.
