### PR TITLE
Constrain window by final cycle point

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,9 @@ workflow's public database file was not closed properly.
 
 ### Fixes
 
+[#4272](https://github.com/cylc/cylc-flow/pull/4272) - Workflow visualisation
+data (data-store) now constrained by final cycle point.
+
 [#4248](https://github.com/cylc/cylc-flow/pull/4248)
  - Fix parameter expansion in inherited task environments.
 

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -698,7 +698,10 @@ class DataStoreMgr:
             self, s_id, s_node, items, active_id, flow_label, reflow,
             edge_distance, descendant=False, is_parent=False):
         """Construct nodes/edges for children/parents of source node."""
+        final_point = self.schd.config.final_point
         for t_name, t_point, _ in items:
+            if t_point > final_point:
+                continue
             t_node = f'{t_name}.{t_point}'
             t_id = (
                 f'{self.workflow_id}{ID_DELIM}{t_point}{ID_DELIM}{t_name}')

--- a/tests/functional/graphql/01-workflow.t
+++ b/tests/functional/graphql/01-workflow.t
@@ -92,8 +92,8 @@ cmp_json "${TEST_NAME}-out" "${TEST_NAME_BASE}-workflows.stdout" << __HERE__
                 "title": "foo",
                 "description": "bar"
             },
-            "newestActiveCyclePoint": "1",
-            "oldestActiveCyclePoint": "1",
+            "newestActiveCyclePoint": "20210101T0000Z",
+            "oldestActiveCyclePoint": "20210101T0000Z",
             "reloaded": false,
             "runMode": "live",
             "stateTotals": {
@@ -117,7 +117,7 @@ cmp_json "${TEST_NAME}-out" "${TEST_NAME_BASE}-workflows.stdout" << __HERE__
             ],
             "states": ["waiting"],
             "latestStateTasks": {
-                "waiting": ["foo.1"]
+                "waiting": ["foo.20210101T0000Z"]
             }
         }
     ]

--- a/tests/functional/graphql/01-workflow/flow.cylc
+++ b/tests/functional/graphql/01-workflow/flow.cylc
@@ -6,8 +6,10 @@
     UTC mode = True
 
 [scheduling]
+    initial cycle point = 20210101T0000Z
+    final cycle point = 20210101T0000Z
     [[graph]]
-        R1 = foo
+        P1Y = foo[-P1Y] => foo
 
 [runtime]
     [[foo]]

--- a/tests/functional/runahead/06-release-update.t
+++ b/tests/functional/runahead/06-release-update.t
@@ -34,9 +34,7 @@ poll_grep_workflow_log -F "spawned bar.${NEXT1}"
 sleep 10
 cylc dump -t "${WORKFLOW_NAME}" | awk '{print $1 $2 $3}' >'log'
 cmp_ok 'log' - <<__END__
-bar,$YYYY,succeeded,
 bar,$NEXT1,waiting,
-foo,$YYYY,succeeded,
 foo,$NEXT1,waiting,
 __END__
 


### PR DESCRIPTION
These changes close #4255

Constrain the data store n-window by the final cycle point (FCP)... (ICP doesn't appear to be an issue)

There would be two ways of doing this:
- change the `taskdef.py` function that generates children
- filter at the window expansion for children whose cycle point extends beyond the FCP.

I chose the latter, because we may wish to (or already do) record the workflow state of tasks beyond the FCP for the purpose of restarting the workflow with an extended FCP.

~~The issue only applies to those tasks in the `[scheduling][[special tasks]]sequential` section, not those defined in the graph as sequential.~~

The test `tests/functional/graphql/01-workflow.t` will fail with the filter commented out.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
