### PR TITLE
config: validate [runtime] task names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,10 @@ functionality is now provided by `[symlink dirs]`.
 
 ### Fixes
 
+[#4199](https://github.com/cylc/cylc-flow/pull/4199) -
+`cylc validate` and `cylc run` now check task/family names in the `[runtime]`
+section for validity.
+
 [#4180](https://github.com/cylc/cylc-flow/pull/4180) - Fix bug where installing
 a workflow that uses the deprecated `suite.rc` filename would symlink `flow.cylc`
 to the `suite.rc` in the source dir instead of the run dir. Also fixes a couple

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -318,7 +318,6 @@ class WorkflowConfig:
         self.mem_log("config.py: before _expand_runtime")
         self._expand_runtime()
         self.mem_log("config.py: after _expand_runtime")
-        self.validate_namespace_names()
 
         self.ns_defn_order = list(self.cfg['runtime'])
 
@@ -465,6 +464,7 @@ class WorkflowConfig:
         self._check_explicit_cycling()
 
         self._check_implicit_tasks()
+        self.validate_namespace_names()
 
         # Check that external trigger messages are only used once (they have to
         # be discarded immediately to avoid triggering the next instance of the
@@ -992,11 +992,10 @@ class WorkflowConfig:
             for name, _ in name_expander.expand(node):
                 expanded_node_attrs[name] = val
         self.cfg['visualization']['node attributes'] = expanded_node_attrs
-        self.validate_namespace_names()
 
     def validate_namespace_names(self):
         """Validate task and family names."""
-        for name, config in self.cfg['runtime'].items():
+        for name in self.cfg['runtime']:
             success, message = TaskNameValidator.validate(name)
             if not success:
                 raise WorkflowConfigError(

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -39,7 +39,10 @@ from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_pool import FlowLabelMgr
 from cylc.flow.loggingutil import CylcLogFormatter
 from cylc.flow.templatevars import load_template_vars
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    CylcOptionParser as COP,
+    Options
+)
 from cylc.flow.workflow_files import parse_workflow_arg
 
 
@@ -71,6 +74,17 @@ def get_option_parser():
     parser.set_defaults(is_validate=True)
 
     return parser
+
+
+ValidateOptions = Options(
+    get_option_parser(),
+    # defaults
+    {
+        'check_circular': False,
+        'profile_mode': False,
+        'run_mode': 'live'
+    }
+)
 
 
 @cli_function(get_option_parser)

--- a/cylc/flow/task_id.py
+++ b/cylc/flow/task_id.py
@@ -24,6 +24,10 @@ from cylc.flow.cycling.loader import get_point, standardise_point_string
 from cylc.flow.exceptions import PointParsingError
 
 
+_TASK_NAME_PREFIX = r'\w'
+_TASK_NAME_CHARACTERS = [r'\w', r'\-', '+', '%', '@']
+
+
 class TaskID:
     """Task ID utilities."""
 
@@ -32,7 +36,7 @@ class TaskID:
     DELIM2 = '/'
     NAME_SUFFIX_RE = r"[\w\-+%@]+"
     NAME_SUFFIX_REC = re.compile(r"\A" + NAME_SUFFIX_RE + r"\Z")
-    NAME_RE = r"\w[\w\-+%@]*"
+    NAME_RE = rf'{_TASK_NAME_PREFIX}[{"".join(_TASK_NAME_CHARACTERS)}]*'
     NAME_REC = re.compile(r"\A" + NAME_RE + r"\Z")
     POINT_RE = r"\S+"
     POINT_REC = re.compile(r"\A" + POINT_RE + r"\Z")

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -18,6 +18,10 @@
 
 import re
 
+from cylc.flow.task_id import (
+    _TASK_NAME_CHARACTERS,
+    _TASK_NAME_PREFIX,
+)
 
 ENGLISH_REGEX_MAP = {
     r'\w': 'alphanumeric',
@@ -102,6 +106,25 @@ def disallowed_characters(*chars):
     return (
         re.compile(r'^[^%s]*$' % ''.join(chars)),
         f'cannot contain: {", ".join(regex_chars_to_text(chars))}'
+    )
+
+
+def starts_with(*chars):
+    """Restrict first character.
+
+    Example:
+        >>> regex, message = starts_with('a', 'b', 'c')
+        >>> message
+        'must start with: ``a``, ``b``, ``c``'
+        >>> bool(regex.match('def'))
+        False
+        >>> bool(regex.match('adef'))
+        True
+
+    """
+    return (
+        re.compile(r'^[%s]' % ''.join(chars)),
+        f'must start with: {", ".join(regex_chars_to_text(chars))}'
     )
 
 
@@ -213,4 +236,13 @@ class TaskOutputValidator(UnicodeRuleChecker):
 
     RULES = [
         disallowed_characters(':')
+    ]
+
+
+class TaskNameValidator(UnicodeRuleChecker):
+    """The rules for valid task and family names:"""
+
+    RULES = [
+        starts_with(_TASK_NAME_PREFIX),
+        allowed_characters(*_TASK_NAME_CHARACTERS)
     ]

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,68 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from cylc.flow.config import WorkflowConfig
+from cylc.flow.scripts.validate import ValidateOptions
+from cylc.flow.exceptions import WorkflowConfigError
+
+
+@pytest.mark.parametrize(
+    'task_name,valid', [
+        # valid task names
+        ('a', True),
+        ('a-b', True),
+        ('a_b', True),
+        ('foo', True),
+        ('0aA-+%', True),
+        # invalid task names
+        ('a b', False),
+        ('a£b', False),
+        ('+ab', False),
+        ('@ab', False),  # not valid in [runtime]
+    ]
+)
+def test_validate_task_name(
+    flow,
+    one_conf,
+    run_dir,
+    task_name: str,
+    valid: bool
+):
+    """It should raise errors for invalid task names in the runtime section."""
+    reg = flow({
+        **one_conf,
+        'runtime': {
+            task_name: {}
+        }
+    })
+
+    validate = partial(
+        WorkflowConfig,
+        reg,
+        str(Path(run_dir, reg, 'flow.cylc')),
+        ValidateOptions()
+    )
+
+    if valid:
+        validate()
+    else:
+        with pytest.raises(WorkflowConfigError) as exc_ctx:
+            validate()
+        assert task_name in str(exc_ctx.value)


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/3160

Validate task names in the `[runtime]` section, autodocument from this code (corrects the docs on valid task name patterns).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [X] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/242
- [x] No dependency changes.
