### PR TITLE
CYLC_SUITE_DEF_PATH

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,12 +41,21 @@ Named checkpoints have been removed ([#3906](https://github.com/cylc/cylc-flow/p
 due to being a seldom-used feature. Workflows can still be restarted from the
 last run, or reflow can be used to achieve the same result.
 
--------------------------------------------------------------------------------
 <!-- The topmost release date is automatically updated by GitHub Actions. When
 creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+-------------------------------------------------------------------------------
+## __cylc-8.0b1 (<span actions:bind='release-date'>Released 2021-04-??</span>)__
+
+### Enhancements
+
+[#4154](https://github.com/cylc/cylc-flow/pull/4154)
+Deprecate `CYLC_SUITE_DEF_PATH` with `CYLC_SUITE_RUN_DIR` (note the deprecated
+variable is still present in the job environment).
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0b0 (<span actions:bind='release-date'>Released 2021-03-29</span>)__
 
 First beta release of Cylc 8.

--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -43,35 +43,11 @@ ID_DELIM = '|'
 
 def environ_init():
     """Initialise cylc environment."""
-    if os.getenv('CYLC_SUITE_DEF_PATH', ''):
-        environ_path_add([os.getenv('CYLC_SUITE_DEF_PATH')])
-
     # Python output buffering delays appearance of stdout and stderr
     # when output is not directed to a terminal (this occurred when
     # running pre-5.0 cylc via the posix nohup command; is it still the
     # case in post-5.0 daemon-mode cylc?)
     os.environ['PYTHONUNBUFFERED'] = 'true'
-
-
-def environ_path_add(dirs, key='PATH'):
-    """For each dir_ in dirs, prepend dir_ to the PATH environment variable.
-
-    If key is specified, prepend dir_ to the named environment variable instead
-    of PATH.
-
-    """
-
-    paths_str = os.getenv(key, '')
-    # ''.split(os.pathsep) gives ['']
-    if paths_str.strip():
-        paths = paths_str.split(os.pathsep)
-    else:
-        paths = []
-    for dir_ in dirs:
-        while dir_ in paths:
-            paths.remove(dir_)
-        paths.insert(0, dir_)
-    os.environ[key] = os.pathsep.join(paths)
 
 
 environ_init()

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1429,14 +1429,17 @@ class SuiteConfig:
     def process_suite_env(self):
         """Suite context is exported to the local environment."""
         for var, val in [
-                ('CYLC_SUITE_NAME', self.suite),
-                ('CYLC_DEBUG', str(cylc.flow.flags.debug).lower()),
-                ('CYLC_VERBOSE', str(cylc.flow.flags.verbose).lower()),
-                ('CYLC_SUITE_DEF_PATH', self.fdir),
-                ('CYLC_SUITE_RUN_DIR', self.run_dir),
-                ('CYLC_SUITE_LOG_DIR', self.log_dir),
-                ('CYLC_SUITE_WORK_DIR', self.work_dir),
-                ('CYLC_SUITE_SHARE_DIR', self.share_dir)]:
+            ('CYLC_SUITE_NAME', self.suite),
+            ('CYLC_DEBUG', str(cylc.flow.flags.debug).lower()),
+            ('CYLC_VERBOSE', str(cylc.flow.flags.verbose).lower()),
+            ('CYLC_SUITE_RUN_DIR', self.run_dir),
+            ('CYLC_SUITE_LOG_DIR', self.log_dir),
+            ('CYLC_SUITE_WORK_DIR', self.work_dir),
+            ('CYLC_SUITE_SHARE_DIR', self.share_dir),
+            # BACK COMPAT: CYLC_SUITE_DEF_PATH
+            #   from: Cylc7
+            ('CYLC_SUITE_DEF_PATH', self.run_dir),
+        ]:
             os.environ[var] = val
 
     def process_config_env(self):

--- a/tests/functional/api-suite-info/00-get-graph-raw-1/flow.cylc
+++ b/tests/functional/api-suite-info/00-get-graph-raw-1/flow.cylc
@@ -4,7 +4,7 @@
 [runtime]
     [[t1]]
         script = """
-python3 ${CYLC_SUITE_DEF_PATH}/bin/ctb-get-graph-raw \
+python3 ${CYLC_SUITE_RUN_DIR}/bin/ctb-get-graph-raw \
   'start_point_string=1' 'stop_point_string=1' 'group_nodes=T' \
     >"${CYLC_SUITE_RUN_DIR}/ctb-get-graph-raw.out"
 """

--- a/tests/functional/api-suite-info/01-get-graph-raw-2/flow.cylc
+++ b/tests/functional/api-suite-info/01-get-graph-raw-2/flow.cylc
@@ -9,7 +9,7 @@
     [[t1]]
         script = """
 if [[ "${CYLC_TASK_CYCLE_POINT}" == '2020' ]]; then
-    python3 ${CYLC_SUITE_DEF_PATH}/bin/ctb-get-graph-raw \
+    python3 ${CYLC_SUITE_RUN_DIR}/bin/ctb-get-graph-raw \
         'start_point_string=2020' 'stop_point_string=None' 'group_nodes=T' \
         >"${CYLC_SUITE_RUN_DIR}/ctb-get-graph-raw.out"
 fi

--- a/tests/functional/api-suite-info/02-get-graph-raw-3/flow.cylc
+++ b/tests/functional/api-suite-info/02-get-graph-raw-3/flow.cylc
@@ -9,7 +9,7 @@
     [[t1]]
         script = """
 if [[ "${CYLC_TASK_CYCLE_POINT}" == '2020' ]]; then
-    python3 ${CYLC_SUITE_DEF_PATH}/bin/ctb-get-graph-raw \
+    python3 ${CYLC_SUITE_RUN_DIR}/bin/ctb-get-graph-raw \
         'start_point_string=2020' 'stop_point_string=2021' 'group_nodes=T' \
         >"${CYLC_SUITE_RUN_DIR}/ctb-get-graph-raw.out"
 fi

--- a/tests/functional/api-suite-info/03-get-graph-raw-4/flow.cylc
+++ b/tests/functional/api-suite-info/03-get-graph-raw-4/flow.cylc
@@ -9,7 +9,7 @@
     [[t1]]
         script = """
 if [[ "${CYLC_TASK_CYCLE_POINT}" == '20200202T0000Z' ]]; then
-    python3 ${CYLC_SUITE_DEF_PATH}/bin/ctb-get-graph-raw \
+    python3 ${CYLC_SUITE_RUN_DIR}/bin/ctb-get-graph-raw \
         'start_point_string=20200202T0000Z' \
         'stop_point_string=20200203T0000Z' \
         'group_nodes=T' \

--- a/tests/functional/broadcast/00-simple/flow.cylc
+++ b/tests/functional/broadcast/00-simple/flow.cylc
@@ -91,8 +91,8 @@ set +x
            # workaround for platforms affected by https://github.com/cylc/cylc-flow/issues/3585
            sed -i '/BASH_XTRACEFD/d' ${PREPLOG}.err
 
-           diff -u "${CYLC_SUITE_DEF_PATH}/expected-prep.out" ${PREPLOG}.out
-           diff -u "${CYLC_SUITE_DEF_PATH}/expected-prep.err" ${PREPLOG}.err
+           diff -u "${CYLC_SUITE_RUN_DIR}/expected-prep.out" ${PREPLOG}.out
+           diff -u "${CYLC_SUITE_RUN_DIR}/expected-prep.err" ${PREPLOG}.err
         """
     [[ENS]]
     [[ENS1]]

--- a/tests/functional/broadcast/10-file-1/flow.cylc
+++ b/tests/functional/broadcast/10-file-1/flow.cylc
@@ -6,7 +6,7 @@
 [runtime]
     [[t1]]
         script = """
-cylc broadcast -n 't2' -F "${CYLC_SUITE_DEF_PATH}/broadcast.cylc" "${CYLC_SUITE_NAME}"
+cylc broadcast -n 't2' -F "${CYLC_SUITE_RUN_DIR}/broadcast.cylc" "${CYLC_SUITE_NAME}"
 """
     [[t2]]
         script = false

--- a/tests/functional/broadcast/11-file-2/flow.cylc
+++ b/tests/functional/broadcast/11-file-2/flow.cylc
@@ -7,8 +7,8 @@
     [[t1]]
         script = """
 cylc broadcast -n 't2' \
-    -F "${CYLC_SUITE_DEF_PATH}/broadcast-1.cylc" \
-    -F "${CYLC_SUITE_DEF_PATH}/broadcast-2.cylc" \
+    -F "${CYLC_SUITE_RUN_DIR}/broadcast-1.cylc" \
+    -F "${CYLC_SUITE_RUN_DIR}/broadcast-2.cylc" \
     "${CYLC_SUITE_NAME}"
 """
     [[t2]]

--- a/tests/functional/broadcast/12-file-stdin/flow.cylc
+++ b/tests/functional/broadcast/12-file-stdin/flow.cylc
@@ -7,7 +7,7 @@
     [[t1]]
         script = """
 cylc broadcast -n 't2' -F - "${CYLC_SUITE_NAME}" \
-    <"${CYLC_SUITE_DEF_PATH}/broadcast.cylc"
+    <"${CYLC_SUITE_RUN_DIR}/broadcast.cylc"
 """
     [[t2]]
         script = false

--- a/tests/functional/broadcast/13-file-cancel/flow.cylc
+++ b/tests/functional/broadcast/13-file-cancel/flow.cylc
@@ -6,8 +6,8 @@
 [runtime]
     [[t1]]
         script = """
-cylc broadcast -n 't2' -F "${CYLC_SUITE_DEF_PATH}/broadcast-1.cylc" "${CYLC_SUITE_NAME}"
-cylc broadcast -n 't2' -G "${CYLC_SUITE_DEF_PATH}/broadcast-2.cylc" "${CYLC_SUITE_NAME}"
+cylc broadcast -n 't2' -F "${CYLC_SUITE_RUN_DIR}/broadcast-1.cylc" "${CYLC_SUITE_NAME}"
+cylc broadcast -n 't2' -G "${CYLC_SUITE_RUN_DIR}/broadcast-2.cylc" "${CYLC_SUITE_NAME}"
 """
     [[t2]]
         script = false

--- a/tests/functional/reload/02-content/flow.cylc
+++ b/tests/functional/reload/02-content/flow.cylc
@@ -11,7 +11,7 @@ fail, unless the first reloads the suite definition after modifying it."""
     [[reloader]]
         script = """
 # change the value of $FALSE to "true" in foo's environment:
-perl -pi -e 's/(FALSE = )false( # marker)/\1true\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(FALSE = )false( # marker)/\1true\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload $CYLC_SUITE_NAME
 """

--- a/tests/functional/reload/04-inheritance/flow.cylc
+++ b/tests/functional/reload/04-inheritance/flow.cylc
@@ -13,7 +13,7 @@
     [[reloader]]
         script = """
 # change the inheritance of inheritor:
-perl -pi -e 's/(inherit = )FAM1( # marker)/\1FAM2\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(inherit = )FAM1( # marker)/\1FAM2\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload $CYLC_SUITE_NAME
 sleep 5

--- a/tests/functional/reload/05-graphing-simple/flow.cylc
+++ b/tests/functional/reload/05-graphing-simple/flow.cylc
@@ -11,7 +11,7 @@
     [[reloader]]
         script = """
 # change the order of foo and bar in the graphing section:
-perl -pi -e 's/(R1 = reloader => inter => )bar => foo( # marker)/\1foo => bar\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(R1 = reloader => inter => )bar => foo( # marker)/\1foo => bar\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload "${CYLC_SUITE_NAME}"
 cylc__job__poll_grep_suite_log -F 'Reload completed'

--- a/tests/functional/reload/06-graphing-fam/flow.cylc
+++ b/tests/functional/reload/06-graphing-fam/flow.cylc
@@ -13,8 +13,8 @@
     [[reloader]]
         script = """
 # change the order of FOO and BAR in the graphing section:
-perl -pi -e 's/(reloader => inter => )BAR( # marker1)/\1FOO\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
-perl -pi -e 's/( )BAR:finish-all => FOO( # marker2)/\1FOO:finish-all => BAR\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(reloader => inter => )BAR( # marker1)/\1FOO\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
+perl -pi -e 's/( )BAR:finish-all => FOO( # marker2)/\1FOO:finish-all => BAR\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload "${CYLC_SUITE_NAME}"
 cylc__job__poll_grep_suite_log -F 'Reload completed'

--- a/tests/functional/reload/07-final-cycle/flow.cylc
+++ b/tests/functional/reload/07-final-cycle/flow.cylc
@@ -15,7 +15,7 @@
     [[reloader]]
         script = """
 # change the final cycle:
-perl -pi -e 's/(final cycle point = )20100102T00( # marker)/\1 20100101T12\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(final cycle point = )20100102T00( # marker)/\1 20100101T12\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload $CYLC_SUITE_NAME
 cylc__job__poll_grep_suite_log -F 'Reload completed'

--- a/tests/functional/reload/08-cycle/flow.cylc
+++ b/tests/functional/reload/08-cycle/flow.cylc
@@ -15,7 +15,7 @@
     [[reloader]]
         script = """
 # change the order of FOO and BAR in the graphing section:
-sed -i 's/T00,T12 = a\[-PT12H\]/T00,T06,T12,T18 = a[-PT6H]/' "${CYLC_SUITE_DEF_PATH}/flow.cylc"
+sed -i 's/T00,T12 = a\[-PT12H\]/T00,T06,T12,T18 = a[-PT6H]/' "${CYLC_SUITE_RUN_DIR}/flow.cylc"
 # reload
 cylc reload "${CYLC_SUITE_NAME}"
 cylc__job__poll_grep_suite_log -F 'Reload completed'

--- a/tests/functional/reload/12-remove-task/flow.cylc
+++ b/tests/functional/reload/12-remove-task/flow.cylc
@@ -8,7 +8,7 @@
 [runtime]
     [[reloader]]
         script = """
-            sed -i "s/remove_me =>//g" $CYLC_SUITE_DEF_PATH/flow.cylc
+            sed -i "s/remove_me =>//g" $CYLC_SUITE_RUN_DIR/flow.cylc
             cylc reload $CYLC_SUITE_NAME
             cylc__job__poll_grep_suite_log -F 'Reload completed'
         """

--- a/tests/functional/reload/13-add-task/flow.cylc
+++ b/tests/functional/reload/13-add-task/flow.cylc
@@ -12,7 +12,7 @@
         script = true
     [[reloader]]
         script = """
-sed -i "s/\(R1 = reloader => foo\)\s*$/\1 => add_me/" $CYLC_SUITE_DEF_PATH/flow.cylc
+sed -i "s/\(R1 = reloader => foo\)\s*$/\1 => add_me/" $CYLC_SUITE_RUN_DIR/flow.cylc
 cylc reload $CYLC_SUITE_NAME
 sleep 10
         """

--- a/tests/functional/reload/16-remove-add-alter-task/flow.cylc
+++ b/tests/functional/reload/16-remove-add-alter-task/flow.cylc
@@ -22,12 +22,12 @@ do_reload() {
         sleep 1
     done
 }
-sed -i "s/\(R1 = reloader => inter\).*/\1/" "${CYLC_SUITE_DEF_PATH}/flow.cylc"
+sed -i "s/\(R1 = reloader => inter\).*/\1/" "${CYLC_SUITE_RUN_DIR}/flow.cylc"
 do_reload 1
 sed -i "s/\(R1 = reloader => inter\)/\1 => remove_add_alter_me/" \
-    "${CYLC_SUITE_DEF_PATH}/flow.cylc"
+    "${CYLC_SUITE_RUN_DIR}/flow.cylc"
 do_reload 2
-cat >>"${CYLC_SUITE_DEF_PATH}/flow.cylc" <<'__RUNTIME__'
+cat >>"${CYLC_SUITE_RUN_DIR}/flow.cylc" <<'__RUNTIME__'
 [[remove_add_alter_me]]
     script = true
 __RUNTIME__

--- a/tests/functional/reload/18-broadcast-insert/flow.cylc
+++ b/tests/functional/reload/18-broadcast-insert/flow.cylc
@@ -6,7 +6,7 @@
     [[foo]]
         script="""
 cylc broadcast "${CYLC_SUITE_NAME}" -s '[environment]CYLC_TEST_VAR=1'
-cp -p "${CYLC_SUITE_DEF_PATH}/flow-2.cylc" "${CYLC_SUITE_DEF_PATH}/flow.cylc"
+cp -p "${CYLC_SUITE_RUN_DIR}/flow-2.cylc" "${CYLC_SUITE_RUN_DIR}/flow.cylc"
 cylc reload "${CYLC_SUITE_NAME}"
 sleep 5
 cylc trigger "${CYLC_SUITE_NAME}" 'bar.1'

--- a/tests/functional/reload/garbage/flow.cylc
+++ b/tests/functional/reload/garbage/flow.cylc
@@ -6,7 +6,7 @@
         script = """
 sleep 5
 # change the dependencies section name to garbage:
-perl -pi -e 's/(\[\[)graph(\]\] # marker)/\1garbage\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(\[\[)graph(\]\] # marker)/\1garbage\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 # reload
 cylc reload $CYLC_SUITE_NAME
 """

--- a/tests/functional/reload/runahead/flow.cylc
+++ b/tests/functional/reload/runahead/flow.cylc
@@ -19,6 +19,6 @@
     [[reloader]]
         script = """
 cylc__job__poll_grep_suite_log '\[foo.* (received)failed'
-perl -pi -e 's/(runahead limit = )P2( # marker)/\1 4\2/' $CYLC_SUITE_DEF_PATH/flow.cylc
+perl -pi -e 's/(runahead limit = )P2( # marker)/\1 4\2/' $CYLC_SUITE_RUN_DIR/flow.cylc
 cylc reload $CYLC_SUITE_NAME
 """


### PR DESCRIPTION
Deprecate `CYLC_SUITE_DEF_PATH`.

It is now an alias for `CYLC_SUITE_RUN_DIR`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/233
- [x] No dependency changes.
