### PR TITLE
Cylc review fixes.skip links to source

### DIFF
--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -438,10 +438,11 @@ class CylcReviewService(object):
             SuiteSrvFilesManager.DIR_BASE_SRV,
             "log",
             "share",
-            "work",
-            SuiteSrvFilesManager.FILE_BASE_SUITE_RC]
+            "work"
+        ]
         for dirpath, dnames, fnames in os.walk(
-                user_suite_dir_root, followlinks=True):
+            user_suite_dir_root, followlinks=True
+        ):
             if dirpath != user_suite_dir_root and (
                     any(name in dnames or name in fnames
                         for name in sub_names)):

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -449,6 +449,12 @@ class CylcReviewService(object):
                 dnames[:] = []
             else:
                 continue
+
+            # Don't display the symlink to the latest version of
+            # the Cylc8 Suite
+            if re.match(r'.*runN$', dirpath):
+                continue
+
             item = os.path.relpath(dirpath, user_suite_dir_root)
             if not any(fnmatch(item, glob_) for glob_ in name_globs):
                 continue

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -753,8 +753,10 @@ class CylcReviewService(object):
                                   "mtime": f_stat.st_mtime,
                                   "size": f_stat.st_size}
 
-        # Get cylc suite log files and other files:
+        # Get cylc suite/workflow log files and other files:
         EXTRA_FILES = [
+            "log/workflow/log*",
+            "log/workflow/file-installation-log.*",
             "log/suite/log*",
             "log/suite/file-installation-log.*",
             "log/install/*"

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -279,17 +279,15 @@ class CylcReviewDAO(object):
         return (entries, of_n_entries)
 
     def is_cylc8(self, user_name, suite_name):
-        # Detemine Cylc version for a given suite: Database changes require
-        # A different database query for Cylc8.
+        """Detemine Cylc version for a given suite: Database changes require
+        A different database query for Cylc8.
+        """
         suite_info = self._db_exec(
-            user_name, suite_name, 'SELECT * FROM suite_params', []
+            user_name, suite_name,
+            'SELECT name FROM sqlite_master WHERE type=\'table\';', []
         )
-        cylc_version = None
-        for row in suite_info:
-            if row[0] == u'cylc_version':
-                cylc_version = row[1]
-
-        if cylc_version and cylc_version[0] == '8':
+        suite_info = [i[0] for i in suite_info]
+        if 'workflow_params' in suite_info:
             return True
         else:
             return False

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -279,7 +279,7 @@ class CylcReviewDAO(object):
         return (entries, of_n_entries)
 
     def is_cylc8(self, user_name, suite_name):
-        """Detemine Cylc version for a given suite: Database changes require
+        """Determine Cylc version for a given suite: Database changes require
         A different database query for Cylc8.
         """
         suite_info = self._db_exec(


### PR DESCRIPTION
(dependent on #4233 )
These changes close #4170 and a minor issue without a ticket.

- #4170 Prevent Cylc Review from following links back to source directory for workflows installed using Cylc Install.
- Prevent Cylc Review from Displaying the `runN` symlink to the latest run folder.

[marked against a Cylc 8 milestone because this change only adds support for Cylc 8 workflows, and should not change an aspect of Cylc 7 functioning]

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests: legacy product, manual testing only.
- [x] No change log entry included & No documentation update required: Removing things that we don't want users to see before Gamma release.

### To test
Install a workflow with Cylc 8. 
Switch to Cylc 7 and start Cylc Review (`cylc review start`).
Ensure that you cannot see links to `~/cylc-run/<workflow>/_cylc-install` or `_cylc_install`.
Ensure that you cannot see links to `~/cylc-run/<workflow>/runN`