### PR TITLE
Improve error handling if exception occurs during shutdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,9 +58,14 @@ variable is still present in the job environment).
 [#4164](https://github.com/cylc/cylc-flow/pull/4164) -
 Replace the job "host" field with "platform" in the GraphQL schema.
 
-[#4169](https://github.com/cylc/cylc-flow/pull/4169)
+### Fixes
+
+[#4169](https://github.com/cylc/cylc-flow/pull/4169) -
 Fix a host ⇒ platform upgrade bug where host names were being popped from task
 configs causing subsequent tasks to run on localhost.
+
+[#4168](https://github.com/cylc/cylc-flow/pull/4168) - Fix bug where any
+errors during workflow shutdown were not logged.
 
 -------------------------------------------------------------------------------
 ## __cylc-8.0b0 (<span actions:bind='release-date'>Released 2021-03-29</span>)__

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -16,6 +16,9 @@
 """Exceptions for "expected" errors."""
 
 
+from typing import Iterable
+
+
 class CylcError(Exception):
     """Generic exception for Cylc errors.
 
@@ -103,11 +106,23 @@ class TaskRemoteMgmtError(CylcError):
     MSG_SELECT = "host selection failed"
     MSG_TIDY = "clean up did not complete"
 
+    def __init__(
+        self, message: str, platform_name: str, cmd: Iterable,
+        ret_code: int, out: str, err: str
+    ) -> None:
+        self.msg = message
+        self.platform_n = platform_name
+        self.ret_code = ret_code
+        self.out = out
+        self.err = err
+        self.cmd = cmd
+        if isinstance(cmd, list):
+            self.cmd = " ".join(cmd)
+
     def __str__(self):
-        msg, platform_n, cmd_str, ret_code, out, err = self.args
-        ret = (f"{platform_n}: {msg}:\n"
-               f"COMMAND FAILED ({ret_code}): {cmd_str}\n")
-        for label, item in ('STDOUT', out), ('STDERR', err):
+        ret = (f"{self.platform_n}: {self.msg}:\n"
+               f"COMMAND FAILED ({self.ret_code}): {self.cmd}\n")
+        for label, item in ('STDOUT', self.out), ('STDERR', self.err):
             if item:
                 for line in item.splitlines(True):  # keep newline chars
                     ret += f"COMMAND {label}: {line}"

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -538,7 +538,7 @@ def get_random_platform_for_install_target(
         # No platforms to choose from
         raise PlatformLookupError(
             f'Could not select platform for install target: {install_target}'
-        ) from None
+        )
 
 
 def get_localhost_install_target() -> str:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1618,9 +1618,13 @@ class Scheduler:
             await self._shutdown(reason)
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             # In case of exception in the shutdown method itself.
-            # Suppress the reason for the shutdown, which is logged separately
-            exc.__suppress_context__ = True
-            LOG.exception(exc)
+            LOG.error("Error during shutdown")
+            if isinstance(exc, CylcError):
+                LOG.error(f"{exc.__class__.__name__}: {exc}")
+            else:
+                # Suppress the reason for shutdown, which is logged separately
+                exc.__suppress_context__ = True
+                LOG.exception(exc)
             # Re-raise exception to be caught higher up (sets the exit code)
             raise exc from None
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -29,7 +29,7 @@ import sys
 from threading import Barrier
 from time import sleep, time
 import traceback
-from typing import Iterable, Optional, List
+from typing import Iterable, NoReturn, Optional, List
 from uuid import uuid4
 import zmq
 from zmq.auth.thread import ThreadAuthenticator
@@ -593,11 +593,8 @@ class Scheduler:
                 )
             )
 
-        except SchedulerError as exc:
-            await self.shutdown(exc)
-            raise exc from None
-
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
+            # Includes SchedulerError
             await self.handle_exception(exc)
 
         else:
@@ -1612,15 +1609,23 @@ class Scheduler:
 
         return process
 
-    async def shutdown(self, reason):
-        """Shutdown the suite.
+    async def shutdown(self, reason: Exception) -> None:
+        """Gracefully shut down the scheduler."""
+        # At the moment this method must be called from the main_loop.
+        # In the future it should shutdown the main_loop itself but
+        # we're not quite there yet.
+        try:
+            await self._shutdown(reason)
+        except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
+            # In case of exception in the shutdown method itself.
+            # Suppress the reason for the shutdown, which is logged separately
+            exc.__suppress_context__ = True
+            LOG.exception(exc)
+            # Re-raise exception to be caught higher up (sets the exit code)
+            raise exc from None
 
-        Warning:
-            At the moment this method must be called from the main_loop.
-            In the future it should shutdown the main_loop itself but
-            we're not quite there yet.
-
-        """
+    async def _shutdown(self, reason: Exception) -> None:
+        """Shutdown the suite."""
         if isinstance(reason, SchedulerStop):
             LOG.info(f'Suite shutting down - {reason.args[0]}')
             # Unset the "paused" status of the workflow if not auto-restarting
@@ -1869,17 +1874,13 @@ class Scheduler:
             self.options.stopcp = str(stoppoint)
             self.pool.set_stop_point(get_point(self.options.stopcp))
 
-    async def handle_exception(self, exc):
-        """Gracefully shut down the scheduler.
+    async def handle_exception(self, exc: Exception) -> NoReturn:
+        """Gracefully shut down the scheduler given a caught exception.
 
-        This re-raises the caught exception, to be caught higher up.
+        Re-raises the exception to be caught higher up (sets the exit code).
 
         Args:
             exc: The caught exception to be logged during the shutdown.
         """
-        try:
-            await self.shutdown(exc)
-        except Exception as exc2:
-            # In case of exceptions in the shutdown method itself
-            LOG.exception(exc2)
+        await self.shutdown(exc)
         raise exc from None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -155,13 +155,13 @@ def scheduler():
 
 
 @pytest.fixture(scope='module')
-def mod_run(run_dir):
+def mod_run(run_dir: Path):
     """Run a module-level flow."""
     return partial(_run_flow, run_dir, None)
 
 
 @pytest.fixture
-def run(run_dir, caplog):
+def run(run_dir: Path, caplog: pytest.LogCaptureFixture):
     """Run a function-level flow."""
     return partial(_run_flow, run_dir, caplog)
 

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -59,11 +59,10 @@ async def test_is_paused_after_crash(
     schd.suite_shutdown = ctrl_c
 
     # Run
-    with pytest.raises(asyncio.CancelledError) as exc:
+    with pytest.raises(asyncio.CancelledError):
         async with run(schd):
             assert not schd.is_restart
             assert schd.is_paused
-        assert "Mock keyboard interrupt" in str(exc.value)
     # Stopped
     assert ('is_paused', '1') in db_select(schd, 'suite_params')
     # Reset patched method

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -15,11 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import logging
 import pytest
-from typing import Any, TYPE_CHECKING
+from typing import Any, Callable
 
-if TYPE_CHECKING:
-    from cylc.flow.scheduler import Scheduler
+from cylc.flow.exceptions import CylcError
+from cylc.flow.scheduler import Scheduler
 
 Fixture = Any
 
@@ -56,7 +57,7 @@ async def test_is_paused_after_crash(
         raise asyncio.CancelledError("Mock keyboard interrupt")
     # Patch this part of the main loop
     _schd_suite_shutdown = schd.suite_shutdown
-    schd.suite_shutdown = ctrl_c
+    setattr(schd, 'suite_shutdown', ctrl_c)
 
     # Run
     with pytest.raises(asyncio.CancelledError):
@@ -66,7 +67,7 @@ async def test_is_paused_after_crash(
     # Stopped
     assert ('is_paused', '1') in db_select(schd, 'suite_params')
     # Reset patched method
-    schd.suite_shutdown = _schd_suite_shutdown
+    setattr(schd, 'suite_shutdown', _schd_suite_shutdown)
     # Restart
     schd = scheduler(reg, paused_start=None)
     async with run(schd):
@@ -75,9 +76,9 @@ async def test_is_paused_after_crash(
 
 
 @pytest.mark.asyncio
-async def test_resume_does_not_release_tasks(one: Fixture, run: Fixture):
+async def test_resume_does_not_release_tasks(one: Scheduler, run: Callable):
     """Test that resuming a workflow does not release any held tasks."""
-    schd: 'Scheduler' = one
+    schd: Scheduler = one
     async with run(schd):
         assert schd.is_paused
         itasks = schd.pool.get_all_tasks()
@@ -89,3 +90,27 @@ async def test_resume_does_not_release_tasks(one: Fixture, run: Fixture):
         schd.resume_workflow()
         assert not schd.is_paused
         assert itask.state.is_held
+
+
+@pytest.mark.asyncio
+async def test_exception_logging(one: Scheduler, run: Callable):
+    """Test that if a exception occurs during shutdown, it is
+    logged appropriately."""
+    schd = one
+
+    async def mock_shutdown(*a, **k):
+        raise CylcError("Error on shutdown")
+    setattr(schd, '_shutdown', mock_shutdown)
+
+    log: pytest.LogCaptureFixture
+    with pytest.raises(CylcError) as exc:
+        async with run(schd) as log:
+            pass
+    assert str(exc.value) == "Error on shutdown"
+    last_record = log.records[-1]
+    assert last_record.message == "Error on shutdown"
+    assert last_record.levelno == logging.ERROR
+    assert last_record.exc_text is not None
+    assert last_record.exc_text.startswith("Traceback (most recent call last)")
+    assert ("During handling of the above exception, "
+            "another exception occurred") not in last_record.exc_text

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -25,6 +25,9 @@ import asyncio
 from async_timeout import timeout
 from async_generator import asynccontextmanager
 import logging
+from pathlib import Path
+import pytest
+from typing import Optional
 from uuid import uuid1
 
 from cylc.flow import CYLC_LOG
@@ -61,7 +64,12 @@ def _make_scheduler(reg, **opts):
 
 
 @asynccontextmanager
-async def _run_flow(run_dir, caplog, scheduler, level=logging.INFO):
+async def _run_flow(
+    run_dir: Path,
+    caplog: Optional[pytest.LogCaptureFixture],
+    scheduler: Scheduler,
+    level: int = logging.INFO
+):
     """Start a scheduler."""
     contact = (run_dir / scheduler.suite / SuiteFiles.Service.DIRNAME /
                SuiteFiles.Service.CONTACT)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -14,17 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 from cylc.flow.exceptions import CylcError
 
 
-class TestExceptions(unittest.TestCase):
-
-    def test_cylc_error(self):
-        error = CylcError("abcd")
-        self.assertEqual("abcd", str(error))
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_cylc_error_str():
+    error = CylcError("abcd")
+    assert str(error) == "abcd"


### PR DESCRIPTION
These changes close #4147

Ensure that if an exception occurs during shutdown, it gets logged before exiting.

<del>This is difficult to test for other than manually; see the steps to reproduce in the issue</del> I've added an integration test, but probably worth manually running the example in #4147 too

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests included
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
