### PR TITLE
Make obsolete `[runtime][][remote]suite definition directory`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -206,6 +206,9 @@ rsyncing the following files on install and reinstall:
 - `opt/rose-suite-cylc-install.conf`
 These files should be handled by the cylc-rose plugin if you require them.
 
+[#4126](https://github.com/cylc/cylc-flow/pull/4126) - Make obselete the config
+``flow.cylc:[runtime][__TASK__][remote]suite definition directory``.
+
 
 ### Fixes
 

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1071,7 +1071,6 @@ with Conf(
             with Conf('remote', desc=DEPRECATION_WARN):
                 Conf('host', VDR.V_STRING)
                 Conf('owner', VDR.V_STRING)
-                Conf('suite definition directory', VDR.V_STRING)
                 Conf('retrieve job logs', VDR.V_BOOLEAN)
                 Conf('retrieve job logs max size', VDR.V_STRING)
                 Conf('retrieve job logs retry delays',
@@ -1424,6 +1423,10 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'events', 'mail retry delays'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'extra log files'])
     u.obsolete('8.0.0', ['runtime', '__MANY__', 'job', 'shell'])
+    u.obsolete(
+        '8.0.0',
+        ['runtime', '__MANY__', 'remote', 'suite definition directory']
+    )
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -116,8 +116,8 @@ cylc__job__main() {
     CYLC_TASK_MESSAGE_STARTED_PID=$!
     # System paths:
     # * suite directory (installed run-dir first).
-    export PATH="${CYLC_SUITE_RUN_DIR}/bin:${CYLC_SUITE_DEF_PATH}/bin:${PATH}"
-    export PYTHONPATH="${CYLC_SUITE_RUN_DIR}/lib/python:${CYLC_SUITE_DEF_PATH}/lib/python:${PYTHONPATH:-}"
+    export PATH="${CYLC_SUITE_RUN_DIR}/bin:${PATH}"
+    export PYTHONPATH="${CYLC_SUITE_RUN_DIR}/lib/python:${PYTHONPATH:-}"
     # Create share and work directories
     mkdir -p "${CYLC_SUITE_SHARE_DIR}" || true
     mkdir -p "$(dirname "${CYLC_TASK_WORK_DIR}")" || true

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -209,23 +209,6 @@ class JobFileWriter:
             handle.write(
                 '\n    export CYLC_SUITE_WORK_DIR_ROOT="%s"' % work_d
             )
-        if job_conf['remote_suite_d']:
-            handle.write(
-                '\n    export CYLC_SUITE_DEF_PATH="%s"' %
-                job_conf['remote_suite_d'])
-        else:
-            # replace home dir with '$HOME' for evaluation on the task host
-            cylc_suite_def_path = os.environ['CYLC_SUITE_DEF_PATH']
-            if cylc_suite_def_path.startswith(os.environ['HOME']):
-                cylc_suite_def_path = cylc_suite_def_path.replace(
-                    os.environ['HOME'],
-                    '${HOME}'
-                )
-            handle.write(
-                '\n    export CYLC_SUITE_DEF_PATH="%s"' % cylc_suite_def_path)
-        handle.write(
-            '\n    export CYLC_SUITE_DEF_PATH_ON_SUITE_HOST="%s"' %
-            os.environ['CYLC_SUITE_DEF_PATH'])
         handle.write(
             '\n    export CYLC_SUITE_UUID="%s"' % job_conf['uuid_str'])
 

--- a/tests/functional/cylc-get-config/00-simple/section2.stdout
+++ b/tests/functional/cylc-get-config/00-simple/section2.stdout
@@ -34,7 +34,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -111,7 +110,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -188,7 +186,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -267,7 +264,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -345,7 +341,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -423,7 +418,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -501,7 +495,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -579,7 +572,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -657,7 +649,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -735,7 +726,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -813,7 +803,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -891,7 +880,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 
@@ -969,7 +957,6 @@
     [[[remote]]]
         host = 
         owner = 
-        suite definition directory = 
         retrieve job logs = 
         retrieve job logs max size = 
         retrieve job logs retry delays = 

--- a/tests/functional/restart/34-auto-restart-basic.t
+++ b/tests/functional/restart/34-auto-restart-basic.t
@@ -44,6 +44,9 @@ init_suite "${TEST_NAME}" - <<'__FLOW_CONFIG__'
 [scheduling]
     [[graph]]
         R1 = "task<foo> => task<foo+1>"
+[runtime]
+    [[task<foo>]]
+    [[task_26]]
 __FLOW_CONFIG__
 
 # run suite on localhost normally

--- a/tests/functional/restart/35-auto-restart-recovery.t
+++ b/tests/functional/restart/35-auto-restart-recovery.t
@@ -40,6 +40,8 @@ init_suite "${TEST_NAME}" <<< '
 [scheduling]
     [[graph]]
         R1 = foo
+[runtime]
+    [[foo]]
 '
 create_test_global_config '' "${BASE_GLOBAL_CONFIG}"
 run_ok "${TEST_NAME}-suite-start" \

--- a/tests/functional/restart/37-auto-restart-delay.t
+++ b/tests/functional/restart/37-auto-restart-delay.t
@@ -48,6 +48,8 @@ init_suite "${TEST_NAME_BASE}" <<< '
     initial cycle point = 2000
     [[graph]]
         P1D = foo
+[runtime]
+    [[foo]]
 '
 
 MAX_RESTART_DELAY=30

--- a/tests/functional/restart/38-auto-restart-stopping.t
+++ b/tests/functional/restart/38-auto-restart-stopping.t
@@ -44,6 +44,7 @@ init_suite "${TEST_NAME}" - <<'__FLOW_CONFIG__'
 [runtime]
     [[foo]]
         script = cylc stop "${CYLC_SUITE_NAME}"; sleep 15
+    [[bar]]
 __FLOW_CONFIG__
 
 create_test_global_config '' "

--- a/tests/functional/restart/42-auto-restart-ping-pong.t
+++ b/tests/functional/restart/42-auto-restart-ping-pong.t
@@ -42,7 +42,7 @@ init_suite "${TEST_NAME_BASE}" <<< '
     [[graph]]
         P1Y = foo[-P1Y] => foo
 [runtime]
-    [[root]]
+    [[foo]]
         script = sleep 5
 '
 cd "${SUITE_RUN_DIR}" || exit 1

--- a/tests/functional/restart/43-auto-restart-force-override-normal.t
+++ b/tests/functional/restart/43-auto-restart-force-override-normal.t
@@ -42,6 +42,8 @@ init_suite "${TEST_NAME_BASE}" <<< '
     initial cycle point = 2000
     [[graph]]
         P1Y = foo[-P1Y] => foo
+[runtime]
+    [[foo]]
 '
 
 create_test_global_config '' "

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -67,8 +67,6 @@ def fixture_get_platform():
     yield inner_func
 
 
-@mock.patch.dict(
-    "os.environ", {'CYLC_SUITE_DEF_PATH': 'cylc/suite/def/path'})
 @mock.patch("cylc.flow.job_file.get_remote_suite_run_dir")
 def test_write(mocked_get_remote_suite_run_dir, fixture_get_platform):
     """Test write function outputs jobscript file correctly."""
@@ -292,7 +290,6 @@ def test_write_suite_environment(fixture_get_platform, monkeypatch):
         "get_remote_suite_work_dir",
         lambda a, b: "work/dir"
     )
-    monkeypatch.setenv('CYLC_SUITE_DEF_PATH', 'cylc/suite/def/path')
     cylc.flow.flags.debug = True
     cylc.flow.flags.verbose = True
     suite_env = {'CYLC_UTC': 'True',
@@ -305,9 +302,7 @@ def test_write_suite_environment(fixture_get_platform, monkeypatch):
                 '  export CYLC_UTC="True"\n    export TZ="UTC"\n\n   '
                 ' export CYLC_SUITE_RUN_DIR="cylc-run/farm_noises"\n   '
                 ' export CYLC_SUITE_WORK_DIR_ROOT="work/dir"\n   '
-                ' export CYLC_SUITE_DEF_PATH="remote/suite/dir"\n    expor'
-                't CYLC_SUITE_DEF_PATH_ON_SUITE_HOST="cylc/suite/def/path"'
-                '\n    export CYLC_SUITE_UUID="neigh"')
+                ' export CYLC_SUITE_UUID="neigh"')
     job_conf = {
         "platform": fixture_get_platform({
             "host": "localhost",
@@ -319,7 +314,8 @@ def test_write_suite_environment(fixture_get_platform, monkeypatch):
     rund = "cylc-run/farm_noises"
     with io.StringIO() as fake_file:
         job_file_writer._write_suite_environment(fake_file, job_conf, rund)
-        assert(fake_file.getvalue() == expected)
+        result = fake_file.getvalue()
+        assert result == expected
 
 
 def test_write_suite_environment_no_remote_suite_d(
@@ -327,7 +323,6 @@ def test_write_suite_environment_no_remote_suite_d(
 ):
     """Test suite environment is correctly written in jobscript"""
 
-    monkeypatch.setenv('CYLC_SUITE_DEF_PATH', 'cylc/suite/def/path')
     monkeypatch.setattr(
         cylc.flow.job_file,
         "get_remote_suite_work_dir",
@@ -343,11 +338,8 @@ def test_write_suite_environment_no_remote_suite_d(
                 'ENVIRONMENT:\n    export CYLC_CYCLING_MODE="integer"\n    '
                 'export CYLC_UTC="True"\n    export TZ="UTC"\n\n    export '
                 'CYLC_SUITE_RUN_DIR="cylc-run/farm_noises"\n    '
-                'export CYLC_SUITE'
-                '_WORK_DIR_ROOT="work/dir"\n    export CYLC_SUITE_DEF_PATH='
-                '"cylc/suite/def/path"\n    export '
-                'CYLC_SUITE_DEF_PATH_ON_SUITE_HOST="cylc/suite/def/path"\n'
-                '    export CYLC_SUITE_UUID="neigh"')
+                'export CYLC_SUITE_WORK_DIR_ROOT="work/dir"\n   '
+                ' export CYLC_SUITE_UUID="neigh"')
     job_conf = {
         "platform": fixture_get_platform({
             "host": "localhost",
@@ -359,9 +351,8 @@ def test_write_suite_environment_no_remote_suite_d(
     rund = "cylc-run/farm_noises"
     with io.StringIO() as fake_file:
         job_file_writer._write_suite_environment(fake_file, job_conf, rund)
-        blah = fake_file.getvalue()
-        print(blah)
-        assert(fake_file.getvalue() == expected)
+        result = fake_file.getvalue()
+        assert result == expected
 
 
 def test_write_script():


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #3696 : They are the last config change on the checklist there. 🎉 
That is:
- Remove, and add obseletion warning for config item `flow.cylc:[runtime][__TASK__][remote]suite definition directory` (But _not_ the similar platform item from `global.cylc`).
- Remove CYLC_SUITE_DEF_PATH environment variable.
- Remove CYLC_SUITE_DEF_PATH_ON_REMOTE_HOST environment variable.

Additionally I fixed a few tests broken by the change of default behavior to preventing implicit tasks. (@MetRonnie  Please extra double check these.)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests.
<!-- choose one: -->
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR  cylc/cylc-doc#216
- [x] No dependency changes.
