### PR TITLE
Added an explanation on the reference docs for Cylc7 legacy host/remo…

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -32,6 +32,19 @@ from cylc.flow.task_events_mgr import EventData
 # Regex to check whether a string is a command
 REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 
+
+# Cylc8 Deprecation note.
+DEPRECATION_WARN = '''
+.. warning::
+
+   Deprecated section kept for compatibility with Cylc 7 workflow definitions.
+
+   **It will not be available at Cylc 9**.
+
+   Use :cylc:conf:`flow.cylc[runtime][<namespace>]platform` instead.
+'''
+
+
 with Conf(
     'flow.cylc',
     desc='''
@@ -988,11 +1001,12 @@ with Conf(
             with Conf('job', desc='''
                 This section configures the means by which cylc submits task
                 job scripts to run.
-            '''):
+
+            ''' + DEPRECATION_WARN):
                 Conf('batch system', VDR.V_STRING)
                 Conf('batch submit command template', VDR.V_STRING)
 
-            with Conf('remote'):
+            with Conf('remote', desc=DEPRECATION_WARN):
                 Conf('host', VDR.V_STRING)
                 Conf('owner', VDR.V_STRING)
                 Conf('suite definition directory', VDR.V_STRING)


### PR DESCRIPTION
These changes close #4074
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?) - doc not fn'l change.
- [x] No change log entry required - doc not fn'l change.
- [x] No documentation update required - this _is_ a documentation change.

# question
Should I leave it at this, or should I discuss:
- How the upgrader works?
- What to do if you can't find a suitable platform?

Alternatively, should I leave the issue open, and revisit this once we have an upgrade doc, adding a link to that?