### PR TITLE
Add utf8 to tree command

### DIFF
--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -52,7 +52,7 @@ mkdir .git .svn dir1 dir2
 touch .git/file1 .svn/file1 dir1/file1 dir2/file1 file1 file2
 run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
-tree -a -v -I '*.log|03-file-transfer*' "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
+tree -a -v -I '*.log|03-file-transfer*' --charset=UTF8 "${RND_SUITE_RUNDIR}/" > 'basic-tree.out'
 cmp_ok 'basic-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service
@@ -92,7 +92,7 @@ __END__
 
 run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
 
-tree -a -v -I '*.log|03-file-transfer*' "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
+tree -a -v -I '*.log|03-file-transfer*' --charset=UTF8 "${RND_SUITE_RUNDIR}/" > 'cylc-ignore-tree.out'
 cmp_ok 'cylc-ignore-tree.out'  <<__OUT__
 ${RND_SUITE_RUNDIR}/
 ├── .service


### PR DESCRIPTION
Tree command in Cylc install was resulting in inconsistent results based on terminal settings. Adds UTF8 to tree command, standardising the output.
Thanks to @wxtim. 
This is a small change with no associated Issue.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (adapting test).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
