### PR TITLE
run: fix un-installed flows

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -258,13 +258,6 @@ class Scheduler:
             self.options.templatevars_file
         )
 
-        # directory information
-        self.flow_file = suite_files.get_flow_file(self.suite)
-        self.suite_run_dir = get_workflow_run_dir(self.suite)
-        self.suite_work_dir = get_suite_run_work_dir(self.suite)
-        self.suite_share_dir = get_suite_run_share_dir(self.suite)
-        self.suite_log_dir = get_suite_run_log_dir(self.suite)
-
         # mutable defaults
         self._profile_amounts = {}
         self._profile_update_times = {}
@@ -290,6 +283,13 @@ class Scheduler:
             suite_files.register(self.suite, source=rund)
 
         make_suite_run_tree(self.suite)
+
+        # directory information
+        self.flow_file = suite_files.get_flow_file(self.suite)
+        self.suite_run_dir = get_workflow_run_dir(self.suite)
+        self.suite_work_dir = get_suite_run_work_dir(self.suite)
+        self.suite_share_dir = get_suite_run_share_dir(self.suite)
+        self.suite_log_dir = get_suite_run_log_dir(self.suite)
 
         # Create ZMQ keys
         key_housekeeping(self.suite, platform=self.options.host or 'localhost')

--- a/tests/functional/cylc-run/04-no-install.t
+++ b/tests/functional/cylc-run/04-no-install.t
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Run a workflow that was written directly in the cylc-run dir
+# (rather than being installed by cylc install)
+. "$(dirname "$0")/test_header"
+set_test_number 1
+
+# write a flow in the cylc-run dir
+# (rather than using cylc-install to transfer it)
+SUITE_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}"
+mkdir -p "${RUN_DIR}/${SUITE_NAME}"
+cat > "${RUN_DIR}/${SUITE_NAME}/flow.cylc" <<__HERE__
+[scheduling]
+    [[graph]]
+        R1 = foo
+__HERE__
+
+# ensure it can be run with no further meddling
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --no-detach
+
+purge
+exit


### PR DESCRIPTION
Fixes a bug where flows written directly in the `cylc-run` directory fail to run first time, however, succeed on subsequent attempts:

```console
$ cylc run one 
...
	TypeError: expected str, bytes or os.PathLike object, not NoneType
2021-02-05T15:42:17Z CRITICAL - Suite shutting down - expected str, bytes or os.PathLike object, not NoneType
2021-02-05T15:42:17Z INFO - DONE
$ cylc run one 
...
*** listening on tcp://olivers-macbook-pro.local:43074/ ***
*** publishing on tcp://olivers-macbook-pro.local:43059 ***
...
```

The directory logic was being performed before the Scheduler.install logic had completed which was causing the issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required
- [x] No dependency changes.
