### PR TITLE
Allow Cylc Review to access Cylc 8 Workflow data.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@ cylc-7.9.x (which requires Python 2.7) bundles Jinja2 2.11.
 cylc-8 (master branch, Python 3 - not yet released) uses proper Python package
 management and does not bundle Jinja2.
 
+## __cylc-7.8.8 ()__
+
+### Enhancements
+[#4134](https://github.com/cylc/cylc-flow/pull/4134) - Allow Cylc Review to
+access information about Cylc 8 workflows.
+
 ## __cylc-7.8.7 (2020-12-04)__
 
 ### Enhancements

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -753,13 +753,20 @@ class CylcReviewService(object):
                                   "mtime": f_stat.st_mtime,
                                   "size": f_stat.st_size}
 
-        # Get cylc suite log files
-        for f_name in glob(os.path.join(dir_, "log/suite/log*")):
-            key = os.path.relpath(f_name, dir_)
-            f_stat = os.stat(f_name)
-            logs_info[key] = {"path": key,
-                              "mtime": f_stat.st_mtime,
-                              "size": f_stat.st_size}
+        # Get cylc suite log files and other files:
+        EXTRA_FILES = [
+            "log/suite/log*",
+            "log/install/*"
+        ]
+        for glob_pattern in EXTRA_FILES:
+            for f_name in glob(os.path.join(dir_, glob_pattern)):
+                key = os.path.relpath(f_name, dir_)
+                f_stat = os.stat(f_name)
+                logs_info[key] = {
+                    "path": key,
+                    "mtime": f_stat.st_mtime,
+                    "size": f_stat.st_size
+                }
 
         data["files"]["cylc"] = logs_info
         return data

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -756,6 +756,7 @@ class CylcReviewService(object):
         # Get cylc suite log files and other files:
         EXTRA_FILES = [
             "log/suite/log*",
+            "log/suite/file-installation-log.*",
             "log/install/*"
         ]
         for glob_pattern in EXTRA_FILES:

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -68,6 +68,7 @@ class CylcReviewService(object):
     SEARCH_MODE_TEXT = "TEXT"
     SUITES_PER_PAGE = 100
     VIEW_SIZE_MAX = 10 * 1024 * 1024  # 10MB
+    WORKFLOW_FILES = ['suite.rc', 'suite.rc.processed', 'rose-suite.info', 'flow.cylc']
 
     def __init__(self, *args, **kwargs):
         self.exposed = True
@@ -737,8 +738,7 @@ class CylcReviewService(object):
         dir_ = os.path.expanduser(os.path.join(prefix, d_rel))
 
         # Get cylc files
-        cylc_files = ["cylc-suite-env", "suite.rc", "suite.rc.processed"]
-        for key in cylc_files:
+        for key in self.WORKFLOW_FILES:
             f_name = os.path.join(dir_, key)
             if os.path.isfile(f_name):
                 f_stat = os.stat(f_name)
@@ -849,8 +849,7 @@ class CylcReviewService(object):
             tail = os.path.join(tail1, tail)
         if not (
             head == 'log' or
-            (not head and tail in
-             ['suite.rc', 'suite.rc.processed', 'rose-suite.info'])
+            (not head and tail in cls.WORKFLOW_FILES)
         ):
             raise cherrypy.HTTPError(403)
 

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -74,6 +74,7 @@ class CylcReviewService(object):
         'flow.cylc',
         'flow.cylc.processed',
         'rose-suite.info',
+        'opt/rose-suite-cylc-install.conf'
     ]
 
     def __init__(self, *args, **kwargs):
@@ -853,7 +854,8 @@ class CylcReviewService(object):
             tail = os.path.join(tail1, tail)
         if not (
             head == 'log' or
-            (not head and tail in cls.WORKFLOW_FILES)
+            (not head and tail in cls.WORKFLOW_FILES) or
+            (head, tail) == (u'opt', u'rose-suite-cylc-install.conf')
         ):
             raise cherrypy.HTTPError(403)
 

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -68,7 +68,13 @@ class CylcReviewService(object):
     SEARCH_MODE_TEXT = "TEXT"
     SUITES_PER_PAGE = 100
     VIEW_SIZE_MAX = 10 * 1024 * 1024  # 10MB
-    WORKFLOW_FILES = ['suite.rc', 'suite.rc.processed', 'rose-suite.info', 'flow.cylc']
+    WORKFLOW_FILES = [
+        'suite.rc',
+        'suite.rc.processed',
+        'flow.cylc',
+        'flow.cylc.processed',
+        'rose-suite.info',
+    ]
 
     def __init__(self, *args, **kwargs):
         self.exposed = True
@@ -834,9 +840,7 @@ class CylcReviewService(object):
             cherrypy.HTTPError(403)
 
         Whitelist paths:
-            * ``suite.rc``.
-            * ``suite.rc.processed``.
-            * ``log/``.
+            Paths in cls.WORKFLOW_FILES
 
         Blacklist non-normalised paths - see ``_check_path_normalised``.
 

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -284,11 +284,12 @@ class CylcReviewDAO(object):
         suite_info = self._db_exec(
             user_name, suite_name, 'SELECT * FROM suite_params', []
         )
+        cylc_version = None
         for row in suite_info:
             if row[0] == u'cylc_version':
                 cylc_version = row[1]
 
-        if cylc_version[0] == '8':
+        if cylc_version and cylc_version[0] == '8':
             return True
         else:
             return False

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -208,7 +208,7 @@ class CylcReviewDAO(object):
         # Detemine Cylc version for a given suite: Database changes require
         # A different database query for Cylc8.
         suite_info = self._db_exec(
-            user_name, suite_name, 'SELECT * FROM suite_params',[]
+            user_name, suite_name, 'SELECT * FROM suite_params', []
         )
         for row in suite_info:
             if row[0] == u'cylc_version':


### PR DESCRIPTION
These changes partially address #4113 - Depending upon discussion on that issue, this may be a complete solution.

- [x] Fix access to task jobs list. At this stage I have an informally tested fix. I've put it up for review so that reviewers can try it.
- [x] Allow access to `cylc.flow` file. Modified the list of files so that this can be a 1-stop-shop.
- [x] Existing tests for `cylc-review`  don't break differently to target branch. 😢 
- [ ] ~Create a formal test that Cylc8 Workflows can be read.~ Manual testing only because this a complex test for legacy software.
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate change log entry included.
- [x] No dependency changes.
