### PR TITLE
this tests appears to have been inoperative for some time

### DIFF
--- a/tests/functional/job-submission/19-platform_select.t
+++ b/tests/functional/job-submission/19-platform_select.t
@@ -41,7 +41,7 @@ grep_ok \
 
 # Check that host = `hostname` is correctly evaluated
 grep_ok \
-    'host_subshell_backticks.1:.*`hostname` evaluated as localhost' \
+    "host_subshell_backticks.1:.*\`hostname\` evaluated as localhost" \
     "${logfile}"
 
 # Check that platform = $(echo "improbable platform name") correctly evaluated

--- a/tests/functional/job-submission/19-platform_select.t
+++ b/tests/functional/job-submission/19-platform_select.t
@@ -17,62 +17,37 @@
 #-------------------------------------------------------------------------------
 # Test recovery of a failed host select command for a group of tasks.
 . "$(dirname "$0")/test_header"
-set_test_number 7
+set_test_number 5
 
 create_test_global_config "
 [platforms]
     [[test platform]]
-        hosts = hostname
-
-    [[improbable platform name]]
         hosts = localhost
-        install target = localhost
 "
 
 install_workflow "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
-run_fail "${TEST_NAME_BASE}-run" \
+run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach "${WORKFLOW_NAME}"
 
-declare -A GREP_TESTS
+logfile="${WORKFLOW_RUN_DIR}/log/workflow/log"
 
-# Check that we are warned that platform check will not occur until job-submit
-errname='warn cannot check at validate'
-GREP_TESTS["${errname}"]="""
-    WARNING - Cannot attempt check .*platform_subshell.*\$(echo \"improbable platform name\")
-"""
 
-errname="host subshell eval ok"
 # Check that host = $(hostname) is correctly evaluated
-GREP_TESTS["${errname}"]="""
-    DEBUG.*platform_subshell.1.*evaluated as improbable platform name
-"""
+grep_ok \
+    "platform_subshell.1.*evaluated as improbable platform name" \
+    "${logfile}"
 
 # Check that host = `hostname` is correctly evaluated
-errname="host subshell backticks eval ok"
-# shellcheck disable=SC2006
-GREP_TESTS["${errname}"]="""
-    DEBUG.*host_subshell_backticks.1:.*`hostname` evaluated as localhost
-"""
+grep_ok \
+    'host_subshell_backticks.1:.*`hostname` evaluated as localhost' \
+    "${logfile}"
 
 # Check that platform = $(echo "improbable platform name") correctly evaluated
-errname="platform subshell eval ok"
-GREP_TESTS["${errname}"]="""
-    DEBUG.*platform_subshell.1:.*evaluated as improbable platform name
-"""
-
-errname="fail if platform expression in backticks"
-# shellcheck disable=SC2006,SC2116
-GREP_TESTS["${errname}"]="""
-    ERROR - PlatformLookupError.*\"`echo \"improbable platform name\"`\".*
-"""
-
-for testname in "${!GREP_TESTS[@]}"; do
-    # Symlink to get a better test name from grep_ok
-    ln -s "${WORKFLOW_RUN_DIR}/log/workflow/log" "$testname"
-    grep_ok "${GREP_TESTS[$testname]}" "$testname"
-done
+grep_ok \
+    "platform_subshell.1:.*evaluated as improbable platform name" \
+    "${logfile}"
 
 purge
 exit

--- a/tests/functional/job-submission/19-platform_select/flow.cylc
+++ b/tests/functional/job-submission/19-platform_select/flow.cylc
@@ -12,9 +12,9 @@ purpose = """
 [scheduling]
     [[dependencies]]
         R1 = """
-            platform_subshell
+            platform_subshell:submit-fail => fin
+            platform_no_subshell:submit-fail => fin
             host_subshell
-            platform_no_subshell
             host_no_subshell
             host_subshell_backticks
         """
@@ -35,8 +35,11 @@ purpose = """
 
     [[host_subshell]]
         [[[remote]]]
-            host = $(echo hostname)
+            host = $(hostname)
 
     [[host_subshell_backticks]]
         [[[remote]]]
-            host = `echo hostname`
+            host = `hostname`
+
+    [[fin]]
+        script = cylc remove ${CYLC_SUITE_NAME} platform_*


### PR DESCRIPTION
This is a small change with no associated Issue: 
This test was broken in that it was passing when it should not have been.
This happened because:
- Something about the for loop which did the grepping wasn't working.
- The fail_ok test was passing, because the workflow was failing in an unexpected way.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [x] Already covered by existing tests.
<!-- choose one: -->
- [x] No change log entry required ← invisible to users.
<!-- choose one: -->
- [x] No documentation update required.