### PR TITLE
Terminology: suite to workflow follow-up

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -102,12 +102,16 @@ cylc__job__main() {
         CYLC_WORKFLOW_HOST="$(sed -n 's/^CYLC_WORKFLOW_HOST=//p' "${contact}")"
         CYLC_WORKFLOW_OWNER="$(sed -n 's/^CYLC_WORKFLOW_OWNER=//p' "${contact}")"
         export CYLC_WORKFLOW_HOST CYLC_WORKFLOW_OWNER
-        # Deprecated
+        # BACK COMPAT: DEPRECATED environment variables
+        # remove at:
+        #     Cylc9
         export CYLC_SUITE_HOST="${CYLC_WORKFLOW_HOST}"
         export CYLC_SUITE_OWNER="${CYLC_WORKFLOW_OWNER}"
     fi
 
-    # DEPRECATED environment variables
+    # BACK COMPAT: DEPRECATED environment variables
+    # remove at:
+    #     Cylc9
     export CYLC_SUITE_SHARE_DIR="${CYLC_WORKFLOW_SHARE_DIR}"
     export CYLC_SUITE_SHARE_PATH="${CYLC_WORKFLOW_SHARE_DIR}"
     export CYLC_SUITE_NAME="${CYLC_WORKFLOW_NAME}"

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -154,14 +154,14 @@ def get_option_parser():
             dest="defines"
         )
         parser.add_option(
-            "--define-workflow", "--define-flow", '-S',
+            "--rose-template-variable", '-S',
             help=(
                 "As `--define`, but with an implicit `[SECTION]` for "
                 "workflow variables."
             ),
             action="append",
             default=[],
-            dest="define_workflows"
+            dest="rose_template_var"
         )
     except ImportError:
         pass

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -86,14 +86,14 @@ def get_option_parser():
             dest="defines"
         )
         parser.add_option(
-            "--define-workflow", "--define-flow", '-S',
+            "--rose-template-variable", '-S',
             help=(
                 "As `--define`, but with an implicit `[SECTION]` for "
                 "workflow variables."
             ),
             action="append",
             default=[],
-            dest="define_workflows"
+            dest="rose_template_var"
         )
         parser.add_option(
             "--clear-rose-install-options",


### PR DESCRIPTION
This is a small change with no associated Issue. Follow-up to #4174 

From Teams discussion:

> define flow is very confusing (since it doesn't even do anything to the flow).
>
> So we gotta change now it anyhoo, how about `-S, --rose-template-variable`, that describes what it does without mentioning either suites or flows.
>
> I think for Rose we can just scale back on the word "suite" and try to talk more about "configurations" or the file itself.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
- [x] No dependency changes.
