### PR TITLE
Get codecov to behave?

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2  # Needed to placate codecov
 
       - name: Configure Python
         uses: actions/setup-python@v1

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2  # Needed to placate codecov
 
       - name: Configure Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
This is a small change with no associated Issue.

For some reason, codecov doesn't like a fetch-depth of 1
```
->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
- [x] No dependency changes.
