### PR TITLE
cli: revert from click to argparse

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - aiofiles >=0.7.0,<0.8.0
   - ansimarkup >=1.0.0
-  - click >=7.0
   - colorama >=0.4,<0.5
   - cryptography
   - graphene >=2.1,<3

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ def find_version(*file_paths):
 install_requires = [
     'aiofiles==0.7.*',
     'ansimarkup>=1.0.0',
-    'click>=7.0',
     'colorama>=0.4,<=1',
     'graphene>=2.1,<3',
     'jinja2==2.11.*',

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -19,7 +19,7 @@
 
 . "$(dirname "$0")/test_header"
 # Number of tests depends on the number of 'cylc' commands.
-set_test_number $(( 23 + $(find "${CYLC_REPO_DIR}/bin" -name 'cylc-*' | wc -l) ))
+set_test_number 23
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -35,7 +35,7 @@ done
 # Sub-command - no match
 run_fail "${TEST_NAME_BASE}-aardvark" cylc aardvark
 cmp_ok "${TEST_NAME_BASE}-aardvark.stderr" <<'__STDERR__'
-Error: cylc aardvark: unknown utility. Abort.
+cylc aardvark: unknown utility. Abort.
 Type "cylc help all" for a list of utilities.
 __STDERR__
 


### PR DESCRIPTION
We briefly toyed with moving to click, however, only ever converted one script over and are now less sure of the correct framework.

This PR moves the one click command to argparse (stdlib) to reduce our dependency footprint.

Our CLI simplifications mean there isn't much driving us to move away from optparse, opened a low priority issue for future consideration: https://github.com/cylc/cylc-flow/issues/4231. 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
