### PR TITLE
Refactor cycling_type unit test fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,7 +41,7 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     Args:
         reg: Workflow name.
     """
-    def inner(reg: Optional[str] = None) -> Path:
+    def _tmp_run_dir(reg: Optional[str] = None) -> Path:
         cylc_run_dir = tmp_path / 'cylc-run'
         cylc_run_dir.mkdir(exist_ok=True)
         monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', cylc_run_dir)
@@ -52,32 +52,28 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             (run_dir / WorkflowFiles.Service.DIRNAME).mkdir(exist_ok=True)
             return run_dir
         return cylc_run_dir
-    return inner
+    return _tmp_run_dir
 
 
 @pytest.fixture
-def cycling_type(monkeypatch: pytest.MonkeyPatch):
-    """Initialize the cycling type according to cycling mode.
+def set_cycling_type(monkeypatch: pytest.MonkeyPatch):
+    """Initialize the Cylc cycling type.
+
     Args:
-        mode: The cycling mode.
+        ctype: The cycling type (integer or iso8601).
         time_zone: If using ISO8601/datetime cycling type, you can specify a
             custom time zone to use.
     """
-    def _cycling_type(
-        mode: str = 'integer', time_zone: Optional[str] = None
-    ) -> str:
-        if mode == 'integer':
-            ctype = INTEGER_CYCLING_TYPE
-        else:
-            ctype = ISO8601_CYCLING_TYPE
+    def _set_cycling_type(
+        ctype: str = INTEGER_CYCLING_TYPE, time_zone: Optional[str] = None
+    ) -> None:
         class _DefaultCycler:
             TYPE = ctype
         monkeypatch.setattr(
             'cylc.flow.cycling.loader.DefaultCycler', _DefaultCycler)
         if ctype == ISO8601_CYCLING_TYPE:
             iso8601_init(time_zone=time_zone)
-        return ctype
-    return _cycling_type
+    return _set_cycling_type
 
 
 @pytest.fixture

--- a/tests/unit/test_task_trigger.py
+++ b/tests/unit/test_task_trigger.py
@@ -91,8 +91,8 @@ def test_check_exeption():
         TaskTrigger.get_trigger_name("Foo:Elephant")
 
 
-def test_get_parent_point(cycling_type):
-    cycling_type()
+def test_get_parent_point(set_cycling_type):
+    set_cycling_type()
 
     one = get_point('1')
     two = get_point('2')
@@ -112,8 +112,8 @@ def test_get_parent_point(cycling_type):
     assert trigger.get_parent_point(one) == two
 
 
-def test_get_child_point(cycling_type):
-    cycling_type()
+def test_get_child_point(set_cycling_type):
+    set_cycling_type()
 
     zero = get_point('0')
     one = get_point('1')
@@ -143,8 +143,8 @@ def test_get_child_point(cycling_type):
     assert trigger.get_child_point(one, None) == two
 
 
-def test_get_point(cycling_type):
-    cycling_type()
+def test_get_point(set_cycling_type):
+    set_cycling_type()
 
     one = get_point('1')
     two = get_point('2')
@@ -163,11 +163,8 @@ def test_get_point(cycling_type):
     assert trigger.get_point(one) == one
 
 
-def test_str(cycling_type):
-    cycling_type()
-
-    one = get_point('1')
-    two = get_point('2')
+def test_str(set_cycling_type):
+    set_cycling_type()
 
     trigger = TaskTrigger('name', '1', 'output', offset_is_absolute=True)
     assert str(trigger) == 'name[1]:output'


### PR DESCRIPTION
This is a small change with no associated Issue. Follow up to #4227

I have tried to make the `cycling_type` (now `set_cycling_type`) fixture simpler.

Note the difference between:
- cycling type: `integer` or `iso8601`
- cycling mode: `integer`, `gregorian`, `365day` etc.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
