### PR TITLE
Close public database correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,7 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
-## __cylc-8.0b2 (<span actions:bind='release-date'>Released 2021-??-??</span>)__
+## __cylc-8.0b2 (<span actions:bind='release-date'>Upcoming, 2021</span>)__
 
 Third beta release of Cylc 8.
 
@@ -69,6 +69,9 @@ functionality is now provided by `[symlink dirs]`.
 
 [#4142](https://github.com/cylc/cylc-flow/pull/4142) - Record source directory
 version control information on installation of a workflow.
+
+[#4222](https://github.com/cylc/cylc-flow/pull/4222) - Fix bug where a
+workflow's public database file was not closed properly.
 
 ### Fixes
 

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -349,16 +349,16 @@ class CylcWorkflowDAO:
         """
         self.tables[table_name].add_update_item(set_args, where_args)
 
-    def close(self):
+    def close(self) -> None:
         """Explicitly close the connection."""
         if self.conn is not None:
             try:
                 self.conn.close()
-            except sqlite3.Error:
-                pass
+            except sqlite3.Error as exc:
+                LOG.debug(f"Error closing connection to DB: {exc}")
             self.conn = None
 
-    def connect(self):
+    def connect(self) -> sqlite3.Connection:
         """Connect to the database."""
         if self.conn is None:
             self.conn = sqlite3.connect(self.db_file_name, self.CONN_TIMEOUT)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,10 +68,10 @@ def pytest_runtest_makereport(item, call):
     item.module._module_outcomes = _module_outcomes
 
 
-def _pytest_passed(request):
+def _pytest_passed(request: pytest.FixtureRequest) -> bool:
     """Returns True if the test(s) a fixture was used in passed."""
     if hasattr(request.node, '_function_outcome'):
-        return request.node._function_outcome in {'passed', 'skipped'}
+        return request.node._function_outcome.outcome in {'passed', 'skipped'}
     return all((
         report.outcome in {'passed', 'skipped'}
         for report in request.node.obj._module_outcomes.values()
@@ -105,7 +105,7 @@ def mod_test_dir(request, ses_test_dir):
     yield path
     if _pytest_passed(request):
         # test passed -> remove all files
-        rmtree(path, ignore_errors=True)
+        rmtree(path, ignore_errors=False)
     else:
         # test failed -> remove the test dir if empty
         _rm_if_empty(path)
@@ -119,7 +119,7 @@ def test_dir(request, mod_test_dir):
     yield path
     if _pytest_passed(request):
         # test passed -> remove all files
-        rmtree(path, ignore_errors=True)
+        rmtree(path, ignore_errors=False)
     else:
         # test failed -> remove the test dir if empty
         _rm_if_empty(path)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,11 +18,10 @@
 import asyncio
 from functools import partial
 from pathlib import Path
+import pytest
 import re
 from shutil import rmtree
 from typing import List, TYPE_CHECKING
-
-import pytest
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.pathutil import get_workflow_run_dir
@@ -139,14 +138,24 @@ def flow(run_dir, test_dir):
 
 @pytest.fixture(scope='module')
 def mod_scheduler():
-    """Return a scheduler object for a flow."""
-    return _make_scheduler
+    """Return a Scheduler object for a flow.
+
+    Usage: see scheduler() below
+    """
+    with _make_scheduler() as _scheduler:
+        yield _scheduler
 
 
 @pytest.fixture
 def scheduler():
-    """Return a scheduler object for a flow."""
-    return _make_scheduler
+    """Return a Scheduler object for a flow.
+
+    Args:
+        reg (str): Workflow name.
+        **opts (Any): Options to be passed to the Scheduler.
+    """
+    with _make_scheduler() as _scheduler:
+        yield _scheduler
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -13,13 +13,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from unittest.mock import Mock
 
+from typing import Callable
 import pytest
+from unittest.mock import Mock
 
 from cylc.flow.data_store_mgr import ID_DELIM, EDGES, TASK_PROXIES
 from cylc.flow.network.resolvers import Resolvers
 from cylc.flow.network.schema import parse_node_id
+from cylc.flow.scheduler import Scheduler
 
 
 @pytest.fixture
@@ -46,7 +48,10 @@ def node_args():
 
 
 @pytest.fixture(scope='module')
-async def flow(mod_flow, mod_scheduler, mod_run):
+async def mock_flow(
+    mod_flow: Callable[..., str],
+    mod_scheduler: Callable[..., Scheduler]
+) -> Scheduler:
     ret = Mock()
     ret.reg = mod_flow({
         'scheduler': {
@@ -85,122 +90,122 @@ async def flow(mod_flow, mod_scheduler, mod_run):
         for edge in ret.data[EDGES].values()
     ]
 
-    yield ret
+    return ret
 
 
 @pytest.mark.asyncio
-async def test_get_workflows(flow, flow_args):
+async def test_get_workflows(mock_flow, flow_args):
     """Test method returning workflow messages satisfying filter args."""
-    flow_args['workflows'].append((flow.owner, flow.name, None))
-    flow_msgs = await flow.resolvers.get_workflows(flow_args)
+    flow_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
+    flow_msgs = await mock_flow.resolvers.get_workflows(flow_args)
     assert len(flow_msgs) == 1
 
 
 @pytest.mark.asyncio
-async def test_get_nodes_all(flow, node_args):
+async def test_get_nodes_all(mock_flow, node_args):
     """Test method returning workflow(s) node message satisfying filter args.
     """
-    node_args['workflows'].append((flow.owner, flow.name, None))
+    node_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
     node_args['states'].append('failed')
-    nodes = await flow.resolvers.get_nodes_all(TASK_PROXIES, node_args)
+    nodes = await mock_flow.resolvers.get_nodes_all(TASK_PROXIES, node_args)
     assert len(nodes) == 0
     node_args['ghosts'] = True
     node_args['states'] = []
-    node_args['ids'].append(parse_node_id(flow.node_ids[0], TASK_PROXIES))
+    node_args['ids'].append(parse_node_id(mock_flow.node_ids[0], TASK_PROXIES))
     nodes = [
-        n
-        for n in await flow.resolvers.get_nodes_all(TASK_PROXIES, node_args)
-        if n in flow.data[TASK_PROXIES].values()
+        n for n in await mock_flow.resolvers.get_nodes_all(
+            TASK_PROXIES, node_args)
+        if n in mock_flow.data[TASK_PROXIES].values()
     ]
     assert len(nodes) == 1
 
 
 @pytest.mark.asyncio
-async def test_get_nodes_by_ids(flow, node_args):
+async def test_get_nodes_by_ids(mock_flow, node_args):
     """Test method returning workflow(s) node messages
     who's ID is a match to any given."""
-    node_args['workflows'].append((flow.owner, flow.name, None))
-    nodes = await flow.resolvers.get_nodes_by_ids(TASK_PROXIES, node_args)
+    node_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
+    nodes = await mock_flow.resolvers.get_nodes_by_ids(TASK_PROXIES, node_args)
     assert len(nodes) == 0
 
     node_args['ghosts'] = True
-    node_args['native_ids'] = flow.node_ids
+    node_args['native_ids'] = mock_flow.node_ids
     nodes = [
         n
-        for n in await flow.resolvers.get_nodes_by_ids(
+        for n in await mock_flow.resolvers.get_nodes_by_ids(
             TASK_PROXIES, node_args
         )
-        if n in flow.data[TASK_PROXIES].values()
+        if n in mock_flow.data[TASK_PROXIES].values()
     ]
     assert len(nodes) > 0
 
 
 @pytest.mark.asyncio
-async def test_get_node_by_id(flow, node_args):
+async def test_get_node_by_id(mock_flow, node_args):
     """Test method returning a workflow node message
     who's ID is a match to that given."""
     node_args['id'] = f'me{ID_DELIM}mine{ID_DELIM}20500808T00{ID_DELIM}jin'
-    node_args['workflows'].append((flow.owner, flow.name, None))
-    node = await flow.resolvers.get_node_by_id(TASK_PROXIES, node_args)
+    node_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
+    node = await mock_flow.resolvers.get_node_by_id(TASK_PROXIES, node_args)
     assert node is None
-    node_args['id'] = flow.node_ids[0]
-    node = await flow.resolvers.get_node_by_id(TASK_PROXIES, node_args)
-    assert node in flow.data[TASK_PROXIES].values()
+    node_args['id'] = mock_flow.node_ids[0]
+    node = await mock_flow.resolvers.get_node_by_id(TASK_PROXIES, node_args)
+    assert node in mock_flow.data[TASK_PROXIES].values()
 
 
 @pytest.mark.asyncio
-async def test_get_edges_all(flow, flow_args):
+async def test_get_edges_all(mock_flow, flow_args):
     """Test method returning all workflow(s) edges."""
     edges = [
         e
-        for e in await flow.resolvers.get_edges_all(flow_args)
-        if e in flow.data[EDGES].values()
+        for e in await mock_flow.resolvers.get_edges_all(flow_args)
+        if e in mock_flow.data[EDGES].values()
     ]
     assert len(edges) > 0
 
 
 @pytest.mark.asyncio
-async def test_get_edges_by_ids(flow, node_args):
+async def test_get_edges_by_ids(mock_flow, node_args):
     """Test method returning workflow(s) edge messages
     who's ID is a match to any given edge IDs."""
-    edges = await flow.resolvers.get_edges_by_ids(node_args)
+    edges = await mock_flow.resolvers.get_edges_by_ids(node_args)
     assert len(edges) == 0
-    node_args['native_ids'] = flow.edge_ids
+    node_args['native_ids'] = mock_flow.edge_ids
     edges = [
         e
-        for e in await flow.resolvers.get_edges_by_ids(node_args)
-        if e in flow.data[EDGES].values()
+        for e in await mock_flow.resolvers.get_edges_by_ids(node_args)
+        if e in mock_flow.data[EDGES].values()
     ]
     assert len(edges) > 0
 
 
 @pytest.mark.asyncio
-async def test_mutator(flow, flow_args):
+async def test_mutator(mock_flow, flow_args):
     """Test the mutation method."""
-    flow_args['workflows'].append((flow.owner, flow.name, None))
+    flow_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
     args = {}
-    response = await flow.resolvers.mutator(
+    response = await mock_flow.resolvers.mutator(
         None,
         'pause',
         flow_args,
         args
     )
-    assert response[0]['id'] == flow.id
+    assert response[0]['id'] == mock_flow.id
 
 
 @pytest.mark.asyncio
-async def test_nodes_mutator(flow, flow_args):
+async def test_nodes_mutator(mock_flow, flow_args):
     """Test the nodes mutation method."""
-    flow_args['workflows'].append((flow.owner, flow.name, None))
-    ids = [parse_node_id(n, TASK_PROXIES) for n in flow.node_ids]
-    response = await flow.resolvers.nodes_mutator(
+    flow_args['workflows'].append((mock_flow.owner, mock_flow.name, None))
+    ids = [parse_node_id(n, TASK_PROXIES) for n in mock_flow.node_ids]
+    response = await mock_flow.resolvers.nodes_mutator(
         None, 'force_trigger_tasks', ids, flow_args, {}
     )
-    assert response[0]['id'] == flow.id
+    assert response[0]['id'] == mock_flow.id
 
 
 @pytest.mark.asyncio
-async def test_mutation_mapper(flow):
+async def test_mutation_mapper(mock_flow):
     """Test the mapping of mutations to internal command methods."""
-    response = await flow.resolvers._mutation_mapper('pause', {})
+    response = await mock_flow.resolvers._mutation_mapper('pause', {})
     assert response is not None


### PR DESCRIPTION
These changes partially address #3666

When the scheduler starts, the public database is synced with the private database. This is done by copying the private database into a tempfile, which is then renamed to replace the public database file (the tempfile is not deleted) (see https://github.com/cylc/cylc-flow/pull/1493#issuecomment-111044334 for the rationale behind this). But the file descriptor for the tempfile was not closed at any point, hence the Python process held on to the file beyond the shutdown of the scheduler.

I have not tackled the suggestion of persisting the connection(s) to the databases.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (integration tests will <del>fail</del><ins> error during teardown</ins> if this issue reappears).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
