### PR TITLE
Platforms.fix popping host info2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,10 @@ ones in. -->
 Deprecate `CYLC_SUITE_DEF_PATH` with `CYLC_SUITE_RUN_DIR` (note the deprecated
 variable is still present in the job environment).
 
+[#4169](https://github.com/cylc/cylc-flow/pull/4169)
+Fix a host ⇒ platform upgrade bug where host names were being popped from task
+configs causing subsequent tasks to run on localhost.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0b0 (<span actions:bind='release-date'>Released 2021-03-29</span>)__
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -178,12 +178,17 @@ def platform_from_name(
         f"No matching platform \"{platform_name}\" found")
 
 
-def platform_from_job_info(platforms, job, remote):
+def platform_from_job_info(
+    platforms: Dict[str, Any],
+    job: Dict[str, Any],
+    remote: Dict[str, Any]
+) -> str:
     """
     Find out which job platform to use given a list of possible platforms
     and the task dictionary with cylc 7 definitions in it.
 
-    (Note: "batch system" and "job runner" mean the same thing)
+    (Note: "batch system" (Cylc 7) and "job runner" (Cylc 8)
+    mean the same thing)
 
           +------------+ Yes    +-----------------------+
     +-----> Tried all  +------->+ RAISE                 |
@@ -228,16 +233,12 @@ def platform_from_job_info(platforms, job, remote):
     +<---------------------------------+
 
     Args:
-        job (dict):
-            Suite config [runtime][TASK][job] section
-        remote (dict):
-            Suite config [runtime][TASK][remote] section
-        platforms (dict):
-            Dictionary containing platform definitions.
+        job: Suite config [runtime][TASK][job] section.
+        remote: Suite config [runtime][TASK][remote] section.
+        platforms: Dictionary containing platform definitions.
 
     Returns:
-        platform (str):
-            string representing a platform from the global config.
+        platform: string representing a platform from the global config.
 
     Raises:
         PlatformLookupError:
@@ -317,7 +318,11 @@ def platform_from_job_info(platforms, job, remote):
     raise PlatformLookupError('No platform found matching your task')
 
 
-def generic_items_match(platform_spec: Dict, job: Dict, remote: Dict) -> bool:
+def generic_items_match(
+    platform_spec: Dict[str, Any],
+    job: Dict[str, Any],
+    remote: Dict[str, Any]
+) -> bool:
     """Checks generic items from job/remote against a platform.
 
     We carry out extra checks on ``[remote]host`` and ``[job]batch system``

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -252,12 +252,16 @@ def platform_from_job_info(platforms, job, remote):
         ...         }
         ... }
         >>> job = {'batch system': 'slurm'}
-        >>> remote = {'host': 'sugar'}
+        >>> remote = {'host': 'localhost'}
         >>> platform_from_job_info(platforms, job, remote)
         'sugar'
         >>> remote = {}
         >>> platform_from_job_info(platforms, job, remote)
-        'localhost'
+        'sugar'
+        >>> remote ={'host': 'desktop92'}
+        >>> job = {}
+        >>> platform_from_job_info(platforms, job, remote)
+        'desktop92'
     """
 
     # These settings are removed from the incoming dictionaries for special
@@ -266,19 +270,17 @@ def platform_from_job_info(platforms, job, remote):
     #   - In the case of "batch system" we want to match the name of the
     #     system/job runner to a platform when host is localhost.
     if 'host' in remote.keys() and remote['host']:
-        task_host = remote.pop('host')
+        task_host = remote['host']
     else:
         task_host = 'localhost'
     if 'batch system' in job.keys() and job['batch system']:
-        task_job_runner = job.pop('batch system')
+        task_job_runner = job['batch system']
     else:
         # Necessary? Perhaps not if batch system default is 'background'
         task_job_runner = 'background'
-
     # Riffle through the platforms looking for a match to our task settings.
     # reverse dict order so that user config platforms added last are examined
     # before site config platforms.
-    output = None
     for platform_name, platform_spec in reversed(list(platforms.items())):
         # Handle all the items requiring an exact match.
         # All items other than batch system and host must be an exact match
@@ -290,7 +292,7 @@ def platform_from_job_info(platforms, job, remote):
                 not is_remote_host(task_host) and
                 task_job_runner == 'background'
         ):
-            output = 'localhost'
+            return 'localhost'
 
         elif (
             'hosts' in platform_spec.keys() and
@@ -299,30 +301,58 @@ def platform_from_job_info(platforms, job, remote):
         ):
             # If we have localhost with a non-background batch system we
             # use the batch system to give a sensible guess at the platform
-            output = platform_name
+            return platform_name
 
         elif (
-                re.fullmatch(platform_name, task_host) and
+            re.fullmatch(platform_name, task_host) and (
+                (
+                    task_job_runner == 'background' and
+                    'job runner' not in platform_spec
+                ) or
                 task_job_runner == platform_spec['job runner']
+            )
         ):
-            output = task_host
-
-    if task_host:
-        remote['host'] = task_host
-    if task_job_runner:
-        job['batch system'] = task_job_runner
-
-    if output is not None:
-        return output
+            return task_host
 
     raise PlatformLookupError('No platform found matching your task')
 
 
-def generic_items_match(platform_spec, job, remote):
+def generic_items_match(platform_spec: Dict, job: Dict, remote: Dict) -> bool:
     """Checks generic items from job/remote against a platform.
+
+    We carry out extra checks on ``[remote]host`` and ``[job]batch system``
+    but all other set config items must match between a platform and old
+    settings for that platform to match the legacy settings.
+
+    Args:
+        platform_spec: Dictionary of platform spec.
+        job: Dictionary of config spec section ``[runtime][TASK][job]``
+        remote: Dictionary of config spec section ``[runtime][TASK][remote]``
+
+    Returns:
+        Does this platform have generic items (not ``[job]batch system``
+        or ``[remote]host`` which are treated specially) that are the same.
     """
-    for task_section in [job, remote]:
+    # Don't check Host and batch system - they have their own logic.
+    if 'host' in remote:
+        remote_generic = {
+            k: v for k, v in remote.items()
+            if k != 'host' and v is not None
+        }
+    else:
+        remote_generic = remote
+    if 'batch system' in job:
+        job_generic = {
+            k: v for k, v in job.items()
+            if k != 'batch system' and v is not None
+        }
+    else:
+        job_generic = job
+
+    for task_section in [job_generic, remote_generic]:
+        # Get a set of items actually set in both platform and task_section.
         shared_items = set(task_section).intersection(set(platform_spec))
+        # If any set items do not match, we can't use this platform.
         if not all([
             platform_spec[item] == task_section[item]
             for item in shared_items

--- a/tests/functional/platforms/02-host-to-platform-upgrade.t
+++ b/tests/functional/platforms/02-host-to-platform-upgrade.t
@@ -21,7 +21,7 @@
 #   - Task with a host setting that should match the test platform
 export REQUIRE_PLATFORM='loc:remote'
 . "$(dirname "$0")/test_header"
-set_test_number 5
+set_test_number 6
 
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
@@ -50,6 +50,10 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
     -s CYLC_TEST_HOST="'$CYLC_TEST_HOST'" \
     -s CYLC_TEST_HOST_FQDN="'$(ssh "$CYLC_TEST_HOST" hostname -f)'" \
     "${SUITE_NAME}"
+
+grep "host=" "${SUITE_RUN_DIR}/log/suite/log" > hosts.log
+
+grep_ok "\[t2\.2021.*\].*host=${CYLC_TEST_HOST}" hosts.log
 
 purge
 exit

--- a/tests/functional/platforms/02-host-to-platform-upgrade.t
+++ b/tests/functional/platforms/02-host-to-platform-upgrade.t
@@ -53,7 +53,7 @@ suite_run_ok "${TEST_NAME_BASE}-run" \
 
 grep "host=" "${SUITE_RUN_DIR}/log/suite/log" > hosts.log
 
-grep_ok "\[t2\.2021.*\].*host=${CYLC_TEST_HOST}" hosts.log
+grep_ok "\[t2\.2.*\].*host=${CYLC_TEST_HOST}" hosts.log
 
 purge
 exit

--- a/tests/functional/platforms/02-host-to-platform-upgrade/flow.cylc
+++ b/tests/functional/platforms/02-host-to-platform-upgrade/flow.cylc
@@ -4,8 +4,10 @@
     UTC mode = True
 
 [scheduling]
+    initial cycle point = 2020
+    final cycle point = 2021
     [[graph]]
-        R1 = """
+        P1Y = """
             no_settings & t1 & t2 => fin
         """
 

--- a/tests/functional/platforms/02-host-to-platform-upgrade/flow.cylc
+++ b/tests/functional/platforms/02-host-to-platform-upgrade/flow.cylc
@@ -4,10 +4,11 @@
     UTC mode = True
 
 [scheduling]
-    initial cycle point = 2020
-    final cycle point = 2021
+    cycling mode = integer
+    initial cycle point = 1
+    final cycle point = 2
     [[graph]]
-        P1Y = """
+        P1 = """
             no_settings & t1 & t2 => fin
         """
 

--- a/tests/functional/platforms/02-host-to-platform-upgrade/reference.log
+++ b/tests/functional/platforms/02-host-to-platform-upgrade/reference.log
@@ -1,10 +1,10 @@
 Initial point: 1
 Final point: 1
-[fin.20200101T0000Z] -triggered off ['no_settings.20200101T0000Z', 't1.20200101T0000Z', 't2.20200101T0000Z']
-[fin.20210101T0000Z] -triggered off ['no_settings.20210101T0000Z', 't1.20210101T0000Z', 't2.20210101T0000Z']
-[no_settings.20200101T0000Z] -triggered off []
-[no_settings.20210101T0000Z] -triggered off []
-[t1.20200101T0000Z] -triggered off []
-[t1.20210101T0000Z] -triggered off []
-[t2.20200101T0000Z] -triggered off []
-[t2.20210101T0000Z] -triggered off []
+[fin.1] -triggered off ['no_settings.1', 't1.1', 't2.1']
+[fin.2] -triggered off ['no_settings.2', 't1.2', 't2.2']
+[no_settings.1] -triggered off []
+[no_settings.2] -triggered off []
+[t1.1] -triggered off []
+[t1.2] -triggered off []
+[t2.1] -triggered off []
+[t2.2] -triggered off []

--- a/tests/functional/platforms/02-host-to-platform-upgrade/reference.log
+++ b/tests/functional/platforms/02-host-to-platform-upgrade/reference.log
@@ -1,6 +1,10 @@
 Initial point: 1
 Final point: 1
-[no_settings.1] -triggered off []
-[t1.1] -triggered off []
-[t2.1] -triggered off []
-[fin.1] -triggered off ['no_settings.1', 't1.1', 't2.1']
+[fin.20200101T0000Z] -triggered off ['no_settings.20200101T0000Z', 't1.20200101T0000Z', 't2.20200101T0000Z']
+[fin.20210101T0000Z] -triggered off ['no_settings.20210101T0000Z', 't1.20210101T0000Z', 't2.20210101T0000Z']
+[no_settings.20200101T0000Z] -triggered off []
+[no_settings.20210101T0000Z] -triggered off []
+[t1.20200101T0000Z] -triggered off []
+[t1.20210101T0000Z] -triggered off []
+[t2.20200101T0000Z] -triggered off []
+[t2.20210101T0000Z] -triggered off []


### PR DESCRIPTION
Discovered a bug where host ⇒ plaform upgrade only worked on first cycle.
Cause: becuase Python passes refs rather than creating objects the upgrader
    function popped the required info for the first instance of a task.
Fix: have `platform_from_job_info` put popped information back when it's
    finished.

These changes close #4167 
**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
