### PR TITLE
entry points: centralise entry point iteration

### DIFF
--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -17,6 +17,7 @@
 
 import os
 import logging
+import pkg_resources
 
 
 CYLC_LOG = 'cylc'
@@ -53,3 +54,14 @@ def environ_init():
 environ_init()
 
 __version__ = '8.0b2.dev'
+
+
+def iter_entry_points(entry_point_name):
+    """Iterate over Cylc entry points."""
+    yield from (
+        entry_point
+        for entry_point in pkg_resources.iter_entry_points(entry_point_name)
+        # filter out the cylc namespace as it should be empty
+        # all cylc packages should take the form cylc-<name>
+        if entry_point.dist.key != 'cylc'
+    )

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -159,9 +159,7 @@ from inspect import (
 from textwrap import indent
 from time import time
 
-import pkg_resources
-
-from cylc.flow import LOG
+from cylc.flow import LOG, iter_entry_points
 from cylc.flow.exceptions import CylcError, UserInputError
 
 
@@ -314,7 +312,7 @@ def load(config, additional_plugins=None):
     entry_points = {
         entry_point.name: entry_point
         for entry_point in
-        pkg_resources.iter_entry_points('cylc.main_loop')
+        iter_entry_points('cylc.main_loop')
     }
     plugins = {
         'state': {},

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -34,10 +34,9 @@ import os
 import re
 import sys
 
-import pkg_resources
 from pathlib import Path
 
-from cylc.flow import __version__
+from cylc.flow import __version__, iter_entry_points
 from cylc.flow import LOG
 from cylc.flow.exceptions import PluginError
 from cylc.flow.parsec.exceptions import FileParseError, ParsecError
@@ -225,7 +224,7 @@ def process_plugins(fpath):
         'template_variables': {},
         'templating_detected': None
     }
-    for entry_point in pkg_resources.iter_entry_points(
+    for entry_point in iter_entry_points(
         'cylc.pre_configure'
     ):
         try:

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -26,7 +26,7 @@ import click
 from colorama import init as color_init
 import pkg_resources
 
-from cylc.flow import __version__
+from cylc.flow import __version__, iter_entry_points
 from cylc.flow.scripts import cylc_header
 from cylc.flow.terminal import (
     centered,
@@ -97,7 +97,7 @@ USAGE = cparse(USAGE)
 COMMANDS: dict = {
     entry_point.name: entry_point
     for entry_point
-    in pkg_resources.iter_entry_points('cylc.command')
+    in iter_entry_points('cylc.command')
 }
 
 
@@ -356,7 +356,7 @@ def list_plugins():
         entry_point_name: [
             entry_point
             for entry_point
-            in pkg_resources.iter_entry_points(entry_point_name)
+            in iter_entry_points(entry_point_name)
             if not entry_point.module_name.startswith('cylc.flow')
         ]
         for entry_point_name in entry_point_names

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -69,10 +69,9 @@ multiple workflow run directories that link to the same workflow definition.
 
 """
 
-
-import pkg_resources
 from typing import Optional, TYPE_CHECKING
 
+from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.workflow_files import (
@@ -189,7 +188,7 @@ def install(
         source = search_install_source_dirs(reg)
     flow_name = opts.flow_name or reg
 
-    for entry_point in pkg_resources.iter_entry_points(
+    for entry_point in iter_entry_points(
         'cylc.pre_configure'
     ):
         try:
@@ -215,7 +214,7 @@ def install(
         no_symlinks=opts.no_symlinks
     )
 
-    for entry_point in pkg_resources.iter_entry_points(
+    for entry_point in iter_entry_points(
         'cylc.post_install'
     ):
         try:

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -38,9 +38,9 @@ Examples:
 """
 
 from pathlib import Path
-import pkg_resources
 from typing import Optional, TYPE_CHECKING
 
+from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError, WorkflowFilesError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.pathutil import get_workflow_run_dir
@@ -138,7 +138,7 @@ def main(
             f'Restore the source or modify the "{source_path}"'
             ' symlink to continue.'
         )
-    for entry_point in pkg_resources.iter_entry_points(
+    for entry_point in iter_entry_points(
         'cylc.pre_configure'
     ):
         try:
@@ -159,7 +159,7 @@ def main(
         dry_run=False  # TODO: ready for dry run implementation
     )
 
-    for entry_point in pkg_resources.iter_entry_points(
+    for entry_point in iter_entry_points(
         'cylc.post_install'
     ):
         try:

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -65,7 +65,7 @@ def pre_configure_error(*_, **__):
 def test_pre_configure(monkeypatch):
     """It should call the plugin."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.pkg_resources.iter_entry_points',
+        'cylc.flow.parsec.fileparse.iter_entry_points',
         lambda x: [pre_configure_basic]
     )
     extra_vars = process_plugins(None)
@@ -83,7 +83,7 @@ def test_pre_configure(monkeypatch):
 def test_pre_configure_duplicate(monkeypatch):
     """It should error when plugins clash."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.pkg_resources.iter_entry_points',
+        'cylc.flow.parsec.fileparse.iter_entry_points',
         lambda x: [
             pre_configure_basic,
             pre_configure_basic
@@ -96,7 +96,7 @@ def test_pre_configure_duplicate(monkeypatch):
 def test_pre_configure_templating_detected(monkeypatch):
     """It should error when plugins clash (for templating)."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.pkg_resources.iter_entry_points',
+        'cylc.flow.parsec.fileparse.iter_entry_points',
         lambda x: [
             pre_configure_templating_detected,
             pre_configure_templating_detected
@@ -109,7 +109,7 @@ def test_pre_configure_templating_detected(monkeypatch):
 def test_pre_configure_exception(monkeypatch):
     """It should wrap plugin errors."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.pkg_resources.iter_entry_points',
+        'cylc.flow.parsec.fileparse.iter_entry_points',
         lambda x: [pre_configure_error]
     )
     with pytest.raises(PluginError) as exc_ctx:


### PR DESCRIPTION
Centralise all of the `iter_entry_points` calls into one place.

This is kinda a good thing to do but the real motivation is to screen out the `cylc` distribution. This distribution shouldn't exist, this distribution is called `cylc-flow`, however, due to some strange factors beyond my comprehension it shows up on my system for dev installs.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.