### PR TITLE
Tweak terminal logo.

### DIFF
--- a/cylc/flow/scripts/__init__.py
+++ b/cylc/flow/scripts/__init__.py
@@ -27,19 +27,19 @@ _copyright_year = 2021  # This is set by GH Actions update_copyright workflow
 # fmt: off
 LOGO_LETTERS = (
     (
-        "oooo",
-        "oo  ",
+        "ooo",
+        "oo ",
         "oooo",
     ),
     (
         "oo oo",
         "ooooo",
-        "   oo",
+        " ooo",
     ),
     (
-        "oo",
-        "oo",
-        "oo",
+        "oo ",
+        "ooo",
+        "ooo",
     ),
     (
         "oooo",


### PR DESCRIPTION
A bit of fluff. Pushing up the tweak I made for the demo in my presentation last night.

Master:
![shot-old](https://user-images.githubusercontent.com/2362137/122130648-13ed6380-ce8c-11eb-84fc-fea80c9272a0.png)

This branch:
![shot](https://user-images.githubusercontent.com/2362137/122130669-1bad0800-ce8c-11eb-90ec-621c0441328d.png)
 
IMO the new one is more readable: the "Y" looks less like a "4"; the word looks less like "chic" because the "L" doesn't look like an "I"; and it is also more balanced with the tail on the "L" ... while still looking colourful and graphic.

