### PR TITLE
cylc-rose: functional test for re-installation.

### DIFF
--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -992,6 +992,7 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
         '.svn',
         '.cylcignore',
         'log',
+        'opt/rose-suite-cylc-install.conf',
         SuiteFiles.Install.DIRNAME,
         SuiteFiles.Service.DIRNAME]
     for exclude in ignore_dirs:


### PR DESCRIPTION
Companion of [Cylc-Rose#35](https://github.com/cylc/cylc-rose/pull/35)

Allow cylc-rose to be able to have an awareness of previous installs by preventing `opt/rose-suite-cylc-install.conf` from  being rsynced by cylc reinstall:

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
<!-- choose one: -->
- [x] Does not need tests: Covered by tests in cylc-rose
<!-- choose one: -->
- [x] No change log entry required. Part of pre-first release work.
<!-- choose one: -->