### PR TITLE
Docstring changes

### DIFF
--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -1608,7 +1608,7 @@ def upgrade_param_env_templates(cfg, descr):
 def warn_about_depr_platform(cfg):
     """Validate platforms config.
 
-    - Warn if deprecated host or batch system appear in config,
+    - Warn if deprecated host or batch system appear in config.
     - Raise if platforms section is also present.
     - Or raise if using invalid subshell syntax for platform def.
     """

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -62,8 +62,9 @@ def get_platform(
             messages.
 
     Returns:
-        platform: Actually it returns either get_platform() or
-            platform_from_job_info(), but to the user these look the same.
+        platform: A platform definition dictionary. Uses either
+            get_platform() or platform_from_job_info(), but to the
+            user these look the same.
     """
     if task_conf is None or isinstance(task_conf, str):
         # task_conf is a platform name, or get localhost if None


### PR DESCRIPTION
A couple of docstrings that I thought could be better.

One person review.
Please squash on merge.
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests: Tiny doc-string changes.
- [x] No change log entry required: Tiny doc-string changes.
- [x] No documentation update required: Tiny doc-string changes.
- [x] No dependency changes.
