### PR TITLE
actions: test manylinux compatibility

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -1,0 +1,75 @@
+name: manylinux-compatibility
+
+# Ensure that cylc-flow remains installable with manylinx1 binaries for use
+# with older systems.
+
+# Ideally we would use the Docker images from PyPa
+# (https://github.com/pypa/manylinux).
+# The manylinux1 image is based on CentOS=5, glibc=2.5), however, this is so
+# old that installing contemporary Python on them is quite hard:
+# * native package manager has no package for CentOS5
+# * miniforge can't work with glibc < 2.12
+# * micromamba can't work with glibc < 2.6
+# * need zlib to compile Python / install pip but the package manager can't
+#   download it because the package stream is offline (past EOL)
+
+# So this will have to do. This isn't a perfect test as non manylinux compat
+# packages may attempt to compile from source. This might succeed here but not
+# on an older host.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'setup.py'
+      - 'setup.cfg'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        manylinux: ['1']
+        os: ['ubuntu-16.04']  # run on the oldest linux we have access to
+        python-version: ['3.7', '3.8', '3.9']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Configure Manylinux Compatibility
+        # Make this platform look older than it is. For info see:
+        # https://stackoverflow.com/questions/37231799/
+        # exclude-manylinux-wheels-when-downloading-from-pip
+        run: |
+          cat > _manylinux.py <<__HERE__
+          manylinux1_compatible = False
+          manylinux2010_compatible = False
+          manylinux2014_compatible = False
+          __HERE__
+          echo \
+            "manylinux${{ matrix.manylinux }}_compatible = True" \
+            >> _manylinux.py
+
+      - name: Install
+        timeout-minutes: 15
+        run: |
+          PYTHONPATH="$PWD:$PYTHONPATH" pip install ."[all]"
+
+      - name: Test Import
+        shell: python
+        run: |
+          import cylc.flow
+          import cylc.flow.scheduler
+
+      - name: Test
+        timeout-minutes: 15
+        run: |
+          pytest -n 5


### PR DESCRIPTION
Ensure our dependency tree remains `manylinux1` compatible for installation on older OSes.

> **TLDR;**
>
> The `manylinux<v>` identifiers define a standardish "base" environment for Linux binaries to be compiled
> against. The `manylinux1` identifier is based off of centos5 which is beyond EOL, consequently manylinux1
> is also EOL but still fairly well supported. The purpose of this test is to scan dependency changes to ensure
> we don't end up with something which can't be built but which doesn't provide a manylinux1 binary.

[Example run](https://github.com/oliver-sanders/cylc-flow/actions/runs/777370753)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
