### PR TITLE
Fix workflow source name determination.

### DIFF
--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -1114,7 +1114,7 @@ def install_workflow(
         source = Path(source).parent
     source = Path(expand_path(source))
     if not flow_name:
-        flow_name = Path.cwd().stem
+        flow_name = source.stem
     validate_flow_name(flow_name)
     if run_name in SuiteFiles.RESERVED_NAMES:
         raise WorkflowFilesError(


### PR DESCRIPTION
This is a small change with no associated Issue.

Bug:
```
$ pwd
~/beef  # (not in workflow source dir)
$ cylc install -C ~/cylc-src/demo
INSTALLED beef from ~/cylc-src/demo -> ~/cylc-run/beef/run1
```
Result should be:
```
INSTALLED demo from ~/cylc-src/demo -> ~/cylc-run/demo/run1
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (fix new functionality).
- [x] No documentation update required.
- [x] No dependency changes.
