### PR TITLE
logging: log graphql requests at debug level

### DIFF
--- a/cylc/flow/network/authorisation.py
+++ b/cylc/flow/network/authorisation.py
@@ -37,7 +37,7 @@ def authorise():
     """
     def wrapper(fcn):
         @wraps(fcn)  # preserve args and docstrings
-        def _authorise(self, *args, user='?', meta=None, **kwargs):
+        def _call(self, *args, user='?', meta=None, **kwargs):
             if not meta:
                 meta = {}
             host = meta.get('host', '?')
@@ -46,11 +46,11 @@ def authorise():
 
             # Hardcoded, for new - but much of this functionality can be
             # removed more swingingly.
-            LOG.info(
+            LOG.debug(
                 '[client-command] %s %s://%s@%s:%s',
                 fcn.__name__, comms_method, user, host, prog
             )
             return fcn(self, *args, **kwargs)
 
-        return _authorise
+        return _call
     return wrapper


### PR DESCRIPTION
Pet peeve of mine, graphql logs (especially from Tui and the UIS) fill up the suite log.

Shifted the graphql line to debug level:

* this line contains the host and script and protocol that issued the command
* later log entries contain the command and args

Lets see what tests get broken... nothing 🎉.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
