### PR TITLE
Make remote init return messages more informative

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -493,7 +493,9 @@ def get_random_platform_for_install_target(install_target):
         return random.choice(platforms)
     except IndexError:
         # No platforms to choose from
-        return None
+        raise PlatformLookupError(
+            f'Could not select platform for install target: {install_target}'
+        ) from None
 
 
 def get_localhost_install_target():

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -489,7 +489,11 @@ def get_all_platforms_for_install_target(install_target):
 def get_random_platform_for_install_target(install_target):
     """Return a randomly selected platform (dict) for given install target."""
     platforms = get_all_platforms_for_install_target(install_target)
-    return random.choice(platforms)
+    try:
+        return random.choice(platforms)
+    except IndexError:
+        # No platforms to choose from
+        return None
 
 
 def get_localhost_install_target():

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -351,7 +351,8 @@ async def _run(parser, options, reg, scheduler):
         ret = 1
     except (KeyboardInterrupt, asyncio.CancelledError):
         ret = 2
-    except Exception:
+    except Exception as exc:
+        LOG.exception(exc)
         ret = 3
 
     # kthxbye

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -230,6 +230,9 @@ class TaskRemoteMgr:
             if install_target == get_localhost_install_target():
                 continue
             platform = get_random_platform_for_install_target(install_target)
+            if platform is None:
+                LOG.debug(f"Remote tidy not required for {install_target}.")
+                continue
             platform_n = platform['name']
             cmd = ['remote-tidy']
             if cylc.flow.flags.debug:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -230,9 +230,6 @@ class TaskRemoteMgr:
             if install_target == get_localhost_install_target():
                 continue
             platform = get_random_platform_for_install_target(install_target)
-            if platform is None:
-                LOG.debug(f"Remote tidy not required for {install_target}.")
-                continue
             platform_n = platform['name']
             cmd = ['remote-tidy']
             if cylc.flow.flags.debug:

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -17,7 +17,7 @@
 
 from pathlib import Path
 from unittest.mock import patch
-from _pytest.capture import CaptureFixture
+from pytest import CaptureFixture
 
 from cylc.flow.suite_files import SuiteFiles
 from cylc.flow.task_remote_cmd import remote_init
@@ -32,7 +32,10 @@ def test_existing_key_raises_error(tmp_path: Path, capsys: CaptureFixture):
     (srvdir / 'client_wrong.key').touch()
 
     remote_init('test_install_target', str(rundir))
-    assert capsys.readouterr().out == "REMOTE INIT FAILED\n"
+    assert capsys.readouterr().out == (
+        "REMOTE INIT FAILED\nUnexpected authentication key"
+        " \"client_wrong.key\" exists. Check global.cylc install target is"
+        " configured correctly for this platform.\n")
 
 
 @patch('os.path.expandvars')
@@ -42,4 +45,22 @@ def test_unexpandable_symlink_env_var_returns_failed(
     mocked_expandvars.side_effect = ['some/rund/path', '$blah']
 
     remote_init('test_install_target', 'some_rund', 'run=$blah')
-    assert capsys.readouterr().out == "REMOTE INIT FAILED\n"
+    assert capsys.readouterr().out == (
+        "REMOTE INIT FAILED\nError occurred when symlinking."
+        " $blah contains an invalid environment variable.\n")
+
+
+def test_existing_client_key_dir_raises_error(
+        tmp_path: Path, capsys: CaptureFixture):
+    """Test .service directory that contains existing incorrect key,
+       results in REMOTE INIT FAILED
+    """
+    rundir = tmp_path / 'some_rund'
+    keydir = rundir / SuiteFiles.Service.DIRNAME / "client_public_keys"
+    keydir.mkdir(parents=True)
+
+    remote_init('test_install_target', rundir)
+    assert capsys.readouterr().out == (
+        f"REMOTE INIT FAILED\nUnexpected key directory exists: {keydir}"
+        " Check global.cylc install target is configured correctly for this"
+        " platform.\n")


### PR DESCRIPTION
The aim of this PR is to ensure the reason for remote init failures is documented in the workflow log.
This PR also adds an additional check for the `client_public_keys` directory on the remote which will catch misconfigurations of the install target for platforms which share fs with localhost.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
