### PR TITLE
fix type hinting for cylc-rose options

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -315,6 +315,9 @@ class Options:
         False
 
     """
+    opt_conf_keys: list
+    defines: list
+    define_suites: list
 
     def __init__(
         self, parser: OptionParser, overrides: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
This is a small change with no associated Issue.

Fixes: Cylc-Rose uses types from `cylc.flow.option_parsers.Options`, although these may not always be present as they only get created if Cylc-Rose is installed. MyPy needs help to see what they should be.

Question: Should the type be `Iterable`, rather than list?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests (MyPy Checks)
- [x] No change log entry required (invisible to users).
- [x] No documentation update required (internal change).
- [x] No dependency changes.
