### PR TITLE
Made a template vars clash variable and make Cylc handle it elegently

### DIFF
--- a/cylc/flow/parsec/exceptions.py
+++ b/cylc/flow/parsec/exceptions.py
@@ -88,6 +88,10 @@ class FileParseError(ParsecError):
         return msg
 
 
+class TemplateVarLanguageClash(FileParseError):
+    ...
+
+
 class EmPyError(FileParseError):
     """Wrapper class for EmPy exceptions."""
 

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -347,7 +347,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
     # Fail if templating_detected ≠ hashbang
     hashbang = hashbang_and_plugin_templating_clash(
-        extra_vars['templating_detected'], flines[0]
+        extra_vars['templating_detected'], flines
     )
 
     # process with EmPy

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -35,6 +35,7 @@ import re
 import sys
 
 from pathlib import Path
+from typing import List
 
 from cylc.flow import __version__, iter_entry_points
 from cylc.flow import LOG
@@ -344,20 +345,19 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
     template_vars['CYLC_TEMPLATE_VARS'] = template_vars
 
+    # Fail if templating_detected ≠ hashbang
+    hashbang = hashbang_and_plugin_templating_clash(
+        extra_vars['templating_detected'], flines[0]
+    )
+
     # process with EmPy
     if do_empy:
         if (
             extra_vars['templating_detected'] == 'empy' and
-            not re.match(r'^#![Ee]m[Pp]y\s*', flines[0])
+            not hashbang and
+            hashbang != 'empy'
         ):
-            if not re.match(r'^#!', flines[0]):
-                flines.insert(0, '#!empy')
-            else:
-                raise TemplateVarLanguageClash(
-                    "Plugins set templating engine = "
-                    f"{extra_vars['templating_detected']}"
-                    f" which does not match {flines[0]} set in flow.cylc."
-                )
+            flines.insert(0, '#!empy')
         if flines and re.match(r'^#![Ee]m[Pp]y\s*', flines[0]):
             LOG.debug('Processing with EmPy')
             try:
@@ -373,16 +373,10 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
     if do_jinja2:
         if (
             extra_vars['templating_detected'] == 'jinja2' and
-            not re.match(r'^#![jJ]inja2\s*', flines[0])
+            not hashbang and
+            hashbang != 'jinja2'
         ):
-            if not re.match(r'^#!', flines[0]):
-                flines.insert(0, '#!jinja2')
-            else:
-                raise TemplateVarLanguageClash(
-                    "Plugins set templating engine = "
-                    f"{extra_vars['templating_detected']}"
-                    f" which does not match {flines[0]} set in flow.cylc."
-                )
+            flines.insert(0, '#!jinja2')
         if flines and re.match(r'^#![jJ]inja2\s*', flines[0]):
             LOG.debug('Processing with Jinja2')
             try:
@@ -400,6 +394,54 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
     # return rstripped lines
     return [fl.rstrip() for fl in flines]
+
+
+def hashbang_and_plugin_templating_clash(
+    templating: str, flines: List[str]
+) -> str:
+    """Check whether plugin set template engine and #!hashbang line match.
+
+    Args:
+        templating (str): [description]
+        flines (List[str]): [description]
+
+    Raises:
+        TemplateVarLanguageClash
+
+    Returns:
+        str: the hashbang, in lower case, to allow for users using any of
+        ['empy', 'EmPy', 'EMPY'], or similar in other templating languages.
+
+    Examples:
+        - Hashbang and templating_detected match:
+            >>> thisfunc = hashbang_and_plugin_templating_clash
+            >>> thisfunc('jinja2', ['#!Jinja2', 'stuff'])
+            'jinja2'
+
+        - Function returns nothing:
+            >>> thisfunc('', [''])
+
+        - Function raises if templating engines clash:
+            >>> thisfunc('empy', ['#!jinja2'])
+            Traceback (most recent call last):
+                ...
+            cylc.flow.parsec.exceptions.TemplateVarLanguageClash: ...
+    """
+    if flines and re.match(r'^#!(.*)\s*', flines[0]):
+        hashbang = re.findall(r'^#!(.*)\s*', flines[0])[0].lower()
+    else:
+        hashbang = None
+    if (
+        hashbang and templating
+        and templating != 'template variables'
+        and hashbang != templating
+    ):
+        raise TemplateVarLanguageClash(
+            "Plugins set templating engine = "
+            f"{templating}"
+            f" which does not match {flines[0]} set in flow.cylc."
+        )
+    return hashbang
 
 
 def parse(fpath, output_fname=None, template_vars=None):

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -35,7 +35,7 @@ import re
 import sys
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from cylc.flow import __version__, iter_entry_points
 from cylc.flow import LOG
@@ -398,7 +398,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
 
 def hashbang_and_plugin_templating_clash(
     templating: str, flines: List[str]
-) -> str:
+) -> Optional[str]:
     """Check whether plugin set template engine and #!hashbang line match.
 
     Args:

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -39,7 +39,9 @@ from pathlib import Path
 from cylc.flow import __version__, iter_entry_points
 from cylc.flow import LOG
 from cylc.flow.exceptions import PluginError
-from cylc.flow.parsec.exceptions import FileParseError, ParsecError
+from cylc.flow.parsec.exceptions import (
+    FileParseError, ParsecError, TemplateVarLanguageClash
+)
 from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.include import inline
 from cylc.flow.parsec.util import itemstr
@@ -351,7 +353,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
             if not re.match(r'^#!', flines[0]):
                 flines.insert(0, '#!empy')
             else:
-                raise FileParseError(
+                raise TemplateVarLanguageClash(
                     "Plugins set templating engine = "
                     f"{extra_vars['templating_detected']}"
                     f" which does not match {flines[0]} set in flow.cylc."
@@ -376,7 +378,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
             if not re.match(r'^#!', flines[0]):
                 flines.insert(0, '#!jinja2')
             else:
-                raise FileParseError(
+                raise TemplateVarLanguageClash(
                     "Plugins set templating engine = "
                     f"{extra_vars['templating_detected']}"
                     f" which does not match {flines[0]} set in flow.cylc."

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -17,6 +17,7 @@
 
 import asyncio
 from collections import deque
+from cylc.flow.parsec.exceptions import TemplateVarLanguageClash
 from dataclasses import dataclass
 import logging
 from optparse import Values
@@ -1643,7 +1644,10 @@ class Scheduler:
                 self.resume_workflow(quiet=True)
         elif isinstance(reason, SchedulerError):
             LOG.error(f'Workflow shutting down - {reason}')
-        elif isinstance(reason, CylcError):
+        elif (
+            isinstance(reason, CylcError)
+            or isinstance(reason, TemplateVarLanguageClash)
+        ):
             LOG.error(
                 "Workflow shutting down - "
                 f"{reason.__class__.__name__}: {reason}")

--- a/tests/unit/parsec/test_fileparse_templating_clash.py
+++ b/tests/unit/parsec/test_fileparse_templating_clash.py
@@ -1,0 +1,40 @@
+
+from os import read
+import pytest
+
+from cylc.flow.parsec import fileparse
+from cylc.flow.parsec.fileparse import read_and_proc
+from cylc.flow.parsec.exceptions import TemplateVarLanguageClash
+
+
+@pytest.mark.parametrize(
+    'templating, hashbang',
+    [
+        ['empy', 'jinja2'],
+        ['jinja2', 'empy']
+    ]
+)
+def test_read_and_proc_raises_TemplateVarLanguageClash(
+    monkeypatch, tmp_path, templating, hashbang
+):
+    """func fails when diffn't templating engines set in hashbang and plugin.
+    """
+
+    def fake_process_plugins(_):
+        extra_vars = {
+            'env': {},
+            'template_variables': {'foo': 52},
+            'templating_detected': templating
+        }
+        return extra_vars
+    monkeypatch.setattr(fileparse, 'process_plugins', fake_process_plugins)
+
+    file_ = tmp_path / 'flow.cylc'
+    file_.write_text(
+        f'#!{hashbang}\nfoo'
+    )
+
+    with pytest.raises(TemplateVarLanguageClash) as exc:
+        read_and_proc(file_)
+
+    assert exc.type == TemplateVarLanguageClash

--- a/tests/unit/parsec/test_fileparse_templating_clash.py
+++ b/tests/unit/parsec/test_fileparse_templating_clash.py
@@ -13,21 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
-# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from os import read
 import pytest

--- a/tests/unit/parsec/test_fileparse_templating_clash.py
+++ b/tests/unit/parsec/test_fileparse_templating_clash.py
@@ -13,6 +13,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from os import read
 import pytest

--- a/tests/unit/parsec/test_fileparse_templating_clash.py
+++ b/tests/unit/parsec/test_fileparse_templating_clash.py
@@ -1,3 +1,18 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from os import read
 import pytest


### PR DESCRIPTION
These changes close #4210 , alongside https://github.com/cylc/cylc-rose/pull/60.

During fixing #4210  I created a test to which revealed an additional bug, where handling of `# rose-suite.conf:[jinja2:suite.rc]` and `flow.cylc:#!empy` was not symmetrical with the templating clash being the other way around which failed in the desired manner. I moved the check above the loops which process jinja2 and empy. The code is now tidier, and more susceptible to unit testing when future bugs are found.

There is much more scope for unitizing this bit of code and testing it in bits in the future.

**tests are likely to fail in CI - manual checkout of both branches is required** 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (refactor).
- [x] No documentation update required.
