### PR TITLE
conf: cylc executable => cylc path

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -427,10 +427,21 @@ with Conf('global.cylc', desc='''
 
                    ssh user@host 'bash --login cylc ...'
 
-                which will source ``/etc/profile`` and ``~/.profile`` to set up
-                the user environment.  However, for security reasons some
-                institutions do not allow unattended commands to start login
-                shells, so you can turn off this behaviour to get:
+                which will source the following files (in order):
+
+                * ``/etc/profile``
+                * ``~/.bash_profile``
+                * ``~/.bash_login``
+                * ``~/.profile``
+
+                .. _Bash man pages: https://linux.die.net/man/1/bash
+
+                For more information on login shells see the "Invocation"
+                section of the `Bash man pages`_.
+
+                For security reasons some institutions do not allow unattended
+                commands to start login shells, so you can turn off this
+                behaviour to get:
 
                 .. code-block:: bash
 
@@ -441,17 +452,33 @@ with Conf('global.cylc', desc='''
                 environment.
             ''')
             Conf('hosts', VDR.V_STRING_LIST)
-            Conf('cylc executable', VDR.V_STRING, 'cylc', desc='''
-                The ``cylc`` executable on a remote host.
+            Conf('cylc path', VDR.V_STRING, desc='''
+                The path containing the ``cylc`` executable on a remote host.
+
+                This may be necessary if the ``cylc`` executable is not in the
+                ``$PATH`` for an ``ssh`` call.
+                Test whether this is the case by using
+                ``ssh <host> command -v cylc``.
+
+                This path is used for remote invocations of the ``cylc``
+                command and is added to the ``$PATH`` in job scripts
+                for the configured platform.
 
                 .. note::
 
-                   This should normally point to the cylc multi-version wrapper
-                   on the host, not ``bin/cylc`` for a specific installed
-                   version.
+                   If :cylc:conf:`[..]use login shell = True` (the default)
+                   then an alternative approach is to add ``cylc`` to the
+                   ``$PATH`` in the system or user Bash profile files
+                   (e.g. ``~/.bash_profile``).
 
-                Specify a full path if ``cylc`` is not in ``$PATH`` when it is
-                invoked via ``ssh`` on this host.
+                .. tip::
+
+                   For multi-version installations this should point to the
+                   Cylc wrapper script rather than the ``cylc`` executable
+                   itself.
+
+                   See :ref:`managing environments` for more information on
+                   the wrapper script.
             ''')
             Conf('global init-script', VDR.V_STRING, desc='''
                 If specified, the value of this setting will be inserted to

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -170,14 +170,10 @@ class JobFileWriter:
             job_conf)
         if vacation_signals_str:
             handle.write("\nCYLC_VACATION_SIGNALS='%s'" % vacation_signals_str)
-        # Path to cylc executable, if defined.
-        cylc_exec = job_conf['platform']['cylc executable']
-        if not cylc_exec.endswith('cylc'):
-            raise ValueError(
-                f'ERROR: bad cylc executable in global config: {cylc_exec}')
-        cylc_bin = os.path.dirname(cylc_exec)
-        if cylc_bin:
-            handle.write(f"\nexport PATH={cylc_bin}:$PATH")
+        # Path to the `cylc` executable, if defined.
+        cylc_path = job_conf['platform']['cylc path']
+        if cylc_path:
+            handle.write(f"\nexport PATH={cylc_path}:$PATH")
         # Environment variables for prelude
         if cylc.flow.flags.debug:
             handle.write("\nexport CYLC_DEBUG=true")

--- a/tests/functional/job-submission/18-clean-env.t
+++ b/tests/functional/job-submission/18-clean-env.t
@@ -22,7 +22,7 @@
 create_test_global_config "" "
 [platforms]
    [[localhost]]
-      cylc executable = $(command -v cylc)
+      cylc path = $(dirname "$(command -v cylc)")
       clean job submission environment = True
       job submission environment pass-through = BEEF
 "

--- a/tests/functional/jobscript/00-torture.t
+++ b/tests/functional/jobscript/00-torture.t
@@ -28,7 +28,7 @@ export PATH_TO_CYLC_BIN="/path/to/cylc/bin"
 create_test_global_config '' "
 [platforms]
     [[localhost]]
-        cylc executable = $PATH_TO_CYLC_BIN/cylc"
+        cylc path = $PATH_TO_CYLC_BIN"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
 suite_run_ok "${TEST_NAME}" cylc play --reference-test --debug --no-detach "${SUITE_NAME}"

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -67,20 +67,6 @@ def fixture_get_platform():
     yield inner_func
 
 
-def test_write_prelude_invalid_cylc_command():
-    job_conf = {
-        "platform": {
-            "job runner": "background",
-            "hosts": ["localhost"],
-            "cylc executable": "sl -a"
-        }
-    }
-    with pytest.raises(ValueError) as ex:
-        with TemporaryFile(mode="w+") as handle:
-            JobFileWriter()._write_prelude(handle, job_conf)
-        assert("bad cylc executable" in str(ex))
-
-
 @mock.patch.dict(
     "os.environ", {'CYLC_SUITE_DEF_PATH': 'cylc/suite/def/path'})
 @mock.patch("cylc.flow.job_file.get_remote_suite_run_dir")
@@ -286,7 +272,7 @@ def test_write_prelude(monkeypatch, fixture_get_platform):
             "copyable environment variables": [
                 "CYLC_SUITE_INITIAL_CYCLE_POINT"
             ],
-            "cylc executable": "moo/baa/cylc"
+            "cylc path": "moo/baa"
         }),
         "directives": {"restart": "yes"},
     }


### PR DESCRIPTION
sibling: https://github.com/cylc/cylc-doc/pull/206

Small change that came out of `comms mode = ssh` discussions.

The `cylc executable` config is a bit strange, for remote `cylc` invocations the `cylc executable` is used, however, for job scripts the containing directory is added to the `$PATH`.

We have had to add a check in multiple places to make sure that the `cylc executable` isn't set to something which isn't `cylc`.

This PR:

* Changes `cylc executable` to `cylc path`.
* Documents the role of `cylc path` in the job script.
* Corrects the `use login shell` docs for the profile files that are sourced.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
- [ ] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] No dependency changes.
