### PR TITLE
pause: workflow cannot be stalled if it is paused

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1593,6 +1593,8 @@ class Scheduler:
         """Check if workflow is stalled or not."""
         if self.is_stalled:  # already reported
             return True
+        if self.is_paused:  # cannot be stalled it's not even running
+            return False
         self.is_stalled = self.pool.is_stalled()
         if self.is_stalled:
             self.run_event_handlers(self.EVENT_STALLED, 'workflow stalled')


### PR DESCRIPTION
closes https://github.com/cylc/cylc-flow/issues/4243

Fixes bug where the stall detection could release runahead tasks.

Spotted by @MetRonnie on https://github.com/cylc/cylc-flow/pull/4237#issuecomment-852954395

Bug was intermittent, however, could be made dependable by jamming an `await asyncio.sleep(1)` into `tests/i/test_scan::test_scan_sigstop`.

The released can be seen an extra log message in the test output which was causing the failure:

```
E             Full diff:
E               [
E             +  (20,
E             +   '[one.1] -released from runahead'),
E                (30,...
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? bug never released)
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [x] (7.8.x branch) I have updated the documentation in this PR branch.
- [x] No documentation update required.