### PR TITLE
actions: upload coverage with flag

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -76,7 +76,10 @@ jobs:
         run: |
           pytest --cov --cov-append -n 5 tests/integration
 
-      - name: Coverage
-        run: |
-          coverage report
-          bash <(curl -s https://codecov.io/bash)
+      - name: Coverage Upload
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: .coverage
+          flags: ${{ matrix.os }}_${{ matrix.python-version }}
+          fail_ci_if_error: false

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -247,8 +247,15 @@ jobs:
         run: |
           etc/bin/swarm kill
 
-      - name: Coverage
+      - name: Coverage Combine
         run: |
           coverage combine -a
           coverage report
-          bash <(curl -s https://codecov.io/bash)
+
+      - name: Coverage Upload
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: .coverage
+          flags: ${{ steps.uploadname.outputs.uploadname }}
+          fail_ci_if_error: false


### PR DESCRIPTION
Use a flag when uploading coverage reports to help us identify which builds coverage is coming from.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
