### PR TITLE
Cylc install update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,11 @@ version control information on installation of a workflow.
 
 ### Fixes
 
+[#4193](https://github.com/cylc/cylc-flow/pull/4193) - Standard `cylc install`
+now correctly installs from directories with a `.` in the name. Symlink dirs
+now correctly expands environment variables on the remote. Fixes minor cosmetic
+bugs.
+
 [#4199](https://github.com/cylc/cylc-flow/pull/4199) -
 `cylc validate` and `cylc run` now check task/family names in the `[runtime]`
 section for validity.
@@ -77,7 +82,6 @@ section for validity.
 a workflow that uses the deprecated `suite.rc` filename would symlink `flow.cylc`
 to the `suite.rc` in the source dir instead of the run dir. Also fixes a couple
 of other, small bugs.
-
 
 -------------------------------------------------------------------------------
 ## __cylc-8.0b1 (<span actions:bind='release-date'>Released 2021-04-21</span>)__

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -163,7 +163,7 @@ def make_localhost_symlinks(rund, named_sub_dir):
 
 def get_dirs_to_symlink(install_target, flow_name):
     """Returns dictionary of directories to symlink from glbcfg.
-        Note the paths should remain unexpanded, to be expanded on the remote.
+       Note the paths should remain unexpanded, to be expanded on the remote.
     """
     dirs_to_symlink = {}
     symlink_conf = glbl_cfg().get(['symlink dirs'])

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -161,7 +161,9 @@ def make_localhost_symlinks(rund, named_sub_dir):
 
 
 def get_dirs_to_symlink(install_target, flow_name):
-    """Returns dictionary of directories to symlink from glbcfg."""
+    """Returns dictionary of directories to symlink from glbcfg.
+        Note the paths should remain unexpanded, to be expanded on the remote.
+    """
     dirs_to_symlink = {}
     symlink_conf = glbl_cfg().get(['symlink dirs'])
 
@@ -169,14 +171,12 @@ def get_dirs_to_symlink(install_target, flow_name):
         return dirs_to_symlink
     base_dir = symlink_conf[install_target]['run']
     if base_dir is not None:
-        dirs_to_symlink['run'] = os.path.join(
-            expand_path(base_dir), 'cylc-run', flow_name)
+        dirs_to_symlink['run'] = os.path.join(base_dir, 'cylc-run', flow_name)
     for dir_ in ['log', 'share', 'share/cycle', 'work']:
         link = symlink_conf[install_target][dir_]
         if link is None or link == base_dir:
             continue
-        dirs_to_symlink[dir_] = os.path.join(
-            expand_path(link), 'cylc-run', flow_name, dir_)
+        dirs_to_symlink[dir_] = os.path.join(link, 'cylc-run', flow_name, dir_)
     return dirs_to_symlink
 
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -23,8 +23,8 @@ Install a new workflow.
 The workflow can then be started, stopped, and targeted by name.
 
 Normal installation creates a directory "~/cylc-run/REG/", with a run
-directory "~/cylc-run/REG/run1" containing a "_cylc-install/source" symlink to
-the source directory.
+directory "~/cylc-run/REG/run1". A "_cylc-install/source" symlink to the source
+directory will be created in the REG directory.
 Any files or directories (excluding .git, .svn) from the source directory are
 copied to the new run directory.
 A ".service" directory will also be created and used for server authentication

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -549,8 +549,6 @@ def register(
            - Nested workflow run directories.
     """
     validate_flow_name(flow_name)
-    import mdb
-    mdb.debug()
     if source is not None:
         if os.path.basename(source) == WorkflowFiles.FLOW_FILE:
             source = os.path.dirname(source)

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1120,7 +1120,6 @@ def install_workflow(
             Another workflow already has this name (unless --redirect).
             Trying to install a workflow that is nested inside of another.
     """
-
     if not source:
         source = Path.cwd()
     elif Path(source).name == WorkflowFiles.FLOW_FILE:
@@ -1181,7 +1180,9 @@ def install_workflow(
     if not source_link.exists():
         install_log.info(f"Creating symlink from {source_link}")
         source_link.symlink_to(source)
-    elif source_link.exists() and (os.readlink(source_link) == str(source)):
+    elif source_link.exists() and (
+        source_link.resolve() == source.resolve()
+    ):
         install_log.info(
             f"Symlink from \"{source_link}\" to \"{source}\" in place.")
     else:

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1143,10 +1143,10 @@ def install_workflow(
             " name, using the --run-name option.")
     check_nested_run_dirs(rundir, flow_name)
     symlinks_created = {}
+    sub_dir = flow_name
+    if run_num:
+        sub_dir = os.path.join(sub_dir, f'run{run_num}')
     if not no_symlinks:
-        sub_dir = flow_name
-        if run_num:
-            sub_dir = os.path.join(sub_dir, f'run{run_num}')
         symlinks_created = make_localhost_symlinks(rundir, sub_dir)
     install_log = _get_logger(rundir, 'cylc-install')
     if not no_symlinks and bool(symlinks_created) is True:
@@ -1186,8 +1186,8 @@ def install_workflow(
         raise WorkflowFilesError(
             "Source directory between runs are not consistent.")
     # check source link matches the source symlink from workflow dir.
-    install_log.info(f'INSTALLED {flow_name} from {source} -> {rundir}')
-    print(f'INSTALLED {flow_name} from {source} -> {rundir}')
+    install_log.info(f'INSTALLED {sub_dir} from {source} -> {rundir}')
+    print(f'INSTALLED {sub_dir} from {source} -> {rundir}')
     _close_install_log(install_log)
     return source, rundir, flow_name
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1079,8 +1079,8 @@ def reinstall_workflow(named_run, rundir, source, dry_run=False):
             f"An error occurred when copying files from {source} to {rundir}")
         reinstall_log.warning(f" Error: {stderr}")
     check_flow_file(rundir, symlink_suiterc=True, logger=reinstall_log)
-    reinstall_log.info(f'REINSTALLED {named_run} from {source} -> {rundir}')
-    print(f'REINSTALLED {named_run} from {source} -> {rundir}')
+    reinstall_log.info(f'REINSTALLED {named_run} from {source}')
+    print(f'REINSTALLED {named_run} from {source}')
     _close_install_log(reinstall_log)
     return
 
@@ -1142,11 +1142,11 @@ def install_workflow(
             " name, using the --run-name option.")
     check_nested_run_dirs(rundir, flow_name)
     symlinks_created = {}
-    sub_dir = flow_name
+    named_run = flow_name
     if run_num:
-        sub_dir = os.path.join(sub_dir, f'run{run_num}')
+        named_run = os.path.join(named_run, f'run{run_num}')
     if not no_symlinks:
-        symlinks_created = make_localhost_symlinks(rundir, sub_dir)
+        symlinks_created = make_localhost_symlinks(rundir, named_run)
     install_log = _get_logger(rundir, 'cylc-install')
     if not no_symlinks and bool(symlinks_created) is True:
         for src, dst in symlinks_created.items():
@@ -1185,8 +1185,8 @@ def install_workflow(
         raise WorkflowFilesError(
             "Source directory between runs are not consistent.")
     # check source link matches the source symlink from workflow dir.
-    install_log.info(f'INSTALLED {sub_dir} from {source} -> {rundir}')
-    print(f'INSTALLED {sub_dir} from {source} -> {rundir}')
+    install_log.info(f'INSTALLED {named_run} from {source}')
+    print(f'INSTALLED {named_run} from {source}')
     _close_install_log(install_log)
     return source, rundir, flow_name
 
@@ -1295,7 +1295,7 @@ def check_flow_file(
         if flow_file_path.is_symlink():
             # Symlink broken or points elsewhere - replace
             flow_file_path.unlink()
-        flow_file_path.symlink_to(suite_rc_path)
+        flow_file_path.symlink_to(WorkflowFiles.SUITE_RC)
         if logger:
             logger.warning(f'{depr_msg}. Symlink created.')
         return flow_file_path
@@ -1354,7 +1354,7 @@ def link_runN(latest_run: Union[Path, str]):
     latest_run = Path(latest_run)
     run_n = Path(latest_run.parent, WorkflowFiles.RUN_N)
     try:
-        run_n.symlink_to(latest_run.relative_to(run_n.parent))
+        run_n.symlink_to(latest_run.name)
     except OSError:
         pass
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -536,7 +536,7 @@ def register(
     Creates the .service directory.
 
     Args:
-        flow_name: workflow name, default basename($PWD).
+        flow_name: workflow name.
         source: directory location of flow.cylc file, default $PWD.
 
     Return:
@@ -549,6 +549,8 @@ def register(
            - Nested workflow run directories.
     """
     validate_flow_name(flow_name)
+    import mdb
+    mdb.debug()
     if source is not None:
         if os.path.basename(source) == WorkflowFiles.FLOW_FILE:
             source = os.path.dirname(source)
@@ -1143,7 +1145,9 @@ def install_workflow(
     check_nested_run_dirs(rundir, flow_name)
     symlinks_created = {}
     named_run = flow_name
-    if run_num:
+    if run_name:
+        named_run = os.path.join(named_run, run_name)
+    elif run_num:
         named_run = os.path.join(named_run, f'run{run_num}')
     if not no_symlinks:
         symlinks_created = make_localhost_symlinks(rundir, named_run)
@@ -1174,6 +1178,7 @@ def install_workflow(
     if no_run_name:
         cylc_install = Path(rundir, WorkflowFiles.Install.DIRNAME)
     source_link = cylc_install.joinpath(WorkflowFiles.Install.SOURCE)
+    # check source link matches the source symlink from workflow dir.
     cylc_install.mkdir(parents=True, exist_ok=True)
     if not source_link.exists():
         install_log.info(f"Creating symlink from {source_link}")
@@ -1184,7 +1189,6 @@ def install_workflow(
     else:
         raise WorkflowFilesError(
             "Source directory between runs are not consistent.")
-    # check source link matches the source symlink from workflow dir.
     install_log.info(f'INSTALLED {named_run} from {source}')
     print(f'INSTALLED {named_run} from {source}')
     _close_install_log(install_log)

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -34,7 +34,7 @@ pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -59,7 +59,7 @@ __ERR__
 TEST_NAME="${TEST_NAME_BASE}-REG-install-ok"
 run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -74,7 +74,7 @@ touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 # test symlink not made in source dir
 exists_fail "flow.cylc"
@@ -111,7 +111,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}-olaf"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}-olaf from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf/run1
+INSTALLED ${RND_WORKFLOW_NAME}-olaf/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf/run1
 __OUT__
 popd || exit 1
 rm -rf "${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf"
@@ -136,7 +136,7 @@ TEST_NAME="${TEST_NAME_BASE}-option--directory"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 purge_rnd_workflow
 
@@ -147,12 +147,12 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-2"
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run2
+INSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run2
 __OUT__
 popd || exit 1
 purge_rnd_workflow

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -34,7 +34,7 @@ pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -59,7 +59,7 @@ __ERR__
 TEST_NAME="${TEST_NAME_BASE}-REG-install-ok"
 run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -74,7 +74,7 @@ touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 # test symlink not made in source dir
 exists_fail "flow.cylc"
@@ -84,7 +84,7 @@ exists_ok "flow.cylc"
 
 TEST_NAME="${TEST_NAME_BASE}-suite.rc-flow.cylc-readlink"
 readlink "flow.cylc" > "${TEST_NAME}.out"
-cmp_ok "${TEST_NAME}.out" <<< "${RND_WORKFLOW_RUNDIR}/run1/suite.rc"
+cmp_ok "${TEST_NAME}.out" <<< "suite.rc"
 
 INSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*.log')"
 grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Symlink created." "${INSTALL_LOG}"
@@ -99,7 +99,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --no-run-name
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}
+INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -111,7 +111,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}-olaf"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}-olaf/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf/run1
+INSTALLED ${RND_WORKFLOW_NAME}-olaf/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 rm -rf "${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf"
@@ -124,7 +124,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}-olaf" --no-run-name
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}-olaf from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf
+INSTALLED ${RND_WORKFLOW_NAME}-olaf from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 rm -rf "${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf"
@@ -136,7 +136,7 @@ TEST_NAME="${TEST_NAME_BASE}-option--directory"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 purge_rnd_workflow
 
@@ -147,12 +147,12 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-2"
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run2
+INSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -41,7 +41,7 @@ TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 
 TEST_SYM="${TEST_NAME_BASE}-run-symlink-exists-ok"
@@ -82,7 +82,7 @@ TEST_NAME="${TEST_NAME_BASE}-no-symlinks-created"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --no-symlink-dirs --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 
 

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -41,7 +41,7 @@ TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 
 TEST_SYM="${TEST_NAME_BASE}-run-symlink-exists-ok"
@@ -82,7 +82,7 @@ TEST_NAME="${TEST_NAME_BASE}-no-symlinks-created"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --no-symlink-dirs --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 
 

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -131,7 +131,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --run-name=olaf
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/olaf
+INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-mix-options-1-2nd-install"
 run_fail "${TEST_NAME}" cylc install
@@ -149,7 +149,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-mix-options-2-2nd-install"
 run_fail "${TEST_NAME}" cylc install --run-name=olaf
@@ -167,7 +167,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --run-name=olaf
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/olaf
+INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-same-run-name-2nd-install"
 run_fail "${TEST_NAME}" cylc install --run-name=olaf

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -149,7 +149,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-mix-options-2-2nd-install"
 run_fail "${TEST_NAME}" cylc install --run-name=olaf

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -131,7 +131,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --run-name=olaf
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
+INSTALLED ${RND_WORKFLOW_NAME}/olaf from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-mix-options-1-2nd-install"
 run_fail "${TEST_NAME}" cylc install
@@ -167,7 +167,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install --run-name=olaf
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
+INSTALLED ${RND_WORKFLOW_NAME}/olaf from ${RND_WORKFLOW_SOURCE}
 __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-same-run-name-2nd-install"
 run_fail "${TEST_NAME}" cylc install --run-name=olaf

--- a/tests/functional/cylc-install/03-file-transfer.t
+++ b/tests/functional/cylc-install/03-file-transfer.t
@@ -53,7 +53,7 @@ ${RND_WORKFLOW_RUNDIR}/
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}
+INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -87,7 +87,7 @@ ${RND_WORKFLOW_RUNDIR}/
 __OUT__
 
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}
+INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -26,7 +26,7 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 run_ok "basic-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
@@ -42,7 +42,7 @@ pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1/flow.cylc"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
 grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
@@ -58,7 +58,7 @@ touch suite.rc
 run_ok "${TEST_NAME}" cylc install
 run_ok "${TEST_NAME}-reinstall-suite.rc" cylc reinstall "${RND_WORKFLOW_NAME}/run1/suite.rc"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
 grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
@@ -71,7 +71,7 @@ make_rnd_workflow
 pushd "${TMPDIR}" || exit 1
 run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
 __OUT__
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
@@ -88,7 +88,7 @@ rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 # test symlink not made in source dir
 exists_fail "flow.cylc"
@@ -121,7 +121,7 @@ TEST_NAME="${TEST_NAME_BASE}-no-args"
 make_rnd_workflow
 run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
 __OUT__
 pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
 touch "${RND_WORKFLOW_SOURCE}/new_file"

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -26,11 +26,11 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 run_ok "basic-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
+grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
 
 popd || exit 1
 purge_rnd_workflow
@@ -42,10 +42,10 @@ pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}" cylc install
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1/flow.cylc"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
+grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
 popd || exit 1
 purge_rnd_workflow
 
@@ -58,10 +58,10 @@ touch suite.rc
 run_ok "${TEST_NAME}" cylc install
 run_ok "${TEST_NAME}-reinstall-suite.rc" cylc reinstall "${RND_WORKFLOW_NAME}/run1/suite.rc"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
+grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
 popd || exit 1
 purge_rnd_workflow
 
@@ -71,11 +71,11 @@ make_rnd_workflow
 pushd "${TMPDIR}" || exit 1
 run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
-REINSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
+REINSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -88,14 +88,14 @@ rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 # test symlink not made in source dir
 exists_fail "flow.cylc"
 # test symlink correctly made in run dir
 pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
 exists_ok "flow.cylc"
-if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "${RND_WORKFLOW_RUNDIR}/run1/suite.rc" ]] ; then
+if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "suite.rc" ]] ; then
     ok "symlink.suite.rc"
 else
     fail "symlink.suite.rc"
@@ -106,7 +106,7 @@ grep_ok "The filename \"suite.rc\" is deprecated in favour of \"flow.cylc\". Sym
 rm -rf flow.cylc
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 exists_ok "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc"
-if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "${RND_WORKFLOW_RUNDIR}/run1/suite.rc" ]] ; then
+if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "suite.rc" ]] ; then
     ok "symlink.suite.rc"
 else
     fail "symlink.suite.rc"
@@ -121,13 +121,13 @@ TEST_NAME="${TEST_NAME_BASE}-no-args"
 make_rnd_workflow
 run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}/run1
+INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
 touch "${RND_WORKFLOW_SOURCE}/new_file"
 run_ok "${TEST_NAME}-reinstall" cylc reinstall
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1" "${REINSTALL_LOG}"
+grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
 exists_ok new_file
 popd || exit 1
 purge_rnd_workflow
@@ -138,13 +138,13 @@ make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_ok "${TEST_NAME}-install" cylc install --no-run-name -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RUN_DIR}/${RND_WORKFLOW_NAME}
+INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
 __OUT__
 pushd "${RND_WORKFLOW_RUNDIR}" || exit 1
 touch "${RND_WORKFLOW_SOURCE}/new_file"
 run_ok "${TEST_NAME}-reinstall" cylc reinstall
 REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}" "${REINSTALL_LOG}"
+grep_ok "REINSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
 exists_ok new_file
 popd || exit 1
 popd || exit 1

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -49,7 +49,7 @@ ${RND_WORKFLOW_RUNDIR}/run1
     \`-- install
 __OUT__
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 run_ok "${TEST_NAME}" cylc install
 mkdir new_dir
@@ -79,7 +79,7 @@ ${RND_WORKFLOW_RUNDIR}/run2
     \`-- new_file2
 __OUT__
 contains_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
-REINSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run2
+REINSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 
 # Test cylc reinstall affects only named run, i.e. run1 should be unaffected in this case

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -49,7 +49,7 @@ ${RND_WORKFLOW_RUNDIR}/run1
     \`-- install
 __OUT__
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE} -> ${RND_WORKFLOW_RUNDIR}/run1
 __OUT__
 run_ok "${TEST_NAME}" cylc install
 mkdir new_dir

--- a/tests/functional/deprecations/03-suiterc.t
+++ b/tests/functional/deprecations/03-suiterc.t
@@ -38,7 +38,7 @@ init_suiterc "${TEST_NAME_BASE}" <<'__FLOW__'
         R1 = foo => bar
 __FLOW__
 
-MSG='The filename "suite.rc" is deprecated in favour of "flow.cylc". Symlink created.'
+MSG='The filename "suite.rc" is deprecated in favour of "flow.cylc"'
 
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate .
@@ -54,7 +54,7 @@ exists_ok "flow.cylc"
 
 TEST_NAME="flow.cylc-readlink"
 readlink "flow.cylc" > "${TEST_NAME}.out"
-cmp_ok "${TEST_NAME}.out" <<< "${WORKFLOW_RUN_DIR}/suite.rc"
+cmp_ok "${TEST_NAME}.out" <<< "suite.rc"
 
 INSTALL_LOG="$(find "${WORKFLOW_RUN_DIR}/log/install" -type f -name '*.log')"
 grep_ok "$MSG" "${INSTALL_LOG}"

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -212,12 +212,13 @@ def test_make_workflow_run_tree(
                 'log': '$DEE/cylc-run/workflow3/log',
                 'share': '$DEE/cylc-run/workflow3/share'})
     ], ids=["1", "2", "3"])
-def test_get_dirs_to_symlink(
-        workflow, install_target, mocked_glbl_cfg, output, mock_glbl_cfg):
+def test_get_dirs_to_symlink(workflow, install_target, mocked_glbl_cfg,
+        output, mock_glbl_cfg, tmp_path):
+    os.environ['DEE'] = f"{tmp_path}"  # Ensures dirs returned are unexpanded
     mock_glbl_cfg('cylc.flow.pathutil.glbl_cfg', mocked_glbl_cfg)
     dirs = get_dirs_to_symlink(install_target, workflow)
     assert dirs == output
-
+    os.environ.pop('DEE')
 
 @patch('os.path.expandvars')
 @patch('cylc.flow.pathutil.get_workflow_run_dir')

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -213,12 +213,12 @@ def test_make_workflow_run_tree(
                 'share': '$DEE/cylc-run/workflow3/share'})
     ], ids=["1", "2", "3"])
 def test_get_dirs_to_symlink(workflow, install_target, mocked_glbl_cfg,
-        output, mock_glbl_cfg, tmp_path):
-    os.environ['DEE'] = f"{tmp_path}"  # Ensures dirs returned are unexpanded
+                             output, mock_glbl_cfg, tmp_path, monkeypatch):
+    # Using env variable 'DEE' to ensure dirs returned are unexpanded
+    monkeypatch.setenv('DEE', str(tmp_path))
     mock_glbl_cfg('cylc.flow.pathutil.glbl_cfg', mocked_glbl_cfg)
     dirs = get_dirs_to_symlink(install_target, workflow)
     assert dirs == output
-    os.environ.pop('DEE')
 
 
 @patch('os.path.expandvars')
@@ -236,6 +236,7 @@ def test_make_localhost_symlinks_calls_make_symlink_for_each_key_value_dir(
         'share': '$DEE/workflow3/share'}
     mocked_get_workflow_run_dir.return_value = "rund"
     mocked_expandvars.return_value = "expanded"
+    mocked_make_symlink.return_value = True
     make_localhost_symlinks('rund', 'workflow')
     mocked_make_symlink.assert_has_calls([
         call('expanded', 'rund'),

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -220,6 +220,7 @@ def test_get_dirs_to_symlink(workflow, install_target, mocked_glbl_cfg,
     assert dirs == output
     os.environ.pop('DEE')
 
+
 @patch('os.path.expandvars')
 @patch('cylc.flow.pathutil.get_workflow_run_dir')
 @patch('cylc.flow.pathutil.make_symlink')

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -622,7 +622,7 @@ def test_reinstall_workflow(tmp_path, capsys):
     run_dir = cylc_install_dir.parent
     reinstall_workflow("flow-name", run_dir, source_dir)
     assert capsys.readouterr().out == (
-        f"REINSTALLED flow-name from {source_dir} -> {run_dir}\n")
+        f"REINSTALLED flow-name from {source_dir}\n")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses some feedback on `cylc install` from @dpmatthews.

* Logging of symlink making was inaccurate. (added a condition to dict used for logging)
* Tidied the symlinks created for `suite.rc` and `runN` so they are now relative paths 
* Symlink dirs env variables had been changed to being expanded on the scheduler, (reverted that change) 
* Standard `cylc install` now correctly installs from directories with a `.` in the name
* Updated the `cylc install` help to correctly document location of source symlink.
* Localhost symlinks are now skipped if they exist but point to another location, rather that raising a `Workflow Files Error`
* cylc install now logs the named run rather than flow_name

 This is a small change with no associated Issue.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests (adapted).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
