### PR TITLE
Pluralise rose_template_vars

### DIFF
--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -161,7 +161,7 @@ def get_option_parser():
             ),
             action="append",
             default=[],
-            dest="rose_template_var"
+            dest="rose_template_vars"
         )
     except ImportError:
         pass

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -93,7 +93,7 @@ def get_option_parser():
             ),
             action="append",
             default=[],
-            dest="rose_template_var"
+            dest="rose_template_vars"
         )
         parser.add_option(
             "--clear-rose-install-options",


### PR DESCRIPTION
This is a small change with no associated Issue, other than https://github.com/cylc/cylc-rose/pull/56#discussion_r622181398

Pluralise a variable name because it's actually a list; the singular might be misleading

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
