### PR TITLE
Remove suite_owner option and make --colour cli help more informative

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -245,9 +245,8 @@ TASK_GLOB matches task or family names at a given cycle point.
                 '--color', '--colour', metavar='WHEN', action='store',
                 default='auto', choices=['never', 'auto', 'always'],
                 help=(
-                    "Determine when to use color in terminal output. "
-                    "Options available are 'never', 'auto' and 'always'. "
-                    "'never' will also remove bold typeface."
+                    "Determine when to use color/bold text in terminal output. "
+                    "Options available are 'never', 'auto' and 'always'."
                 )
             )
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -245,8 +245,8 @@ TASK_GLOB matches task or family names at a given cycle point.
                 '--color', '--colour', metavar='WHEN', action='store',
                 default='auto', choices=['never', 'auto', 'always'],
                 help=(
-                    "Determine when to use color/bold text in terminal output. "
-                    "Options available are 'never', 'auto' and 'always'."
+                    "Determine when to use color/bold text in terminal output."
+                    " Options available are 'never', 'auto' and 'always'."
                 )
             )
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -244,7 +244,12 @@ TASK_GLOB matches task or family names at a given cycle point.
             self.add_std_option(
                 '--color', '--colour', metavar='WHEN', action='store',
                 default='auto', choices=['never', 'auto', 'always'],
-                help='Determine when to use color in terminal output.')
+                help=(
+                    "Determine when to use color in terminal output. "
+                    "Options available are 'never', 'auto' and 'always'. "
+                    "'never' will also remove bold typeface."
+                )
+            )
 
         if self.prep:
             self.add_std_option(

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -431,15 +431,13 @@ def get_workflow_source_dir(
             return None, None
 
 
-def get_workflow_srv_dir(reg, workflow_owner=None):
+def get_workflow_srv_dir(reg):
     """Return service directory of a workflow."""
-    if not workflow_owner:
-        workflow_owner = get_user()
     run_d = os.getenv("CYLC_WORKFLOW_RUN_DIR")
     if (
         not run_d
         or os.getenv("CYLC_WORKFLOW_NAME") != reg
-        or os.getenv("CYLC_WORKFLOW_OWNER") != workflow_owner
+        or os.getenv("CYLC_WORKFLOW_OWNER") != get_user()
     ):
         run_d = get_workflow_run_dir(reg)
     return os.path.join(run_d, WorkflowFiles.Service.DIRNAME)


### PR DESCRIPTION
This is a very small change with no associated Issue.

Removed suite owner from the cli options and listed options available to users for colour in the help.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (removing code, tests unaffected).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
- [x] No dependency changes.
