### PR TITLE
update syntax highlighting to reflect latest changes in configs

### DIFF
--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -88,6 +88,7 @@
         -->
         <!--TAG_FOR_AUTO_UPDATE-->
         <keyword>xtriggers</keyword>
+        <keyword>workflow state polling</keyword>
         <keyword>work sub-directory</keyword>
         <keyword>warning handler</keyword>
         <keyword>visualization</keyword>
@@ -104,8 +105,6 @@
         <keyword>templates</keyword>
         <keyword>task parameters</keyword>
         <keyword>task event batch interval</keyword>
-        <keyword>suite state polling</keyword>
-        <keyword>workflow state polling</keyword>
         <keyword>succeeded handler</keyword>
         <keyword>submitted handler</keyword>
         <keyword>submission timeout handler</keyword>
@@ -213,6 +212,7 @@
         <keyword>clock-expire</keyword>
         <keyword>batch system</keyword>
         <keyword>batch submit command template</keyword>
+        <keyword>allow implicit tasks</keyword>
         <keyword>aborted handler</keyword>
         <keyword>abort on timeout</keyword>
         <keyword>abort on stalled</keyword>

--- a/cylc/flow/etc/syntax/cylc.xml
+++ b/cylc/flow/etc/syntax/cylc.xml
@@ -14,6 +14,7 @@
         The sort is in reverse order to allow longer keywords to take precedence over sub-sets. -->
         <!--TAG_FOR_AUTO_UPDATE-->
         <RegExpr attribute='Keyword' String=' xtriggers '/>
+        <RegExpr attribute='Keyword' String=' workflow state polling '/>
         <RegExpr attribute='Keyword' String=' work sub-directory '/>
         <RegExpr attribute='Keyword' String=' warning handler '/>
         <RegExpr attribute='Keyword' String=' visualization '/>
@@ -30,8 +31,6 @@
         <RegExpr attribute='Keyword' String=' templates '/>
         <RegExpr attribute='Keyword' String=' task parameters '/>
         <RegExpr attribute='Keyword' String=' task event batch interval '/>
-        <RegExpr attribute='Keyword' String=' suite state polling '/>
-        <RegExpr attribute='Keyword' String=' workflow state polling '/>
         <RegExpr attribute='Keyword' String=' succeeded handler '/>
         <RegExpr attribute='Keyword' String=' submitted handler '/>
         <RegExpr attribute='Keyword' String=' submission timeout handler '/>
@@ -139,6 +138,7 @@
         <RegExpr attribute='Keyword' String=' clock-expire '/>
         <RegExpr attribute='Keyword' String=' batch system '/>
         <RegExpr attribute='Keyword' String=' batch submit command template '/>
+        <RegExpr attribute='Keyword' String=' allow implicit tasks '/>
         <RegExpr attribute='Keyword' String=' aborted handler '/>
         <RegExpr attribute='Keyword' String=' abort on timeout '/>
         <RegExpr attribute='Keyword' String=' abort on stalled '/>


### PR DESCRIPTION
This is a small change with no associated Issue: Whilst reviewing something else I noticed that the automated syntax highlighting script had not been run, and so some of the syntax highlighting was out of date. Fixed here.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests: Not a tested feature.
- [x] No change log entry required: Change to something that should already be working
- [x] No documentation update required.
