### PR TITLE
Remove error logging

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -351,8 +351,7 @@ async def _run(parser, options, reg, scheduler):
         ret = 1
     except (KeyboardInterrupt, asyncio.CancelledError):
         ret = 2
-    except Exception as exc:
-        LOG.exception(exc)
+    except Exception:
         ret = 3
 
     # kthxbye


### PR DESCRIPTION
PR: https://github.com/cylc/cylc-flow/pull/4138 added logging exceptions. This additional logging is making the logs look messier than necessary.
The reason this was added was due to an error added at cylc-tidy stage (scheduler side), was not appearing in logs for some reason. This needs further investigation (I will open an issue) 

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (Removal of code, not affecting tests).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
