### PR TITLE
scan: avoid runN and source links

### DIFF
--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -83,6 +83,11 @@ FLOW_FILES = {
     'log'
 }
 
+EXCLUDE_FILES = {
+    SuiteFiles.RUN_N,
+    SuiteFiles.Install.SOURCE
+}
+
 
 def dir_is_flow(listing):
     """Return True if a Path contains a flow at the top level.
@@ -169,7 +174,8 @@ async def scan(run_dir=None, scan_dir=None, max_depth=MAX_SCAN_DEPTH):
             elif depth < max_depth:
                 # we may have a nested flow, lets see...
                 for subdir in contents:
-                    if subdir.is_dir():
+                    if (subdir.is_dir()
+                            and subdir.stem not in EXCLUDE_FILES):
                         running.append(
                             asyncio.create_task(
                                 _scandir(subdir, depth + 1)


### PR DESCRIPTION
This is a small change with no associated Issue.

Tweak `cylc scan` to handle `cylc install` run dir structure.

Currently on master:
```
$ cylc scan --state=all
foo/runN  # oops!
foo/run2
foo/run1
foo/_cylc-install/source  # oops!
```

On this branch:
```
$ cylc scan --state=all
foo/run2
foo/run1
```

Any suggestion on best way to test that cylc scan detects only what we want it to?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (fixing very recent break).
- [x] No documentation update required.
- [x] No dependency changes.
