### PR TITLE
Fix Mypy

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -62,7 +62,9 @@ jobs:
 
       - name: typing
         run: |
-          mypy
+          mypy --explicit-package-bases
+        # Need --explicit-package-bases because we don't have __init__.py in
+        # top-level dir
 
       - name: Doctests
         run: |

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -170,13 +170,8 @@ class SuiteConfig:
         self.first_graph = True
         self.clock_offsets = {}
         self.expiration_offsets = {}
-        # Old external triggers (client/server)
-        self.ext_triggers = {}
-        if xtrigger_mgr is None:
-            # For validation and graph etc.
-            self.xtrigger_mgr = XtriggerManager(self.suite)
-        else:
-            self.xtrigger_mgr = xtrigger_mgr
+        self.ext_triggers = {}  # Old external triggers (client/server)
+        self.xtrigger_mgr = xtrigger_mgr
         self.suite_polling_tasks = {}
         self._last_graph_raw_id = None
         self._last_graph_raw_edges = []
@@ -1715,7 +1710,10 @@ class SuiteConfig:
                 sig = xtrig.get_signature()
                 raise SuiteConfigError(
                     f"clock xtriggers need date-time cycling: {label} = {sig}")
-            self.xtrigger_mgr.add_trig(label, xtrig, self.fdir)
+            if self.xtrigger_mgr is None:
+                XtriggerManager.validate_xtrigger(label, xtrig, self.fdir)
+            else:
+                self.xtrigger_mgr.add_trig(label, xtrig, self.fdir)
             self.taskdefs[right].add_xtrig_label(label, seq)
 
     def get_actual_first_point(self, start_point):

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -64,7 +64,7 @@ import zlib
 
 from cylc.flow import __version__ as CYLC_VERSION, LOG, ID_DELIM
 from cylc.flow.exceptions import SuiteConfigError
-from cylc.flow.data_messages_pb2 import (
+from cylc.flow.data_messages_pb2 import (  # type: ignore
     PbEdge, PbEntireWorkflow, PbFamily, PbFamilyProxy, PbJob, PbTask,
     PbTaskProxy, PbWorkflow, AllDeltas, EDeltas, FDeltas, FPDeltas,
     JDeltas, TDeltas, TPDeltas, WDeltas)

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -32,7 +32,7 @@ from cylc.flow.network.graphql import (
 from cylc.flow.network.resolvers import Resolvers
 from cylc.flow.network.schema import schema
 from cylc.flow.data_store_mgr import DELTAS_MAP
-from cylc.flow.data_messages_pb2 import PbEntireWorkflow
+from cylc.flow.data_messages_pb2 import PbEntireWorkflow  # type: ignore
 
 # maps server methods to the protobuf message (for client/UIS import)
 PB_METHOD_MAP = {

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -22,7 +22,8 @@ from cylc.flow import ID_DELIM
 from cylc.flow.conditional_simplifier import ConditionalSimplifier
 from cylc.flow.cycling.loader import get_point
 from cylc.flow.exceptions import TriggerExpressionError
-from cylc.flow.data_messages_pb2 import PbPrerequisite, PbCondition
+from cylc.flow.data_messages_pb2 import (  # type: ignore
+    PbPrerequisite, PbCondition)
 
 
 class Prerequisite:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -178,13 +178,13 @@ class Scheduler:
     options: Optional[Values] = None
 
     # suite params
-    stop_mode: StopMode = None
+    stop_mode: Optional[StopMode] = None
     stop_task: Optional[str] = None
     stop_clock_time: Optional[int] = None
 
     # configuration
-    config: SuiteConfig = None  # flow config
-    cylc_config: DictTree = None  # [scheduler] config
+    config: Optional[SuiteConfig] = None  # flow config
+    cylc_config: Optional[DictTree] = None  # [scheduler] config
     flow_file: Optional[str] = None
     flow_file_update_time: Optional[float] = None
 
@@ -202,30 +202,30 @@ class Scheduler:
     # main loop
     main_loop_intervals: deque = deque(maxlen=10)
     main_loop_plugins: Optional[dict] = None
-    auto_restart_mode: AutoRestartMode = None
+    auto_restart_mode: Optional[AutoRestartMode] = None
     auto_restart_time: Optional[float] = None
 
     # tcp / zmq
     zmq_context: zmq.Context = None
     port: Optional[int] = None
     pub_port: Optional[int] = None
-    server: SuiteRuntimeServer = None
-    publisher: WorkflowPublisher = None
+    server: Optional[SuiteRuntimeServer] = None
+    publisher: Optional[WorkflowPublisher] = None
     barrier: Optional[Barrier] = None
     curve_auth: ThreadAuthenticator = None
     client_pub_key_dir: Optional[str] = None
 
     # managers
-    profiler: Profiler = None
-    pool: TaskPool = None
-    proc_pool: SubProcPool = None
-    task_job_mgr: TaskJobManager = None
-    task_events_mgr: TaskEventsManager = None
-    suite_event_handler: SuiteEventHandler = None
-    data_store_mgr: DataStoreMgr = None
-    suite_db_mgr: SuiteDatabaseManager = None
-    broadcast_mgr: BroadcastMgr = None
-    xtrigger_mgr: XtriggerManager = None
+    profiler: Optional[Profiler] = None
+    pool: Optional[TaskPool] = None
+    proc_pool: Optional[SubProcPool] = None
+    task_job_mgr: Optional[TaskJobManager] = None
+    task_events_mgr: Optional[TaskEventsManager] = None
+    suite_event_handler: Optional[SuiteEventHandler] = None
+    data_store_mgr: Optional[DataStoreMgr] = None
+    suite_db_mgr: Optional[SuiteDatabaseManager] = None
+    broadcast_mgr: Optional[BroadcastMgr] = None
+    xtrigger_mgr: Optional[XtriggerManager] = None
 
     # queues
     command_queue: Optional[Queue] = None

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -363,7 +363,7 @@ class Scheduler:
 
         self.xtrigger_mgr = XtriggerManager(
             self.suite,
-            self.owner,
+            user=self.owner,
             broadcast_mgr=self.broadcast_mgr,
             data_store_mgr=self.data_store_mgr,
             proc_pool=self.proc_pool,

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -243,10 +243,10 @@ class XtriggerManager:
         """Get a real function context from the template.
 
         Args:
-            itask (TaskProxy): task proxy
-            label (str): xtrigger label
+            itask: task proxy
+            label: xtrigger label
         Returns:
-            SubFuncContext: function context
+            function context
         """
         farg_templ = {
             TMPL_TASK_CYCLE_POINT: str(itask.point),
@@ -255,7 +255,6 @@ class XtriggerManager:
         }
         farg_templ.update(self.farg_templ)
         ctx = deepcopy(self.functx_map[label])
-        ctx.point = itask.point
         kwargs = {}
         args = []
         for val in ctx.func_args:
@@ -308,7 +307,7 @@ class XtriggerManager:
                         xtrigger_env = [{'environment': {key: val}} for
                                         key, val in res.items()]
                         self.broadcast_mgr.put_broadcast(
-                            [str(ctx.point)],
+                            [str(itask.point)],
                             [itask.tdef.name],
                             xtrigger_env
                         )

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -18,7 +18,7 @@ import json
 import re
 from copy import deepcopy
 from time import time
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from cylc.flow import LOG
 import cylc.flow.flags
@@ -88,25 +88,25 @@ class XtriggerManager:
     call.
 
     Args:
-        suite (str): suite name
-        user (str): suite owner
-        broadcast_mgr (BroadcastMgr): the Broadcast Manager
-        proc_pool (SubProcPool): pool of Subprocesses
-        suite_run_dir (str): suite run directory
-        suite_share_dir (str): suite share directory
+        suite: suite name
+        user: suite owner
+        broadcast_mgr: the Broadcast Manager
+        proc_pool: pool of Subprocesses
+        suite_run_dir: suite run directory
+        suite_share_dir: suite share directory
 
     """
 
     def __init__(
         self,
         suite: str,
-        user: str = None,
+        user: Optional[str] = None,
         *,  # following must be keyword args
-        broadcast_mgr: BroadcastMgr = None,
-        data_store_mgr: DataStoreMgr = None,
-        proc_pool: SubProcPool = None,
-        suite_run_dir: str = None,
-        suite_share_dir: str = None,
+        broadcast_mgr: Optional[BroadcastMgr] = None,
+        data_store_mgr: Optional[DataStoreMgr] = None,
+        proc_pool: Optional[SubProcPool] = None,
+        suite_run_dir: Optional[str] = None,
+        suite_share_dir: Optional[str] = None,
     ):
         # Suite function and clock triggers by label.
         self.functx_map: dict = {}
@@ -133,9 +133,13 @@ class XtriggerManager:
             TMPL_SUITE_SHARE_DIR: suite_share_dir,
             TMPL_DEBUG_MODE: cylc.flow.flags.debug
         }
-        self.proc_pool: 'SubProcPool' = proc_pool
-        self.broadcast_mgr: 'BroadcastMgr' = broadcast_mgr
-        self.data_store_mgr: 'DataStoreMgr' = data_store_mgr
+
+        if proc_pool is not None:
+            self.proc_pool: SubProcPool = proc_pool
+        if broadcast_mgr is not None:
+            self.broadcast_mgr: BroadcastMgr = broadcast_mgr
+        if data_store_mgr is not None:
+            self.data_store_mgr: DataStoreMgr = data_store_mgr
 
     @staticmethod
     def validate_xtrigger(fname: str, fdir: str):

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,7 @@
 python_version = 3.7
 ignore_missing_imports = True
 files = cylc/flow
+
+# Enable PEP 420 style namespace packages, which we use.
+# Needed for associating "import foo.bar" with foo/bar.py
+namespace_packages = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,5 @@ files = cylc/flow
 # Enable PEP 420 style namespace packages, which we use.
 # Needed for associating "import foo.bar" with foo/bar.py
 namespace_packages = True
+
+strict_equality = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,4 +26,6 @@ addopts = --verbose
     --ignore=cylc/flow/parsec/empysupport.py
     --ignore=cylc/flow/parsec/example
 testpaths =
+    cylc/flow/
     tests/unit/
+    tests/integration/

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
     package_data={
         'cylc.flow': [
             'etc/*.yaml', 'etc/flow*.eg', 'etc/job.sh',
-            'etc/syntax/*', 'etc/cylc-bash-completion'
+            'etc/syntax/*', 'etc/cylc-bash-completion', 'py.typed'
         ]
     },
     install_requires=install_requires,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,8 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Standard pytest fixtures for unit tests."""
+from cylc.flow.data_store_mgr import DataStoreMgr
 import pytest
 from shutil import rmtree
+from unittest.mock import create_autospec, Mock
 
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.cycling.loader import (
@@ -23,6 +25,8 @@ from cylc.flow.cycling.loader import (
     INTEGER_CYCLING_TYPE
 )
 from cylc.flow.parsec.config import ParsecConfig
+from cylc.flow.scheduler import Scheduler
+from cylc.flow.xtrigger_mgr import XtriggerManager
 
 
 @pytest.fixture
@@ -83,3 +87,16 @@ def mock_glbl_cfg(tmp_path, monkeypatch):
 
     yield _mock
     rmtree(tmp_path)
+
+
+@pytest.fixture
+def xtrigger_mgr() -> XtriggerManager:
+    """A fixture to build an XtriggerManager which uses a mocked proc_pool,
+    and uses a mocked broadcast_mgr."""
+    return XtriggerManager(
+        suite="sample_suite",
+        user="john-foo",
+        proc_pool=Mock(put_command=lambda *a, **k: True),
+        broadcast_mgr=Mock(put_broadcast=lambda *a, **k: True),
+        data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from typing import Any, Dict, Optional, Tuple, Type
+from pathlib import Path
 import pytest
 import logging
 from unittest.mock import Mock
@@ -26,6 +27,7 @@ from cylc.flow.cycling import iso8601, loader
 from cylc.flow.exceptions import SuiteConfigError
 from cylc.flow.suite_files import SuiteFiles
 from cylc.flow.wallclock import get_utc_mode, set_utc_mode
+from cylc.flow.xtrigger_mgr import XtriggerManager
 
 Fixture = Any
 
@@ -93,7 +95,9 @@ def get_test_inheritance_quotes():
 class TestSuiteConfig:
     """Test class for the Cylc SuiteConfig object."""
 
-    def test_xfunction_imports(self, mock_glbl_cfg, tmp_path):
+    def test_xfunction_imports(
+            self, mock_glbl_cfg: Fixture, tmp_path: Path,
+            xtrigger_mgr: XtriggerManager):
         """Test for a suite configuration with valid xtriggers"""
         mock_glbl_cfg(
             'cylc.flow.platforms.glbl_cfg',
@@ -118,8 +122,10 @@ class TestSuiteConfig:
                 R1 = '@tree => qux'
         """
         flow_file.write_text(flow_config)
-        suite_config = SuiteConfig(suite="name_a_tree", fpath=flow_file,
-                                   options=Mock(spec=[]))
+        suite_config = SuiteConfig(
+            suite="name_a_tree", fpath=flow_file, options=Mock(spec=[]),
+            xtrigger_mgr=xtrigger_mgr
+        )
         assert 'tree' in suite_config.xtrigger_mgr.functx_map
 
     def test_xfunction_import_error(self, mock_glbl_cfg, tmp_path):

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -15,26 +15,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for remote initialisation."""
 
+from pathlib import Path
 from unittest.mock import patch
+from _pytest.capture import CaptureFixture
 
+from cylc.flow.suite_files import SuiteFiles
 from cylc.flow.task_remote_cmd import remote_init
 
 
-@patch('os.makedirs')
-@patch('os.listdir')
-@patch('os.path.join')
-@patch('os.path.expandvars')
-def test_existing_key_raises_error(
-        mocked_expandvars, mocked_pathjoin, mocked_listdir,
-        mocked_makedirs, capsys):
+def test_existing_key_raises_error(tmp_path: Path, capsys: CaptureFixture):
     """Test .service directory that contains existing incorrect key,
-       results in REMOTE INIT FAILED
-    """
-    mocked_expandvars.return_value = "some/expanded/path"
-    mocked_pathjoin.return_value = "joined.path"
-    mocked_listdir.return_value = ['client_wrong.key']
+    results in REMOTE INIT FAILED"""
+    rundir = tmp_path / 'some_rund'
+    srvdir = rundir / SuiteFiles.Service.DIRNAME
+    srvdir.mkdir(parents=True)
+    (srvdir / 'client_wrong.key').touch()
 
-    remote_init('test_install_target', 'some_rund')
+    remote_init('test_install_target', str(rundir))
     assert capsys.readouterr().out == "REMOTE INIT FAILED\n"
 
 

--- a/tests/unit/test_xtrigger_mgr.py
+++ b/tests/unit/test_xtrigger_mgr.py
@@ -91,10 +91,6 @@ def test_add_xtrigger_with_unknown_params(xtrigger_mgr):
     with pytest.raises(ValueError):
         xtrigger_mgr.add_trig("xtrig", xtrig, 'fdir')
 
-    # TODO: is it intentional? At the moment when we fail to validate the
-    #       function parameters, we add it to the dict anyway.
-    assert xtrigger_mgr.functx_map["xtrig"] == xtrig
-
 
 def test_load_xtrigger_for_restart(xtrigger_mgr):
     """Test loading a xtrigger for restart.
@@ -130,6 +126,7 @@ def test_housekeeping_nothing_satisfied(xtrigger_mgr):
 def test_housekeeping_with_xtrigger_satisfied(xtrigger_mgr):
     """The housekeeping method makes sure only satisfied xtrigger function
     are kept."""
+    xtrigger_mgr.validate_xtrigger = lambda *a, **k: True  # Ignore validation
     xtrig = SubFuncContext(
         label="get_name",
         func_name="get_name",
@@ -160,8 +157,10 @@ def test_housekeeping_with_xtrigger_satisfied(xtrigger_mgr):
     assert xtrigger_mgr.sat_xtrig
 
 
-def test_satisfy_xtrigger(xtrigger_mgr_procpool_broadcast):
+def test_satisfy_xtrigger(xtrigger_mgr):
     """Test satisfy_xtriggers"""
+    xtrigger_mgr.validate_xtrigger = lambda *a, **k: True  # Ignore validation
+
     # the echo1 xtrig (not satisfied)
     echo1_xtrig = SubFuncContext(
         label="echo1",
@@ -171,7 +170,7 @@ def test_satisfy_xtrigger(xtrigger_mgr_procpool_broadcast):
     )
 
     echo1_xtrig.out = "[\"True\", {\"name\": \"herminia\"}]"
-    xtrigger_mgr_procpool_broadcast.add_trig("echo1", echo1_xtrig, "fdir")
+    xtrigger_mgr.add_trig("echo1", echo1_xtrig, "fdir")
     # the echo2 xtrig (satisfied through callback later)
     echo2_xtrig = SubFuncContext(
         label="echo2",
@@ -180,7 +179,7 @@ def test_satisfy_xtrigger(xtrigger_mgr_procpool_broadcast):
         func_kwargs={}
     )
     echo2_xtrig.out = "[\"True\", {\"name\": \"herminia\"}]"
-    xtrigger_mgr_procpool_broadcast.add_trig("echo2", echo2_xtrig, "fdir")
+    xtrigger_mgr.add_trig("echo2", echo2_xtrig, "fdir")
     # create a task
     tdef = TaskDef(
         name="foo",
@@ -199,35 +198,37 @@ def test_satisfy_xtrigger(xtrigger_mgr_procpool_broadcast):
         tdef, start_point, FlowLabelMgr().get_new_label())
 
     # we start with no satisfied xtriggers, and nothing active
-    assert len(xtrigger_mgr_procpool_broadcast.sat_xtrig) == 0
-    assert len(xtrigger_mgr_procpool_broadcast.active) == 0
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 0
 
     # after calling satisfy_xtriggers the first time, we get two active
-    xtrigger_mgr_procpool_broadcast.satisfy_xtriggers(itask)
-    assert len(xtrigger_mgr_procpool_broadcast.sat_xtrig) == 0
-    assert len(xtrigger_mgr_procpool_broadcast.active) == 2
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 2
 
     # calling satisfy_xtriggers again does not change anything
-    xtrigger_mgr_procpool_broadcast.satisfy_xtriggers(itask)
-    assert len(xtrigger_mgr_procpool_broadcast.sat_xtrig) == 0
-    assert len(xtrigger_mgr_procpool_broadcast.active) == 2
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 0
+    assert len(xtrigger_mgr.active) == 2
 
     # now we call callback manually as the proc_pool we passed is a mock
     # then both should be satisfied
-    xtrigger_mgr_procpool_broadcast.callback(echo1_xtrig)
-    xtrigger_mgr_procpool_broadcast.callback(echo2_xtrig)
+    xtrigger_mgr.callback(echo1_xtrig)
+    xtrigger_mgr.callback(echo2_xtrig)
     # so both were satisfied, and nothing is active
-    assert len(xtrigger_mgr_procpool_broadcast.sat_xtrig) == 2
-    assert len(xtrigger_mgr_procpool_broadcast.active) == 0
+    assert len(xtrigger_mgr.sat_xtrig) == 2
+    assert len(xtrigger_mgr.active) == 0
 
     # calling satisfy_xtriggers again still does not change anything
-    xtrigger_mgr_procpool_broadcast.satisfy_xtriggers(itask)
-    assert len(xtrigger_mgr_procpool_broadcast.sat_xtrig) == 2
-    assert len(xtrigger_mgr_procpool_broadcast.active) == 0
+    xtrigger_mgr.satisfy_xtriggers(itask)
+    assert len(xtrigger_mgr.sat_xtrig) == 2
+    assert len(xtrigger_mgr.active) == 0
 
 
 def test_collate(xtrigger_mgr):
     """Test that collate properly tallies the totals of current xtriggers."""
+    xtrigger_mgr.validate_xtrigger = lambda *a, **k: True  # Ignore validation
+
     xtrigger_mgr.collate(itasks=[])
     assert not xtrigger_mgr.all_xtrig
 
@@ -332,13 +333,14 @@ def test_callback(xtrigger_mgr):
     assert xtrigger_mgr.sat_xtrig
 
 
-def test_check_xtriggers(xtrigger_mgr_procpool):
+def test_check_xtriggers(xtrigger_mgr):
     """Test check_xtriggers call.
 
     check_xtriggers does pretty much the same as collate. The
     difference is that besides tallying on all the xtriggers and
     clock xtriggers available, it then proceeds to trying to
     satisfy them."""
+    xtrigger_mgr.validate_xtrigger = lambda *a, **k: True  # Ignore validation
 
     # add a xtrigger
     # that will cause all_xtrig to be populated, but not all_xclock
@@ -348,7 +350,7 @@ def test_check_xtriggers(xtrigger_mgr_procpool):
         func_args=[],
         func_kwargs={}
     )
-    xtrigger_mgr_procpool.add_trig("get_name", get_name, 'fdir')
+    xtrigger_mgr.add_trig("get_name", get_name, 'fdir')
     get_name.out = "[\"True\", {\"name\": \"Yossarian\"}]"
     tdef1 = TaskDef(
         name="foo",
@@ -373,7 +375,7 @@ def test_check_xtriggers(xtrigger_mgr_procpool):
         func_kwargs={}
     )
     wall_clock.out = "[\"True\", \"1\"]"
-    xtrigger_mgr_procpool.add_trig("wall_clock", wall_clock, "fdir")
+    xtrigger_mgr.add_trig("wall_clock", wall_clock, "fdir")
     # create a task
     tdef2 = TaskDef(
         name="foo",
@@ -388,71 +390,32 @@ def test_check_xtriggers(xtrigger_mgr_procpool):
     itask2 = TaskProxy(
         tdef2, start_point, FlowLabelMgr().get_new_label())
 
-    xtrigger_mgr_procpool.check_xtriggers([itask1, itask2])
+    xtrigger_mgr.check_xtriggers([itask1, itask2])
     # won't be satisfied, as it is async, we are are not calling callback
-    assert not xtrigger_mgr_procpool.sat_xtrig
-    assert xtrigger_mgr_procpool.all_xtrig
+    assert not xtrigger_mgr.sat_xtrig
+    assert xtrigger_mgr.all_xtrig
 
 
 # mock objects
 
 class MockedProcPool(SubProcPool):
 
-    def put_command(self, ctx, callback=None, callback_args=None):
+    def put_command(self, *args, **kwargs):
         return True
 
 
 class MockedBroadcastMgr(BroadcastMgr):
 
-    def put_broadcast(
-            self, point_strings=None, namespaces=None, settings=None):
+    def put_broadcast(self, *args, **kwargs):
         return True
+
 
 # fixtures
 
-
 @pytest.fixture
 def xtrigger_mgr() -> XtriggerManager:
-    """A fixture to build an XtriggerManager that ignores validation.
-
-    Returns:
-        XtriggerManager: an XtriggerManager that ignores validation
-    """
-    xtrigger_mgr = XtriggerManager(
-        suite="suitea",
-        user="john-foo",
-        data_store_mgr=DataStoreMgr(create_autospec(Scheduler)))
-    xtrigger_mgr.validate_xtrigger = lambda fn, fdir: True
-    return xtrigger_mgr
-
-
-@pytest.fixture
-def xtrigger_mgr_procpool() -> XtriggerManager:
-    """A fixture to build an XtriggerManager that ignores validation,
-    and uses a mocked proc_pool.
-
-    Returns:
-        XtriggerManager: an XtriggerManager that ignores validation and
-            uses a mocked proc_pool
-    """
-    xtrigger_mgr = XtriggerManager(
-        suite="suitea",
-        user="john-foo",
-        proc_pool=MockedProcPool()
-    )
-    xtrigger_mgr.validate_xtrigger = lambda fn, fdir: True
-    return xtrigger_mgr
-
-
-@pytest.fixture
-def xtrigger_mgr_procpool_broadcast() -> XtriggerManager:
-    """A fixture to build an XtriggerManager that ignores validation,
-    uses a mocked proc_pool, and uses a mocked broadacast_mgr.
-
-    Returns:
-        XtriggerManager: an XtriggerManager that ignores validation,
-            uses a mocked proc_pool, and uses a mocked broadacast_mgr
-    """
+    """A fixture to build an XtriggerManager which uses a mocked proc_pool,
+    and uses a mocked broadcast_mgr."""
     xtrigger_mgr = XtriggerManager(
         suite="sample_suite",
         user="john-foo",
@@ -461,5 +424,4 @@ def xtrigger_mgr_procpool_broadcast() -> XtriggerManager:
             suite_db_mgr=None, data_store_mgr=None),
         data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
     )
-    xtrigger_mgr.validate_xtrigger = lambda fn, fdir: True
     return xtrigger_mgr

--- a/tests/unit/test_xtrigger_mgr.py
+++ b/tests/unit/test_xtrigger_mgr.py
@@ -15,18 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-from unittest.mock import create_autospec
 
-from cylc.flow.broadcast_mgr import BroadcastMgr
-from cylc.flow.data_store_mgr import DataStoreMgr
 from cylc.flow.cycling.iso8601 import ISO8601Point, ISO8601Sequence, init
-from cylc.flow.scheduler import Scheduler
 from cylc.flow.subprocctx import SubFuncContext
-from cylc.flow.subprocpool import SubProcPool
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_pool import FlowLabelMgr
 from cylc.flow.taskdef import TaskDef
-from cylc.flow.xtrigger_mgr import XtriggerManager, RE_STR_TMPL
+from cylc.flow.xtrigger_mgr import RE_STR_TMPL
 
 
 def test_constructor(xtrigger_mgr):
@@ -394,34 +389,3 @@ def test_check_xtriggers(xtrigger_mgr):
     # won't be satisfied, as it is async, we are are not calling callback
     assert not xtrigger_mgr.sat_xtrig
     assert xtrigger_mgr.all_xtrig
-
-
-# mock objects
-
-class MockedProcPool(SubProcPool):
-
-    def put_command(self, *args, **kwargs):
-        return True
-
-
-class MockedBroadcastMgr(BroadcastMgr):
-
-    def put_broadcast(self, *args, **kwargs):
-        return True
-
-
-# fixtures
-
-@pytest.fixture
-def xtrigger_mgr() -> XtriggerManager:
-    """A fixture to build an XtriggerManager which uses a mocked proc_pool,
-    and uses a mocked broadcast_mgr."""
-    xtrigger_mgr = XtriggerManager(
-        suite="sample_suite",
-        user="john-foo",
-        proc_pool=MockedProcPool(),
-        broadcast_mgr=MockedBroadcastMgr(
-            suite_db_mgr=None, data_store_mgr=None),
-        data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
-    )
-    return xtrigger_mgr


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

I have been driven mad falling down a rabbit hole trying to understand why an imported function from another file in `cylc/flow/`  that was properly type-hinted, did not raise any errors if I passed args of an incorrect type to it and then ran `mypy`!

Turns out we needed to add some mypy options to get it to work fully. There is some useful doc here: https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-paths-to-modules

However, I have also discovered that mypy is skipping lots of methods and functions that don't use type hints in their args, even if type hints are used elsewhere in the file. Sorting that out can come later, I think.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
