### PR TITLE
Nicer cylc header text

### DIFF
--- a/cylc/flow/daemonize.py
+++ b/cylc/flow/daemonize.py
@@ -24,24 +24,9 @@ from time import sleep, time
 from cylc.flow.pathutil import get_workflow_run_log_name
 from cylc.flow.workflow_files import PS_OPTS
 
-
-WORKFLOW_SCAN_INFO_TMPL = r"""
-
-To view scheduler contact information:
- $ cylc get-workflow-contact %(workflow)s
-
-Other ways to see if the workflow is still running:
- $ cylc scan -n '%(workflow)s'
- $ cylc ping -v %(workflow)s
- $ ssh %(host)s ps %(ps_opts)s %(pid)s
- $ cylc tui %(workflow)s    # A terminal graphic UI
-
-"""
-
-_INFO_TMPL = r"""
-*** listening on %(url)s ***
-*** publishing on %(pub_url)s ***""" + WORKFLOW_SCAN_INFO_TMPL
-
+WORKFLOW_INFO_TMPL = (
+    "%(workflow)s: %(host)s PID=%(pid)s\n"
+)
 
 _TIMEOUT = 300.0  # 5 minutes
 
@@ -114,10 +99,11 @@ def daemonize(schd):
                 "ps_opts": PS_OPTS,
                 "pid": workflow_pid
             }
+
             if schd.options.format == 'json':
                 sys.stdout.write(json.dumps(info, indent=4))
             else:
-                sys.stdout.write(_INFO_TMPL % info)
+                sys.stdout.write(WORKFLOW_INFO_TMPL % info)
             # exit parent 1
             sys.exit(0)
     except OSError as exc:

--- a/cylc/flow/daemonize.py
+++ b/cylc/flow/daemonize.py
@@ -99,7 +99,6 @@ def daemonize(schd):
                 "ps_opts": PS_OPTS,
                 "pid": workflow_pid
             }
-
             if schd.options.format == 'json':
                 sys.stdout.write(json.dumps(info, indent=4))
             else:

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -196,7 +196,7 @@ def get_option_parser(add_std_opts=False):
     )
 
     parser.add_option(
-        "--quiet",
+        "-q", "--quiet",
         help="Don't print the Cylc header to stdout.",
         action="store_true", default=False, dest="quiet"
     )

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -195,6 +195,12 @@ def get_option_parser(add_std_opts=False):
         action="store_true", default=False, dest="abort_if_any_task_fails"
     )
 
+    parser.add_option(
+        "--quiet",
+        help="Don't print the Cylc header to stdout.",
+        action="store_true", default=False, dest="quiet"
+    )
+
     if add_std_opts:
         # This is for the API wrapper for integration tests. Otherwise (CLI
         # use) "standard options" are added later in options.parse_args().
@@ -279,7 +285,7 @@ def scheduler_cli(parser, options, reg):
     _distribute(options.host)
 
     # print the start message
-    if options.no_detach or options.format == 'plain':
+    if not options.quiet and (options.no_detach or options.format == 'plain'):
         print(
             cparse(
                 cylc_header()

--- a/cylc/flow/scripts/__init__.py
+++ b/cylc/flow/scripts/__init__.py
@@ -14,9 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from re import sub
 from itertools import zip_longest
-from textwrap import dedent
-import re
 from ansimarkup import strip
 
 from cylc.flow import __version__
@@ -52,7 +51,7 @@ LOGO_LETTERS = (
 
 LOGO = [
     ''.join(
-        re.sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
+        sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
         for tag, letter in zip(
             ('red', 'yellow', 'green', 'blue'),
             LOGO_LETTERS
@@ -87,7 +86,7 @@ def cylc_header(width=None):
         len(strip(LOGO[0]))
     )
     if width >= lmax + 1:
-        header = f'\n'.join(
+        header = '\n'.join(
             ('{0} {1}').format(*x)
             for x in zip_longest(
                 LOGO,

--- a/cylc/flow/scripts/__init__.py
+++ b/cylc/flow/scripts/__init__.py
@@ -50,7 +50,7 @@ LOGO_LETTERS = (
 )
 # fmt: on
 
-LOGO_LINES = [
+LOGO = [
     ''.join(
         re.sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
         for tag, letter in zip(
@@ -61,12 +61,6 @@ LOGO_LINES = [
     for ind in range(len(LOGO_LETTERS[0]))
 ]
 
-LICENSE = dedent(f"""
-    The Cylc Workflow Engine [{__version__}]
-    Copyright (C) 2008-{_copyright_year} NIWA &
-    British Crown (Met Office) & Contributors
-""")
-
 CYLC = (
     "<b>"
     "<red>C</red>"
@@ -76,26 +70,30 @@ CYLC = (
     "</b>"
 )
 
+VERSION = f"<b><yellow>{__version__}</yellow></b>"
+
+LICENSE = [
+    f"{CYLC} Workflow Engine {VERSION}",
+    f"Copyright (C) 2008-{_copyright_year} NIWA",
+    "& British Crown (Met Office) & Contributors"
+]
+
 
 def cylc_header(width=None):
     """Print copyright and license information."""
-    if not width:
-        width = get_width()
-    # center license lines
-    llines = LICENSE.strip().splitlines()
-    lmax = max(len(line) for line in llines)
-    llines = [
-        line.center(lmax)
-        for line in llines
-        if line
-    ]
-    llines[0] = re.sub('Cylc', CYLC, llines[0])
-    tlmax = lmax + len(strip(LOGO_LINES[0]))
-    lpad = int((width - tlmax) / 2) * ' '
-    return '\n' + lpad + f'\n{lpad}'.join(
-        ('{0}  {1}').format(*x)
-        for x in zip_longest(
-            LOGO_LINES,
-            llines
-        )
+    width = width or get_width()
+    lmax = (
+        max(len(strip(line)) for line in LICENSE) +
+        len(strip(LOGO[0]))
     )
+    if width >= lmax + 1:
+        header = f'\n'.join(
+            ('{0} {1}').format(*x)
+            for x in zip_longest(
+                LOGO,
+                LICENSE
+            )
+        )
+    else:
+        header = '\n'.join(LOGO) + '\n' + '\n'.join(LICENSE)
+    return f"\n{header}\n"

--- a/cylc/flow/scripts/__init__.py
+++ b/cylc/flow/scripts/__init__.py
@@ -16,7 +16,7 @@
 
 from itertools import zip_longest
 from textwrap import dedent
-
+import re
 from ansimarkup import strip
 
 from cylc.flow import __version__
@@ -28,82 +28,74 @@ _copyright_year = 2021  # This is set by GH Actions update_copyright workflow
 # fmt: off
 LOGO_LETTERS = (
     (
-        "      ",
-        "      ",
-        "._____",
-        "| .___",
-        "| !___",
-        "!_____",
-        "      ",
-        "      "
+        "oooo",
+        "oo  ",
+        "oooo",
     ),
     (
-        "      ",
-        "      ",
-        "._. ._",
-        "| | | ",
-        "| !_! ",
-        "!___. ",
-        ".___! ",
-        "!_____"
+        "oo oo",
+        "ooooo",
+        "   oo",
     ),
     (
-        "._.",
-        "| |",
-        "| |",
-        "| |",
-        "| |",
-        "|_!",
-        "|  ",
-        "!  "
+        "oo",
+        "oo",
+        "oo",
     ),
     (
-        "        ",
-        "        ",
-        "_____.  ",
-        " .___|  ",
-        " !___.  ",
-        "_____!  ",
-        "        ",
-        "        "
+        "oooo",
+        "oo  ",
+        "oooo",
     )
 )
 # fmt: on
 
 LOGO_LINES = [
     ''.join(
-        f'<{tag}>{letter[ind]}</{tag}>'
+        re.sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
         for tag, letter in zip(
-            ('red', 'green', 'yellow', 'blue'),
+            ('red', 'yellow', 'green', 'blue'),
             LOGO_LETTERS
         )
     )
     for ind in range(len(LOGO_LETTERS[0]))
 ]
 
-LICENCE = dedent(f"""
+LICENSE = dedent(f"""
     The Cylc Workflow Engine [{__version__}]
-    Copyright (C) 2008-{_copyright_year} NIWA
-    & British Crown (Met Office) & Contributors.
+    Copyright (C) 2008-{_copyright_year} NIWA &
+    British Crown (Met Office) & Contributors
 """)
+
+CYLC = (
+    "<b>"
+    "<red>C</red>"
+    "<yellow>y</yellow>"
+    "<green>l</green>"
+    "<blue>c</blue>"
+    "</b>"
+)
 
 
 def cylc_header(width=None):
     """Print copyright and license information."""
     if not width:
         width = get_width()
-    cylc_license = '\n\n' + LICENCE + '\n\n'
-    license_lines = cylc_license.splitlines()
-    lmax = max(len(line) for line in license_lines)
+    # center license lines
+    llines = LICENSE.strip().splitlines()
+    lmax = max(len(line) for line in llines)
+    llines = [
+        line.center(lmax)
+        for line in llines
+        if line
+    ]
+    llines[0] = re.sub('Cylc', CYLC, llines[0])
     tlmax = lmax + len(strip(LOGO_LINES[0]))
     lpad = int((width - tlmax) / 2) * ' '
-    return lpad + f'\n{lpad}'.join(
-        ('{0} {1: ^%s}' % lmax).format(*x)
+    return '\n' + lpad + f'\n{lpad}'.join(
+        ('{0}  {1}').format(*x)
         for x in zip_longest(
             LOGO_LINES,
-            license_lines,
-            fillvalue=' ' * (
-                len(LOGO_LINES[-1]) + 1
-            )
+            llines
         )
     )

--- a/tests/functional/cylc-play/02-format.t
+++ b/tests/functional/cylc-play/02-format.t
@@ -36,12 +36,8 @@ run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
 # format=plain
 TEST_NAME="${TEST_NAME_BASE}-run-format-plain"
 workflow_run_ok "${TEST_NAME}" cylc play --format plain "${WORKFLOW_NAME}"
-grep_ok 'listening on tcp:' "${TEST_NAME}.stdout"
-grep_ok 'publishing on tcp:' "${TEST_NAME}.stdout"
-grep_ok 'To view scheduler contact information:' \
-    "${TEST_NAME}.stdout"
-grep_ok 'Other ways to see if the workflow is still running:' \
-    "${TEST_NAME}.stdout"
+grep_ok "Copyright" "${TEST_NAME}.stdout"
+grep_ok "${WORKFLOW_NAME}:" "${TEST_NAME}.stdout"
 poll_workflow_stopped
 
 delete_db
@@ -57,6 +53,13 @@ print(list(sorted(data)), file=sys.stderr)
 assert list(sorted(data)) == [
     "host", "pid", "ps_opts", "pub_url", "url", "workflow"]
 ' "${TEST_NAME}.stdout"
+poll_workflow_stopped
+
+delete_db
+# quiet
+TEST_NAME="${TEST_NAME_BASE}-run-quiet"
+workflow_run_ok "${TEST_NAME}" cylc play --quiet "${WORKFLOW_NAME}"
+grep_ok "${WORKFLOW_NAME}:" "${TEST_NAME}.stdout"
 poll_workflow_stopped
 
 purge


### PR DESCRIPTION
A quick bit of fluff, because why not.

Several things have long annoyed me about the current "Cylc header" printed at the top of `cylc help` and `cylc play` stdout:
- it is too wide, and too tall
- yellow and green are the wrong way around
- the ASCII art looks:
   -  decidedly crappy
   - and :scream: kind of like a thinly disguised swastika (once you've seen this, you can't un-see it!)

The old:
![shot](https://user-images.githubusercontent.com/2362137/117923461-28e44d80-b348-11eb-8875-136529065ec3.png)

The new:
![shot3](https://user-images.githubusercontent.com/2362137/118064352-f3466f80-b3ee-11eb-986a-950969c4478a.png)
![shot2](https://user-images.githubusercontent.com/2362137/118064356-f5103300-b3ee-11eb-90f1-f82dad9f612e.png)
![shot1](https://user-images.githubusercontent.com/2362137/118064358-f5a8c980-b3ee-11eb-9477-fc7ba726c845.png)


Bolder, less verbose, more compact, not offensive! - what's not to like? 

