### PR TITLE
Slight platforms refactor

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1606,14 +1606,19 @@ def upgrade_param_env_templates(cfg, descr):
 
 
 def warn_about_depr_platform(cfg):
-    """Warn if deprecated host or batch system appear in config."""
+    """Validate platforms config.
+
+    - Warn if deprecated host or batch system appear in config,
+    - Raise if platforms section is also present.
+    - Or raise if using invalid subshell syntax for platform def.
+    """
     if 'runtime' not in cfg:
         return
     for task_name, task_cfg in cfg['runtime'].items():
         if 'platform' in task_cfg and task_cfg['platform']:
-            if is_platform_definition_subshell(task_cfg['platform']):
-                continue  # e.g. platform = $(foo); cannot validate
             fail_if_platform_and_host_conflict(task_cfg, task_name)
+            # Fail if backticks subshell e.g. platform = `foo`:
+            is_platform_definition_subshell(task_cfg['platform'])
         else:
             depr = get_platform_deprecated_settings(task_cfg, task_name)
             if depr:

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -70,14 +70,14 @@ def get_platform(
         return platform_from_name(task_conf)
 
     elif 'platform' in task_conf and task_conf['platform']:
+        # Check whether task has conflicting Cylc7 items.
+        fail_if_platform_and_host_conflict(task_conf, task_id)
+
         if is_platform_definition_subshell(task_conf['platform']):
             # Platform definition is using subshell e.g. platform = $(foo);
             # won't be evaluated until job submit so cannot get or
             # validate platform
             return None
-
-        # Check whether task has conflicting Cylc7 items.
-        fail_if_platform_and_host_conflict(task_conf, task_id)
 
         # If platform name exists and doesn't clash with Cylc7 Config items.
         return platform_from_name(task_conf['platform'])

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -19,7 +19,7 @@
 import random
 import re
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING, Tuple
 
 from cylc.flow.exceptions import PlatformLookupError
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from collections import OrderedDict
 
 
-FORBIDDEN_WITH_PLATFORM = (
+FORBIDDEN_WITH_PLATFORM: Tuple[Tuple[str, str, List[Optional[str]]], ...] = (
     ('remote', 'host', ['localhost', None]),
     ('job', 'batch system', [None]),
     ('job', 'batch submit command template', [None])
@@ -48,7 +48,7 @@ PLATFORM_REC_COMMAND = re.compile(r'(\$\()\s*(.*)\s*([)])$')
 #     Cylc9
 # remove at:
 #     Cylc9
-def get_platform(task_conf=None, task_id='unknown task', warn_only=False):
+def get_platform(task_conf=None, task_id='unknown task'):
     """Get a platform.
 
     Looking at a task config this method decides whether to get platform from
@@ -61,89 +61,47 @@ def get_platform(task_conf=None, task_id='unknown task', warn_only=False):
         task_id (str):
             Task identification string - help produce more helpful error
             messages.
-        warn_only(bool):
-            If true, warnings about tasks requiring upgrade will be returned.
 
     Returns:
         platform (platform, or string):
             Actually it returns either get_platform() or
             platform_from_job_info(), but to the user these look the same.
-            When working in warn_only mode, warnings are returned as strings.
-
     """
-    if task_conf is None:
-        # Just a simple way of accessing localhost items.
-        output = platform_from_name()
-
-    elif isinstance(task_conf, str):
-        # If task_conf is str assume that it is a platform name.
-        output = platform_from_name(task_conf)
+    if task_conf is None or isinstance(task_conf, str):
+        # task_conf is a platform name, or get localhost if None
+        return platform_from_name(task_conf)
 
     elif 'platform' in task_conf and task_conf['platform']:
-        if PLATFORM_REC_COMMAND.match(task_conf['platform']) and warn_only:
-            # In warning mode this function might have been passed an
-            # un-expanded platform string - warn that they won't deal with
-            # with this until job submit.
+        if is_platform_definition_subshell(task_conf['platform']):
+            # Platform definition is using subshell e.g. platform = $(foo);
+            # won't be evaluated until job submit so cannot get or
+            # validate platform
             return None
-        if HOST_REC_COMMAND.match(task_conf['platform']) and warn_only:
-            raise PlatformLookupError(
-                f"platform = {task_conf['platform']}: "
-                "backticks are not supported; "
-                "please use $()"
-            )
 
         # Check whether task has conflicting Cylc7 items.
         fail_if_platform_and_host_conflict(task_conf, task_id)
 
         # If platform name exists and doesn't clash with Cylc7 Config items.
-        output = platform_from_name(task_conf['platform'])
+        return platform_from_name(task_conf['platform'])
 
     else:
-        # If forbidden items present calculate platform else platform is
-        # local
-        platform_is_localhost = True
-
-        warn_msgs = []
-        for section, key, exceptions in FORBIDDEN_WITH_PLATFORM:
-            # if section not in task_conf:
-            #     task_conf[section] = {}
-            if (
-                section in task_conf and
-                key in task_conf[section] and
-                task_conf[section][key] not in exceptions
-            ):
-                platform_is_localhost = False
-                if warn_only:
-                    warn_msgs.append(
-                        f"[runtime][{task_id}][{section}]{key} = "
-                        f"{task_conf[section][key]}\n"
-                    )
-
-        if platform_is_localhost:
-            output = platform_from_name()
-
-        elif warn_only:
-            output = (
-                f'Task {task_id} Deprecated "host" and "batch system" will be '
-                'removed at Cylc 9 - upgrade to platform:'
-                f'\n{"".join(warn_msgs)}'
-            )
-
+        if get_platform_deprecated_settings(task_conf) == []:
+            # No deprecated items; platform is localhost
+            return platform_from_name()
         else:
+            # Need to calculate platform
             task_job_section, task_remote_section = {}, {}
             if 'job' in task_conf:
                 task_job_section = task_conf['job']
             if 'remote' in task_conf:
                 task_remote_section = task_conf['remote']
-            output = platform_from_name(
+            return platform_from_name(
                 platform_from_job_info(
                     glbl_cfg(cached=False).get(['platforms']),
                     task_job_section,
                     task_remote_section
                 )
             )
-
-    return output
 
 
 def platform_from_name(platform_name=None, platforms=None):
@@ -428,6 +386,44 @@ def fail_if_platform_and_host_conflict(task_conf, task_name):
                 f"\"{task_name}\" has the following settings which "
                 f"are not compatible:\n{fail_items}"
             )
+
+
+def get_platform_deprecated_settings(
+    task_conf: Dict[str, Any], task_name: str = 'unknown task'
+) -> List[str]:
+    """Return deprecated [runtime][<task_name>] settings that should be
+    upgraded to platforms.
+
+    Args:
+        task_conf: Runtime configuration for the task.
+        task_name: The task name.
+    """
+    result: List[str] = []
+    for section, key, exceptions in FORBIDDEN_WITH_PLATFORM:
+        if (
+            section in task_conf and
+            key in task_conf[section] and
+            task_conf[section][key] not in exceptions
+        ):
+            result.append(
+                f'[runtime][{task_name}][{section}]{key} = '
+                f'{task_conf[section][key]}'
+            )
+    return result
+
+
+def is_platform_definition_subshell(value: str) -> bool:
+    """Is the platform definition using subshell? E.g. platform = $(foo)
+
+    Raise PlatformLookupError if using backticks.
+    """
+    if PLATFORM_REC_COMMAND.match(value):
+        return True
+    if HOST_REC_COMMAND.match(value):
+        raise PlatformLookupError(
+            f"platform = {value}: backticks are not supported; please use $()"
+        )
+    return False
 
 
 def get_install_target_from_platform(platform: Dict[str, Any]) -> str:

--- a/tests/unit/cfgspec/test_suite.py
+++ b/tests/unit/cfgspec/test_suite.py
@@ -52,7 +52,7 @@ from cylc.flow.exceptions import PlatformLookupError
             {
                 'foo': {'platform': 'fine'},
                 'bar': {
-                    'platform': 'six',
+                    'platform': '$(fine)',
                     'job': {'batch system': 'pbs'}
                 }
             },

--- a/tests/unit/cfgspec/test_suite.py
+++ b/tests/unit/cfgspec/test_suite.py
@@ -1,0 +1,89 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import pytest
+from typing import Any, Dict, Optional
+
+from cylc.flow import CYLC_LOG
+from cylc.flow.cfgspec.suite import warn_about_depr_platform
+from cylc.flow.exceptions import PlatformLookupError
+
+
+@pytest.mark.parametrize(
+    'runtime_cfg, fail_expected, expected_warning',
+    [
+        pytest.param(
+            {
+                'foo': {'script': 'true'}
+            },
+            False, None,
+            id="No platform setting"
+        ),
+        pytest.param(
+            {
+                'foo': {'platform': 'fine'}
+            },
+            False, None,
+            id="Valid platform"
+        ),
+        pytest.param(
+            {
+                'foo': {'platform': 'fine'},
+                'bar': {'platform': '`not good`'}
+            },
+            True, None,
+            id="Invalid subshell notation"
+        ),
+        pytest.param(
+            {
+                'foo': {'platform': 'fine'},
+                'bar': {
+                    'platform': 'six',
+                    'job': {'batch system': 'pbs'}
+                }
+            },
+            True, None,
+            id="Platform/host conflict"
+        ),
+        pytest.param(
+            {
+                'foo': {'platform': 'fine'},
+                'bar': {
+                    'job': {'batch system': 'pbs'}
+                }
+            },
+            False, "Task bar: deprecated \"host\" and \"batch system\"",
+            id="Deprecated settings"
+        )
+    ]
+)
+def test_warn_about_depr_platform(
+        runtime_cfg: Dict[str, Any], fail_expected: bool,
+        expected_warning: Optional[str],
+        caplog: pytest.LogCaptureFixture):
+    """Test warn_about_depr_platform()"""
+    caplog.set_level(logging.WARNING, CYLC_LOG)
+    cfg = {'runtime': runtime_cfg}
+    if fail_expected:
+        with pytest.raises(PlatformLookupError):
+            warn_about_depr_platform(cfg)
+    else:
+        warn_about_depr_platform(cfg)
+        if expected_warning:
+            assert expected_warning in caplog.text
+        else:
+            assert caplog.record_tuples == []

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -196,23 +196,6 @@ def test_get_platform_using_platform_from_job_info(
     assert get_platform(task_conf)['name'] == expected_platform_name
 
 
-def test_get_platform_warn_mode(caplog):
-    task_conf = {
-        'remote': {'host': 'cylcdevbox'},
-        'job': {
-            'batch system': 'pbs',
-            'batch submit command template': 'some template'
-        }
-    }
-    output = get_platform(task_conf, warn_only=True)
-    for forbidden_item in (
-        'batch submit command template = some template',
-        'host = cylcdevbox',
-        'batch system = pbs'
-    ):
-        assert forbidden_item in output
-
-
 def test_get_platform_groups_basic(mock_glbl_cfg):
     # get platform from group works.
     mock_glbl_cfg(
@@ -243,7 +226,7 @@ def test_get_platform_warn_mode_fail_if_backticks():
         'platform': '`echo ${chamber}`'
     }
     with pytest.raises(PlatformLookupError) as err:
-        get_platform(task_conf, warn_only=True)
+        get_platform(task_conf)
     assert err.match(
         r'platform = `echo \$\{chamber\}`: '
         r'backticks are not supported; please use \$\(\)'


### PR DESCRIPTION
This is a small change with no associated Issue.

Move validation-y parts of `get_platform()` to their own functions. Changes should help improve type safety.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
