### PR TITLE
Added missing documentation for `flow.cylc`

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -854,11 +854,48 @@ with Conf(
 
                 ``$CYLC_TASK_CYCLE_POINT/shared/``
             ''')
-            Conf('execution polling intervals', VDR.V_INTERVAL_LIST, None)
-            Conf('execution retry delays', VDR.V_INTERVAL_LIST, None)
-            Conf('execution time limit', VDR.V_INTERVAL)
-            Conf('submission polling intervals', VDR.V_INTERVAL_LIST, None)
-            Conf('submission retry delays', VDR.V_INTERVAL_LIST, None)
+            Conf(
+                'execution polling intervals',
+                VDR.V_INTERVAL_LIST,
+                None,
+                desc='''
+                    .. warning::
+
+                       Deprecated, use :cylc:conf:`global.cylc[platforms]
+                       [<platform name>]execution polling intervals`
+                ''')
+            Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
+                .. warning::
+
+                   Deprecated, use :cylc:conf:`global.cylc[platforms]
+                   [<platform name>]execution retry delays`
+            ''')
+            Conf('execution time limit', VDR.V_INTERVAL, desc='''
+                .. warning::
+
+                   Deprecated, use :cylc:conf:`global.cylc[platforms]
+                   [<platform name>]execution time limit`
+            ''')
+            Conf(
+                'submission polling intervals',
+                VDR.V_INTERVAL_LIST,
+                None,
+                desc='''
+                    .. warning::
+
+                       Deprecated, use :cylc:conf:`global.cylc[platforms]
+                       [<platform name>]submission polling intervals`
+            ''')
+            Conf(
+                'submission retry delays',
+                VDR.V_INTERVAL_LIST,
+                None,
+                desc='''
+                    .. warning::
+
+                       Deprecated, use :cylc:conf:`global.cylc[platforms]
+                       [<platform name>]submission retry delays`
+            ''')
 
             with Conf('meta', desc=r'''
                 Section containing metadata items for this task or family

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -865,16 +865,28 @@ with Conf(
                        [<platform name>]execution polling intervals`
                 ''')
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
-                .. warning::
+                Cylc can automate resubmission of failed a task job.
 
-                   Deprecated, use :cylc:conf:`global.cylc[platforms]
-                   [<platform name>]execution retry delays`
+                Execution retry delays are a list of ISO 8601
+                durations/intervals which tell Cylc how long to wait before
+                resubmitting a failed job.
+
+                Each time Cylc resubmits a task job it will increment the
+                variable $CYLC_TASK_TRY_NUMBER in the task execution
+                environment. $CYLC_TASK_TRY_NUMBER allows you to vary task
+                behavior between submission attempts.
             ''')
             Conf('execution time limit', VDR.V_INTERVAL, desc='''
-                .. warning::
+                Set the execution time (wall clock) limit a job of a task.
 
-                   Deprecated, use :cylc:conf:`global.cylc[platforms]
-                   [<platform name>]execution time limit`
+                For ``background`` and ``at`` job runners Cylc invokes the
+                job's script using the timeout command. For other job runners
+                Cylc will convert execution time limit to a directive.
+
+                If a task job exceeds its execution time limit Cylc can
+                poll the job multiple times. You you can set polling
+                intervals using cylc:conf:`global.cylc[platforms]
+                [<platform name>]execution time limit polling intervals`
             ''')
             Conf(
                 'submission polling intervals',

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -879,7 +879,8 @@ with Conf(
                 behavior between submission attempts.
             ''')
             Conf('execution time limit', VDR.V_INTERVAL, desc='''
-                Set the execution (:ref:`wall-clock`) time limit of a task job.
+                Set the execution (:term:`wall-clock <wall-clock time>`) time
+                limit of a task job.
 
                 For ``background`` and ``at`` job runners Cylc invokes the
                 job's script using the timeout command. For other job runners

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1508,10 +1508,13 @@ def upg(cfg, descr):
         ):
             if job_setting in cfg['runtime'][task]:
                 LOG.warning(
-                    f"'[runtime][{task}]{job_setting}' set in "
-                    "global.cylc[platforms] at Cylc 8.\n"
-                    "Currently this item will over-ride the platform config, "
-                    "but this config item will be obsolete at Cylc 9."
+                    "* (8.0.0) '[runtime][{task}]{job_setting}' - this "
+                    "setting is deprecated; use"
+                    "'global.cylc[platforms][<platform name>]{job_setting}' "
+                    "instead. "
+                    "Currently, this item will override the corresponding "
+                    "item in global.cylc,"
+                    "but support for this will be removed in Cylc 9."
                 )
 
 

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1496,21 +1496,22 @@ def upg(cfg, descr):
     warn_about_depr_event_handler_tmpl(cfg)
 
     # Warn about config items moved to global.cylc.
-    for job_setting, task in product(
-        [
-            'execution polling intervals',
-            'submission polling intervals',
-            'submission retry delays'
-        ],
-        cfg['runtime'].keys()
-    ):
-        if job_setting in cfg['runtime'][task]:
-            LOG.warning(
-                f"'[runtime][{task}]{job_setting}' set in "
-                "global.cylc[platforms] at Cylc 8.\n"
-                "Currently this item will over-ride the platform config, "
-                "but this config item will be obsolete at Cylc 9."
-            )
+    if 'runtime' in cfg:
+        for job_setting, task in product(
+            [
+                'execution polling intervals',
+                'submission polling intervals',
+                'submission retry delays'
+            ],
+            cfg['runtime'].keys()
+        ):
+            if job_setting in cfg['runtime'][task]:
+                LOG.warning(
+                    f"'[runtime][{task}]{job_setting}' set in "
+                    "global.cylc[platforms] at Cylc 8.\n"
+                    "Currently this item will over-ride the platform config, "
+                    "but this config item will be obsolete at Cylc 9."
+                )
 
 
 def upgrade_graph_section(cfg, descr):

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -17,6 +17,8 @@
 
 import re
 
+from itertools import product
+
 from metomi.isodatetime.data import Calendar
 
 from cylc.flow import LOG
@@ -1483,16 +1485,6 @@ def upg(cfg, descr):
             ['runtime', '__MANY__', 'job', job_setting],
             ['runtime', '__MANY__', job_setting]
         )
-    for job_setting in [
-        'execution polling intervals',
-        'submission polling intervals',
-        'submission retry delays'
-    ]:
-        LOG.warning(
-            f"'{job_setting}' set in global.cylc[platforms] at Cylc 8.\n"
-            "Currently this item will over-ride the platform config, "
-            "but this config item will be obsolete at Cylc 9."
-        )
 
     u.deprecate('8.0.0', ['cylc'], ['scheduler'])
     u.upgrade()
@@ -1502,6 +1494,23 @@ def upg(cfg, descr):
 
     warn_about_depr_platform(cfg)
     warn_about_depr_event_handler_tmpl(cfg)
+
+    # Warn about config items moved to global.cylc.
+    for job_setting, task in product(
+        [
+            'execution polling intervals',
+            'submission polling intervals',
+            'submission retry delays'
+        ],
+        cfg['runtime'].keys()
+    ):
+        if job_setting in cfg['runtime'][task]:
+            LOG.warning(
+                f"'[runtime][{task}]{job_setting}' set in "
+                "global.cylc[platforms] at Cylc 8.\n"
+                "Currently this item will over-ride the platform config, "
+                "but this config item will be obsolete at Cylc 9."
+            )
 
 
 def upgrade_graph_section(cfg, descr):

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -884,7 +884,7 @@ with Conf(
 
                 For ``background`` and ``at`` job runners Cylc invokes the
                 job's script using the timeout command. For other job runners
-                Cylc will convert execution time limit to a :ref:`directive`.
+                Cylc will convert execution time limit to a :term:`directive`.
 
                 If a task job exceeds its execution time limit Cylc can
                 poll the job multiple times. You can set polling

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -865,27 +865,27 @@ with Conf(
                        [<platform name>]execution polling intervals`
                 ''')
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
-                Cylc can automate resubmission of failed a task job.
+                Cylc can automate resubmission of a failed task job.
 
                 Execution retry delays are a list of ISO 8601
                 durations/intervals which tell Cylc how long to wait before
                 resubmitting a failed job.
 
                 Each time Cylc resubmits a task job it will increment the
-                variable $CYLC_TASK_TRY_NUMBER in the task execution
-                environment. $CYLC_TASK_TRY_NUMBER allows you to vary task
+                variable ``$CYLC_TASK_TRY_NUMBER`` in the task execution
+                environment. ``$CYLC_TASK_TRY_NUMBER`` allows you to vary task
                 behavior between submission attempts.
             ''')
             Conf('execution time limit', VDR.V_INTERVAL, desc='''
-                Set the execution time (wall clock) limit a job of a task.
+                Set the execution (:ref:`wall-clock`) time limit of a task job.
 
                 For ``background`` and ``at`` job runners Cylc invokes the
                 job's script using the timeout command. For other job runners
-                Cylc will convert execution time limit to a directive.
+                Cylc will convert execution time limit to a :ref:`directive`.
 
                 If a task job exceeds its execution time limit Cylc can
-                poll the job multiple times. You you can set polling
-                intervals using cylc:conf:`global.cylc[platforms]
+                poll the job multiple times. You can set polling
+                intervals using :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
             ''')
             Conf(
@@ -908,7 +908,6 @@ with Conf(
                        Deprecated, use :cylc:conf:`global.cylc[platforms]
                        [<platform name>]submission retry delays`
             ''')
-
             with Conf('meta', desc=r'''
                 Section containing metadata items for this task or family
                 namespace.  Several items (title, description, URL) are
@@ -1483,6 +1482,16 @@ def upg(cfg, descr):
             '8.0.0',
             ['runtime', '__MANY__', 'job', job_setting],
             ['runtime', '__MANY__', job_setting]
+        )
+    for job_setting in [
+        'execution polling intervals',
+        'submission polling intervals',
+        'submission retry delays'
+    ]:
+        LOG.warning(
+            f"'{job_setting}' set in global.cylc[platforms] at Cylc 8.\n"
+            "Currently this item will over-ride the platform config, "
+            "but this config item will be obsolete at Cylc 9."
         )
 
     u.deprecate('8.0.0', ['cylc'], ['scheduler'])

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -630,8 +630,13 @@ class CylcConfigValidator(ParsecValidator):
         ),
         V_INTERVAL_LIST: (
             'time interval list',
-            'A comma separated list of time intervals',
-            ['P1Y, P2Y, P3Y'],
+            'A comma separated list of time intervals. '
+            'These can include multipliers.',
+            {
+                'P1Y, P2Y, P3Y': 'After 1, 2 and 3 years.',
+                'PT1M, 2*PT1H, P1D': 'After 1 minute, 1 hour, 1 hour and 1 '
+                'day'
+            },
             [('std:term', 'ISO8601 duration')]
         ),
         V_PARAMETER_LIST: (

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -30,9 +30,6 @@ WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution time limit] -> [run
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission polling intervals] -> [runtime][foo, cat, dog][submission polling intervals] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission retry delays] -> [runtime][foo, cat, dog][submission retry delays] - value unchanged
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged
-WARNING - '[runtime][foo, cat, dog]execution polling intervals' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
-WARNING - '[runtime][foo, cat, dog]submission polling intervals' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
-WARNING - '[runtime][foo, cat, dog]submission retry delays' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
+WARNING - * (8.0.0) '[runtime][{task}]{job_setting}' - this setting is deprecated; use'global.cylc[platforms][<platform name>]{job_setting}' instead. Currently, this item will override the corresponding item in global.cylc,but support for this will be removed in Cylc 9.
+WARNING - * (8.0.0) '[runtime][{task}]{job_setting}' - this setting is deprecated; use'global.cylc[platforms][<platform name>]{job_setting}' instead. Currently, this item will override the corresponding item in global.cylc,but support for this will be removed in Cylc 9.
+WARNING - * (8.0.0) '[runtime][{task}]{job_setting}' - this setting is deprecated; use'global.cylc[platforms][<platform name>]{job_setting}' instead. Currently, this item will override the corresponding item in global.cylc,but support for this will be removed in Cylc 9.

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -1,3 +1,9 @@
+WARNING - 'execution polling intervals' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
+WARNING - 'submission polling intervals' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
+WARNING - 'submission retry delays' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
 WARNING - deprecated items were automatically upgraded in "suite definition"
 WARNING -  * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -1,9 +1,3 @@
-WARNING - 'execution polling intervals' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
-WARNING - 'submission polling intervals' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
-WARNING - 'submission retry delays' set in global.cylc[platforms] at Cylc 8.
-	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
 WARNING - deprecated items were automatically upgraded in "suite definition"
 WARNING -  * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
@@ -36,3 +30,9 @@ WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution time limit] -> [run
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission polling intervals] -> [runtime][foo, cat, dog][submission polling intervals] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission retry delays] -> [runtime][foo, cat, dog][submission retry delays] - value unchanged
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged
+WARNING - '[runtime][foo, cat, dog]execution polling intervals' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
+WARNING - '[runtime][foo, cat, dog]submission polling intervals' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.
+WARNING - '[runtime][foo, cat, dog]submission retry delays' set in global.cylc[platforms] at Cylc 8.
+	Currently this item will over-ride the platform config, but this config item will be obsolete at Cylc 9.


### PR DESCRIPTION
Updated docs for config sections moved from [runtime][job] to runtime.
Updated docs for parsec time interval list type to include reference to multipliers.

This is a small change with no associated Issue.

- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Documentation change - does not require tests or changelog.