### PR TITLE
Bug fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,16 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.0b2 (<span actions:bind='release-date'>Released 2021-??-??</span>)__
+
+### Fixes
+
+[#4180](https://github.com/cylc/cylc-flow/pull/4180) - Fix bug where installing
+a workflow that uses the deprecated `suite.rc` filename would symlink `flow.cylc`
+to the `suite.rc` in the source dir instead of the run dir. Also fixes a couple
+of other, small bugs.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0b1 (<span actions:bind='release-date'>Released 2021-04-21</span>)__
 
 ### Enhancements
@@ -64,7 +74,7 @@ Replace the job "host" field with "platform" in the GraphQL schema.
 Fix a host ⇒ platform upgrade bug where host names were being popped from task
 configs causing subsequent tasks to run on localhost.
 
-[#4173](https://github.com/cylc/cylc-flow/pull/4173)
+[#4173](https://github.com/cylc/cylc-flow/pull/4173) -
 Fix the state totals shown in both the UI and TUI, including incorrect counts
 during workflow run and post pause.
 

--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -52,4 +52,4 @@ def environ_init():
 
 environ_init()
 
-__version__ = '8.0b1'
+__version__ = '8.0b2.dev'

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -18,6 +18,7 @@
 import re
 
 from itertools import product
+from typing import Any, Dict, Set
 
 from metomi.isodatetime.data import Calendar
 
@@ -1534,7 +1535,7 @@ def upg(cfg, descr):
                 )
 
 
-def upgrade_graph_section(cfg, descr):
+def upgrade_graph_section(cfg: Dict[str, Any], descr: str) -> None:
     """Upgrade Cylc 7 `[scheduling][dependencies][X]graph` format to
     `[scheduling][graph]X`."""
     # Parsec upgrader cannot do this type of move
@@ -1548,23 +1549,25 @@ def upgrade_graph_section(cfg, descr):
                     f'because {msg_new[:-1]} already exists.'
                 )
             else:
-                keys = set()
+                keys: Set[str] = set()
                 cfg['scheduling'].setdefault('graph', {})
                 cfg['scheduling']['graph'].update(
                     cfg['scheduling'].pop('dependencies')
                 )
-                graphdict = cfg['scheduling']['graph']
+                graphdict: Dict[str, Any] = cfg['scheduling']['graph']
                 for key, value in graphdict.copy().items():
                     if isinstance(value, dict) and 'graph' in value:
                         graphdict[key] = value['graph']
                         keys.add(key)
+                    elif key == 'graph' and isinstance(value, str):
+                        graphdict[key] = value
+                        keys.add(key)
                 if keys:
-                    keys = ', '.join(sorted(keys))
                     LOG.warning(
                         'deprecated graph items were automatically upgraded '
                         f'in "{descr}":\n'
                         f' * (8.0.0) {msg_old} -> {msg_new} - for X in:\n'
-                        f'       {keys}'
+                        f"       {', '.join(sorted(keys))}"
                     )
     except KeyError:
         pass

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -42,9 +42,7 @@ from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import SuiteConfig
 from cylc.flow.cycling.loader import get_point
 from cylc.flow.data_store_mgr import DataStoreMgr, parse_job_item
-from cylc.flow.exceptions import (
-    CyclingError, CylcError, SuiteConfigError, PlatformLookupError
-)
+from cylc.flow.exceptions import CyclingError, CylcError
 import cylc.flow.flags
 from cylc.flow.host_select import select_suite_host
 from cylc.flow.hostuserutil import (
@@ -1636,10 +1634,9 @@ class Scheduler:
                 self.resume_workflow(quiet=True)
         elif isinstance(reason, SchedulerError):
             LOG.error(f'Suite shutting down - {reason}')
-        elif isinstance(reason, SuiteConfigError):
-            LOG.error(f'{SuiteConfigError.__name__}: {reason}')
-        elif isinstance(reason, PlatformLookupError):
-            LOG.error(f'{PlatformLookupError.__name__}: {reason}')
+        elif isinstance(reason, CylcError):
+            LOG.error(
+                f"Suite shutting down - {reason.__class__.__name__}: {reason}")
         else:
             LOG.exception(reason)
             if str(reason):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -616,7 +616,6 @@ class Scheduler:
 
         """
         try:
-            await self.install()
             await self.initialise()
             await self.configure()
             await self.start_servers()

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1616,11 +1616,13 @@ class Scheduler:
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             # In case of exception in the shutdown method itself.
             LOG.error("Error during shutdown")
+            # Suppress the reason for shutdown, which is logged separately
+            exc.__suppress_context__ = True
             if isinstance(exc, CylcError):
                 LOG.error(f"{exc.__class__.__name__}: {exc}")
+                if cylc.flow.flags.debug:
+                    LOG.exception(exc)
             else:
-                # Suppress the reason for shutdown, which is logged separately
-                exc.__suppress_context__ = True
                 LOG.exception(exc)
             # Re-raise exception to be caught higher up (sets the exit code)
             raise exc from None
@@ -1637,6 +1639,8 @@ class Scheduler:
         elif isinstance(reason, CylcError):
             LOG.error(
                 f"Suite shutting down - {reason.__class__.__name__}: {reason}")
+            if cylc.flow.flags.debug:
+                LOG.exception(reason)
         else:
             LOG.exception(reason)
             if str(reason):

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -291,7 +291,7 @@ def scheduler_cli(parser, options, reg):
     #       then shutdown async generators and closes the event loop
     scheduler = Scheduler(reg, options)
     asyncio.run(
-        _setup(parser, options, reg, scheduler)
+        _setup(scheduler)
     )
 
     # daemonize if requested
@@ -306,7 +306,7 @@ def scheduler_cli(parser, options, reg):
 
     # run the workflow
     ret = asyncio.run(
-        _run(parser, options, reg, scheduler)
+        _run(scheduler)
     )
 
     # exit
@@ -331,7 +331,7 @@ def _distribute(host):
         sys.exit(0)
 
 
-async def _setup(parser, options, reg, scheduler):
+async def _setup(scheduler: Scheduler) -> None:
     """Initialise the scheduler."""
     try:
         await scheduler.install()
@@ -339,7 +339,7 @@ async def _setup(parser, options, reg, scheduler):
         sys.exit(exc)
 
 
-async def _run(parser, options, reg, scheduler):
+async def _run(scheduler: Scheduler) -> int:
     """Run the workflow and handle exceptions."""
     # run cylc run
     ret = 0

--- a/cylc/flow/suite_db_mgr.py
+++ b/cylc/flow/suite_db_mgr.py
@@ -559,7 +559,7 @@ class SuiteDatabaseManager:
                 f"{self.pri_dao.db_file_name}")
             self.pub_dao.n_tries = 0
 
-    def restart_check(self):
+    def restart_check(self) -> bool:
         """Check & vacuum the runtime DB for a restart.
 
         Raises SuiteServiceFileError if DB is incompatible.
@@ -571,8 +571,7 @@ class SuiteDatabaseManager:
         except FileNotFoundError:
             return False
         except SuiteServiceFileError as exc:
-            raise SuiteServiceFileError(
-                f"Cannot restart - {exc}")
+            raise SuiteServiceFileError(f"Cannot restart - {exc}")
         pri_dao = self.get_pri_dao()
         try:
             pri_dao.vacuum()
@@ -582,7 +581,7 @@ class SuiteDatabaseManager:
             pri_dao.close()
         return True
 
-    def check_suite_db_compatibility(self):
+    def check_suite_db_compatibility(self) -> None:
         """Raises SuiteServiceFileError if the existing suite database is
         incompatible with the current version of Cylc."""
         if not os.path.isfile(self.pri_path):

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -503,7 +503,7 @@ def parse_suite_arg(options, arg):
             if os.path.isdir(arg):
                 path = os.path.join(arg, SuiteFiles.FLOW_FILE)
                 name = os.path.basename(arg)
-                check_flow_file(arg)
+                check_flow_file(arg, logger=None)
             else:
                 path = arg
                 name = os.path.basename(os.path.dirname(arg))
@@ -545,7 +545,7 @@ def register(
         source = os.getcwd()
     # flow.cylc must exist so we can detect accidentally reversed args.
     source = os.path.abspath(source)
-    check_flow_file(source, symlink_suiterc=True)
+    check_flow_file(source, symlink_suiterc=True, logger=None)
     symlinks_created = make_localhost_symlinks(
         get_workflow_run_dir(flow_name), flow_name)
     if bool(symlinks_created):
@@ -1244,7 +1244,7 @@ def detect_flow_exists(run_path_base, numbered):
 def check_flow_file(
     path: Union[Path, str],
     symlink_suiterc: bool = False,
-    logger: 'Logger' = LOG
+    logger: Optional['Logger'] = LOG
 ) -> Path:
     """Raises WorkflowFilesError if no flow file in path sent.
 
@@ -1258,22 +1258,29 @@ def check_flow_file(
     Returns the path of the flow file if present.
     """
     flow_file_path = Path(expand_path(path), SuiteFiles.FLOW_FILE)
-    suite_rc_path = Path(path, SuiteFiles.SUITE_RC)
+    suite_rc_path = Path(expand_path(path), SuiteFiles.SUITE_RC)
+    depr_msg = (
+        f'The filename "{SuiteFiles.SUITE_RC}" is deprecated '
+        f'in favour of "{SuiteFiles.FLOW_FILE}"')
     if flow_file_path.is_file():
-        if (not flow_file_path.is_symlink() or
-                flow_file_path.resolve() == suite_rc_path):
-            # Normal file, or a symlink that points to *existing* suite.rc
+        if not flow_file_path.is_symlink():
+            return flow_file_path
+        if flow_file_path.resolve() == suite_rc_path.resolve():
+            # A symlink that points to *existing* suite.rc
+            if logger:
+                logger.warning(depr_msg)
             return flow_file_path
     if suite_rc_path.is_file():
         if not symlink_suiterc:
+            if logger:
+                logger.warning(depr_msg)
             return suite_rc_path
         if flow_file_path.is_symlink():
             # Symlink broken or points elsewhere - replace
             flow_file_path.unlink()
         flow_file_path.symlink_to(suite_rc_path)
-        logger.warning(
-            f'The filename "{SuiteFiles.SUITE_RC}" is deprecated in '
-            f'favour of "{SuiteFiles.FLOW_FILE}". Symlink created.')
+        if logger:
+            logger.warning(f'{depr_msg}. Symlink created.')
         return flow_file_path
     raise WorkflowFilesError(
         f"no {SuiteFiles.FLOW_FILE} or {SuiteFiles.SUITE_RC} in {path}")
@@ -1309,7 +1316,7 @@ def validate_source_dir(source, flow_name):
         raise WorkflowFilesError(
             f'{flow_name} installation failed. Source directory should not be '
             f'in {cylc_run_dir}')
-    check_flow_file(source)
+    check_flow_file(source, logger=None)
 
 
 def unlink_runN(path: Union[Path, str]) -> bool:
@@ -1345,7 +1352,7 @@ def search_install_source_dirs(flow_name: str) -> Path:
             "does not contain any paths")
     for path in search_path:
         try:
-            flow_file = check_flow_file(Path(path, flow_name))
+            flow_file = check_flow_file(Path(path, flow_name), logger=None)
             return flow_file.parent
         except WorkflowFilesError:
             continue

--- a/cylc/flow/suite_files.py
+++ b/cylc/flow/suite_files.py
@@ -1142,9 +1142,8 @@ def install_workflow(
             INSTALL_LOG.info(f"Symlink created from {src} to {dst}")
     try:
         rundir.mkdir(exist_ok=True)
-    except OSError as e:
-        if e.strerror == "File exists":
-            raise WorkflowFilesError(f"Run directory already exists : {e}")
+    except FileExistsError:
+        raise WorkflowFilesError("Run directory already exists")
     if relink:
         link_runN(rundir)
     create_workflow_srv_dir(rundir)
@@ -1153,7 +1152,7 @@ def install_workflow(
     stdout, stderr = proc.communicate()
     INSTALL_LOG.info(f"Copying files from {source} to {rundir}")
     INSTALL_LOG.info(f"{stdout}")
-    if not proc.returncode == 0:
+    if proc.returncode != 0:
         INSTALL_LOG.warning(
             f"An error occurred when copying files from {source} to {rundir}")
         INSTALL_LOG.warning(f" Error: {stderr}")

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -66,7 +66,8 @@ purge_rnd_suite
 
 # -----------------------------------------------------------------------------
 # Test cylc install succeeds if suite.rc file in source dir
-TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
+# See also tests/functional/deprecations/03-suiterc.t
+TEST_NAME="${TEST_NAME_BASE}-suite.rc"
 make_rnd_suite
 rm -f "${RND_SUITE_SOURCE}/flow.cylc"
 touch "${RND_SUITE_SOURCE}/suite.rc"
@@ -80,11 +81,10 @@ exists_fail "flow.cylc"
 # test symlink correctly made in run dir
 pushd "${RND_SUITE_RUNDIR}/run1" || exit 1
 exists_ok "flow.cylc"
-if [[ $(readlink "${RND_SUITE_RUNDIR}/run1/flow.cylc") == "${RND_SUITE_RUNDIR}/run1/suite.rc" ]] ; then
-    ok "symlink.suite.rc"
-else
-    fail "symlink.suite.rc"
-fi
+
+TEST_NAME="${TEST_NAME_BASE}-suite.rc-flow.cylc-readlink"
+readlink "flow.cylc" > "${TEST_NAME}.out"
+cmp_ok "${TEST_NAME}.out" <<< "${RND_SUITE_RUNDIR}/run1/suite.rc"
 
 INSTALL_LOG="$(find "${RND_SUITE_RUNDIR}/run1/log/install" -type f -name '*.log')"
 grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${INSTALL_LOG}"

--- a/tests/functional/deprecations/01-cylc8-basic/flow.cylc
+++ b/tests/functional/deprecations/01-cylc8-basic/flow.cylc
@@ -34,8 +34,9 @@
 
     initial cycle point = 20150808T00
     final cycle point = 20150808T00
-    [[graph]]
-        P1D = foo => cat & dog
+    [[dependencies]]
+        [[[P1D]]]
+            graph = foo => cat & dog
 
 [runtime]
     [[foo, cat, dog]]

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -30,6 +30,9 @@ WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution time limit] -> [run
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission polling intervals] -> [runtime][foo, cat, dog][submission polling intervals] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission retry delays] -> [runtime][foo, cat, dog][submission retry delays] - value unchanged
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged
+WARNING - deprecated graph items were automatically upgraded in "suite definition":
+	 * (8.0.0) [scheduling][dependencies][X]graph -> [scheduling][graph]X - for X in:
+	       P1D
 WARNING - * (8.0.0) '[runtime][foo, cat, dog]execution polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]execution polling intervals' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.
 WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission polling intervals' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.
 WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission retry delays' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission retry delays' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.

--- a/tests/functional/deprecations/03-suiterc.t
+++ b/tests/functional/deprecations/03-suiterc.t
@@ -18,7 +18,7 @@
 # Test backwards compatibility for suite.rc files
 
 . "$(dirname "$0")/test_header"
-set_test_number 7
+set_test_number 6
 
 init_suiterc() {
     local TEST_NAME="$1"
@@ -38,34 +38,27 @@ init_suiterc "${TEST_NAME_BASE}" <<'__FLOW__'
         R1 = foo => bar
 __FLOW__
 
+MSG='The filename "suite.rc" is deprecated in favour of "flow.cylc". Symlink created.'
+
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate .
-grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${TEST_NAME_BASE}-validate.stderr"
-TEST_NAME="${TEST_NAME_BASE}-install"
+grep_ok "$MSG" "${TEST_NAME_BASE}-validate.stderr"
+
+# Test install upgrades suite.rc and logs deprecation notification, even after validation
+# See also tests/functional/cylc-install/00-simple.t
+TEST_NAME="${TEST_NAME_BASE}-install-after-validate"
 run_ok "${TEST_NAME}" cylc install --flow-name="${SUITE_NAME}" --no-run-name
+
 cd "${SUITE_RUN_DIR}" || exit 1
 exists_ok "flow.cylc"
-cd "${TEST_DIR}" || exit 1
-rm -rf "${TEST_DIR:?}/${SUITE_NAME}/"
-purge
 
-# Test install upgrades suite.rc and logs deprecation notification
+TEST_NAME="flow.cylc-readlink"
+readlink "flow.cylc" > "${TEST_NAME}.out"
+cmp_ok "${TEST_NAME}.out" <<< "${SUITE_RUN_DIR}/suite.rc"
 
-init_suiterc "${TEST_NAME_BASE}" <<'__FLOW__'
-[scheduler]
-    allow implicit tasks = True
-[scheduling]
-    [[graph]]
-        R1 = foo => bar
-__FLOW__
-
-
-TEST_NAME="${TEST_NAME_BASE}-install"
-run_ok "${TEST_NAME}" cylc install --flow-name="${SUITE_NAME}" --no-run-name
-cd "${SUITE_RUN_DIR}" || exit 1
-exists_ok "flow.cylc"
 INSTALL_LOG="$(find "${SUITE_RUN_DIR}/log/install" -type f -name '*.log')"
-grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${INSTALL_LOG}"
+grep_ok "$MSG" "${INSTALL_LOG}"
+
 cd "${TEST_DIR}" || exit 1
 rm -rf "${TEST_DIR:?}/${SUITE_NAME}/"
 purge

--- a/tests/functional/deprecations/04-simple-graph.t
+++ b/tests/functional/deprecations/04-simple-graph.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test deprecation notice for Cylc 7 simple graph (no recurrence section)
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+init_suite "${TEST_NAME_BASE}" << __FLOW__
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    [[dependencies]]
+        graph = foo
+__FLOW__
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "$TEST_NAME" cylc validate -v "$SUITE_NAME"
+
+TEST_NAME="${TEST_NAME_BASE}-cmp"
+cylc validate "$SUITE_NAME" 2> 'val.out'
+cmp_ok val.out <<__END__
+WARNING - deprecated graph items were automatically upgraded in "suite definition":
+	 * (8.0.0) [scheduling][dependencies][X]graph -> [scheduling][graph]X - for X in:
+	       graph
+__END__
+
+purge

--- a/tests/functional/events/37-suite-event-bad-custom-template.t
+++ b/tests/functional/events/37-suite-event-bad-custom-template.t
@@ -35,8 +35,8 @@ suite_run_fail "${TEST_NAME_BASE}-run2" \
     cylc play --reference-test --debug --no-detach \
         -s 'ABORT="True"' "${SUITE_NAME}"
 
-run_ok "${TEST_NAME_BASE}-run2-err" \
-    grep -q -F "Suite shutting down - ${MESSAGE}" \
+run_ok "${TEST_NAME_BASE}-run2-grep" \
+    grep -q -F "Suite shutting down - SuiteEventError: ${MESSAGE}" \
     "${TEST_NAME_BASE}-run2.stderr"
 
 purge

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -77,6 +77,7 @@ async def _run_flow(
         caplog.set_level(level, CYLC_LOG)
     task = None
     started = False
+    await scheduler.install()
     try:
         task = asyncio.get_event_loop().create_task(scheduler.run())
         started = await _poll_file(contact)

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -251,7 +251,7 @@ def test_write_prelude(monkeypatch, fixture_get_platform):
     """Test the prelude section of job script file is correctly
     written.
     """
-    cylc.flow.flags.debug = True
+    monkeypatch.setattr('cylc.flow.flags.debug', True)
     expected = ('\nCYLC_FAIL_SIGNALS=\'EXIT ERR TERM XCPU\'\n'
                 'CYLC_VACATION_SIGNALS=\'USR1\'\nexport PATH=moo/baa:$PATH'
                 '\nexport CYLC_DEBUG=true'
@@ -285,8 +285,8 @@ def test_write_suite_environment(fixture_get_platform, monkeypatch):
         "get_remote_suite_work_dir",
         lambda a, b: "work/dir"
     )
-    cylc.flow.flags.debug = True
-    cylc.flow.flags.verbose = True
+    monkeypatch.setattr('cylc.flow.flags.debug', True)
+    monkeypatch.setattr('cylc.flow.flags.verbose', True)
     suite_env = {'CYLC_UTC': 'True',
                  'CYLC_CYCLING_MODE': 'integer'}
     job_file_writer = JobFileWriter()
@@ -323,8 +323,8 @@ def test_write_suite_environment_no_remote_suite_d(
         "get_remote_suite_work_dir",
         lambda a, b: "work/dir"
     )
-    cylc.flow.flags.debug = True
-    cylc.flow.flags.verbose = True
+    monkeypatch.setattr('cylc.flow.flags.debug', True)
+    monkeypatch.setattr('cylc.flow.flags.verbose', True)
     suite_env = {'CYLC_UTC': 'True',
                  'CYLC_CYCLING_MODE': 'integer'}
     job_file_writer = JobFileWriter()

--- a/tests/unit/test_suite_files.py
+++ b/tests/unit/test_suite_files.py
@@ -29,6 +29,7 @@ from cylc.flow.exceptions import (
 from cylc.flow.scripts.clean import get_option_parser as _clean_GOP
 from cylc.flow.suite_files import (
     SuiteFiles,
+    check_flow_file,
     check_nested_run_dirs,
     get_workflow_source_dir,
     reinstall_workflow, search_install_source_dirs)
@@ -691,3 +692,103 @@ def test_search_install_source_dirs_empty(mock_glbl_cfg: Callable):
     assert str(exc.value) == (
         "Cannot find workflow as 'global.cylc[install]source dirs' "
         "does not contain any paths")
+
+
+@pytest.mark.parametrize(
+    'flow_file_exists, suiterc_exists, expected_file',
+    [(True, False, SuiteFiles.FLOW_FILE),
+     (True, True, SuiteFiles.FLOW_FILE),
+     (False, True, SuiteFiles.SUITE_RC)]
+)
+def test_check_flow_file(
+    flow_file_exists: bool, suiterc_exists: bool, expected_file: str,
+    tmp_path: Path
+) -> None:
+    """Test check_flow_file() returns the expected path.
+
+    Params:
+        flow_file_exists: Whether a flow.cylc file is found in the dir.
+        suiterc_exists: Whether a suite.rc file is found in the dir.
+        expected_file: Which file's path should get returned.
+    """
+    if flow_file_exists:
+        tmp_path.joinpath(SuiteFiles.FLOW_FILE).touch()
+    if suiterc_exists:
+        tmp_path.joinpath(SuiteFiles.SUITE_RC).touch()
+
+    assert check_flow_file(tmp_path) == tmp_path.joinpath(expected_file)
+
+
+@pytest.mark.parametrize(
+    'flow_file_target, suiterc_exists, err, expected_file',
+    [
+        pytest.param(
+            SuiteFiles.SUITE_RC, True, None, SuiteFiles.FLOW_FILE,
+            id="flow.cylc symlinked to suite.rc"
+        ),
+        pytest.param(
+            SuiteFiles.SUITE_RC, False, WorkflowFilesError, None,
+            id="flow.cylc symlinked to non-existent suite.rc"
+        ),
+        pytest.param(
+            'other-path', True, None, SuiteFiles.SUITE_RC,
+            id="flow.cylc symlinked to other file, suite.rc exists"
+        ),
+        pytest.param(
+            'other-path', False, WorkflowFilesError, None,
+            id="flow.cylc symlinked to other file, no suite.rc"
+        ),
+        pytest.param(
+            None, True, None, SuiteFiles.SUITE_RC,
+            id="no flow.cylc, suite.rc exists"
+        ),
+        pytest.param(
+            None, False, WorkflowFilesError, None,
+            id="no flow.cylc, no suite.rc"
+        ),
+    ]
+)
+@pytest.mark.parametrize(
+    'symlink_suiterc_arg',
+    [pytest.param(False, id="symlink_suiterc=False "),
+     pytest.param(True, id="symlink_suiterc=True ")]
+)
+def test_check_flow_file_symlink(
+    flow_file_target: Optional[str],
+    suiterc_exists: bool,
+    err: Optional[Type[Exception]],
+    expected_file: Optional[str],
+    symlink_suiterc_arg: bool,
+    tmp_path: Path
+) -> None:
+    """Test check_flow_file() when flow.cylc is a symlink.
+
+    Params:
+        flow_file_target: Relative path of the flow.cylc symlink's target, or
+            None if the symlink doesn't exist.
+        suiterc_exists: Whether there is a suite.rc file in the dir.
+        err: Type of exception if expected to get raised.
+        expected_file: Which file's path should get returned, when
+            symlink_suiterc_arg is FALSE (otherwise it will always be
+            flow.cylc, assuming no exception occurred).
+        symlink_suiterc_arg: Value of the symlink_suiterc arg passed to
+            check_flow_file().
+    """
+    flow_file = tmp_path.joinpath(SuiteFiles.FLOW_FILE)
+    suiterc = tmp_path.joinpath(SuiteFiles.SUITE_RC)
+    tmp_path.joinpath('other-path').touch()
+    if suiterc_exists:
+        suiterc.touch()
+    if flow_file_target:
+        flow_file.symlink_to(flow_file_target)
+
+    if err:
+        with pytest.raises(err):
+            check_flow_file(tmp_path, symlink_suiterc_arg)
+    else:
+        assert expected_file is not None  # otherwise test is wrong
+        result = check_flow_file(tmp_path, symlink_suiterc_arg)
+        if symlink_suiterc_arg is True:
+            assert flow_file.samefile(suiterc)
+            expected_file = SuiteFiles.FLOW_FILE
+        assert result == tmp_path.joinpath(expected_file)


### PR DESCRIPTION
This is a small change with no associated Issue.

- Fix bug where installing a `suite.rc` workflow that had been `cylc validate`d in its source dir would result in a `flow.cylc` symlink being copied over still pointing to the source dir `suite.rc` instead of the one in the run dir
- Fix bug where the deprecated `flow.cylc` config item

  ```ini
  [scheduling]
      [[dependencies]]
          graph = foo
  ```
  (skipped `[[[<recurrence>]]]` section) did not log a warning when upgraded to

  ```ini
  [scheduling]
      [[graph]]
          graph = foo  # (same as R1 = foo)
  ```
- Do not show traceback when any `CylcError` gets raised during running of the workflow, only show traceback for generic uncaught exceptions (unless using `--debug`, in which case show traceback for all exceptions)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
