### PR TITLE
tests/f: fix remote/05

### DIFF
--- a/tests/functional/remote/05-remote-init.t
+++ b/tests/functional/remote/05-remote-init.t
@@ -18,7 +18,7 @@
 # Test remote initialisation - when remote init fails for an install target,
 # check other platforms with same install target can be initialised.
 
-export REQUIRE_PLATFORM='loc:remote fs:indep'
+export REQUIRE_PLATFORM='loc:remote fs:indep comms:tcp'
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
 set_test_number 5


### PR DESCRIPTION
test incompatible with non-default comms as it defines its own platforms.