### PR TITLE
Tui: warn about large flows

### DIFF
--- a/cylc/flow/scripts/tui.py
+++ b/cylc/flow/scripts/tui.py
@@ -21,6 +21,8 @@ View and control running suites in the terminal.
 (Tui = Terminal User Interface)
 
 WARNING: Tui is experimental and may break with large flows.
+An upcoming change to the way Tui receives data from the scheduler will make it
+much more efficient in the future.
 """
 # TODO: remove this warning once Tui is delta-driven
 # https://github.com/cylc/cylc-flow/issues/3527

--- a/cylc/flow/scripts/tui.py
+++ b/cylc/flow/scripts/tui.py
@@ -18,8 +18,13 @@
 
 View and control running suites in the terminal.
 
-(TUI = Terminal User Interface)
+(Tui = Terminal User Interface)
+
+WARNING: Tui is experimental and may break with large flows.
 """
+# TODO: remove this warning once Tui is delta-driven
+# https://github.com/cylc/cylc-flow/issues/3527
+
 from textwrap import indent
 
 from urwid import html_fragment

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -322,7 +322,7 @@ class TuiApp:
             })
         except (ClientError, ClientTimeout) as exc:
             # catch network / client errors
-            self.set_header(('suite_error', str(exc)))
+            self.set_header([('suite_error', str(exc))])
             return False
 
         if isinstance(data, list):
@@ -331,7 +331,7 @@ class TuiApp:
                 message = data[0]['error']['message']
             except (IndexError, KeyError):
                 message = str(data)
-            self.set_header(('suite_error', message))
+            self.set_header([('suite_error', message)])
             return False
 
         if len(data['workflows']) != 1:
@@ -353,7 +353,7 @@ class TuiApp:
         """
         return node.get_value()['id_']
 
-    def set_header(self, message):
+    def set_header(self, message: list):
         """Set the header message for this widget.
 
         Arguments:
@@ -363,12 +363,18 @@ class TuiApp:
 
         """
         # put in a one line gap
-        if isinstance(message, list):
-            message.append('\n')
-        elif isinstance(message, tuple):
-            message = (message[0], message[1] + '\n')
-        else:
-            message += '\n'
+        message.append('\n')
+
+        # TODO: remove once Tui is delta-driven
+        # https://github.com/cylc/cylc-flow/issues/3527
+        message.extend([
+            (
+                'suite_error',
+                'TUI is experimental and may break with large flows'
+            ),
+            '\n'
+        ])
+
         self.view.header = urwid.Text(message)
 
     def _update(self, *_):

--- a/etc/bin/shellchecker
+++ b/etc/bin/shellchecker
@@ -76,6 +76,7 @@ default () {
     # run a strict check on all "functional" scripts
     main '.' \
         --exclude 'etc/bin/live-graph-movie.sh' \
+        --exclude '.git' \
         -- -e SC1090
 }
 


### PR DESCRIPTION
Address a minor point on the beta-0 roadmap.

Add a warning about using with large flows until we get it delta-driven.

See https://github.com/cylc/cylc-flow/issues/3527

One off-topic change, got shellchecker to skip the `.git` dir.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] One off-topic change listed above
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
