### PR TITLE
setup: remove packaging dependency

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - python
   - pyuv >=1.4.0,<1.5.0
   - pyzmq >=18.1.0,<18.2.0
+  - setuptools >=49
   - urwid >=2.0,<2.1
   #- rx >=1.6,<2 # TODO: https://github.com/conda-forge/cylc-feedstock/pull/3#issuecomment-660716268
 # optional dependencies

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -10,13 +10,13 @@ dependencies:
   - cryptography
   - graphene >=2.1,<3
   - jinja2 ==2.11.0,<2.12
-  - metomi-isodatetime ==1!2.0.1
+  - metomi-isodatetime >=1!2.0.2, <1!2.1.0
   - protobuf >=3.15.0,<3.16.0
   - psutil >=5.6.0
   - pyasn1
   - python
   - pyuv >=1.4.0,<1.5.0
-  - pyzmq >=18.1.0,<18.2.0
+  - pyzmq >=19.0.0,<19.1.0
   - setuptools >=49
   - urwid >=2.0,<2.1
   #- rx >=1.6,<2 # TODO: https://github.com/conda-forge/cylc-feedstock/pull/3#issuecomment-660716268

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -19,6 +19,7 @@ import os
 from typing import List, Optional, Tuple
 
 from pkg_resources import parse_version
+from pkg_resources.extern.packaging.version import Version
 
 from cylc.flow import LOG
 from cylc.flow import __version__ as CYLC_VERSION
@@ -802,7 +803,7 @@ def get_version_hierarchy(version: str) -> List[str]:
         ['', '8', '8.0', '8.0.1', '8.0.1a2', '8.0.1a2.dev']
 
     """
-    smart_ver = parse_version(version)
+    smart_ver: Version = parse_version(version)
     base = [str(i) for i in smart_ver.release]
     hierarchy = ['']
     hierarchy += ['.'.join(base[:i]) for i in range(1, len(base) + 1)]

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -17,7 +17,8 @@
 
 import os
 from typing import List, Optional, Tuple
-import packaging.version
+
+from pkg_resources import parse_version
 
 from cylc.flow import LOG
 from cylc.flow import __version__ as CYLC_VERSION
@@ -801,7 +802,7 @@ def get_version_hierarchy(version: str) -> List[str]:
         ['', '8', '8.0', '8.0.1', '8.0.1a2', '8.0.1a2.dev']
 
     """
-    smart_ver = packaging.version.Version(version)
+    smart_ver = parse_version(version)
     base = [str(i) for i in smart_ver.release]
     hierarchy = ['']
     hierarchy += ['.'.join(base[:i]) for i in range(1, len(base) + 1)]

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -25,10 +25,10 @@ This module provides the logic to:
 
 import json
 import os
-import packaging.version
 from shutil import copy, rmtree
 from tempfile import mkstemp
 
+from pkg_resources import parse_version
 
 from cylc.flow import LOG
 from cylc.flow.broadcast_report import get_broadcast_change_iter
@@ -601,12 +601,10 @@ class WorkflowDatabaseManager:
             raise ServiceFileError(f"{incompat_msg}, or is corrupted")
         finally:
             pri_dao.close()
-        try:
-            last_run_ver = packaging.version.Version(last_run_ver)
-        except packaging.version.InvalidVersion:
-            last_run_ver = packaging.version.LegacyVersion(last_run_ver)
-        restart_incompat_ver = packaging.version.Version(
-            CylcWorkflowDAO.RESTART_INCOMPAT_VERSION)
+        last_run_ver = parse_version(last_run_ver)
+        restart_incompat_ver = parse_version(
+            CylcWorkflowDAO.RESTART_INCOMPAT_VERSION
+        )
         if last_run_ver <= restart_incompat_ver:
             raise ServiceFileError(
                 f"{incompat_msg} (workflow last run with Cylc {last_run_ver})")

--- a/setup.py
+++ b/setup.py
@@ -44,17 +44,17 @@ def find_version(*file_paths):
 install_requires = [
     'aiofiles==0.5.*',
     'ansimarkup>=1.0.0',
-    'colorama>=0.4,<=1',
     'click>=7.0',
+    'colorama>=0.4,<=1',
     'graphene>=2.1,<3',
     'jinja2==2.11.*',
     'metomi-isodatetime>=1!2.0.2, <1!2.1.0',
     'protobuf==3.15.*',
+    'psutil>=5.6.0',
     'pyuv==1.4.*',
     'pyzmq==19.0.*',
-    'psutil>=5.6.0',
-    'urwid==2.*',
-    'packaging'
+    'setuptools>=49',
+    'urwid==2.*'
 ]
 tests_require = [
     'async-timeout>=3.0.0',


### PR DESCRIPTION
We have acquired a dependency on packaging for version parsing. This can be done using setuptools which we are already using for this purpose:

https://github.com/cylc/cylc-flow/blob/8b25ae063cfd3273447ec2339efcb83417d721e2/cylc/flow/network/scan.py#L267

* Switched from `packaging` to `setuptools`.
* Added `setuptools` as a dependency, not sure if this is necessary but it's more explicit.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] https://github.com/conda-forge/cylc-flow-feedstock/pull/23