### PR TITLE
aiofiles: bump from 0.5->0.7

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Configure git  # Needed by the odd test
+        uses: cylc/release-actions/configure-git@v1
+
       - name: Configure Python
         uses: actions/setup-python@v2
         with:

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - aiofiles >=0.5.0,<0.6.0
+  - aiofiles >=0.7.0,<0.8.0
   - ansimarkup >=1.0.0
   - click >=7.0
   - colorama >=0.4,<0.5

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -1,7 +1,6 @@
 name: cylc-dev
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - aiofiles >=0.7.0,<0.8.0
   - ansimarkup >=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'aiofiles==0.5.*',
+    'aiofiles==0.7.*',
     'ansimarkup>=1.0.0',
     'click>=7.0',
     'colorama>=0.4,<=1',


### PR DESCRIPTION
aiofiles have fixed their pypi metadata and are now releasing noarch packages on conda-forge which unblocks Python 3.9 support.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
