### PR TITLE
Fix failure to show workflow status

### DIFF
--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -608,9 +608,9 @@ class CylcReviewDAO(object):
             port_str = None
             for line in open(port_file_path):
                 key, value = [item.strip() for item in line.split("=", 1)]
-                if key == "CYLC_SUITE_HOST":
+                if key in ["CYLC_SUITE_HOST", "CYLC_WORKFLOW_HOST"]:
                     host = value
-                elif key == "CYLC_SUITE_PORT":
+                elif key in ["CYLC_SUITE_PORT", "CYLC_WORKFLOW_PORT"]:
                     port_str = value
         except (IOError, ValueError):
             pass


### PR DESCRIPTION
These changes partially address #4261 : Running Cylc 8 Workflows showing as stopped under some circumstances.

Cause of bug: Contact file was being scraped for the word SUITE, not SUITE _or_ WORKFLOW.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Manual testing - run workflows in Cylc8 () and Cylc7 and check that the status at the top of the "Cycles List" and "Task Jobs List" pages works (Picture attached). Testers need to install Cylc8 in non-editable mode (`pip install .`, without `-e`) else changing branch will kill the workflow.
- [x] No change log entry required: Will be logged on closure of #4261 
- [x] No documentation update required - maintains existing functionality.

![image](https://user-images.githubusercontent.com/26465611/122894054-c7e46800-d33e-11eb-9bbc-ca5dcd0f8357.png)

