### PR TITLE
Cylc Reinstall

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,9 @@ how workflows are restarted
 
 ### Enhancements
 
+[#4071](https://github.com/cylc/cylc-flow/pull/4071) - Cylc reinstall command
+added.
+
 [#4014](https://github.com/cylc/cylc-flow/pull/4014) - Rename "ready" task
 state to "preparing".
 

--- a/cylc/flow/etc/cylc-bash-completion
+++ b/cylc/flow/etc/cylc-bash-completion
@@ -38,7 +38,7 @@ _cylc() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     sec="${COMP_WORDS[1]}"
     opts="$(cylc scan -t name 2>/dev/null)"
-    suite_cmds="broadcast|bcast|cat-log|check-versions|clean|compare|diff|dump|edit|ext-trigger|external-trigger|get-suite-config|get-config|get-suite-version|get-cylc-version|graph|hold|insert|install|kill|list|log|ls|tui|ping|play|poll|print|release|unhold|reload|remove|report-timings|reset|scan|search|grep|set-verbosity|show|set-outputs|stop|shutdown|single|suite-state|test-battery|trigger|validate|view|warranty"
+    suite_cmds="broadcast|bcast|cat-log|check-versions|clean|compare|diff|dump|edit|ext-trigger|external-trigger|get-suite-config|get-config|get-suite-version|get-cylc-version|graph|hold|insert|install|kill|list|log|ls|tui|ping|play|poll|print|reinstall|release|unhold|reload|remove|report-timings|reset|scan|search|grep|set-verbosity|show|set-outputs|stop|shutdown|single|suite-state|test-battery|trigger|validate|view|warranty"
 
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 import logging
 from optparse import Values
 import os
+from pathlib import Path
 from queue import Empty, Queue
 from shlex import quote
 from subprocess import Popen, PIPE, DEVNULL
@@ -276,7 +277,7 @@ class Scheduler:
 
         """
         # Install
-        source = suite_files.get_suite_source_dir()
+        source = suite_files.get_workflow_source_dir(Path.cwd())
         if source is None:
             # register workflow
             rund = get_workflow_run_dir(self.suite)
@@ -689,7 +690,6 @@ class Scheduler:
 
         """
         distinct_install_target_platforms = []
-
         for itask in self.pool.get_rh_tasks():
             itask.platform['install target'] = (
                 get_install_target_from_platform(itask.platform))

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -21,20 +21,19 @@
 Reinstall a previously installed workflow.
 
 Examples:
-
- Having previously installed:
+  # Having previously installed:
   $ cylc install myflow
- To reinstall this workflow run:
+  # To reinstall this workflow run:
   $ cylc reinstall myflow/run1
 
- Having previously installed:
- $ cylc install myflow --no-run-name
- To reinstall this workflow run:
+  # Having previously installed:
+  $ cylc install myflow --no-run-name
+  # To reinstall this workflow run:
   $ cylc reinstall myflow
 
- To reinstall a workflow from within the cylc-run directory of a previously
- installed workflow:
- $ cylc reinstall
+  # To reinstall a workflow from within the cylc-run directory of a previously
+  # installed workflow:
+  $ cylc reinstall
 
 """
 

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""cylc reinstall [OPTIONS] ARGS
+
+Reinstall a previously installed workflow.
+
+Examples:
+
+ Having previously installed:
+  $ cylc install myflow
+ To reinstall this workflow run:
+  $ cylc reinstall myflow/run1
+
+ Having previously installed:
+ $ cylc install myflow --no-run-name
+ To reinstall this workflow run:
+  $ cylc reinstall myflow
+
+ To reinstall a workflow from within the cylc-run directory of a previously
+ installed workflow:
+ $ cylc reinstall
+
+"""
+
+
+from pathlib import Path
+import pkg_resources
+
+from cylc.flow.exceptions import PluginError, WorkflowFilesError
+from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.pathutil import get_workflow_run_dir
+from cylc.flow.platforms import get_platform
+from cylc.flow.suite_files import (
+    get_workflow_source_dir,
+    reinstall_workflow,
+    SuiteFiles)
+from cylc.flow.terminal import cli_function
+
+
+def get_option_parser():
+    parser = COP(
+        __doc__, comms=True, prep=True,
+        argdoc=[("[NAMED_RUN]", "Named run. e.g. my-flow/run1")
+                ])
+
+    # If cylc-rose plugin is available ad the --option/-O config
+    try:
+        __import__('cylc.rose')
+        parser.add_option(
+            "--opt-conf-key", "-O",
+            help=(
+                "Use optional Rose Config Setting"
+                "(If Cylc-Rose is installed)"
+            ),
+            action="append",
+            default=[],
+            dest="opt_conf_keys"
+        )
+        parser.add_option(
+            "--define", '-D',
+            help=(
+                "Each of these overrides the `[SECTION]KEY` setting in a "
+                "`rose-suite.conf` file. "
+                "Can be used to disable a setting using the syntax "
+                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
+            ),
+            action="append",
+            default=[],
+            dest="defines"
+        )
+        parser.add_option(
+            "--define-suite", "--define-flow", '-S',
+            help=(
+                "As `--define`, but with an implicit `[SECTION]` for "
+                "workflow variables."
+            ),
+            action="append",
+            default=[],
+            dest="define_suites"
+        )
+    except ImportError:
+        pass
+
+    return parser
+
+
+@cli_function(get_option_parser)
+def main(parser, opts, named_run=None):
+    if not named_run:
+        source = get_workflow_source_dir(Path.cwd())
+        if source is None:
+            raise WorkflowFilesError("Cannot find an installed flow in $PWD. "
+                                     "Try again, stating the named run. "
+                                     "E.g. cylc reinstall my-flow/run1")
+        base_run_dir = Path(
+            get_platform()['run directory'].replace('$HOME', '~')).expanduser()
+        named_run = Path.cwd().relative_to(Path(base_run_dir).resolve())
+    run_dir = Path(get_workflow_run_dir(named_run)).expanduser()
+    if not run_dir.exists():
+        raise(WorkflowFilesError(f"\"{run_dir}\" does not exist. "
+                                 f"Check path provided: \"{named_run}\""))
+    if run_dir.name in [SuiteFiles.FLOW_FILE, SuiteFiles.SUITE_RC]:
+        run_dir = run_dir.parent
+        named_run = named_run.rsplit('/', 1)[0]
+    source = get_workflow_source_dir(run_dir)
+    if not source:
+        raise(WorkflowFilesError("Could not establish source directory. "
+                                 f"Check path provided: \"{named_run}\"")
+              )
+    source = Path(source)
+    if not source.exists():
+        raise(WorkflowFilesError(f"\"{source}\" does not exist. "
+                                 f"Check path provided: \"{named_run}\""))
+    for entry_point in pkg_resources.iter_entry_points(
+        'cylc.pre_configure'
+    ):
+        try:
+            entry_point.resolve()(dir_=source, opts=opts)
+        except Exception as exc:
+            # NOTE: except Exception (purposefully vague)
+            # this is to separate plugin from core Cylc errors
+            raise PluginError(
+                'cylc.pre_configure',
+                entry_point.name,
+                exc
+            ) from None
+
+    reinstall_workflow(
+        named_run=named_run,
+        rundir=run_dir,
+        source=source,
+        dry_run=False  # TODO: ready for dry run implementation
+    )
+
+    for entry_point in pkg_resources.iter_entry_points(
+        'cylc.post_install'
+    ):
+        try:
+            entry_point.resolve()(
+                dir_=source,
+                opts=opts,
+                dest_root=str(run_dir)
+            )
+        except Exception as exc:
+            # NOTE: except Exception (purposefully vague)
+            # this is to separate plugin from core Cylc errors
+            raise PluginError(
+                'cylc.post_install',
+                entry_point.name,
+                exc
+            ) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -385,13 +385,14 @@ def get_workflow_source_dir(dir_):
         SuiteFiles.Install.SOURCE)
     try:
         source = os.readlink(source_path)
+        return source, source_path
     except OSError:
         try:
             source = os.readlink(alt_source_path)
-        except OSError:
-            source = None
+            return source, alt_source_path
 
-    return source
+        except OSError:
+            return None, None
 
 
 def get_suite_srv_dir(reg, suite_owner=None):

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -1026,11 +1026,11 @@ def reinstall_workflow(named_run, rundir, source, dry_run=False):
                        f"\"{source}\" to \"{rundir}\"")
     rsync_cmd = get_rsync_rund_cmd(
         source, rundir, reinstall=True, dry_run=dry_run)
-    proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, text=True)
     stdout, stderr = proc.communicate()
     REINSTALL_LOG.info(f"Copying files from {source} to {rundir}")
     REINSTALL_LOG.info(f"{stdout}")
-    if stderr:
+    if not proc.returncode == 0:
         REINSTALL_LOG.warning(
             f"An error occurred when copying files from {source} to {rundir}")
         REINSTALL_LOG.warning(f" Error: {stderr}")
@@ -1113,11 +1113,11 @@ def install_workflow(flow_name=None, source=None, run_name=None,
         link_runN(rundir)
     create_workflow_srv_dir(rundir)
     rsync_cmd = get_rsync_rund_cmd(source, rundir)
-    proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, text=True)
     stdout, stderr = proc.communicate()
     INSTALL_LOG.info(f"Copying files from {source} to {rundir}")
     INSTALL_LOG.info(f"{stdout}")
-    if stderr:
+    if not proc.returncode == 0:
         INSTALL_LOG.warning(
             f"An error occurred when copying files from {source} to {rundir}")
         INSTALL_LOG.warning(f" Error: {stderr}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ cylc.command =
     play = cylc.flow.scripts.play:main
     poll = cylc.flow.scripts.poll:main
     psutils = cylc.flow.scripts.psutil:main
+    reinstall = cylc.flow.scripts.reinstall:main
     release = cylc.flow.scripts.release:main
     reload = cylc.flow.scripts.reload:main
     remote-init = cylc.flow.scripts.remote_init:main

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -36,27 +36,6 @@ create_test_global_config "" "
         work = \$TMPDIR/\$USER/test_cylc_symlink/
 "
 
-export RND_SUITE_NAME
-export RND_SUITE_SOURCE
-export RND_SUITE_RUNDIR
-
-function make_rnd_suite() {
-    # Create a randomly-named suite source directory.
-    # Define its run directory.
-    RND_SUITE_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
-    RND_SUITE_SOURCE="$PWD/${RND_SUITE_NAME}"
-    mkdir -p "${RND_SUITE_SOURCE}"
-    touch "${RND_SUITE_SOURCE}/flow.cylc"
-    RND_SUITE_RUNDIR="${RUN_DIR}/${RND_SUITE_NAME}"
-}
-
-function purge_rnd_suite() {
-    # Remove the suite source created by make_rnd_suite().
-    # And remove its run-directory too.
-    rm -rf "${RND_SUITE_SOURCE}"
-    rm -rf "${RND_SUITE_RUNDIR}"
-}
-
 # Test "cylc install" ensure symlinks are created
 TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
 make_rnd_suite

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -19,27 +19,6 @@
 # Test workflow installation failures
 
 
-export RND_SUITE_NAME
-export RND_SUITE_SOURCE
-export RND_SUITE_RUNDIR
-
-function make_rnd_suite() {
-    # Create a randomly-named suite source directory.
-    # Define its run directory.
-    RND_SUITE_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
-    RND_SUITE_SOURCE="$PWD/${RND_SUITE_NAME}"
-    mkdir -p "${RND_SUITE_SOURCE}"
-    touch "${RND_SUITE_SOURCE}/flow.cylc"
-    RND_SUITE_RUNDIR="${RUN_DIR}/${RND_SUITE_NAME}"
-}
-
-function purge_rnd_suite() {
-    # Remove the suite source created by make_rnd_suite().
-    # And remove its run-directory too.
-    rm -rf "${RND_SUITE_SOURCE}"
-    rm -rf "${RND_SUITE_RUNDIR}"
-}
-
 . "$(dirname "$0")/test_header"
 set_test_number 37
 
@@ -88,6 +67,7 @@ contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: no flow.cylc or suite.rc in ${RND_SUITE_SOURCE}
 __ERR__
 purge_rnd_suite
+
 
 # Test cylc install fails when given flow-name that is an absolute path
 

--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -23,27 +23,6 @@ if ! command -v 'tree' >'/dev/null'; then
 fi
 set_test_number 6
 
-export RND_SUITE_NAME
-export RND_SUITE_SOURCE
-export RND_SUITE_RUNDIR
-
-function make_rnd_suite() {
-    # Create a randomly-named suite source directory.
-    # Define its run directory.
-    RND_SUITE_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
-    RND_SUITE_SOURCE="$PWD/${RND_SUITE_NAME}"
-    mkdir -p "${RND_SUITE_SOURCE}"
-    touch "${RND_SUITE_SOURCE}/flow.cylc"
-    RND_SUITE_RUNDIR="${RUN_DIR}/${RND_SUITE_NAME}"
-}
-
-function purge_rnd_suite() {
-    # Remove the suite source created by make_rnd_suite().
-    # And remove its run-directory too.
-    rm -rf "${RND_SUITE_SOURCE}"
-    rm -rf "${RND_SUITE_RUNDIR}"
-}
-
 # Test cylc install copies files to run dir successfully.
 TEST_NAME="${TEST_NAME_BASE}-basic"
 make_rnd_suite

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -35,7 +35,7 @@ grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SU
 popd || exit 1
 purge_rnd_suite
 
-# Test basic cylc reinstall, named run (including flow name) given 
+# Test basic cylc reinstall, named run (including ``flow.cylc``) given
 TEST_NAME="${TEST_NAME_BASE}-flow-as-arg"
 make_rnd_suite
 pushd "${RND_SUITE_SOURCE}" || exit 1
@@ -65,39 +65,6 @@ grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SU
 popd || exit 1
 purge_rnd_suite
 
-# Test case cylc install --no-run-name, then reinstall
-TEST_NAME="${TEST_NAME_BASE}--no-run-name-install-before-reinstall"
-make_rnd_suite
-pushd "${RND_SUITE_SOURCE}" || exit 1
-
-run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
-contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}
-__OUT__
-run_ok "${TEST_NAME}" cylc reinstall "${RND_SUITE_NAME}"
-contains_ok "${TEST_NAME}.stdout" <<__OUT__
-REINSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}
-__OUT__
-popd || exit 1
-purge_rnd_suite
-
-
-# Test install/reinstall with named flow
-TEST_NAME="${TEST_NAME_BASE}-named-flow"
-make_rnd_suite
-pushd "${RND_SUITE_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_SUITE_NAME}-olaf" 
-contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_SUITE_NAME}-olaf from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}-olaf/run1
-__OUT__
-popd || exit 1
-run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}-olaf/run1"
-contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
-REINSTALLED $RND_SUITE_NAME-olaf/run1 from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}-olaf/run1
-__OUT__
-rm -rf "${RUN_DIR}/${RND_SUITE_NAME}-olaf"
-purge_rnd_suite
-
 # Test install/reinstall executed from elsewhere in filesystem
 TEST_NAME="${TEST_NAME_BASE}-named-flow"
 make_rnd_suite
@@ -115,7 +82,6 @@ purge_rnd_suite
 rm -rf "${RUN_DIR:?}/${RND_SUITE_NAME}/"
 
 # Test cylc reinstall succeeds if suite.rc file in source dir
-
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_suite
 rm -f "${RND_SUITE_SOURCE}/flow.cylc"

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test workflow re-installation
+. "$(dirname "$0")/test_header"
+set_test_number 44
+
+# Test basic cylc reinstall, named run given 
+TEST_NAME="${TEST_NAME_BASE}-basic-named-run"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}" cylc install
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1
+__OUT__
+run_ok "basic-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1"
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
+grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1" "${REINSTALL_LOG}" 
+
+popd || exit 1
+purge_rnd_suite
+
+# Test basic cylc reinstall, named run (including flow name) given 
+TEST_NAME="${TEST_NAME_BASE}-flow-as-arg"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}" cylc install flow.cylc
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1/flow.cylc"
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1
+__OUT__
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
+grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1" "${REINSTALL_LOG}" 
+popd || exit 1
+purge_rnd_suite
+
+# Test basic cylc reinstall, named run (including suite.rc) given 
+TEST_NAME="${TEST_NAME_BASE}-suite.rc-as-arg"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+rm -rf flow.cylc
+touch suite.rc
+run_ok "${TEST_NAME}" cylc install suite.rc
+run_ok "${TEST_NAME}-reinstall-suite.rc" cylc reinstall "${RND_SUITE_NAME}/run1/suite.rc"
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1
+__OUT__
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
+grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1" "${REINSTALL_LOG}" 
+popd || exit 1
+purge_rnd_suite
+
+# Test case cylc install --no-run-name, then reinstall
+TEST_NAME="${TEST_NAME_BASE}--no-run-name-install-before-reinstall"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+
+run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}" --no-run-name
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}
+__OUT__
+run_ok "${TEST_NAME}" cylc reinstall "${RND_SUITE_NAME}"
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+REINSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}
+__OUT__
+popd || exit 1
+purge_rnd_suite
+
+
+# Test install/reinstall with named flow
+TEST_NAME="${TEST_NAME_BASE}-named-flow"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_SUITE_NAME}-olaf" 
+contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
+INSTALLED ${RND_SUITE_NAME}-olaf from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}-olaf/run1
+__OUT__
+popd || exit 1
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}-olaf/run1"
+contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
+REINSTALLED $RND_SUITE_NAME-olaf/run1 from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}-olaf/run1
+__OUT__
+rm -rf "${RUN_DIR}/${RND_SUITE_NAME}-olaf"
+purge_rnd_suite
+
+# Test install/reinstall executed from elsewhere in filesystem
+TEST_NAME="${TEST_NAME_BASE}-named-flow"
+make_rnd_suite
+pushd "${TMPDIR}" || exit 1
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}"
+contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
+INSTALLED ${RND_SUITE_NAME} from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}/run1
+__OUT__
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1"
+contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
+REINSTALLED $RND_SUITE_NAME/run1 from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}/run1
+__OUT__
+popd || exit 1
+purge_rnd_suite
+rm -rf "${RUN_DIR:?}/${RND_SUITE_NAME}/"
+
+# Test cylc reinstall succeeds if suite.rc file in source dir
+
+TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
+make_rnd_suite
+rm -f "${RND_SUITE_SOURCE}/flow.cylc"
+touch "${RND_SUITE_SOURCE}/suite.rc"
+run_ok "${TEST_NAME}" cylc install --flow-name="${RND_SUITE_NAME}" -C "${RND_SUITE_SOURCE}"
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1
+__OUT__
+# test symlink not made in source dir
+exists_fail "flow.cylc"
+# test symlink correctly made in run dir
+pushd "${RND_SUITE_RUNDIR}/run1" || exit 1
+exists_ok "flow.cylc"
+if [[ $(readlink "${RND_SUITE_RUNDIR}/run1/flow.cylc") == "${RND_SUITE_RUNDIR}/run1/suite.rc" ]] ; then
+    ok "symlink.suite.rc"
+else
+    fail "symlink.suite.rc"
+fi
+
+INSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*.log')"
+grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${INSTALL_LOG}" 
+rm -rf flow.cylc
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1"
+exists_ok "${RND_SUITE_RUNDIR}/run1/flow.cylc"
+if [[ $(readlink "${RND_SUITE_RUNDIR}/run1/flow.cylc") == "${RND_SUITE_RUNDIR}/run1/suite.rc" ]] ; then
+    ok "symlink.suite.rc"
+else
+    fail "symlink.suite.rc"
+fi
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
+grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${REINSTALL_LOG}" 
+popd || exit 1
+purge_rnd_suite
+
+# Test cylc reinstall from within rundir, no args given
+TEST_NAME="${TEST_NAME_BASE}-no-args"
+make_rnd_suite
+run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_SUITE_NAME}" -C "${RND_SUITE_SOURCE}"
+contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
+INSTALLED ${RND_SUITE_NAME} from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}/run1
+__OUT__
+pushd "${RND_SUITE_RUNDIR}/run1" || exit 1
+touch "${RND_SUITE_SOURCE}/new_file"
+run_ok "${TEST_NAME}-reinstall" cylc reinstall
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
+grep_ok "REINSTALLED ${RND_SUITE_NAME}/run1 from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1" "${REINSTALL_LOG}" 
+exists_ok new_file
+popd || exit 1
+purge_rnd_suite
+
+# Test cylc reinstall from within rundir, no args given
+TEST_NAME="${TEST_NAME_BASE}-no-args-no-run-name"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}-install" cylc install "${RND_SUITE_NAME}" --no-run-name -C "${RND_SUITE_SOURCE}"
+contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
+INSTALLED ${RND_SUITE_NAME} from ${RND_SUITE_SOURCE} -> ${RUN_DIR}/${RND_SUITE_NAME}
+__OUT__
+pushd "${RND_SUITE_RUNDIR}" || exit 1
+touch "${RND_SUITE_SOURCE}/new_file"
+run_ok "${TEST_NAME}-reinstall" cylc reinstall
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/log/install" -type f -name '*reinstall.log')"
+grep_ok "REINSTALLED ${RND_SUITE_NAME} from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}" "${REINSTALL_LOG}" 
+exists_ok new_file
+popd || exit 1
+popd || exit 1
+purge_rnd_suite
+
+exit

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation
 . "$(dirname "$0")/test_header"
-set_test_number 44
+set_test_number 36
 
 # Test basic cylc reinstall, named run given 
 TEST_NAME="${TEST_NAME_BASE}-basic-named-run"

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test workflow re-installation file transfer
+. "$(dirname "$0")/test_header"
+set_test_number 14
+
+# Test cylc install copies files to run dir successfully.
+TEST_NAME="${TEST_NAME_BASE}-basic"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+mkdir .git .svn dir1 dir2-be-removed 
+touch .git/file1 .svn/file1 dir1/file1 dir2-be-removed/file1 file1 file2
+run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}"
+# If rose-cylc plugin is installed add install files to tree.
+export ROSE_FILES=''
+if python -c "import cylc.rose" > /dev/null 2>&1; then
+    export ROSE_FILES="├── opt
+│   └── rose-suite-cylc-install.conf
+└── rose-suite.conf"
+else
+    export ROSE_FILES=""
+fi
+
+tree -a -v -I '*.log|01-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/run1" > '01-file-transfer-basic-tree.out'
+
+cmp_ok '01-file-transfer-basic-tree.out'  <<__OUT__
+${RND_SUITE_RUNDIR}/run1
+├── .service
+├── dir1
+│   └── file1
+├── dir2-be-removed
+│   └── file1
+├── file1
+├── file2
+├── flow.cylc
+├── log
+│   └── install
+${ROSE_FILES}
+__OUT__
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_SUITE_NAME from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run1
+__OUT__
+run_ok "${TEST_NAME}" cylc install "${RND_SUITE_NAME}"
+mkdir new_dir
+touch new_dir/new_file1 new_dir/new_file2
+rm -rf dir2-be-removed file2
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run2"
+REINSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run2/log/install" -type f -name '*reinstall.log')"
+grep_ok "deleting dir2-be-removed/file1
+         deleting file2
+         new_dir/
+         new_dir/new_file1
+         new_dir/new_file2" "${REINSTALL_LOG}"
+        
+tree -a -v -I '*.log|01-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/run2" > 'after-reinstall-run2-tree.out'
+cmp_ok 'after-reinstall-run2-tree.out'  <<__OUT__
+${RND_SUITE_RUNDIR}/run2
+├── .service
+├── dir1
+│   └── file1
+├── file1
+├── flow.cylc
+├── log
+│   └── install
+├── new_dir
+│   ├── new_file1
+│   └── new_file2
+${ROSE_FILES}
+__OUT__
+contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
+REINSTALLED $RND_SUITE_NAME/run2 from ${RND_SUITE_SOURCE} -> ${RND_SUITE_RUNDIR}/run2
+__OUT__
+
+# Test cylc reinstall affects only named run, i.e. run1 should be unaffected in this case
+tree -a -v -I '*.log|01-file-transfer*' --charset UTF8 --noreport "${RND_SUITE_RUNDIR}/run1" > 'after-reinstall-run1-tree.out'
+cmp_ok 'after-reinstall-run1-tree.out' '01-file-transfer-basic-tree.out'
+popd || exit 1
+purge_rnd_suite
+
+
+# Test cylc install copies files to run dir successfully.
+TEST_NAME="${TEST_NAME_BASE}-reinstall-creates-flow.cylc-given-suite.rc"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+rm -f flow.cylc
+touch suite.rc
+run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_SUITE_NAME}"
+rm -f "${RND_SUITE_RUNDIR}/flow.cylc"
+exists_fail "${RND_SUITE_RUNDIR}/flow.cylc"
+run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}"
+exists_ok "${RND_SUITE_RUNDIR}/flow.cylc"
+exists_fail "${RND_SUITE_SOURCE}/flow.cylc"
+popd || exit 1
+purge_rnd_suite
+
+exit

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -94,7 +94,7 @@ popd || exit 1
 purge_rnd_suite
 
 
-# Test cylc install copies files to run dir successfully.
+# Test cylc reinstall creates flow.cylc given suite.rc.
 TEST_NAME="${TEST_NAME_BASE}-reinstall-creates-flow.cylc-given-suite.rc"
 make_rnd_suite
 pushd "${RND_SUITE_SOURCE}" || exit 1

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -18,6 +18,9 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation file transfer
 . "$(dirname "$0")/test_header"
+if ! command -v 'tree' >'/dev/null'; then
+    skip_all '"tree" command not available'
+fi
 set_test_number 14
 
 # Test cylc install copies files to run dir successfully.

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test workflow reinstallation expected failures
+. "$(dirname "$0")/test_header"
+set_test_number 20
+
+# Test fails is there is a nested run directory structure in the run directory to be reinstalled
+
+TEST_NAME="${TEST_NAME_BASE}-nested-rundir-forbidden-reinstall"
+make_rnd_suite
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}"
+mkdir "${RND_SUITE_RUNDIR}/run1/nested_run_dir"
+touch "${RND_SUITE_RUNDIR}/run1/nested_run_dir/flow.cylc"
+run_fail "${TEST_NAME}-reinstall-nested-run-dir" cylc reinstall "${RND_SUITE_NAME}"
+contains_ok "${TEST_NAME}-reinstall-nested-run-dir.stderr" <<__ERR__
+WorkflowFilesError: Nested run directories not allowed - cannot install workflow name "${RND_SUITE_NAME}" as "${RND_SUITE_RUNDIR}/run1" is already a valid run directory.
+__ERR__
+purge_rnd_suite
+
+# Test fail no suite source dir
+
+TEST_NAME="${TEST_NAME_BASE}-reinstall-no-run-dir"
+make_rnd_suite
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}" --no-run-name
+rm -rf "${RND_SUITE_RUNDIR}"
+run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}" 
+contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
+WorkflowFilesError: "${RND_SUITE_RUNDIR}" does not exist. Check path provided: "${RND_SUITE_NAME}"
+__ERR__
+purge_rnd_suite
+
+# Test fail no suite source dir
+
+TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-dir"
+make_rnd_suite
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}" 
+rm -rf "${RND_SUITE_SOURCE}"
+run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1"  
+contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
+WorkflowFilesError: "${RND_SUITE_SOURCE}" does not exist. Check path provided: "${RND_SUITE_NAME}/run1"
+__ERR__
+purge_rnd_suite
+
+# Test fail no flow.cylc or suite.rc file
+
+TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
+make_rnd_suite
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}" --no-run-name
+rm -f "${RND_SUITE_SOURCE}/flow.cylc"
+run_fail "${TEST_NAME}" cylc reinstall "${RND_SUITE_NAME}"
+contains_ok "${TEST_NAME}.stderr" <<__ERR__
+WorkflowFilesError: no flow.cylc or suite.rc in ${RND_SUITE_SOURCE}
+__ERR__
+purge_rnd_suite
+
+# Test source dir can not contain '_cylc-install, log, share, work' dirs for cylc reinstall
+
+for DIR in 'work' 'share' 'log' '_cylc-install'; do
+    TEST_NAME="${TEST_NAME_BASE}-${DIR}-forbidden-in-source"
+    make_rnd_suite
+    pushd "${RND_SUITE_SOURCE}" || exit 1
+    cylc install --no-run-name --flow-name="${RND_SUITE_NAME}"
+    mkdir ${DIR}
+    run_fail "${TEST_NAME}" cylc reinstall "${RND_SUITE_NAME}"
+    contains_ok "${TEST_NAME}.stderr" <<__ERR__
+WorkflowFilesError: ${RND_SUITE_NAME} installation failed. - ${DIR} exists in source directory.
+__ERR__
+    purge_rnd_suite
+    popd || exit 1
+done
+
+exit

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow reinstallation expected failures
 . "$(dirname "$0")/test_header"
-set_test_number 23
+set_test_number 26
 
 # Test fails is there is a nested run directory structure in the run directory to be reinstalled
 
@@ -95,6 +95,21 @@ rm -rf "_cylc-install"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall
 contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
 WorkflowFilesError: Cannot find an installed flow in \$PWD. Try again, stating the named run. E.g. cylc reinstall my-flow/run1
+__ERR__
+popd || exit 1
+popd || exit 1
+purge_rnd_suite
+
+# Test cylc reinstall (args given) raises error when no source dir.
+TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error2"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_SUITE_NAME}"
+pushd "${RND_SUITE_RUNDIR}" || exit 1
+rm -rf "_cylc-install"
+run_fail "${TEST_NAME}-reinstall" cylc reinstall "$RND_SUITE_NAME"
+contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
+WorkflowFilesError: Could not establish source directory. Check path provided: "$RND_SUITE_NAME"
 __ERR__
 popd || exit 1
 popd || exit 1

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -41,7 +41,7 @@ run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name=
 rm -rf "${RND_SUITE_RUNDIR}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}" 
 contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-WorkflowFilesError: "${RND_SUITE_RUNDIR}" does not exist. Check path provided: "${RND_SUITE_NAME}"
+WorkflowFilesError: "${RND_SUITE_NAME}" is not an installed workflow.
 __ERR__
 purge_rnd_suite
 
@@ -49,11 +49,12 @@ purge_rnd_suite
 
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-dir"
 make_rnd_suite
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}" 
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_SUITE_SOURCE}" --flow-name="${RND_SUITE_NAME}" --no-run-name
 rm -rf "${RND_SUITE_SOURCE}"
-run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}/run1"  
+run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_SUITE_NAME}"  
 contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-WorkflowFilesError: "${RND_SUITE_SOURCE}" does not exist. Check path provided: "${RND_SUITE_NAME}/run1"
+WorkflowFilesError: Workflow source dir is not accessible: "${RND_SUITE_SOURCE}".
+Restore the source or modify the "${RND_SUITE_RUNDIR}/_cylc-install/source" symlink to continue.
 __ERR__
 purge_rnd_suite
 
@@ -93,8 +94,9 @@ run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_SUIT
 pushd "${RND_SUITE_RUNDIR}" || exit 1
 rm -rf "_cylc-install"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall
+CWD=$(pwd -P)
 contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-WorkflowFilesError: Cannot find an installed flow in \$PWD. Try again, stating the named run. E.g. cylc reinstall my-flow/run1
+WorkflowFilesError: "${CWD}" is not a workflow run directory.
 __ERR__
 popd || exit 1
 popd || exit 1
@@ -109,7 +111,7 @@ pushd "${RND_SUITE_RUNDIR}" || exit 1
 rm -rf "_cylc-install"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "$RND_SUITE_NAME"
 contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-WorkflowFilesError: Could not establish source directory. Check path provided: "$RND_SUITE_NAME"
+WorkflowFilesError: "${RND_SUITE_NAME}" was not installed with cylc install.
 __ERR__
 popd || exit 1
 popd || exit 1

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow reinstallation expected failures
 . "$(dirname "$0")/test_header"
-set_test_number 20
+set_test_number 23
 
 # Test fails is there is a nested run directory structure in the run directory to be reinstalled
 
@@ -84,5 +84,20 @@ __ERR__
     purge_rnd_suite
     popd || exit 1
 done
+
+# Test cylc reinstall (no args given) raises error when no source dir.
+TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error"
+make_rnd_suite
+pushd "${RND_SUITE_SOURCE}" || exit 1
+run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_SUITE_NAME}"
+pushd "${RND_SUITE_RUNDIR}" || exit 1
+rm -rf "_cylc-install"
+run_fail "${TEST_NAME}-reinstall" cylc reinstall
+contains_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
+WorkflowFilesError: Cannot find an installed flow in \$PWD. Try again, stating the named run. E.g. cylc reinstall my-flow/run1
+__ERR__
+popd || exit 1
+popd || exit 1
+purge_rnd_suite
 
 exit

--- a/tests/functional/cylc-reinstall/test_header
+++ b/tests/functional/cylc-reinstall/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -81,6 +81,8 @@
 #         tries grepping for each PATTERN in turn. Tests will only pass if the
 #         PATTERNs appear in FILE in the correct order. Runs one test per
 #         pattern, each prefixed by TEST_NAME.
+#     make_rnd_suite
+#         Create a randomly-named suite source directory.
 #     mock_smtpd_init
 #         Start a mock SMTP server daemon for testing. Write host:port setting
 #         to the variable TEST_SMTPD_HOST. Write pid of daemon to
@@ -108,7 +110,10 @@
 #         guaranteed to be running.
 #     purge [SUITE_NAME [PLATFORM]]
 #         Remove a workflow from the filesystem.
-#         Defaults to remving $SUITE_NAME on $CYLC_TEST_PLATFORM
+#         Defaults to removing $SUITE_NAME on $CYLC_TEST_PLATFORM
+#     purge_rnd_suite
+#         Remove a workflow source dir and rundir.
+#         Typically used with make_rnd_suite
 #     skip N SKIP_REASON
 #         echo "ok $((++T)) # skip SKIP_REASON" N times.
 #     skip_all SKIP_REASON
@@ -119,6 +124,7 @@
 #         Install a reference suite using `install_suite`, run a validation
 #         test on the suite and run the reference suite with `suite_run_ok`.
 #         Expect 2 OK tests.
+#     
 #     create_test_global_config [PRE [POST]]
 #         Create a new global config file $PWD/etc from global-tests.cylc
 #         with PRE and POST pre- and ap-pended (PRE for e.g. jinja2 shebang).
@@ -490,6 +496,19 @@ log_scan () {
     done
 }
 
+make_rnd_suite() {
+    # Create a randomly-named suite source directory.
+    # Define its run directory.
+    RND_SUITE_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
+    RND_SUITE_SOURCE="$PWD/${RND_SUITE_NAME}"
+    mkdir -p "${RND_SUITE_SOURCE}"
+    touch "${RND_SUITE_SOURCE}/flow.cylc"
+    RND_SUITE_RUNDIR="${RUN_DIR}/${RND_SUITE_NAME}"
+    export RND_SUITE_NAME
+    export RND_SUITE_SOURCE
+    export RND_SUITE_RUNDIR
+}
+
 # shellcheck disable=2120
 # these arguments are intentionally optional
 purge () {
@@ -543,6 +562,12 @@ purge () {
     # remove the suite run directory tree locally - if empty
     # NOTE: do this after remote purge as this removes the test config too
     bash -c "$CMD" 2>/dev/null || true
+}
+purge_rnd_suite() {
+    # Remove the suite source created by make_rnd_suite().
+    # And remove its run-directory too.
+    rm -rf "${RND_SUITE_SOURCE}"
+    rm -rf "${RND_SUITE_RUNDIR}"
 }
 
 poll() {

--- a/tests/unit/test_suite_files.py
+++ b/tests/unit/test_suite_files.py
@@ -639,9 +639,10 @@ def test_get_workflow_source_dir_numbered_run(tmp_path):
     run_dir.mkdir()
     source_dir = (tmp_path / "cylc-source" / "flow-name")
     source_dir.mkdir(parents=True)
-    assert get_workflow_source_dir(run_dir) is None
+    assert get_workflow_source_dir(run_dir) == (None, None)
     (cylc_install_dir / "source").symlink_to(source_dir)
-    assert get_workflow_source_dir(run_dir) == str(source_dir)
+    assert get_workflow_source_dir(run_dir) == (
+        str(source_dir), cylc_install_dir / "source")
 
 
 def test_get_workflow_source_dir_named_run(tmp_path):
@@ -655,7 +656,10 @@ def test_get_workflow_source_dir_named_run(tmp_path):
     source_dir = (tmp_path / "cylc-source" / "flow-name")
     source_dir.mkdir(parents=True)
     (cylc_install_dir / "source").symlink_to(source_dir)
-    assert get_workflow_source_dir(cylc_install_dir.parent) == str(source_dir)
+    assert get_workflow_source_dir(
+        cylc_install_dir.parent) == (
+        str(source_dir),
+        cylc_install_dir / "source")
 
 
 def test_reinstall_workflow(tmp_path, capsys):


### PR DESCRIPTION
# Cylc Reinstall Command
Follows on from Cylc Install (https://github.com/cylc/cylc-flow/pull/4000)
Users can now reinstall an already installed workflow using the `cylc reinstall` command.

Proposal: https://github.com/cylc/cylc-admin/blob/master/docs/proposal-rose-suite-run.md
__________________________________________________________________
Example use cases:

`cylc install myflow`
`cylc reinstall myflow/run1`
   
`cylc install myflow --no-run-name`
`cylc reinstall myflow`

`cylc reinstall` from within an installed flow in the cylc run dir.
___________________________________________________________________

New reinstall log added in log directory: log/install/timestamp-reinstall.log

I have also addressed an issue (related change, https://github.com/cylc/cylc-flow/pull/4000#pullrequestreview-577209692) with the symlink of flow.cylc/suite.rc file being created in the source directory. It is now created in the run dir.

These changes close https://github.com/cylc/cylc-flow/issues/3890
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation Issue at https://github.com/cylc/cylc-doc/issues/198
- [x] No dependency changes.
