### PR TITLE
Symlink dirs cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,10 @@ Add an option for displaying source workflows in `cylc scan`.
 - Expose runahead limiting to UIs; restore correct force-triggering of queued
 tasks for Cylc 8.
 
+[#4250](https://github.com/cylc/cylc-flow/pull/4250) -
+Symlink dirs localhost symlinks are now overridable with cli option
+`--symlink-dirs`.
+
 [#4103](https://github.com/cylc/cylc-flow/pull/4103) -
 Expose runahead limiting to UIs; restore correct force-triggering of queued
 tasks for Cylc 8.
@@ -122,7 +126,6 @@ when initial cycle point is not valid for the cycling type.
 
 [#4228](https://github.com/cylc/cylc-flow/pull/4228) - Interacting with a
 workflow on the cli using `runN` is now supported.
-
 
 [#4193](https://github.com/cylc/cylc-flow/pull/4193) - Standard `cylc install`
 now correctly installs from directories with a `.` in the name. Symlink dirs

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -369,6 +369,61 @@ with Conf('global.cylc', desc='''
                If workflow source directories of the same name exist in more
                than one of these paths, only the first one will be picked up.
         ''')
+        # Symlink Dirs
+        with Conf('symlink dirs',  # noqa: SIM117 (keep same format)
+                  desc="""
+            Define directories to be moved, symlinks from the the original
+            ``$HOME/cylc-run`` directories will be created.
+        """):
+            with Conf('<install target>'):
+                Conf('run', VDR.V_STRING, None, desc="""
+                    Specifies the directory where the workflow run directories
+                    are created. If specified, the workflow run directory will
+                    be created in ``<run dir>/cylc-run/<workflow-name>`` and a
+                    symbolic link will be created from
+                    ``$HOME/cylc-run/<workflow-name>``.
+                    If not specified the workflow run directory will be created
+                    in ``$HOME/cylc-run/<workflow-name>``.
+                    All the workflow files and the ``.service`` directory get
+                    installed into this directory.
+                """)
+                Conf('log', VDR.V_STRING, None, desc="""
+                    Specifies the directory where log directories are created.
+                    If specified the workflow log directory will be created in
+                    ``<log dir>/cylc-run/<workflow-name>/log`` and a symbolic
+                    link will be created from
+                    ``$HOME/cylc-run/<workflow-name>/log``. If not specified
+                    the workflow log directory will be created in
+                    ``$HOME/cylc-run/<workflow-name>/log``.
+                """)
+                Conf('share', VDR.V_STRING, None, desc="""
+                    Specifies the directory where share directories are
+                    created. If specified the workflow share directory will be
+                    created in ``<share dir>/cylc-run/<workflow-name>/share``
+                    and a symbolic link will be created from
+                    ``<$HOME/cylc-run/<workflow-name>/share``. If not specified
+                    the workflow share directory will be created in
+                    ``$HOME/cylc-run/<workflow-name>/share``.
+                """)
+                Conf('share/cycle', VDR.V_STRING, None, desc="""
+                    Specifies the directory where share/cycle directories are
+                    created. If specified the workflow share/cycle directory
+                    will be created in
+                    ``<share/cycle dir>/cylc-run/<workflow-name>/share/cycle``
+                    and a symbolic link will be created from
+                    ``$HOME/cylc-run/<workflow-name>/share/cycle``. If not
+                    specified the workflow share/cycle directory will be
+                    created in ``$HOME/cylc-run/<workflow-name>/share/cycle``.
+                """)
+                Conf('work', VDR.V_STRING, None, desc="""
+                    Specifies the directory where work directories are created.
+                    If specified the workflow work directory will be created in
+                    ``<work dir>/cylc-run/<workflow-name>/work`` and a symbolic
+                    link will be created from
+                    ``$HOME/cylc-run/<workflow-name>/work``. If not specified
+                    the workflow work directory will be created in
+                    ``$HOME/cylc-run/<workflow-name>/work``.
+                """)
 
     with Conf('editors', desc='''
         Choose your favourite text editor for editing workflow configurations.
@@ -711,60 +766,6 @@ with Conf('global.cylc', desc='''
     with Conf('platform groups'):  # noqa: SIM117 (keep same format)
         with Conf('<group>'):
             Conf('platforms', VDR.V_STRING_LIST)
-    # Symlink Dirs
-    with Conf('symlink dirs',   # noqa: SIM117 (keep same format)
-              desc="""
-        Define directories to be moved, symlinks from the the original
-        ``$HOME/cylc-run`` directories will be created.
-    """):
-        with Conf('<install target>'):
-            Conf('run', VDR.V_STRING, None, desc="""
-                Specifies the directory where the workflow run directories are
-                created. If specified, the workflow run directory will be
-                created in ``<run dir>/cylc-run/<workflow-name>`` and a
-                symbolic link will be created from
-                ``$HOME/cylc-run/<workflow-name>``.
-                If not specified the workflow run directory will be created in
-                ``$HOME/cylc-run/<workflow-name>``.
-                All the workflow files and the ``.service`` directory get
-                installed into this directory.
-            """)
-            Conf('log', VDR.V_STRING, None, desc="""
-                Specifies the directory where log directories are created. If
-                specified the workflow log directory will be created in
-                ``<log dir>/cylc-run/<workflow-name>/log`` and a symbolic link
-                will be created from ``$HOME/cylc-run/<workflow-name>/log``. If
-                not specified the workflow log directory will be created in
-                ``$HOME/cylc-run/<workflow-name>/log``.
-            """)
-            Conf('share', VDR.V_STRING, None, desc="""
-                Specifies the directory where share directories are created.
-                If specified the workflow share directory will be created in
-                ``<share dir>/cylc-run/<workflow-name>/share`` and a symbolic
-                link will be created from
-                ``<$HOME/cylc-run/<workflow-name>/share``. If not specified the
-                workflow share directory will be created in
-                ``$HOME/cylc-run/<workflow-name>/share``.
-            """)
-            Conf('share/cycle', VDR.V_STRING, None, desc="""
-                Specifies the directory where share/cycle directories are
-                created. If specified the workflow share/cycle directory will
-                be created in
-                ``<share/cycle dir>/cylc-run/<workflow-name>/share/cycle`` and
-                a symbolic link will be created from
-                ``$HOME/cylc-run/<workflow-name>/share/cycle``. If not
-                specified the workflow share/cycle directory will be created in
-                ``$HOME/cylc-run/<workflow-name>/share/cycle``.
-            """)
-            Conf('work', VDR.V_STRING, None, desc="""
-                Specifies the directory where work directories are created.
-                If specified the workflow work directory will be created in
-                ``<work dir>/cylc-run/<workflow-name>/work`` and a symbolic
-                link will be created from
-                ``$HOME/cylc-run/<workflow-name>/work``. If not specified the
-                workflow work directory will be created in
-                ``$HOME/cylc-run/<workflow-name>/work``.
-            """)
     # task
     with Conf('task events', desc='''
         Global site/user defaults for

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -372,13 +372,12 @@ with Conf('global.cylc', desc='''
         # Symlink Dirs
         with Conf('symlink dirs',  # noqa: SIM117 (keep same format)
                   desc="""
-            Define directories to be moved, symlinks from the the original
-            ``$HOME/cylc-run`` directories will be created.
+            Configure alternate workflow run directory locations. Symlinks from
+            the the standard ``$HOME/cylc-run`` locations will be created.
         """):
             with Conf('<install target>'):
                 Conf('run', VDR.V_STRING, None, desc="""
-                    Specifies the directory where the workflow run directories
-                    are created. If specified, the workflow run directory will
+                    If specified, the workflow run directory will
                     be created in ``<run dir>/cylc-run/<workflow-name>`` and a
                     symbolic link will be created from
                     ``$HOME/cylc-run/<workflow-name>``.
@@ -388,7 +387,6 @@ with Conf('global.cylc', desc='''
                     installed into this directory.
                 """)
                 Conf('log', VDR.V_STRING, None, desc="""
-                    Specifies the directory where log directories are created.
                     If specified the workflow log directory will be created in
                     ``<log dir>/cylc-run/<workflow-name>/log`` and a symbolic
                     link will be created from
@@ -397,8 +395,7 @@ with Conf('global.cylc', desc='''
                     ``$HOME/cylc-run/<workflow-name>/log``.
                 """)
                 Conf('share', VDR.V_STRING, None, desc="""
-                    Specifies the directory where share directories are
-                    created. If specified the workflow share directory will be
+                    If specified the workflow share directory will be
                     created in ``<share dir>/cylc-run/<workflow-name>/share``
                     and a symbolic link will be created from
                     ``<$HOME/cylc-run/<workflow-name>/share``. If not specified
@@ -406,8 +403,7 @@ with Conf('global.cylc', desc='''
                     ``$HOME/cylc-run/<workflow-name>/share``.
                 """)
                 Conf('share/cycle', VDR.V_STRING, None, desc="""
-                    Specifies the directory where share/cycle directories are
-                    created. If specified the workflow share/cycle directory
+                    If specified the workflow share/cycle directory
                     will be created in
                     ``<share/cycle dir>/cylc-run/<workflow-name>/share/cycle``
                     and a symbolic link will be created from
@@ -416,7 +412,6 @@ with Conf('global.cylc', desc='''
                     created in ``$HOME/cylc-run/<workflow-name>/share/cycle``.
                 """)
                 Conf('work', VDR.V_STRING, None, desc="""
-                    Specifies the directory where work directories are created.
                     If specified the workflow work directory will be created in
                     ``<work dir>/cylc-run/<workflow-name>/work`` and a symbolic
                     link will be created from

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -788,7 +788,7 @@ with Conf(
 
                 The top level share and work directory location can be changed
                 (e.g. to a large data area) by a global config setting (see
-                :cylc:conf:`global.cylc[symlink dirs]`).
+                :cylc:conf:`global.cylc[install][symlink dirs]`).
 
                 .. note::
 

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -142,14 +142,17 @@ def make_localhost_symlinks(
     Returns:
         Dictionary of symlinks with sources as keys and
         destinations as values: ``{source: destination}``
+        symlink_conf: Symlinks dirs configuration passed from cli
 
     """
+    symlinks_created = {}
     dirs_to_symlink = get_dirs_to_symlink(
         get_localhost_install_target(),
         named_sub_dir, symlink_conf=symlink_conf
     )
-    symlinks_created = {}
     for key, value in dirs_to_symlink.items():
+        if value is None:
+            continue
         if key == 'run':
             symlink_path = rund
         else:

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -19,7 +19,7 @@ import os
 from pathlib import Path
 import re
 from shutil import rmtree
-from typing import Dict, Iterable, Set, Union, Optional, OrderedDict, Any
+from typing import Dict, Iterable, Set, Union, Optional, Any
 
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
@@ -131,7 +131,7 @@ def make_workflow_run_tree(workflow):
 
 def make_localhost_symlinks(
     rund: Union[Path, str],
-    named_sub_dir: str, 
+    named_sub_dir: str,
     symlink_conf: Optional[Dict[str, Dict[str, str]]] = None
 ) -> Dict[str, Union[Path, str]]:
     """Creates symlinks for any configured symlink dirs from glbl_cfg.
@@ -190,7 +190,7 @@ def get_dirs_to_symlink(
         dirs_to_symlink: [directory: symlink_path]
     """
     dirs_to_symlink: Dict[str, Any] = {}
-    if not symlink_conf:
+    if symlink_conf is None:
         symlink_conf = glbl_cfg().get(['install', 'symlink dirs'])
     if install_target not in symlink_conf.keys():
         return dirs_to_symlink
@@ -199,7 +199,7 @@ def get_dirs_to_symlink(
         dirs_to_symlink['run'] = os.path.join(base_dir, 'cylc-run', flow_name)
     for dir_ in ['log', 'share', 'share/cycle', 'work']:
         link = symlink_conf[install_target].get(dir_, None)
-        if (not link) is None or link == base_dir:
+        if (not link) or link == base_dir:
             continue
         dirs_to_symlink[dir_] = os.path.join(link, 'cylc-run', flow_name, dir_)
     return dirs_to_symlink

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -138,11 +138,11 @@ def make_localhost_symlinks(
     Args:
         rund: the entire run directory path
         named_sub_dir: e.g flow_name/run1
+        symlink_conf: Symlinks dirs configuration passed from cli
 
     Returns:
         Dictionary of symlinks with sources as keys and
         destinations as values: ``{source: destination}``
-        symlink_conf: Symlinks dirs configuration passed from cli
 
     """
     symlinks_created = {}
@@ -215,7 +215,7 @@ def make_symlink(path: Union[Path, str], target: Union[Path, str]) -> bool:
     path = Path(path)
     target = Path(target)
     if path.exists():
-        if path.is_symlink() and path.samefile(target):
+        if path.is_symlink() and target.exists() and path.samefile(target):
             # correct symlink already exists
             return False
         # symlink name is in use by a physical file or directory
@@ -232,6 +232,11 @@ def make_symlink(path: Union[Path, str], target: Union[Path, str]) -> bool:
             raise WorkflowFilesError(
                 f"Error when symlinking. Failed to unlink bad symlink {path}.")
     target.mkdir(parents=True, exist_ok=True)
+
+    # This is needed in case share and share/cycle have the same symlink dir:
+    if path.exists():
+        return False
+
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         path.symlink_to(target)

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -215,6 +215,8 @@ def make_symlink(path: Union[Path, str], target: Union[Path, str]) -> bool:
     path = Path(path)
     target = Path(target)
     if path.exists():
+        # note all three checks are needed here due to case where user has set
+        # their own symlink which does not match the global config set one.
         if path.is_symlink() and target.exists() and path.samefile(target):
             # correct symlink already exists
             return False

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -75,7 +75,7 @@ from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.workflow_files import (
-    install_workflow, search_install_source_dirs, get_sym_dirs
+    install_workflow, search_install_source_dirs, parse_cli_sym_dirs
 )
 from cylc.flow.terminal import cli_function
 
@@ -223,7 +223,7 @@ def install(
     if opts.symlink_dirs == '':
         cli_symdirs = {}
     elif opts.symlink_dirs:
-        cli_symdirs = get_sym_dirs(opts.symlink_dirs)
+        cli_symdirs = parse_cli_sym_dirs(opts.symlink_dirs)
     source_dir, rundir, _flow_name = install_workflow(
         flow_name=flow_name,
         source=source,

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -155,11 +155,12 @@ def get_option_parser():
         help=(
             "Enter a list, in the form 'log=path/to/store, share = $...'"
             ". Use this option to override local symlinks for directories run,"
-            " log, work, share, share/cycle, as configured in global.cylc."
+            " log, work, share, share/cycle, as configured in global.cylc. "
+            "Enter an empty list \"\" to skip making localhost symlink dirs."
         ),
         action="store",
-        default=None,
-        dest="symlink_dirs")
+        dest="symlink_dirs"
+    )
 
     parser.add_option(
         "--run-name",
@@ -219,9 +220,10 @@ def install(
                 exc
             ) from None
     cli_symdirs: Optional[Dict[str, Dict[str, Any]]] = None
-    if opts.symlink_dirs:
+    if opts.symlink_dirs == '':
+        cli_symdirs = {}
+    elif opts.symlink_dirs:
         cli_symdirs = get_sym_dirs(opts.symlink_dirs)
-
     source_dir, rundir, _flow_name = install_workflow(
         flow_name=flow_name,
         source=source,

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -153,10 +153,10 @@ def get_option_parser():
     parser.add_option(
         "--symlink-dirs",
         help=(
-            "Enter a list, in the form ['log'= 'path/to/store', share = '$...'"
-            "]. Use this option to override creating default local symlinks"
-            ", for directories run, log, work, share, share/cycle, as"
-            " configured in global.cylc."),
+            "Enter a list, in the form 'log=path/to/store, share = $...'"
+            ". Use this option to override local symlinks for directories run,"
+            " log, work, share, share/cycle, as configured in global.cylc."
+        ),
         action="store",
         default=None,
         dest="symlink_dirs")

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -69,7 +69,7 @@ multiple workflow run directories that link to the same workflow definition.
 
 """
 
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Dict, Any
 
 from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError
@@ -218,17 +218,16 @@ def install(
                 entry_point.name,
                 exc
             ) from None
+    cli_symdirs: Optional[Dict[str, Dict[str, Any]]] = None
     if opts.symlink_dirs:
-        symdirs = get_sym_dirs(opts.symlink_dirs)
-    else:
-        symdirs = None
+        cli_symdirs = get_sym_dirs(opts.symlink_dirs)
 
     source_dir, rundir, _flow_name = install_workflow(
         flow_name=flow_name,
         source=source,
         run_name=opts.run_name,
         no_run_name=opts.no_run_name,
-        symlink_dirs=symdirs
+        cli_symlink_dirs=cli_symdirs
     )
 
     for entry_point in iter_entry_points(

--- a/tests/functional/cylc-clean/00-basic.t
+++ b/tests/functional/cylc-clean/00-basic.t
@@ -28,13 +28,14 @@ SYM_NAME="$(mktemp -u)"
 SYM_NAME="${SYM_NAME##*tmp.}"
 
 create_test_global_config "" "
-[symlink dirs]
-    [[localhost]]
-        run = ${TEST_DIR}/${SYM_NAME}/run
-        log = ${TEST_DIR}/${SYM_NAME}/log
-        share = ${TEST_DIR}/${SYM_NAME}/share
-        share/cycle = ${TEST_DIR}/${SYM_NAME}/cycle
-        work = ${TEST_DIR}/${SYM_NAME}/work
+[install]
+    [[symlink dirs]]
+        [[[localhost]]]
+            run = ${TEST_DIR}/${SYM_NAME}/run
+            log = ${TEST_DIR}/${SYM_NAME}/log
+            share = ${TEST_DIR}/${SYM_NAME}/share
+            share/cycle = ${TEST_DIR}/${SYM_NAME}/cycle
+            work = ${TEST_DIR}/${SYM_NAME}/work
 "
 init_workflow "${TEST_NAME_BASE}" << '__FLOW__'
 [scheduler]

--- a/tests/functional/cylc-clean/01-remote.t
+++ b/tests/functional/cylc-clean/01-remote.t
@@ -32,13 +32,14 @@ SYM_NAME="$(mktemp -u)"
 SYM_NAME="${SYM_NAME##*tmp.}"
 
 create_test_global_config "" "
-[symlink dirs]
-    [[${CYLC_TEST_INSTALL_TARGET}]]
-        run = ${TEST_DIR}/${SYM_NAME}/run
-        log = ${TEST_DIR}/${SYM_NAME}/other
-        share = ${TEST_DIR}/${SYM_NAME}/other
-        share/cycle = ${TEST_DIR}/${SYM_NAME}/cycle
-        work = ${TEST_DIR}/${SYM_NAME}/other
+[install]
+    [[symlink dirs]]
+        [[[${CYLC_TEST_INSTALL_TARGET}]]]
+            run = ${TEST_DIR}/${SYM_NAME}/run
+            log = ${TEST_DIR}/${SYM_NAME}/other
+            share = ${TEST_DIR}/${SYM_NAME}/other
+            share/cycle = ${TEST_DIR}/${SYM_NAME}/cycle
+            work = ${TEST_DIR}/${SYM_NAME}/other
 "
 init_workflow "${TEST_NAME_BASE}" << __FLOW__
 [scheduler]

--- a/tests/functional/cylc-clean/02-targeted.t
+++ b/tests/functional/cylc-clean/02-targeted.t
@@ -28,14 +28,15 @@ SYM_NAME="$(mktemp -u)"
 SYM_NAME="sym-${SYM_NAME##*tmp.}"
 
 create_test_global_config "" "
-[symlink dirs]
-    [[localhost]]
-        run = ${TEST_DIR}/${SYM_NAME}/run
-        log = ${TEST_DIR}/${SYM_NAME}/other
-        share = ${TEST_DIR}/${SYM_NAME}/other
-        work = ${TEST_DIR}/${SYM_NAME}/other
-        # Need to override any symlink dirs set in global-tests.cylc:
-        share/cycle =
+[install]
+    [[symlink dirs]]
+        [[[localhost]]]
+            run = ${TEST_DIR}/${SYM_NAME}/run
+            log = ${TEST_DIR}/${SYM_NAME}/other
+            share = ${TEST_DIR}/${SYM_NAME}/other
+            work = ${TEST_DIR}/${SYM_NAME}/other
+            # Need to override any symlink dirs set in global-tests.cylc:
+            share/cycle =
 "
 init_workflow "${TEST_NAME_BASE}" << __FLOW__
 [scheduler]

--- a/tests/functional/cylc-get-site-config/04-homeless.t
+++ b/tests/functional/cylc-get-site-config/04-homeless.t
@@ -22,14 +22,15 @@ set_test_number 3
 
 # shellcheck disable=SC2016
 create_test_global_config '' '
-[symlink dirs]
-    [[localhost]]
-        run = $HOME/dr-malcolm
+[install]
+    [[symlink dirs]]
+        [[[localhost]]]
+            run = $HOME/dr-malcolm
 '
 
 run_ok "${TEST_NAME_BASE}" \
     env -u HOME \
-    cylc config --item='[symlink dirs][localhost]run'
+    cylc config --item='[install][symlink dirs][localhost]run'
 cmp_ok "${TEST_NAME_BASE}.stdout" <<<"\$HOME/dr-malcolm"
 cmp_ok "${TEST_NAME_BASE}.stderr" <'/dev/null'
 exit

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -24,7 +24,7 @@ if [[ -z ${TMPDIR:-} || -z ${USER:-} || $TMPDIR/$USER == "$HOME" ]]; then
     skip_all '"TMPDIR" or "USER" not defined or "TMPDIR"/"USER" is "HOME"'
 fi
 
-set_test_number 17
+set_test_number 25
 
 create_test_global_config "" "
 [install]
@@ -44,89 +44,104 @@ run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --director
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
+WORKFLOW_RUN_DIR="$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1"
+TEST_SYM="${TEST_NAME_BASE}-run-glblcfg"
+run_ok "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}")" \
+    = "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1"
 
-TEST_SYM="${TEST_NAME_BASE}-run-symlink-exists-ok"
-
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1") == \
-    "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1" ]]; then
-        ok "$TEST_SYM"
-else
-    fail "$TEST_SYM"
-fi
-
-TEST_SYM="${TEST_NAME_BASE}-share/cycle-symlink-exists-ok"
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle") == \
-"$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle" ]]; then
-    ok "$TEST_SYM"
-else
-    fail "$TEST_SYM"
-# # Test "cylc install" ensure symlinks are created
-TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
-make_rnd_workflow
-
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1") == \
-    "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1" ]]; then
-        ok "$TEST_SYM"
-else
-    fail "$TEST_SYM"
-fi
-
-TEST_SYM="${TEST_NAME_BASE}-share/cycle-symlink-exists-ok"
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle") == \
-"$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle" ]]; then
-fi
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1") == \
-    "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1" ]]; then
-        ok "$TEST_SYM"
-else
-    fail "$TEST_SYM"
-fi
-
-TEST_SYM="${TEST_NAME_BASE}-share/cycle-symlink-exists-ok"
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle") == \
-"$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle" ]]; then
-fi
+TEST_SYM="${TEST_NAME_BASE}-share-cycle-glblcfg"
+run_ok "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}/share/cycle")" \
+    = "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle"
 
 for DIR in 'work' 'share' 'log'; do
-    TEST_SYM="${TEST_NAME_BASE}-${DIR}-symlink-exists-ok"
-    if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}") == \
-   "$TMPDIR/${USER}/test_cylc_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}" ]]; then
-        ok "$TEST_SYM"
-    else
-        fail "$TEST_SYM"
-    fi
+    TEST_SYM="${TEST_NAME_BASE}-${DIR}-glbcfg"
+    run_ok "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}/${DIR}")" \
+   = "$TMPDIR/${USER}/test_cylc_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}"
 done
 rm -rf "${TMPDIR}/${USER}/test_cylc_symlink/"
 purge_rnd_workflow
 
 # test cli --symlink-dirs overrides the glblcfg
-VAR=$TMPDIR/$USER/test_cylc_cli_symlink/
+SYMDIR=${TMPDIR}/${USER}/test_cylc_cli_symlink/
 
-TEST_NAME="${TEST_NAME_BASE}-symlinks-cli-opt"
+TEST_NAME="${TEST_NAME_BASE}-cli-opt-install"
 make_rnd_workflow
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" \
 --directory="${RND_WORKFLOW_SOURCE}" \
---symlink-dirs="run= ${VAR}run, log=${VAR}, share=${VAR}, work = ${VAR}, share/cycle=${VAR}cylctb_tmp_share_dir"
+--symlink-dirs="run= ${SYMDIR}cylctb_tmp_run_dir, log=${SYMDIR}, share=${SYMDIR}, \
+work = ${SYMDIR}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
+WORKFLOW_RUN_DIR="$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1"
 
-TEST_SYM="${TEST_NAME_BASE}-share-cycle-symlink-cli-ok"
-if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle") == \
-"$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/share/cycle" ]]; then
-    fail "$TEST_SYM"
-else
-    ok "$TEST_SYM"
-fi
+TEST_SYM="${TEST_NAME_BASE}-run-cli"
+run_ok "$TEST_SYM" test "$(readlink "${WORKFLOW_RUN_DIR}")" \
+   =  "$TMPDIR/${USER}/test_cylc_cli_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1"
+
 
 for DIR in 'work' 'share' 'log'; do
-    TEST_SYM="${TEST_NAME_BASE}-${DIR}-symlink-cli-ok"
-    if [[ $(readlink "$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}") == \
-   "$TMPDIR/${USER}/test_cylc_cli_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}" ]]; then
-        ok "$TEST_SYM"
-    else
-        fail "$TEST_SYM"
-    fi
+    TEST_SYM="${TEST_NAME_BASE}-${DIR}-cli"
+    run_ok "$TEST_SYM" test "$(readlink "${WORKFLOW_RUN_DIR}/${DIR}")" \
+   = "${TMPDIR}/${USER}/test_cylc_cli_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}"
 done
+
+INSTALL_LOG="$(find "${WORKFLOW_RUN_DIR}/log/install" -type f -name '*.log')"
+ 
+for DIR in 'work' 'share' 'log'; do
+    grep_ok "${TMPDIR}/${USER}/test_cylc_cli_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}" "${INSTALL_LOG}"
+done
+
+# test cylc play symlinks after cli opts (mapping to different directories)
+
+pushd "${WORKFLOW_RUN_DIR}" || exit 1
+cat > 'flow.cylc' << __FLOW__
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = true
+__FLOW__
+
+popd || exit 1
+
+run_ok "${TEST_NAME_BASE}-play" cylc play "${RND_WORKFLOW_NAME}/runN" --debug
+
+# test ensure symlinks, not in cli install are not created from glbl cfg.
+TEST_SYM="${TEST_NAME_BASE}-share-cycle-cli"
+run_fail "$TEST_SYM" test "$(readlink "${WORKFLOW_RUN_DIR}/share/cycle")" \
+= "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle"
+
 rm -rf "${TMPDIR}/${USER}/test_cylc_cli_symlink/"
+purge_rnd_workflow
+
+
+# test no symlinks created with --symlink-dirs=None
+
+
+TEST_NAME="${TEST_NAME_BASE}-no-sym-dirs-cli"
+make_rnd_workflow
+run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" \
+--directory="${RND_WORKFLOW_SOURCE}" --symlink-dirs=None
+contains_ok "${TEST_NAME}.stdout" <<__OUT__
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
+__OUT__
+WORKFLOW_RUN_DIR="$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1"
+
+
+TEST_SYM="${TEST_NAME}-run"
+run_fail "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}")" \
+    = "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_run_dir/cylc-run/${RND_WORKFLOW_NAME}/run1"
+
+TEST_SYM="${TEST_NAME}-share-cycle"
+run_fail "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}/share/cycle")" \
+    = "$TMPDIR/${USER}/test_cylc_symlink/cylctb_tmp_share_dir/cylc-run/${RND_WORKFLOW_NAME}/run1/share/cycle"
+
+for DIR in 'work' 'share' 'log'; do
+    TEST_SYM="${TEST_NAME}-${DIR}"
+    run_fail "${TEST_SYM}" test "$(readlink "${WORKFLOW_RUN_DIR}/${DIR}")" \
+   = "$TMPDIR/${USER}/test_cylc_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}"
+done
+
 purge_rnd_workflow

--- a/tests/functional/remote/04-symlink-dirs.t
+++ b/tests/functional/remote/04-symlink-dirs.t
@@ -27,19 +27,20 @@ fi
 set_test_number 12
 
 create_test_global_config "" "
-[symlink dirs]
-    [[localhost]]
-        run = \$TMPDIR/\$USER/cylctb_tmp_run_dir
-        share = \$TMPDIR/\$USER
-        log = \$TMPDIR/\$USER
-        share/cycle = \$TMPDIR/\$USER/cylctb_tmp_share_dir
-        work = \$TMPDIR/\$USER
-    [[$CYLC_TEST_INSTALL_TARGET]]
-        run = \$TMPDIR/\$USER/test_cylc_symlink/ctb_tmp_run_dir
-        share = \$TMPDIR/\$USER/test_cylc_symlink/
-        log = \$TMPDIR/\$USER/test_cylc_symlink/
-        share/cycle = \$TMPDIR/\$USER/test_cylc_symlink/ctb_tmp_share_dir
-        work = \$TMPDIR/\$USER/test_cylc_symlink/
+[install]
+    [[symlink dirs]]
+        [[[localhost]]]
+            run = \$TMPDIR/\$USER/cylctb_tmp_run_dir
+            share = \$TMPDIR/\$USER
+            log = \$TMPDIR/\$USER
+            share/cycle = \$TMPDIR/\$USER/cylctb_tmp_share_dir
+            work = \$TMPDIR/\$USER
+        [[[$CYLC_TEST_INSTALL_TARGET]]]
+            run = \$TMPDIR/\$USER/test_cylc_symlink/ctb_tmp_run_dir
+            share = \$TMPDIR/\$USER/test_cylc_symlink/
+            log = \$TMPDIR/\$USER/test_cylc_symlink/
+            share/cycle = \$TMPDIR/\$USER/test_cylc_symlink/ctb_tmp_share_dir
+            work = \$TMPDIR/\$USER/test_cylc_symlink/
 "
 
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,8 +63,9 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     Args:
         reg: Workflow name.
+        installed: named or no-name. Creates 
     """
-    def _tmp_run_dir(reg: Optional[str] = None) -> Path:
+    def _tmp_run_dir(reg: Optional[str] = None, installed = None) -> Path:
         cylc_run_dir = tmp_path / 'cylc-run'
         cylc_run_dir.mkdir(exist_ok=True)
         monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', cylc_run_dir)
@@ -73,6 +74,11 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             run_dir.mkdir(parents=True, exist_ok=True)
             (run_dir / WorkflowFiles.FLOW_FILE).touch(exist_ok=True)
             (run_dir / WorkflowFiles.Service.DIRNAME).mkdir(exist_ok=True)
+            if installed == 'named':
+                (run_dir.parent / WorkflowFiles.Install.DIRNAME).mkdir(exist_ok=True)
+            elif installed == 'no-name':
+                (run_dir / WorkflowFiles.Install.DIRNAME).mkdir(exist_ok=True)
+
             return run_dir
         return cylc_run_dir
     return _tmp_run_dir

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -63,9 +63,17 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     Args:
         reg: Workflow name.
-        installed: named or no-name. Creates 
+        installed: If True, make it look like the workflow was installed
+            using cylc install (creates _cylc-install dir).
+        named: If True and installed is True, the _cylc-install dir will
+            be created in the parent to make it look like this is a
+            named run.
     """
-    def _tmp_run_dir(reg: Optional[str] = None, installed = None) -> Path:
+    def _tmp_run_dir(
+        reg: Optional[str] = None,
+        installed: bool = False,
+        named: bool = False
+    ) -> Path:
         cylc_run_dir = tmp_path / 'cylc-run'
         cylc_run_dir.mkdir(exist_ok=True)
         monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', cylc_run_dir)
@@ -74,10 +82,15 @@ def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             run_dir.mkdir(parents=True, exist_ok=True)
             (run_dir / WorkflowFiles.FLOW_FILE).touch(exist_ok=True)
             (run_dir / WorkflowFiles.Service.DIRNAME).mkdir(exist_ok=True)
-            if installed == 'named':
-                (run_dir.parent / WorkflowFiles.Install.DIRNAME).mkdir(exist_ok=True)
-            elif installed == 'no-name':
-                (run_dir / WorkflowFiles.Install.DIRNAME).mkdir(exist_ok=True)
+            if installed:
+                if named:
+                    if len(Path(reg).parts) < 2:
+                        raise ValueError("Named run requires two-level reg")
+                    (run_dir.parent / WorkflowFiles.Install.DIRNAME).mkdir(
+                        exist_ok=True)
+                else:
+                    (run_dir / WorkflowFiles.Install.DIRNAME).mkdir(
+                        exist_ok=True)
 
             return run_dir
         return cylc_run_dir

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -174,8 +174,9 @@ def test_make_workflow_run_tree(
     [
         pytest.param(  # basic
             '''
-            [symlink dirs]
-                [[the_matrix]]
+            [install]
+            [[symlink dirs]]
+                [[[the_matrix]]]
                     run = $DEE
                     work = $DAH
                     log = $DUH
@@ -193,8 +194,9 @@ def test_make_workflow_run_tree(
         ),
         pytest.param(  # remove nested run symlinks
             '''
-            [symlink dirs]
-                [[the_matrix]]
+            [install]
+            [[symlink dirs]]
+                [[[the_matrix]]]
                     run = $DEE
                     work = $DAH
                     log = $DEE
@@ -211,8 +213,9 @@ def test_make_workflow_run_tree(
         ),
         pytest.param(  # remove only nested run symlinks
             '''
-            [symlink dirs]
-                [[the_matrix]]
+            [install]
+            [[symlink dirs]]
+                [[[the_matrix]]]
                     run = $DOH
                     log = $DEE
                     share = $DEE
@@ -226,8 +229,9 @@ def test_make_workflow_run_tree(
         ),
         pytest.param(  # blank entries
             '''
-            [symlink dirs]
-                [[the_matrix]]
+            [install]
+            [[symlink dirs]]
+                [[[the_matrix]]]
                     run =
                     log = ""
                     share =

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1462,7 +1462,7 @@ def test_check_flow_file_symlink(
          "'log=$DIR, share=$DIR2, ...'",
             None
          ),
-        ('run=$NICE, log= $Garibaldi, share/cycle=$RichTea', 'None',
+        ('run=$NICE, log= $Garibaldi, share/cycle=$RichTea', None,
             {'localhost': {
                 'run': '$NICE',
                 'log': '$Garibaldi',
@@ -1482,7 +1482,7 @@ def test_parse_cli_sym_dirs(
 ):
     """Test parse_cli_sym_dirs returns dict or correctly raises errors on cli
     symlink dir options"""
-    if err_msg != 'None':
+    if err_msg is not None:
         with pytest.raises(UserInputError) as exc:
             parse_cli_sym_dirs(symlink_dirs)
             assert(err_msg) in str(exc)

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -42,6 +42,8 @@ from cylc.flow.workflow_files import (
     check_nested_run_dirs,
     get_sym_dirs,
     get_symlink_dirs,
+    is_installed,
+    get_sym_dirs,
     get_workflow_source_dir,
     glob_in_run_dir,
     reinstall_workflow,
@@ -1485,3 +1487,16 @@ def test_get_sym_dirs(
         actual = get_sym_dirs(symlink_dirs)
 
         assert actual == expected
+
+@pytest.mark.parametrize(
+    'reg, installed, expected',
+    [('reg1/run1', 'named', True),
+     ('reg2', 'no-name', True),
+     ('reg3', None, False)]
+)
+def test_is_installed(tmp_run_dir: Callable,reg, installed, expected):
+    
+
+    cylc_run_dir: Path = tmp_run_dir(reg, installed=installed)
+    actual = is_installed(cylc_run_dir)
+    assert actual == expected

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -41,10 +41,10 @@ from cylc.flow.workflow_files import (
     _remote_clean_cmd,
     check_flow_file,
     check_nested_run_dirs,
-    get_sym_dirs,
+    parse_cli_sym_dirs,
     get_symlink_dirs,
     is_installed,
-    get_sym_dirs,
+    parse_cli_sym_dirs,
     get_workflow_source_dir,
     glob_in_run_dir,
     reinstall_workflow,
@@ -1475,32 +1475,32 @@ def test_check_flow_file_symlink(
          ),
     ]
 )
-def test_get_sym_dirs(
+def test_parse_cli_sym_dirs(
     symlink_dirs: str,
     err_msg: str,
     expected: Dict[str, Dict[str, Any]]
 ):
-    """Test get_sym_dirs returns dict or correctly raises errors on cli symlink
-        dir options"""
+    """Test parse_cli_sym_dirs returns dict or correctly raises errors on cli
+    symlink dir options"""
     if err_msg != 'None':
         with pytest.raises(UserInputError) as exc:
-            get_sym_dirs(symlink_dirs)
+            parse_cli_sym_dirs(symlink_dirs)
             assert(err_msg) in str(exc)
 
     else:
-        actual = get_sym_dirs(symlink_dirs)
+        actual = parse_cli_sym_dirs(symlink_dirs)
 
         assert actual == expected
 
-@pytest.mark.parametrize(
-    'reg, installed, expected',
-    [('reg1/run1', 'named', True),
-     ('reg2', 'no-name', True),
-     ('reg3', None, False)]
-)
-def test_is_installed(tmp_run_dir: Callable,reg, installed, expected):
-    
 
-    cylc_run_dir: Path = tmp_run_dir(reg, installed=installed)
+@pytest.mark.parametrize(
+    'reg, installed, named,  expected',
+    [('reg1/run1', True, True, True),
+     ('reg2', True, False, True),
+     ('reg3', False, False, False)]
+)
+def test_is_installed(tmp_run_dir: Callable, reg, installed, named, expected):
+    """Test is_installed correctly identifies presence of _cylc-install dir"""
+    cylc_run_dir: Path = tmp_run_dir(reg, installed=installed, named=named)
     actual = is_installed(cylc_run_dir)
     assert actual == expected

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -29,6 +29,7 @@ from cylc.flow.exceptions import (
     CylcError,
     ServiceFileError,
     TaskRemoteMgmtError,
+    UserInputError,
     WorkflowFilesError
 )
 from cylc.flow.option_parsers import Options
@@ -1450,13 +1451,16 @@ def test_check_flow_file_symlink(
 @pytest.mark.parametrize(
     'symlink_dirs, err_msg, expected',
     [
-        ('log=$shortbread, share= $bourbon,share/cycle= $digestive, ', 'None',
-            {'localhost': {
-                'run': None,
-                'log': "$shortbread",
-                'share': '$bourbon',
-                'share/cycle': '$digestive'
-            }}
+        ('log=$shortbread, share= $bourbon,share/cycle= $digestive, ',
+         "There is an error in --symlink-dirs option:",
+            None
+         ),
+        ('log=$shortbread share= $bourbon share/cycle= $digestive ',
+         "There is an error in --symlink-dirs option:"
+         " log=$shortbread share= $bourbon share/cycle= $digestive . "
+         "Try entering option in the form --symlink-dirs="
+         "'log=$DIR, share=$DIR2, ...'",
+            None
          ),
         ('run=$NICE, log= $Garibaldi, share/cycle=$RichTea', 'None',
             {'localhost': {
@@ -1479,7 +1483,7 @@ def test_get_sym_dirs(
     """Test get_sym_dirs returns dict or correctly raises errors on cli symlink
         dir options"""
     if err_msg != 'None':
-        with pytest.raises(WorkflowFilesError) as exc:
+        with pytest.raises(UserInputError) as exc:
             get_sym_dirs(symlink_dirs)
             assert(err_msg) in str(exc)
 

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1450,6 +1450,7 @@ def test_check_flow_file_symlink(
     [
         ('log=$shortbread, share= $bourbon,share/cycle= $digestive, ', 'None',
             {'localhost': {
+                'run': None,
                 'log': "$shortbread",
                 'share': '$bourbon',
                 'share/cycle': '$digestive'
@@ -1468,11 +1469,17 @@ def test_check_flow_file_symlink(
          ),
     ]
 )
-def test_get_sym_dirs(symlink_dirs, err_msg, expected):
-    """Test get_sym_dirs raises errors on cli symlink options"""
+def test_get_sym_dirs(
+    symlink_dirs: str,
+    err_msg: str,
+    expected: Dict[str, Dict[str, Any]]
+):
+    """Test get_sym_dirs returns dict or correctly raises errors on cli symlink
+        dir options"""
     if err_msg != 'None':
-        with pytest.raises(WorkflowFilesError):
+        with pytest.raises(WorkflowFilesError) as exc:
             get_sym_dirs(symlink_dirs)
+            assert(err_msg) in str(exc)
 
     else:
         actual = get_sym_dirs(symlink_dirs)


### PR DESCRIPTION
Adds cli option (`--symlink-dirs`) for over-riding localhost symlink dirs in global config when executing `cylc install`. 
Removes --no-symlink-dirs option, this is replaced by --symlink-dirs=None

Also moves symlink dirs into install section of config...(these changes close https://github.com/cylc/cylc-flow/issues/4219)

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/252
