### PR TITLE
Job script: remove the use of here-string's

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -73,17 +73,16 @@ cylc__job__main() {
     export CYLC_WORKFLOW_LOG_DIR="${CYLC_WORKFLOW_RUN_DIR}/log/workflow"
     export CYLC_WORKFLOW_SHARE_DIR="${CYLC_WORKFLOW_RUN_DIR}/share"
     export CYLC_WORKFLOW_WORK_DIR="${CYLC_WORKFLOW_RUN_DIR}/work"
-    CYLC_TASK_CYCLE_POINT="$(cut -d '/' -f 1 <<<"${CYLC_TASK_JOB}")"
-    CYLC_TASK_NAME="$(cut -d '/' -f 2 <<<"${CYLC_TASK_JOB}")"
-    export CYLC_TASK_NAME CYLC_TASK_CYCLE_POINT ISODATETIMEREF
+    export CYLC_TASK_CYCLE_POINT="${CYLC_TASK_JOB%%/*}"
+    export CYLC_TASK_NAME="${CYLC_TASK_JOB#*/}"
+    CYLC_TASK_NAME="${CYLC_TASK_NAME%/*}"
     if [[ "${CYLC_CYCLING_MODE}" != "integer" ]]; then  # i.e. date-time cycling
-        ISODATETIMECALENDAR="${CYLC_CYCLING_MODE}"
-        ISODATETIMEREF="${CYLC_TASK_CYCLE_POINT}"
-        export ISODATETIMECALENDAR ISODATETIMEREF
+        export ISODATETIMECALENDAR="${CYLC_CYCLING_MODE}"
+        export ISODATETIMEREF="${CYLC_TASK_CYCLE_POINT}"
     fi
     # The "10#" part ensures that the submit number is interpreted in base 10.
     # Otherwise, a zero padded number will be interpreted as an octal.
-    export CYLC_TASK_SUBMIT_NUMBER=$((10#$(cut -d '/' -f 3 <<<"${CYLC_TASK_JOB}")))
+    export CYLC_TASK_SUBMIT_NUMBER="$((10#${CYLC_TASK_JOB##*/}))"
     export CYLC_TASK_ID="${CYLC_TASK_NAME}.${CYLC_TASK_CYCLE_POINT}"
     export CYLC_TASK_LOG_DIR="${CYLC_WORKFLOW_RUN_DIR}/log/job/${CYLC_TASK_JOB}"
     export CYLC_TASK_LOG_ROOT="${CYLC_TASK_LOG_DIR}/job"


### PR DESCRIPTION
We've previously removed the use of here-document's (#2622).
However, here-string's suffer from the same problem (using temporary files):
https://askubuntu.com/questions/678915/whats-the-difference-between-and-in-bash
These are a particular problem in bash 3.2 because it ignores $TMPDIR:
https://lists.gnu.org/archive/html/bug-bash/2013-12/msg00056.html

To remove the need for here-string's I've replaced the use of `cut` with bash parameter expansion:
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

I've also removed the use of separate `export` statements except where needed to avoid failing https://github.com/koalaman/shellcheck/wiki/SC2155.

This is a small change with no associated Issue.

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [X] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [X] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [X] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [X] No documentation update required.
