### PR TITLE
CYLC_SITE_CONF_PATH: look in flow sub-dir

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -90,7 +90,7 @@ with Conf('global.cylc', desc='''
     .. envvar:: CYLC_SITE_CONF_PATH
 
        By default the site configuration is located in ``/etc/cylc/``. For
-       installations where this is not convenient this path can be overridden
+       installations where this is not convenient, this path can be overridden
        by setting ``CYLC_SITE_CONF_PATH`` to point at another location.
 
        Configuration for different Cylc components should be in sub-directories

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -836,6 +836,10 @@ class GlobalConfig(ParsecConfig):
             cls._DEFAULT.load()
         return cls._DEFAULT
 
+    def _load(self, fname, conf_type):
+        if os.access(fname, os.F_OK | os.R_OK):
+            self.loadcfg(fname, conf_type)
+
     def load(self):
         """Load or reload configuration from files."""
         self.sparse.clear()
@@ -845,16 +849,13 @@ class GlobalConfig(ParsecConfig):
         if conf_path_str:
             # Explicit config file override.
             fname = os.path.join(conf_path_str, self.CONF_BASENAME)
-            if os.access(fname, os.F_OK | os.R_OK):
-                self.loadcfg(fname, upgrader.USER_CONFIG)
+            self._load(fname, upgrader.USER_CONFIG)
         elif conf_path_str is None:
             # Use default locations.
             for conf_type, conf_dir in self.conf_dir_hierarchy:
                 fname = os.path.join(conf_dir, self.CONF_BASENAME)
-                if not os.access(fname, os.F_OK | os.R_OK):
-                    continue
                 try:
-                    self.loadcfg(fname, conf_type)
+                    self._load(fname, conf_type)
                 except ParsecError as exc:
                     if conf_type == upgrader.SITE_CONFIG:
                         # Warn on bad site file (users can't fix it).

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,19 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Standard pytest fixtures for unit tests."""
-from pathlib import Path
-from shutil import rmtree
-from tempfile import TemporaryDirectory
-from unittest.mock import create_autospec, Mock
-
+from cylc.flow.data_store_mgr import DataStoreMgr
 import pytest
+from shutil import rmtree
+from unittest.mock import create_autospec, Mock
 
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.cycling.loader import (
     ISO8601_CYCLING_TYPE,
     INTEGER_CYCLING_TYPE
 )
-from cylc.flow.data_store_mgr import DataStoreMgr
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.xtrigger_mgr import XtriggerManager
@@ -106,12 +103,3 @@ def xtrigger_mgr() -> XtriggerManager:
         broadcast_mgr=Mock(put_broadcast=lambda *a, **k: True),
         data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
     )
-
-
-@pytest.fixture(scope='module')
-def mod_tmp_path():
-    """A tmp_path fixture with module-level scope."""
-    path = Path(TemporaryDirectory().name)
-    path.mkdir()
-    yield path
-    rmtree(path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,16 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Standard pytest fixtures for unit tests."""
-from cylc.flow.data_store_mgr import DataStoreMgr
-import pytest
+from pathlib import Path
 from shutil import rmtree
+from tempfile import TemporaryDirectory
 from unittest.mock import create_autospec, Mock
+
+import pytest
 
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.cycling.loader import (
     ISO8601_CYCLING_TYPE,
     INTEGER_CYCLING_TYPE
 )
+from cylc.flow.data_store_mgr import DataStoreMgr
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.xtrigger_mgr import XtriggerManager
@@ -103,3 +106,12 @@ def xtrigger_mgr() -> XtriggerManager:
         broadcast_mgr=Mock(put_broadcast=lambda *a, **k: True),
         data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
     )
+
+
+@pytest.fixture(scope='module')
+def mod_tmp_path():
+    """A tmp_path fixture with module-level scope."""
+    path = Path(TemporaryDirectory().name)
+    path.mkdir()
+    yield path
+    rmtree(path)

--- a/tests/unit/scripts/test_config.py
+++ b/tests/unit/scripts/test_config.py
@@ -30,7 +30,7 @@ HOME: str = str(Path('~').expanduser())
 
 @pytest.fixture
 def conf_env(monkeypatch):
-    """Clear any env vars that effect which conf files get loaded.
+    """Clear any env vars that affect which conf files get loaded.
 
     Return a convenience function for setting environment variables.
     """

--- a/tests/unit/scripts/test_config.py
+++ b/tests/unit/scripts/test_config.py
@@ -14,19 +14,45 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional, List
+
+import pytest
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.scripts.config import get_config_file_hierarchy
 
+from cylc.flow import (
+    CYLC_LOG,
+    __version__ as VERSION,
+)
+from cylc.flow.cfgspec.globalcfg import GlobalConfig
+
+
 Fixture = Any
+HOME: str = str(Path('~').expanduser())
+MAJVER: str = VERSION[0]
 
 
-def test_get_config_file_hierarchy_global(monkeypatch: Fixture):
+@pytest.fixture
+def clear_env(monkeypatch):
+    """Clear any env vars that effect which conf files get loaded."""
+    for envvar in ('CYLC_SITE_CONF_PATH', 'CYLC_CONF_PATH'):
+        if envvar in os.environ:
+            monkeypatch.delenv(envvar)
+
+
+def test_get_config_file_hierarchy_global(
+    monkeypatch: Fixture,
+    clear_env: Fixture
+):
     """Test get_config_file_hierarchy() for the global hierarchy only."""
-    for cls_attr, val in {'SITE_CONF_PATH': '/etc/cylc/flow',
-                          'USER_CONF_PATH': '~/.cylc/flow',
-                          'VERSION_HIERARCHY': ['', '1', '1.0']}.items():
+    for cls_attr, val in [
+        ('USER_CONF_PATH', '~/.cylc/flow'),
+        ('VERSION_HIERARCHY', ['', '1', '1.0'])
+    ]:
         monkeypatch.setattr(
             f'cylc.flow.cfgspec.globalcfg.GlobalConfig.{cls_attr}', val)
     # Prevent the cached global config from being used, as this can be
@@ -41,4 +67,147 @@ def test_get_config_file_hierarchy_global(monkeypatch: Fixture):
         '~/.cylc/flow/global.cylc',
         '~/.cylc/flow/1/global.cylc',
         '~/.cylc/flow/1.0/global.cylc'
+    ]
+
+
+@pytest.fixture(scope='module')
+def conf_dirs(mod_tmp_path):
+    """Directory with some dirs for testing global config loading."""
+    dirs = {
+        '<tmp1>': mod_tmp_path / 'a',
+        '<tmp1>/flow': Path(mod_tmp_path / 'a', 'flow'),
+        '<tmp2>': mod_tmp_path / 'b',
+        '<site>': mod_tmp_path / 'flow'
+    }
+    for dir_ in dirs.values():
+        dir_.mkdir(exist_ok=True)
+        (dir_ / 'global.cylc').touch()
+        flow_dir = dir_ / 'flow'
+        flow_dir.mkdir()
+        (flow_dir / 'global.cylc').touch()
+    return dirs
+
+
+@pytest.mark.parametrize(
+    'conf_path,site_conf_path,files',
+    [
+        pytest.param(
+            None,
+            None,
+            [
+                '<site>',
+                '~/.cylc/flow/global.cylc',
+                f'~/.cylc/flow/{MAJVER}/global.cylc',
+                f'~/.cylc/flow/{VERSION}/global.cylc',
+            ],
+            id='(default)'
+        ),
+
+        pytest.param(
+            None,
+            '<tmp1>',
+            [
+                '<tmp1>/flow',
+                '~/.cylc/flow/global.cylc',
+                f'~/.cylc/flow/{MAJVER}/global.cylc',
+                f'~/.cylc/flow/{VERSION}/global.cylc',
+            ],
+            id='CYLC_SITE_CONF_PATH=valid'
+        ),
+
+        pytest.param(
+            None,
+            'elephant',
+            [
+                '~/.cylc/flow/global.cylc',
+                f'~/.cylc/flow/{MAJVER}/global.cylc',
+                f'~/.cylc/flow/{VERSION}/global.cylc',
+            ],
+            id='CYLC_SITE_CONF_PATH=invalid'
+        ),
+
+        pytest.param(
+            '<tmp1>',
+            None,
+            ['<tmp1>'],
+            id='CYLC_CONF_PATH=valid'
+        ),
+
+        pytest.param(
+            'elephant',
+            None,
+            [],
+            id='CYLC_CONF_PATH=invalid'
+        ),
+
+        pytest.param(
+            '<tmp1>',
+            '<tmp2>',
+            ['<tmp1>'],  # should ignore CYLC_SITE_CONF_PATH
+            id='CYLC_CONF_PATH=valid, CYLC_SITE_CONF_PATH=valid'
+        ),
+
+        pytest.param(
+            'elephant',
+            '<tmp1>',
+            [],
+            id='CYLC_CONF_PATH=invalid, CYLC_SITE_CONF_PATH=valid'
+        ),
+    ]
+)
+def test_cylc_site_conf_path_env_var(
+    monkeypatch: Fixture,
+    caplog: Fixture,
+    clear_env: Fixture,
+    conf_dirs: Fixture,
+    conf_path: Optional[str],
+    site_conf_path: Optional[str],
+    files: List[str],
+):
+    """Test that the right files are loaded according to env vars."""
+    # patch the default site config path
+    monkeypatch.setattr(
+        GlobalConfig,
+        'DEFAULT_SITE_CONF_PATH',
+        str(conf_dirs['<site>'].parent)
+    )
+
+    # del/set the relevant environment variables
+    for var, env_var in (
+        (conf_path, 'CYLC_CONF_PATH'),
+        (site_conf_path, 'CYLC_SITE_CONF_PATH')
+    ):
+        if var is None:
+            pass
+        elif var in conf_dirs:
+            monkeypatch.setenv(env_var, conf_dirs[var])
+        elif var:
+            monkeypatch.setenv(env_var, var)
+
+    # reset the global config
+    monkeypatch.setattr(
+        GlobalConfig,
+        '_DEFAULT',
+        None,
+    )
+
+    # capture logging
+    caplog.clear()
+    caplog.set_level(logging.DEBUG, logger=CYLC_LOG)
+
+    # load the global config
+    GlobalConfig.get_inst()
+
+    # make sure the right files are loaded
+    assert [
+        msg
+        .replace('Reading file ', '')
+        .replace(HOME, '~')
+        for *_, msg in caplog.record_tuples
+        if msg.startswith('Reading file ')
+    ] == [
+        str(conf_dirs[file_] / 'global.cylc')
+        if file_ in conf_dirs
+        else file_
+        for file_ in files
     ]


### PR DESCRIPTION
Required for: https://github.com/cylc/cylc-uiserver/pull/192

Required for us to use `CYLC_SITE_CONF_PATH` to source the global config for the UIS.

* Look for global config in `${CYLC_SITE_CONF_DIR}/flow/global.cylc`.
* This is to allow this env var to be used by other cylc components - namely the UIS.
* Tried to match the annotations from #4099 to minimise diff.

To explain the `:envvar:` stuff - https://github.com/cylc/cylc-doc/issues/226

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] Docs included
- [x] No dependency changes.
