### PR TITLE
Shutdown: remove contact file after closing DB connection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -214,6 +214,9 @@ Python 3.8+.
 a trailing slash in the suite/workflow name would cause `cylc stop`
 (and possibly other commands) to silently fail.
 
+[#4046](https://github.com/cylc/cylc-flow/pull/4046) - Fix bug where a workflow
+database could still be active for a short time after the workflow stops.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0a2 (2020-07-03)__
 

--- a/tests/flakyfunctional/shutdown/00-rm-db.t
+++ b/tests/flakyfunctional/shutdown/00-rm-db.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------
+# Test that removing the DB quickly after a shutdown does not cause it to be
+# regenerated due to any outstanding connection to the DB.
+# NOTE: this test is not guaranteed to catch the issue, but is more likely
+# to do so on slower filesystems. However, faster filesystems are
+# less likely to have the original issue in the first place. See
+# https://github.com/cylc/cylc-flow/pull/4046
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 5
+
+init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduling]
+    [[dependencies]]
+        R1 = foo
+__FLOW_CONFIG__
+
+pri_db="${SUITE_RUN_DIR}/.service/db"
+pub_db="${SUITE_RUN_DIR}/log/db"
+
+TEST_NAME="${TEST_NAME_BASE}-run"
+suite_run_ok "${TEST_NAME}" cylc run "${SUITE_NAME}"
+
+poll_suite_stopped  # This waits for contact file to be removed
+# Delete the DB without delay
+rm -f "$pri_db" "$pub_db"
+# Check if DB exists without delay
+exists_fail "$pri_db"
+exists_fail "$pub_db"
+
+sleep 10
+# Check if DB exists after delay
+exists_fail "$pri_db"
+exists_fail "$pub_db"
+
+purge
+exit


### PR DESCRIPTION
This is a small change with no associated Issue.

Detecting whether a workflow is still running or has shut down relies on checking for the existence of a contact file. However, before this PR, when shutting down a workflow, the contact file would get removed before shutting the database, which led to the small possiblity of problems (e.g. if the database is deleted in this short time, it would get regenerated).

This PR reverse the order, so any DB connections are definitely closed when the contact file is removed and the workflow is considered to have shut down.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.