### PR TITLE
cli: list installed plugins and entry points

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -123,3 +123,7 @@ cylc.main_loop =
     log_main_loop = cylc.flow.main_loop.log_main_loop
     log_memory = cylc.flow.main_loop.log_memory
     prune_flow_labels = cylc.flow.main_loop.prune_flow_labels
+# NOTE: all entry points should be listed here even if Cylc Flow does not
+# provide any implementations to make entry point scraping easier
+cylc.pre_configure =
+cylc.post_install =

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -70,12 +70,12 @@ cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
 
 # Check "cylc version --long" output is correct.
-cylc version --long > long1
+cylc version --long | head -n 1 > long1
 WHICH="$(command -v cylc)"
 PARENT1="$(dirname "${WHICH}")"
 PARENT2="$(dirname "${PARENT1}")"
 echo "$(cylc version) (${PARENT2})" > long2
-# the concise version of the above is a shellcheck quoting nightmare:
+# the concise version of the above is a bash quoting nightmare:
 # echo "$(cylc version) ($(dirname $(dirname $(which cylc))))" > long2
 cmp_ok long1 long2
 


### PR DESCRIPTION
List installed plugins in `cylc version --long`.

Addresses https://github.com/cylc/cylc-admin/issues/76.

```console
$ cylc version --long
8.0b0 (/Users/oliver/miniforge/envs/cylc8)

Plugins:
  cylc-rose       0.1.0   /Users/oliver/cylc-rose
  cylc-uiserver   0.3.0   /Users/oliver/cylc-uiserver

Entry Points:
  cylc.command:
    hub = cylc.uiserver.scripts.hub:main
    uiserver = cylc.uiserver.scripts.uis:main
  cylc.post_install:
    rose_opts = cylc.rose.entry_points:post_install
  cylc.pre_configure:
    rose = cylc.rose.entry_points:pre_configure
```

Plugins are detected providing that they provide at least one `cylc.*` entry point and are not contained within the `cylc.flow` distribution.

> **Context:**
> 
> We have now settled on the following points which we weren't clear on near the start of the project:
> * The cylc-meta version will match the cylc-flow version.
> * We should expect cylc-flow to be installed in all places where cylc-meta is installed.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (tricky but possible to test)
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
