### PR TITLE
Add glob to have review syntax highlight flow.cylc(.processed) files.

### DIFF
--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -584,7 +584,7 @@ class CylcReviewService(object):
                         break
         if (
             fnmatch(os.path.basename(path), "suite*.rc*")
-            or fnmatch(os.path.basename(path), "flow*.cylc*")
+            or fnmatch(os.path.basename(path), "flow.cylc*")
         ):
             file_content = "cylc-suite-rc"
         elif fnmatch(os.path.basename(path), "rose*.conf"):

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -582,7 +582,10 @@ class CylcReviewService(object):
                     if entry["submit_num"] == int(submit_num):
                         job_entry = entry
                         break
-        if fnmatch(os.path.basename(path), "suite*.rc*"):
+        if (
+            fnmatch(os.path.basename(path), "suite*.rc*")
+            or fnmatch(os.path.basename(path), "flow*.cylc*")
+        ):
             file_content = "cylc-suite-rc"
         elif fnmatch(os.path.basename(path), "rose*.conf"):
             file_content = "rose-conf"


### PR DESCRIPTION
These changes partially address #4261 : Cylc Review is not identifying `cylc.flow` and `cylc.flow.processed` as files to be syntax highlighted.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Manual testing only: Legacy Software. To test check that `cylc.flow` and `cylc.flow.processed` are highlighted.
- [x] No change log entry: Will add a changelog entry covering all parts of #4261 
- [x] No documentation update required.

I think that this needs only 1 review.
