### PR TITLE
Remove run dir housekeeping

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -134,10 +134,6 @@ with Conf('global.cylc', desc='''
                The default is set quite high to avoid killing important
                processes when the system is under load.
         ''')
-        Conf('run directory rolling archive length', VDR.V_INTEGER, -1,
-             desc='''
-            The number of old run directory trees to retain at start-up.
-        ''')
         Conf('auto restart delay', VDR.V_INTERVAL, desc='''
             Relates to Cylc's auto stop-restart mechanism (see
             :ref:`auto-stop-restart`).  When a host is set to automatically

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -115,22 +115,7 @@ def get_suite_test_log_name(suite):
 
 def make_suite_run_tree(suite):
     """Create all top-level cylc-run output dirs on the suite host."""
-    cfg = glbl_cfg().get()
-    # Roll archive
-    archlen = cfg['scheduler']['run directory rolling archive length']
     dir_ = get_workflow_run_dir(suite)
-    for i in range(archlen, -1, -1):  # archlen...0
-        if i > 0:
-            dpath = f'{dir_}.{i}'
-        else:
-            dpath = dir_
-        if os.path.exists(dpath):
-            if i >= archlen:
-                # remove oldest backup
-                rmtree(dpath)
-            else:
-                # roll others over
-                os.rename(dpath, f'{dir_}.{i + 1}')
     # Create
     for dir_ in (
         get_workflow_run_dir(suite),

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -184,8 +184,6 @@ class TestPathutil(TestCase):
 )
 def test_make_suite_run_tree(caplog, tmpdir, mock_glbl_cfg, subdir):
     glbl_conf_str = f'''
-        [scheduler]
-            run directory rolling archive length = 1
         [platforms]
             [[localhost]]
                 run directory = {tmpdir}
@@ -196,17 +194,11 @@ def test_make_suite_run_tree(caplog, tmpdir, mock_glbl_cfg, subdir):
     mock_glbl_cfg('cylc.flow.pathutil.glbl_cfg', glbl_conf_str)
 
     caplog.set_level(logging.DEBUG)
-    # running the logic three times to ensure that the rolling
-    # archive logic is covered.
-    for i in range(3):
-        make_suite_run_tree('my-workflow')
+
+    make_suite_run_tree('my-workflow')
 
     # Check that directories have been created
     assert (tmpdir / 'my-workflow' / subdir).isdir() is True
-    # ...and 1 rolling archive ...
-    assert (tmpdir / 'my-workflow.1' / subdir).isdir() is True
-    # ... but not 2.
-    assert (tmpdir / 'my-workflow.2' / subdir).isdir() is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small change, removes `run directory rolling archive length` from config and associated functionality. This has already been removed in Cylc 7, see https://github.com/cylc/cylc-flow/pull/3326.

These changes close https://github.com/cylc/cylc-flow/issues/4033

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (Removing code).
- [x] No change log entry required (why? This has been removed in Cylc7 and so users will not expect functionality in Cylc8).
- [x] No documentation update required - can not see any reference to this in docs, auto documentation will update.
- [x] No dependency changes.
