### PR TITLE
Cylc.rose pre release refactor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -172,13 +172,28 @@ to control the job submission environment.
 longer check for a cyclic/circular graph if there are more than 100 tasks,
 unless the option  `--check-circular` is used. This is to improve performance.
 
+[#3913](https://github.com/cylc/cylc-flow/pull/3913) - Add ability to use
+pre-install entry point from cylc-rose plugin to provide environment and
+template variables for a workflow.
+
 [#4023](https://github.com/cylc/cylc-flow/pull/4023) - Add ability to use
-post-install entry point from rose-cylc to use Rose style CLI settings of
+post-install entry point from cylc-rose to use Rose style CLI settings of
 configurations in Cylc install. If Cylc-rose is installed three new CLI
 options will be available:
 - `--opt_conf_keys="foo, bar"`
 - `--defines="[env]FOO=BAR"`
-- `--suite-defines="FOO=BAR"
+- `--suite-defines="FOO=BAR"`
+
+[#4101](https://github.com/cylc/cylc-flow/pull/4101) - Add the ability to
+ignore (clear) rose install options from an earlier install:
+`cylc reinstall --clear-rose-install-options`
+
+[#4094](https://github.com/cylc/cylc-flow/pull/4094) - Prevent Cylc from
+rsyncing the following files on install and reinstall:
+- `rose-suite.conf`
+- `opt/rose-suite-cylc-install.conf`
+These files should be handled by the cylc-rose plugin if you require them.
+
 
 ### Fixes
 

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -225,7 +225,7 @@ def process_plugins(fpath):
         'cylc.pre_configure'
     ):
         try:
-            plugin_result = entry_point.resolve()(fpath)
+            plugin_result = entry_point.resolve()(srcdir=fpath)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -166,10 +166,10 @@ def main(parser, opts, flow_name=None, src=None):
     ):
         try:
             if opts.source:
-                entry_point.resolve()(dir_=opts.source, opts=opts)
+                entry_point.resolve()(srcdir=opts.source, opts=opts)
             else:
                 from pathlib import Path
-                entry_point.resolve()(dir_=Path().cwd(), opts=opts)
+                entry_point.resolve()(srcdir=Path().cwd(), opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors
@@ -192,9 +192,9 @@ def main(parser, opts, flow_name=None, src=None):
     ):
         try:
             entry_point.resolve()(
-                dir_=source_dir,
+                srcdir=source_dir,
                 opts=opts,
-                dest_root=str(rundir)
+                rundir=str(rundir)
             )
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -140,7 +140,7 @@ def main(parser, opts, named_run=None):
         'cylc.pre_configure'
     ):
         try:
-            entry_point.resolve()(dir_=source, opts=opts)
+            entry_point.resolve()(srcdir=source, opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors
@@ -162,9 +162,9 @@ def main(parser, opts, named_run=None):
     ):
         try:
             entry_point.resolve()(
-                dir_=source,
+                srcdir=source,
                 opts=opts,
-                dest_root=str(run_dir)
+                rundir=str(run_dir)
             )
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -36,7 +36,7 @@ class EntryPointWrapper:
 
 
 @EntryPointWrapper
-def pre_configure_basic(*_):
+def pre_configure_basic(*_, **__):
     """Simple plugin that returns one env var and one template var."""
     return {
         'env': {
@@ -49,7 +49,7 @@ def pre_configure_basic(*_):
 
 
 @EntryPointWrapper
-def pre_configure_templating_detected(*_):
+def pre_configure_templating_detected(*_, **__):
     """Plugin that detects a random templating engine."""
     return {
         'templating_detected': str(random())
@@ -57,7 +57,7 @@ def pre_configure_templating_detected(*_):
 
 
 @EntryPointWrapper
-def pre_configure_error(*_):
+def pre_configure_error(*_, **__):
     """Plugin that raises an exception."""
     raise Exception('foo')
 


### PR DESCRIPTION
Tidy up some naming conventions for Cylc-rose. 
This is a small change with no associated Issue.

Companion [PR 40 for cylc-rose](https://github.com/cylc/cylc-rose/pull/40)
**Requirements check-list**
- [x] Does not need tests: Testing for this functionality is in cylc-rose.
<!-- choose one: -->
- [x] No change log entry required - invisible to users.
<!-- choose one: -->
- [x] No documentation update required.
<!-- choose one: -->
- [x] No dependency changes.
