### PR TITLE
Don't count hidden pool for runahead limiting.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,8 +56,14 @@ Third beta release of Cylc 8.
 
 ### Enhancements
 
+[#4258](https://github.com/cylc/cylc-flow/pull/4258) -
+Make runahead limiting depend only on active tasks.
+
 [#4284](https://github.com/cylc/cylc-flow/pull/4284)
  - Make `--color=never` work with `cylc <command> --help`.
+
+[#4259](https://github.com/cylc/cylc-flow/pull/4259) -
+Ignore pre-initial dependencies with `cylc play --start-task`
 
 [#4103](https://github.com/cylc/cylc-flow/pull/4103) -
 Expose runahead limiting to UIs; restore correct force-triggering of queued

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -303,7 +303,6 @@ class TaskPool:
         # Any finished tasks can be released immediately (this can happen at
         # restart when all tasks are initially loaded into the runahead pool).
         # And any manually-triggered task.
-
         for itask in (
             itask
             for point_id_map in self.main_pool.values()
@@ -320,7 +319,7 @@ class TaskPool:
             released = True
 
         points = []
-        for point, itasks in sorted(self.get_tasks_by_point().items()):
+        for point, itasks in sorted(self._get_main_tasks_by_point().items()):
             if points or any(
                 not itask.state(
                     TASK_STATUS_FAILED,
@@ -689,17 +688,11 @@ class TaskPool:
                 self.hidden_pool_list.extend(list(itask_id_maps.values()))
         return self.hidden_pool_list
 
-    def get_tasks_by_point(self):
-        """Return a map of task proxies by cycle point."""
+    def _get_main_tasks_by_point(self):
+        """Return a map of main pool task proxies by cycle point."""
         point_itasks = {}
         for point, itask_id_map in self.main_pool.items():
             point_itasks[point] = list(itask_id_map.values())
-        for point, itask_id_map in self.hidden_pool.items():
-            if point not in point_itasks:
-                point_itasks[point] = list(itask_id_map.values())
-            else:
-                point_itasks[point] += list(itask_id_map.values())
-
         return point_itasks
 
     def _get_hidden_task_by_id(self, id_):

--- a/tests/functional/reload/10-runahead.t
+++ b/tests/functional/reload/10-runahead.t
@@ -30,7 +30,7 @@ run_fail "${TEST_NAME}" cylc play --debug --no-detach "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-check-fail
 DB_FILE="$RUN_DIR/${WORKFLOW_NAME}/log/db"
-QUERY='SELECT COUNT(*) FROM task_states WHERE status == "failed"'
+QUERY='SELECT COUNT(*) FROM task_states WHERE status == "succeeded" AND name == "foo"'
 cmp_ok <(sqlite3 "$DB_FILE" "$QUERY") <<< "4"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/reload/runahead/flow.cylc
+++ b/tests/functional/reload/runahead/flow.cylc
@@ -8,7 +8,6 @@
     final cycle point = 2010-01-05
     runahead limit = PT12H # marker
     [[graph]]
-        # oops is stuck waiting task to hold back runahead
         R1 = "foo:start => reloader"
         PT6H ="foo" 
 [runtime]

--- a/tests/functional/reload/runahead/flow.cylc
+++ b/tests/functional/reload/runahead/flow.cylc
@@ -1,24 +1,30 @@
 [scheduler]
     UTC mode = True
     [[events]]
-        timeout = PT0.2M
-        abort on timeout = True
+        abort on inactivity = True
+        inactivity = PT10S
 [scheduling]
     initial cycle point = 2010-01-01
     final cycle point = 2010-01-05
-    runahead limit = P2 # marker
+    runahead limit = PT12H # marker
     [[graph]]
         # oops is stuck waiting task to hold back runahead
-        R1/T00 = "foo & reloader => oops"
-        T00/PT6H = "foo => bar"
+        R1 = "foo:start => reloader"
+        PT6H ="foo" 
 [runtime]
     [[foo]]
-        script = false
-    [[bar, oops]]
-        script = true
+        script = """
+            if [[ "$CYLC_TASK_JOB" == '20100101T0000Z/foo/01' ]]; then
+                # keep running until scheduler is gone
+                while cylc ping $CYLC_WORKFLOW_NAME; do
+                    sleep 10
+                done
+            else
+                true
+            fi
+        """
     [[reloader]]
         script = """
-cylc__job__poll_grep_workflow_log '\[foo.* (received)failed'
-perl -pi -e 's/(runahead limit = )P2( # marker)/\1 P4\2/' $CYLC_WORKFLOW_RUN_DIR/flow.cylc
+perl -pi -e 's/(runahead limit = )PT12H( # marker)/\1 P1D\2/' $CYLC_WORKFLOW_RUN_DIR/flow.cylc
 cylc reload $CYLC_WORKFLOW_NAME
 """

--- a/tests/functional/runahead/00-runahead.t
+++ b/tests/functional/runahead/00-runahead.t
@@ -34,6 +34,7 @@ run_ok "${TEST_NAME}" sqlite3 "${DB}" \
     "select max(cycle) from task_states where status!='waiting'"
 cmp_ok "${TEST_NAME}.stdout" <<< "4"
 #-------------------------------------------------------------------------------
-grep_ok 'Workflow shutting down - Abort on workflow stalled is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
+grep_ok 'Workflow shutting down - Abort on workflow inactivity is set' \
+    "${WORKFLOW_RUN_DIR}/log/workflow/log"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/runahead/01-check-default-simple.t
+++ b/tests/functional/runahead/01-check-default-simple.t
@@ -28,9 +28,6 @@ run_ok "${TEST_NAME}" cylc validate -v "${WORKFLOW_NAME}"
 TEST_NAME="${TEST_NAME_BASE}-run"
 run_fail "${TEST_NAME}" cylc play --debug --no-detach "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
-# Testing runahead by counting tasks after a stall is tricky, so this test
-# might not be optimal. For instance, abort-on-stall aborts even if tasks
-# could immediately be released from the runahead pool.
 TEST_NAME="${TEST_NAME_BASE}-max-cycle"
 DB="${WORKFLOW_RUN_DIR}/log/db"
 run_ok "${TEST_NAME}" sqlite3 "${DB}" \
@@ -38,6 +35,6 @@ run_ok "${TEST_NAME}" sqlite3 "${DB}" \
 cmp_ok "${TEST_NAME}.stdout" <<< "20100102T0000Z"
 # i.e. should have spawned 5 cycle points from initial 01T00
 #-------------------------------------------------------------------------------
-grep_ok 'Workflow shutting down - Abort on workflow stalled is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
+grep_ok 'Workflow shutting down - Abort on workflow inactivity is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/runahead/02-check-default-complex.t
+++ b/tests/functional/runahead/02-check-default-complex.t
@@ -35,6 +35,6 @@ run_ok "${TEST_NAME}" sqlite3 "${DB}" \
 cmp_ok "${TEST_NAME}.stdout" <<< "20100101T1200Z"
 # i.e. should have spawned 5 cycle points from initial T00
 #-------------------------------------------------------------------------------
-grep_ok 'Workflow shutting down - Abort on workflow stalled is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
+grep_ok 'Workflow shutting down - Abort on workflow inactivity is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
 #-------------------------------------------------------------------------------
 purge

--- a/tests/functional/runahead/07-time-limit.t
+++ b/tests/functional/runahead/07-time-limit.t
@@ -34,7 +34,8 @@ run_ok "$TEST_NAME" sqlite3 "$DB" \
     "select max(cycle) from task_states where status!='waiting'"
 cmp_ok "${TEST_NAME}.stdout" <<< "20200101T0400Z"
 #-------------------------------------------------------------------------------
-grep_ok 'Workflow shutting down - Abort on workflow stalled is set' "${WORKFLOW_RUN_DIR}/log/workflow/log"
+grep_ok 'Workflow shutting down - Abort on workflow inactivity is set' \
+    "${WORKFLOW_RUN_DIR}/log/workflow/log"
 #-------------------------------------------------------------------------------
 purge
 exit

--- a/tests/functional/runahead/default-complex/flow.cylc
+++ b/tests/functional/runahead/default-complex/flow.cylc
@@ -1,25 +1,29 @@
 [scheduler]
     UTC mode = True
-    allow implicit tasks = True
     [[events]]
-        abort on stalled = True
-        timeout = PT30S
-        abort on timeout = True
+        abort on inactivity = True
+        inactivity = PT10S
 [scheduling]
     initial cycle point = 20100101T00
     final cycle point = 20100105T00
     [[graph]]
         # T00, T07, T14, ...
-        # oops makes bar spawn as waiting
-        PT7H = "foo & oops => bar"
+        PT7H = "foo"
         # T00, T12, T18...
         T00, T12, T18 = "foo"
         # T04...
-        T04 = "run_ok"
+        T04 = "foo"
         # T05...
-        T05 = "run_ok_2"
+        T05 = "foo"
 [runtime]
-    [[foo, fail]]
-        script = false
-    [[bar]]
-        script = true
+    [[foo]]
+        script = """
+            if [[ "$CYLC_TASK_JOB" == '20100101T0000Z/foo/01' ]]; then
+                # keep running until scheduler is gone
+                while cylc ping $CYLC_WORKFLOW_NAME; do
+                    sleep 10
+                done
+            else
+                true
+            fi
+        """

--- a/tests/functional/runahead/default-simple/flow.cylc
+++ b/tests/functional/runahead/default-simple/flow.cylc
@@ -1,19 +1,23 @@
 [scheduler]
     UTC mode = True
-    allow implicit tasks = True
     [[events]]
-        abort on stalled = True
-        timeout = PT30S
-        abort on timeout = True
+        abort on inactivity = True
+        inactivity = PT10S
 [scheduling]
     initial cycle point = 20100101T00
     final cycle point = 20100105T00
     [[graph]]
         # Intervals are all 24 hours, but we really have a 6 hour repetition.
-        # oops makes bar spawn as waiting to hold back the runahead
-        T00, T06, T12, T18 = "foo & oops => bar"
+        T00, T06, T12, T18 = "foo"
 [runtime]
     [[foo]]
-        script = false
-    [[bar]]
-        script = true
+        script = """
+            if [[ "$CYLC_TASK_JOB" == '20100101T0000Z/foo/01' ]]; then
+                # keep running until scheduler is gone
+                while cylc ping $CYLC_WORKFLOW_NAME; do
+                    sleep 10
+                done
+            else
+                true
+            fi
+        """

--- a/tests/functional/runahead/runahead/flow.cylc
+++ b/tests/functional/runahead/runahead/flow.cylc
@@ -1,23 +1,23 @@
 [scheduler]
-    allow implicit tasks = True
     [[events]]
-        abort on stalled = True
-        timeout = PT30S
-        abort on timeout = True
+        abort on inactivity = True
+        inactivity = PT10S
 [scheduling]
     cycling mode = integer
     runahead limit = P4
     initial cycle point = 1
     final cycle point = 20
     [[graph]]
-        P1 = foo & run_ok => bar
-        # foo fails on 1st cycle point only, succeeds on all others.
-        # SoD: run_ok ensures bar spawns as waiting in 1st cycle pt, to
-        # hold back the runahead.
-        # As runahead limit is consecutive, even though cycle points 2 and
-        # above succeed, workflow stalls after 4 cycle points.
+        P1 = foo
 [runtime]
-    [[root]]
-        script = true
     [[foo]]
-        script = if [[ "$CYLC_TASK_JOB" == '1/foo/01' ]]; then false; else true; fi
+        script = """
+            if [[ "$CYLC_TASK_JOB" == '1/foo/01' ]]; then
+                # keep running until scheduler is gone
+                while cylc ping $CYLC_WORKFLOW_NAME; do
+                    sleep 10
+                done
+            else
+                true
+            fi
+        """

--- a/tests/functional/runahead/time-limit/flow.cylc
+++ b/tests/functional/runahead/time-limit/flow.cylc
@@ -1,21 +1,24 @@
+# workflow that shuts down from inactivity once foo hits the runahead limit
 [scheduler]
     UTC mode = True
-    allow implicit tasks = True
     [[events]]
-        abort on stalled = True
+        abort on inactivity = True
+        inactivity = PT10S
 [scheduling]
     runahead limit = PT4H
     initial cycle point = 2020-01-01T00
     final cycle point = 2020-01-02T00
     [[graph]]
-        PT1H = foo & run_ok => bar
-        # foo fails on 1st cycle point (T00) only, succeeds on all others.
-        # SoD: run_ok ensures bar spawns as waiting in 1st cycle pt, to
-        # hold back the runahead.
-        # As runahead limit is consecutive, even though cycle points T01 and
-        # above succeed, workflow stalls after ^+PT4H
+        PT1H = foo
 [runtime]
-    [[root]]
-        script = true
     [[foo]]
-        script = if [[ "$CYLC_TASK_JOB" == '20200101T0000Z/foo/01' ]]; then false; else true; fi
+        script = """
+            if [[ "$CYLC_TASK_JOB" == '20200101T0000Z/foo/01' ]]; then
+                # keep running until scheduler is gone
+                while cylc ping $CYLC_WORKFLOW_NAME; do
+                    sleep 10
+                done
+            else
+                true
+            fi
+        """


### PR DESCRIPTION
This is a small change with no associated Issue.

I noticed that partially-satisfied prerequisites (aka hidden pool task proxies) are being counted for runahead limiting, which is not ~~necessary~~ the right thing to do.

On this branch the runahead limit simply restricts the spread of active tasks.

(This will break a few runahead tests...)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`. (None)
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
