### PR TITLE
Fix Remote Tidy

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -465,8 +465,9 @@ def get_all_platforms_for_install_target(install_target):
     all_platforms = glbl_cfg(cached=True).get(['platforms'], sparse=False)
     for k, v in all_platforms.iteritems():
         if (v.get('install target', k) == install_target):
-            v['name'] = k
-            platforms.append(v)
+            v_copy = deepcopy(v)
+            v_copy['name'] = k
+            platforms.append(v_copy)
     return platforms
 
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -457,3 +457,20 @@ def is_platform_with_target_in_list(install_target, distinct_platforms_list):
     """Determines whether install target is in the list of platforms"""
     for distinct_platform in distinct_platforms_list:
         return install_target == distinct_platform['install target']
+
+
+def get_all_platforms_for_install_target(install_target):
+    """Return list of platform dictionaries for given install target."""
+    platforms = []
+    all_platforms = glbl_cfg(cached=True).get(['platforms'], sparse=False)
+    for k, v in all_platforms.iteritems():
+        if (v.get('install target', k) == install_target):
+            v['name'] = k
+            platforms.append(v)
+    return platforms
+
+
+def get_random_platform_for_install_target(install_target):
+    """Return a randomly selected platform (dict) for given install target."""
+    platforms = get_all_platforms_for_install_target(install_target)
+    return random.choice(platforms)

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -154,7 +154,7 @@ def remote_tidy(install_target, rund):
     """cylc remote-tidy
 
     Arguments:
-        install_target (str): suite install target name
+        install_target (str): install target name
         rund (str): suite run directory
     """
     rund = os.path.expandvars(rund)

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -226,7 +226,7 @@ class TaskRemoteMgr:
             cmd = ['remote-tidy']
             if cylc.flow.flags.debug:
                 cmd.append('--debug')
-            cmd.append(str(f'{install_target}'))
+            cmd.append(install_target)
             cmd.append(get_remote_suite_run_dir(platform, self.suite))
             cmd = construct_ssh_cmd(cmd, platform, timeout='10s')
             LOG.debug(

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -32,7 +32,7 @@ from time import time
 from cylc.flow import LOG, RSYNC_LOG
 from cylc.flow.exceptions import TaskRemoteMgmtError
 import cylc.flow.flags
-from cylc.flow.hostuserutil import (is_remote_host, is_remote_platform)
+from cylc.flow.hostuserutil import is_remote_host
 from cylc.flow.pathutil import (
     get_remote_suite_run_dir,
     get_dirs_to_symlink,
@@ -46,9 +46,7 @@ from cylc.flow.suite_files import (
     KeyType,
     get_suite_srv_dir,
     get_contact_file)
-from cylc.flow.platforms import (
-    get_platform,
-    get_install_target_from_platform)
+from cylc.flow.platforms import get_random_platform_for_install_target
 from cylc.flow.remote import construct_ssh_cmd
 
 # Remote installation literals
@@ -171,7 +169,6 @@ class TaskRemoteMgr:
 
         """
         install_target = platform['install target']
-
         # Set status of install target to in progress while waiting for remote
         # initialisation to finish
         self.remote_init_map[install_target] = REMOTE_INIT_IN_PROGRESS
@@ -219,21 +216,22 @@ class TaskRemoteMgr:
         """
         # Issue all SSH commands in parallel
         procs = {}
-        for platform, init_with_contact in self.remote_init_map.items():
-            platform = get_platform(platform)
-            platform_n = platform['name']
-            self.install_target = get_install_target_from_platform(platform)
-            if init_with_contact != REMOTE_FILE_INSTALL_DONE:
+        for install_target, message in self.remote_init_map.items():
+            if message != REMOTE_FILE_INSTALL_DONE:
                 continue
+            if install_target == 'localhost':
+                continue
+            platform = get_random_platform_for_install_target(install_target)
+            platform_n = platform['name']
             cmd = ['remote-tidy']
             if cylc.flow.flags.debug:
                 cmd.append('--debug')
-            cmd.append(str(f'{self.install_target}'))
+            cmd.append(str(f'{install_target}'))
             cmd.append(get_remote_suite_run_dir(platform, self.suite))
-            if is_remote_platform(platform):
-                cmd = construct_ssh_cmd(cmd, platform, timeout='10s')
-            else:
-                cmd = ['cylc'] + cmd
+            cmd = construct_ssh_cmd(cmd, platform, timeout='10s')
+            LOG.debug(
+                "Removing authentication keys and contact file "
+                f"from remote: \"{install_target}\"")
             procs[platform_n] = (
                 cmd,
                 Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=DEVNULL))

--- a/tests/functional/cylc-ping/04-check-keys-remote.t
+++ b/tests/functional/cylc-ping/04-check-keys-remote.t
@@ -45,12 +45,11 @@ SSH='ssh -n -oBatchMode=yes -oConnectTimeout=5'
  
 ${SSH} "${CYLC_TEST_HOST}" \
 find "${RSRVD}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
-sort >'keys' <<__OUT__
+cmp_ok 'find.out' <<__OUT__
 client_${CYLC_TEST_INSTALL_TARGET}.key
 client.key_secret
 server.key
 __OUT__
-cmp_ok 'find.out' 'keys'
 cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"
 
 grep_ok "Removing authentication keys and contact file from remote: \"${CYLC_TEST_INSTALL_TARGET}\"" "${SUITE_RUN_DIR}/log/suite/log"

--- a/tests/functional/cylc-ping/04-check-keys-remote.t
+++ b/tests/functional/cylc-ping/04-check-keys-remote.t
@@ -45,11 +45,13 @@ SSH='ssh -n -oBatchMode=yes -oConnectTimeout=5'
  
 ${SSH} "${CYLC_TEST_HOST}" \
 find "${RSRVD}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
-cmp_ok 'find.out' <<__OUT__
+
+sort >'keys'<<__OUT__
 client_${CYLC_TEST_INSTALL_TARGET}.key
 client.key_secret
 server.key
 __OUT__
+cmp_ok 'find.out' 'keys'
 cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"
 
 grep_ok "Removing authentication keys and contact file from remote: \"${CYLC_TEST_INSTALL_TARGET}\"" "${SUITE_RUN_DIR}/log/suite/log"

--- a/tests/functional/cylc-ping/04-check-keys-remote.t
+++ b/tests/functional/cylc-ping/04-check-keys-remote.t
@@ -18,7 +18,7 @@
 # Checks remote ZMQ keys are created and deleted on shutdown.
 export REQUIRE_PLATFORM='loc:remote comms:tcp'
 . "$(dirname "$0")/test_header"
-set_test_number 4
+set_test_number 5
 
 init_suite "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 #!jinja2
@@ -37,7 +37,7 @@ __FLOW_CONFIG__
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}" \
     -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" \
-    -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
+    --debug -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 RRUND="cylc-run/${SUITE_NAME}"
 RSRVD="${RRUND}/.service"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'
@@ -45,12 +45,15 @@ SSH='ssh -n -oBatchMode=yes -oConnectTimeout=5'
  
 ${SSH} "${CYLC_TEST_HOST}" \
 find "${RSRVD}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
-cmp_ok 'find.out' <<__OUT__
+sort >'keys' <<__OUT__
 client_${CYLC_TEST_INSTALL_TARGET}.key
 client.key_secret
 server.key
 __OUT__
+cmp_ok 'find.out' 'keys'
 cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"
+
+grep_ok "Removing authentication keys and contact file from remote: \"${CYLC_TEST_INSTALL_TARGET}\"" "${SUITE_RUN_DIR}/log/suite/log"
 ${SSH} "${CYLC_TEST_HOST}" \
 find "${RRUND}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
 cmp_ok 'find.out' <<'__OUT__'

--- a/tests/functional/cylc-ping/04-check-keys-remote.t
+++ b/tests/functional/cylc-ping/04-check-keys-remote.t
@@ -42,11 +42,12 @@ RRUND="cylc-run/${SUITE_NAME}"
 RSRVD="${RRUND}/.service"
 poll_grep_suite_log 'Holding all waiting or queued tasks now'
 SSH='ssh -n -oBatchMode=yes -oConnectTimeout=5'
+ 
 ${SSH} "${CYLC_TEST_HOST}" \
 find "${RSRVD}" -type f -name "*key*"|awk -F/ '{print $NF}'|sort >'find.out'
 cmp_ok 'find.out' <<__OUT__
+client_${CYLC_TEST_INSTALL_TARGET}.key
 client.key_secret
-client_$CYLC_TEST_PLATFORM.key
 server.key
 __OUT__
 cylc stop --max-polls=60 --interval=1 "${SUITE_NAME}"

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -19,8 +19,11 @@
 import pytest
 from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.platforms import (
+    get_all_platforms_for_install_target,
+    get_random_platform_for_install_target,
     platform_from_name, platform_from_job_info,
-    get_install_target_from_platform, get_install_target_to_platforms_map,
+    get_install_target_from_platform,
+    get_install_target_to_platforms_map,
     generic_items_match
 )
 
@@ -471,3 +474,54 @@ def test_get_install_target_to_platforms_map(
 )
 def test_generic_items_match(platform, job, remote, expect):
     assert generic_items_match(platform, job, remote) == expect
+
+
+def test_get_all_platforms_for_install_target(mock_glbl_cfg):
+    mock_glbl_cfg(
+        'cylc.flow.platforms.glbl_cfg',
+        '''
+                [platforms]
+                    [[localhost]]
+                        hosts = localhost
+                        install target = localhost
+                    [[olaf]]
+                        hosts = snow, ice, sparkles
+                        install target = arendelle
+                    [[snow white]]
+                        hosts = happy, sleepy, dopey
+                        install target = forest
+                    [[kristoff]]
+                        hosts = anna, elsa, hans
+                        install target = arendelle
+                    [[belle]]
+                        hosts = beast, maurice
+                        install target = france
+                    [[bambi]]
+                        hosts = thumper, faline, flower
+                        install target = forest
+                    [[merida]]
+                        hosts = angus, fergus
+                        install target = forest
+                    [[forest]]
+                        hosts = oak, elm, fir
+                '''
+    )
+    actual = get_all_platforms_for_install_target('forest')
+    expected = [{'hosts': ['happy', 'sleepy', 'dopey'],
+                 'install target':'forest',
+                 'name':'snow white'},
+                {'hosts': ['thumper', 'faline', 'flower'],
+                 'install target':'forest',
+                 'name':'bambi'},
+                {'hosts': ['angus', 'fergus'],
+                 'install target':'forest',
+                 'name':'merida'},
+                {'hosts': ['oak', 'elm', 'fir'],
+                 'name':'forest'}]
+    assert actual == expected
+    platforms = [{'hosts': ['snow', 'ice', 'sparkles'],
+                  'install target':'arendelle',
+                  'name':'olaf'}, {'hosts': ['anna', 'elsa', 'hans'],
+                                   'install target':'arendelle',
+                                   'name':'kristoff'}]
+    assert get_random_platform_for_install_target('arendelle') in platforms

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -517,11 +517,14 @@ def test_get_all_platforms_for_install_target(mock_glbl_cfg):
                  'install target':'forest',
                  'name':'merida'},
                 {'hosts': ['oak', 'elm', 'fir'],
-                 'name':'forest'}]
+                 'name':'forest'}
+                ]
     assert actual == expected
     platforms = [{'hosts': ['snow', 'ice', 'sparkles'],
                   'install target':'arendelle',
-                  'name':'olaf'}, {'hosts': ['anna', 'elsa', 'hans'],
-                                   'install target':'arendelle',
-                                   'name':'kristoff'}]
+                  'name':'olaf'},
+                 {'hosts': ['anna', 'elsa', 'hans'],
+                  'install target':'arendelle',
+                  'name':'kristoff'}
+                 ]
     assert get_random_platform_for_install_target('arendelle') in platforms

--- a/tests/unit/test_platforms.py
+++ b/tests/unit/test_platforms.py
@@ -503,28 +503,15 @@ def test_get_all_platforms_for_install_target(mock_glbl_cfg):
                         hosts = angus, fergus
                         install target = forest
                     [[forest]]
-                        hosts = oak, elm, fir
+                        hosts = fir, oak, elm
                 '''
     )
     actual = get_all_platforms_for_install_target('forest')
-    expected = [{'hosts': ['happy', 'sleepy', 'dopey'],
-                 'install target':'forest',
-                 'name':'snow white'},
-                {'hosts': ['thumper', 'faline', 'flower'],
-                 'install target':'forest',
-                 'name':'bambi'},
-                {'hosts': ['angus', 'fergus'],
-                 'install target':'forest',
-                 'name':'merida'},
-                {'hosts': ['oak', 'elm', 'fir'],
-                 'name':'forest'}
-                ]
-    assert actual == expected
-    platforms = [{'hosts': ['snow', 'ice', 'sparkles'],
-                  'install target':'arendelle',
-                  'name':'olaf'},
-                 {'hosts': ['anna', 'elsa', 'hans'],
-                  'install target':'arendelle',
-                  'name':'kristoff'}
-                 ]
-    assert get_random_platform_for_install_target('arendelle') in platforms
+    expected = ['snow white', 'bambi', 'merida', 'forest']
+    for platform in actual:
+        assert platform['name'] in expected
+    arendelle_platforms = ['kristoff', 'olaf']
+    assert get_random_platform_for_install_target(
+        'arendelle')['name'] in arendelle_platforms
+    assert get_random_platform_for_install_target(
+        'forest')['name'] not in arendelle_platforms


### PR DESCRIPTION
I have kept basic functionality. This will need looking at again once the intelligent host command has been implemented, so we can adapt the tidy in case where platform fails. I have left this as a basic fix as this may be replaced by some version of `cylc clean`.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests added - functional and unit.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
