### PR TITLE
Fix ICP bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,9 @@ workflow's public database file was not closed properly.
 
 ### Fixes
 
+[#4227](https://github.com/cylc/cylc-flow/pull/4227) - Better error messages
+when initial cycle point is not valid for the cycling type.
+
 [#4193](https://github.com/cylc/cylc-flow/pull/4193) - Standard `cylc install`
 now correctly installs from directories with a `.` in the name. Symlink dirs
 now correctly expands environment variables on the remote. Fixes minor cosmetic

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -739,20 +739,22 @@ class WorkflowConfig:
             WorkflowConfigError - if it fails to validate
         """
         orig_icp = self.cfg['scheduling']['initial cycle point']
-        if orig_icp is None:
-            if self.cfg['scheduling']['cycling mode'] == INTEGER_CYCLING_TYPE:
-                orig_icp = '1'
+        if self.cycling_type == INTEGER_CYCLING_TYPE:
+            if orig_icp is None:
+                icp = orig_icp = '1'
             else:
+                icp = orig_icp
+        elif self.cycling_type == ISO8601_CYCLING_TYPE:
+            if orig_icp is None:
                 raise WorkflowConfigError(
                     "This workflow requires an initial cycle point.")
-        if orig_icp == "now":
-            icp = get_current_time_string()
-        else:
-            try:
-                my_now = get_current_time_string()
-                icp = ingest_time(orig_icp, my_now)
-            except IsodatetimeError as exc:
-                raise WorkflowConfigError(str(exc))
+            if orig_icp == "now":
+                icp = get_current_time_string()
+            else:
+                try:
+                    icp = ingest_time(orig_icp, get_current_time_string())
+                except IsodatetimeError as exc:
+                    raise WorkflowConfigError(str(exc))
         if orig_icp != icp:
             # now/next()/prev() was used, need to store evaluated point in DB
             self.options.icp = icp

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -741,9 +741,8 @@ class WorkflowConfig:
         orig_icp = self.cfg['scheduling']['initial cycle point']
         if self.cycling_type == INTEGER_CYCLING_TYPE:
             if orig_icp is None:
-                icp = orig_icp = '1'
-            else:
-                icp = orig_icp
+                orig_icp = '1'
+            icp = orig_icp
         elif self.cycling_type == ISO8601_CYCLING_TYPE:
             if orig_icp is None:
                 raise WorkflowConfigError(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,24 +56,23 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def cycling_mode(monkeypatch: pytest.MonkeyPatch):
-    """Set the Cylc cycling mode.
-
+def cycling_type(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set the Cylc cycling type.
     Args:
-        mode: The cycling mode.
-        time_zone: If using ISO8601/datetime cycling mode, you can specify a
+        type: The cycling type.
+        time_zone: If using ISO8601/datetime cycling type, you can specify a
             custom time zone to use.
     """
-    def _cycling_mode(
-        mode: str = INTEGER_CYCLING_TYPE, time_zone: Optional[str] = None
+    def _cycling_type(
+        ctype: str = INTEGER_CYCLING_TYPE, time_zone: Optional[str] = None
     ) -> None:
         class _DefaultCycler:
-            TYPE = mode
+            TYPE = ctype
         monkeypatch.setattr(
             'cylc.flow.cycling.loader.DefaultCycler', _DefaultCycler)
-        if mode == ISO8601_CYCLING_TYPE:
+        if ctype == ISO8601_CYCLING_TYPE:
             iso8601_init(time_zone=time_zone)
-    return _cycling_mode
+    return _cycling_type
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,22 +56,27 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def cycling_type(monkeypatch: pytest.MonkeyPatch) -> str:
-    """Set the Cylc cycling type.
+def cycling_type(monkeypatch: pytest.MonkeyPatch):
+    """Initialize the cycling type according to cycling mode.
     Args:
-        type: The cycling type.
+        mode: The cycling mode.
         time_zone: If using ISO8601/datetime cycling type, you can specify a
             custom time zone to use.
     """
     def _cycling_type(
-        ctype: str = INTEGER_CYCLING_TYPE, time_zone: Optional[str] = None
-    ) -> None:
+        mode: str = 'integer', time_zone: Optional[str] = None
+    ) -> str:
+        if mode == 'integer':
+            ctype = INTEGER_CYCLING_TYPE
+        else:
+            ctype = ISO8601_CYCLING_TYPE
         class _DefaultCycler:
             TYPE = ctype
         monkeypatch.setattr(
             'cylc.flow.cycling.loader.DefaultCycler', _DefaultCycler)
         if ctype == ISO8601_CYCLING_TYPE:
             iso8601_init(time_zone=time_zone)
+        return ctype
     return _cycling_type
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -263,7 +263,7 @@ def test_family_inheritance_and_quotes(
         (  # more non-integer ICP for integer cycling type
             {
                 'cycling type': loader.INTEGER_CYCLING_TYPE,
-                'initial cycle point': "now",
+                'initial cycle point': "20500808T0000Z",
                 'initial cycle point constraints': []
             },
             None,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,8 +23,6 @@ from unittest.mock import Mock
 from cylc.flow import CYLC_LOG
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.cycling import loader
-from cylc.flow.cycling.integer import CYCLER_TYPE_INTEGER
-from cylc.flow.cycling.iso8601 import CYCLER_TYPE_ISO8601
 from cylc.flow.exceptions import WorkflowConfigError, PointParsingError
 from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.wallclock import get_utc_mode, set_utc_mode
@@ -232,7 +230,7 @@ def test_family_inheritance_and_quotes(
     [
         (  # Lack of icp
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': None,
                 'initial cycle point constraints': []
             },
@@ -242,7 +240,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # Default icp for integer cycling type
             {
-                'cycling type': CYCLER_TYPE_INTEGER,
+                'cycling mode': 'integer',
                 'initial cycle point': None,
                 'initial cycle point constraints': []
             },
@@ -252,7 +250,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # non-integer ICP for integer cycling type
             {
-                'cycling type': loader.INTEGER_CYCLING_TYPE,
+                'cycling mode': 'integer',
                 'initial cycle point': "now",
                 'initial cycle point constraints': []
             },
@@ -262,7 +260,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # more non-integer ICP for integer cycling type
             {
-                'cycling type': loader.INTEGER_CYCLING_TYPE,
+                'cycling mode': 'integer',
                 'initial cycle point': "20500808T0000Z",
                 'initial cycle point constraints': []
             },
@@ -272,7 +270,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # non-ISO8601 ICP for ISO8601 cycling type
             {
-                'cycling type': loader.ISO8601_CYCLING_TYPE,
+                'cycling mode': '',
                 'initial cycle point': "1",
                 'initial cycle point constraints': []
             },
@@ -282,7 +280,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # "now"
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': 'now',
                 'initial cycle point constraints': []
             },
@@ -292,7 +290,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # Constraints
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'initial cycle point constraints': ['T00', 'T12']
             },
@@ -302,7 +300,7 @@ def test_family_inheritance_and_quotes(
         ),
         (  # Violated constraints
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2021-01-20',
                 'initial cycle point constraints': ['--01-19', '--01-21']
             },
@@ -330,10 +328,10 @@ def test_process_icp(
     """
     cycling_type(scheduling_cfg['cycling mode'], time_zone="+0530")
     mocked_config = Mock()
-    mocked_config.cycling_type = cycling_type(integer=int_cycling_type)
     mocked_config.cfg = {
         'scheduling': scheduling_cfg
     }
+    mocked_config.cycling_type = cycling_type(scheduling_cfg['cycling mode'], time_zone="+0530")
     mocked_config.options.icp = None
     monkeypatch.setattr('cylc.flow.config.get_current_time_string',
                         lambda: '20050102T0615+0530')
@@ -371,7 +369,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         startcp: The start cycle point given by cli option.
         expected: The expected startcp value that gets set.
     """
-    cycling_type(CYCLER_TYPE_ISO8601, time_zone="+0530")
+    cycling_type('', time_zone="+0530")
     mocked_config = Mock(initial_point='18990501T0000+0530')
     mocked_config.options.startcp = startcp
     monkeypatch.setattr('cylc.flow.config.get_current_time_string',
@@ -386,7 +384,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
     [
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2021',
                 'final cycle point': None,
                 'final cycle point constraints': []
@@ -398,7 +396,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2016',
                 'final cycle point': '2021',
                 'final cycle point constraints': []
@@ -410,7 +408,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2016',
                 'final cycle point': '2021',
                 'final cycle point constraints': []
@@ -422,7 +420,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2017-02-11',
                 'final cycle point': '+P4D',
                 'final cycle point constraints': []
@@ -434,7 +432,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2017-02-11',
                 'final cycle point': '---04',
                 'final cycle point constraints': []
@@ -447,7 +445,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_INTEGER,
+                'cycling mode': 'integer',
                 'initial cycle point': '1',
                 'final cycle point': '4',
                 'final cycle point constraints': []
@@ -459,7 +457,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_INTEGER,
+                'cycling mode': 'integer',
                 'initial cycle point': '1',
                 'final cycle point': '+P2',
                 'final cycle point constraints': []
@@ -471,7 +469,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'final cycle point': '2009',
                 'final cycle point constraints': []
@@ -485,7 +483,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'final cycle point': '-PT1S',
                 'final cycle point constraints': []
@@ -499,7 +497,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'final cycle point': '2021',
                 'final cycle point constraints': ['T00', 'T12']
@@ -511,7 +509,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'final cycle point': '2021-01-19',
                 'final cycle point constraints': ['--01-19', '--01-21']
@@ -523,7 +521,7 @@ def test_process_startcp(startcp: Optional[str], expected: str,
         ),
         pytest.param(
             {
-                'cycling type': CYCLER_TYPE_ISO8601,
+                'cycling mode': '',
                 'initial cycle point': '2013',
                 'final cycle point': '2021',
                 'final cycle point constraints': []
@@ -585,7 +583,7 @@ def test_process_fcp(scheduling_cfg: dict, options_fcp: Optional[str],
                 'graph': {'R1': 'foo'}
             },
             {
-                'cycling mode': CYCLER_TYPE_INTEGER,
+                'cycling mode': 'integer',
                 'initial cycle point': '1',
                 'final cycle point': '1',
                 'graph': {'R1': 'foo'}
@@ -595,11 +593,11 @@ def test_process_fcp(scheduling_cfg: dict, options_fcp: Optional[str],
         ),
         pytest.param(
             {
-                'cycling mode': "gregorian",
+                'cycling mode': "",
                 'graph': {'R1': 'foo'}
             },
             {
-                'cycling mode': "gregorian",
+                'cycling mode': "",
                 'graph': {'R1': 'foo'}
             },
             None,
@@ -802,31 +800,30 @@ def test_valid_rsync_includes_returns_correct_list(tmp_path):
 
 
 @pytest.mark.parametrize(
-    'ctype, runahead_limit, valid',
+    'cycling_mode, runahead_limit, valid',
     [
-        (CYCLER_TYPE_INTEGER, 'P14', True),
-        (CYCLER_TYPE_ISO8601, 'P14', True),
-        (CYCLER_TYPE_ISO8601, 'PT12H', True),
-        (CYCLER_TYPE_ISO8601, 'P7D', True),
-        (CYCLER_TYPE_ISO8601, 'P2W', True),
-        (CYCLER_TYPE_ISO8601, '4', True),
+        ('integer', 'P14', True),
+        ('', 'P14', True),
+        ('', 'PT12H', True),
+        ('', 'P7D', True),
+        ('', 'P2W', True),
+        ('', '4', True),
 
-        (CYCLER_TYPE_INTEGER, 'PT12H', False),
-        (CYCLER_TYPE_INTEGER, 'P7D', False),
-        (CYCLER_TYPE_INTEGER, '4', False),
-        (CYCLER_TYPE_ISO8601, '', False),
-        (CYCLER_TYPE_ISO8601, 'asdf', False)
+        ('integer', 'PT12H', False),
+        ('integer', 'P7D', False),
+        ('integer', '4', False),
+        ('', '', False),
+        ('', 'asdf', False)
     ]
 )
 def test_process_runahead_limit(
-    ctype: str, runahead_limit: str, valid: bool,
+    cycling_mode: str, runahead_limit: str, valid: bool,
     cycling_type: Callable
 ) -> None:
-    cycling_type(ctype)
-    mock_config = Mock(cycling_type=ctype)
+    mock_config = Mock(cycling_type=cycling_type(cycling_mode))
     mock_config.cfg = {
         'scheduling': {
-            'cycling type': ctype,
+            'cycling mode': cycling_mode,
             'runahead limit': runahead_limit
         }
     }

--- a/tests/unit/test_task_trigger.py
+++ b/tests/unit/test_task_trigger.py
@@ -91,8 +91,8 @@ def test_check_exeption():
         TaskTrigger.get_trigger_name("Foo:Elephant")
 
 
-def test_get_parent_point(cycling_mode):
-    cycling_mode()
+def test_get_parent_point(cycling_type):
+    cycling_type()
 
     one = get_point('1')
     two = get_point('2')
@@ -112,8 +112,8 @@ def test_get_parent_point(cycling_mode):
     assert trigger.get_parent_point(one) == two
 
 
-def test_get_child_point(cycling_mode):
-    cycling_mode()
+def test_get_child_point(cycling_type):
+    cycling_type()
 
     zero = get_point('0')
     one = get_point('1')
@@ -143,8 +143,8 @@ def test_get_child_point(cycling_mode):
     assert trigger.get_child_point(one, None) == two
 
 
-def test_get_point(cycling_mode):
-    cycling_mode()
+def test_get_point(cycling_type):
+    cycling_type()
 
     one = get_point('1')
     two = get_point('2')
@@ -163,8 +163,8 @@ def test_get_point(cycling_mode):
     assert trigger.get_point(one) == one
 
 
-def test_str(cycling_mode):
-    cycling_mode()
+def test_str(cycling_type):
+    cycling_type()
 
     one = get_point('1')
     two = get_point('2')


### PR DESCRIPTION
These changes close #4225

```
$ cylc play --no-detach five --initial-cycle-point="2^2"

                Cylc Workflow Engine 8.0b2.dev
                Copyright (C) 2008-2021 NIWA
                & British Crown (Met Office) & Contributors

2021-05-25T13:15:56+12:00 ERROR - Workflow shutting down - PointParsingError: Incompatible value for
        <class 'cylc.flow.cycling.integer.IntegerPoint'>: 2^2: invalid literal for int() with base 10: '2^2'
2021-05-25T13:15:56+12:00 INFO - DONE

```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
