### PR TITLE
GH Actions: Roll back to Ubuntu 18

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   bash-docker:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-18.04'
     strategy:
       matrix:
         bash-version:

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-18.04']
         python-version: ['3.7', '3.8', '3.9']
         include:
           - os: 'macos-latest'

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-18.04']
         python-version: ['3.7']
         test-base: ['tests/f']
         chunk: ['1/4', '2/4', '3/4', '4/4']


### PR DESCRIPTION
Tempory fix to try and stop hostname/DNS issues

Update: it didn't work