### PR TITLE
GH Actions: Increase functional test timeout

### DIFF
--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name || matrix.chunk }}
-    timeout-minutes: 40
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Trying to stop `_remote_background_indep_poll` from timing out so often

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
- [x] No dependency changes.
