### PR TITLE
github: adjust dependency change workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ This is a small change with no associated Issue.
 - [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
 - [ ] Contains logically grouped changes (else tidy your branch by rebase).
 - [ ] Does not contain off-topic changes (use other PRs for other changes).
+- [ ] Applied any dependency changes to both `setup.py` and
+  `conda-environment.yml`.
 <!-- choose one: -->
 - [ ] Appropriate tests are included (unit and/or functional).
 - [ ] Already covered by existing tests.
@@ -24,6 +26,3 @@ This is a small change with no associated Issue.
 - [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
 - [ ] (7.8.x branch) I have updated the documentation in this PR branch.
 - [ ] No documentation update required.
-<!-- choose one: -->
-- [ ] Created an issue at [cylc-flow conda-forge repository](https://github.com/conda-forge/cylc-flow-feedstock) with version changes (if you changed dependencies in `setup.py`, see `recipe/meta.yaml`).
-- [ ] No dependency changes.


### PR DESCRIPTION
* Apply dependency changes to a Python/setuptools and Conda dependency
  files.
* On release update conda-forge from these dependencies (where should we record this?).