### PR TITLE
Remove center deprecated tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<center>
 <div
   align="center"
 >
@@ -14,7 +13,6 @@
 [![Documentation](https://img.shields.io/website?label=documentation&up_message=live&url=https%3A%2F%2Fcylc.github.io%2Fcylc-doc%2Fstable%2Fhtml%2Findex.html)](https://cylc.github.io/cylc-doc/stable/html/index.html)
 
 </div>
-</center>
 
 Cylc (pronounced silk) is a general purpose workflow engine
 that specialises in cycling workflows and has strong scaling characteristics.


### PR DESCRIPTION
This is a small change with no associated Issue.

![image](https://user-images.githubusercontent.com/304786/115639638-37eb6780-a369-11eb-9d77-7b44636b559c.png)

In GitHub I think the image will be still center-aligned. I tested on PyCharm with its Markdown rendered, and the result was the same with/without the `center` tag.

![image](https://user-images.githubusercontent.com/304786/115639535-f2c73580-a368-11eb-84db-70dacab33fe0.png)

`<center>` is an HTML deprecated tag, so it could be the reason why it's rendered as plain-text in PYPI. The `div` tag appears to be accepter, although the `align="center"` is ignored. So on PYPI I think the image should be displayed correctly in the next release, but not center-aligned (which is not a big issue I think?).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
