### PR TITLE
proposal: meta package

### DIFF
--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -127,6 +127,10 @@ jobs:
       - name: Install
         run: |
           pip install -e ."[all]"
+          # TEMP: remove any transient cylc-flow dependency
+          pip uninstall -y cylc-flow
+          # TEMP: reinstall to override the cylc executable
+          pip install -e . --no-deps
           mkdir "$HOME/cylc-run"
 
       - name: Configure Atrun

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -126,9 +126,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install git+https://github.com/metomi/rose@master
           pip install -e ."[all]"
-          # pip install --no-deps git+https://github.com/cylc/cylc-rose.git@master
           mkdir "$HOME/cylc-run"
 
       - name: Configure Atrun

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [metadata]
-name = cylc-flow
+name = cylc
 author = Hilary Oliver
 url=https://cylc.github.io/
 description = A workflow engine for cycling systems

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ tests_require = [
 ]
 
 extra_requires = {
+    # these are optional dependencies which unlock extra functionality
     'empy': [
         'EmPy==3.3.*'
     ],
@@ -90,6 +91,13 @@ extra_requires = {
     'main_loop-log_memory': [
         'pympler',
         'matplotlib'
+    ],
+    # these are other cylc components within the cylc meta-package
+    'uiserver': [
+        'cylc-uiserver==0.3.0'
+    ],
+    'rose': [
+        'cylc-rose==0.1.1'
     ]
 }
 extra_requires['all'] = (


### PR DESCRIPTION
sibling: https://github.com/cylc/cylc-doc/pull/234

Easier to code than to explain...

The Cylc "meta" package is intended to bundle together a set of Cylc components at specified versions to insure inter-compatibility, make installation easier and ensure consistency between site installations.

There are two approaches:

1. Create an empty package with the relevant Cylc packages as its dependencies.
  * We could create a PyPi package which provides an empty `cylc.meta` module.
  * We could then create a Conda forge package of that.
  * This may come under "package vendoring" which Forge doesn't like.
2. Make the other Cylc components sub-packages of the "root" Cylc package.

Over discussions over the past year we have concluded:

1. Cylc Flow will be present for all installations.
2. The "meta" package version should always be the same as the Flow version.

We have been heading towards (1), however, considering the above I'm not convinced this is a good idea.
The only real advantage of (1) is that the user is more free to mix and match Cylc components (within the bounds of version pinning), which is more con than pro.

This PR implements (2), simply making the other Cylc components optional dependencies of cylc-flow. See how it would work in the docs PR - https://github.com/cylc/cylc-doc/pull/234.

In Forge-land optional dependencies become package outputs (see Bruno's [working example](https://github.com/conda-forge/cylc-flow-feedstock/pull/11)).

This is nice and simple, easy to maintain and keeps the PyPi/Forge versions nicely coupled. One problem, the "cylc-flow" package is now the "cylc" meta-package.

**Proposal:**

* Go for option (2).
* Deploy this repo as `cylc` on PyPi and Forge rather than `cylc-flow`
  * If Cylc Flow is present in all installations then we don't need a special install tag for it.
  * The name "Flow" is now confused with the many other uses of "Flow".
  * The main component of Cylc "Flow" is called the "Scheduler".
  * We already have deployments in these namespaces).
* Wipe the old `cylc-flow` namespaces as best we can.
* Rename this repo back to `cylc` 🤦.

**TODO:**

* [ ] Convert `cylc-flow` references to `cylc`

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/234
- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
