### PR TITLE
CLI make colourization optional for cmd --help

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,9 @@ Third beta release of Cylc 8.
 
 ### Enhancements
 
+[#4284](https://github.com/cylc/cylc-flow/pull/4284)
+ - Make `--color=never` work with `cylc <command> --help`.
+
 [#4103](https://github.com/cylc/cylc-flow/pull/4103) -
 Expose runahead limiting to UIs; restore correct force-triggering of queued
 tasks for Cylc 8.

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -30,7 +30,7 @@ from cylc.flow.loggingutil import CylcLogFormatter
 
 
 def format_shell_examples(string):
-    """Put comments in the terminal "dimished" colour."""
+    """Put comments in the terminal "diminished" colour."""
     return cparse(
         re.sub(
             r'^(\s*(?:\$[^#]+)?)(#.*)$',
@@ -167,8 +167,10 @@ TASK_GLOB matches task or family names at a given cycle point.
             else:
                 argdoc = [('REG', 'Workflow name')]
 
-        # make comments grey in usage for readability
-        usage = format_shell_examples(usage)
+        if '--color=never' not in '='.join(sys.argv[2:]):
+            # Before option parsing, for `--help`, make comments grey in usage.
+            # (This catches both '--color=never' and '--color never'.)
+            usage = format_shell_examples(usage)
 
         if multitask:
             usage += self.MULTITASKCYCLE_USAGE

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+import sys
 import cylc.flow.flags
 from cylc.flow.option_parsers import CylcOptionParser as COP
 
@@ -23,6 +24,20 @@ from cylc.flow.option_parsers import CylcOptionParser as COP
 @pytest.fixture(scope='module')
 def parser():
     return COP('usage')
+
+
+@pytest.fixture(scope='module')
+def parser_nocolor():
+    argv = sys.argv
+    sys.argv = ['cmd', 'arg', '--help', '--color=never']
+    cop = COP('usage \n # comment')
+    sys.argv = argv
+    return cop
+
+
+@pytest.fixture(scope='module')
+def parser_color():
+    return COP('usage \n # comment')
 
 
 @pytest.mark.parametrize(
@@ -46,3 +61,13 @@ def test_verbosity(args, verbosity, parser, monkeypatch):
     assert opts.verbosity == verbosity
     # test side-effect, the verbosity flag should be set
     assert cylc.flow.flags.verbosity == verbosity
+
+
+def test_help_color(parser_color):
+    """Test for colorized comments in 'cylc cmd --help'."""
+    assert not parser_color.usage.startswith('usage \n # comment')
+
+
+def test_help_nocolor(parser_nocolor):
+    """Test for no colorization in 'cylc cmd --help --color=never'."""
+    assert parser_nocolor.usage.startswith('usage \n # comment')

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -21,6 +21,9 @@ import cylc.flow.flags
 from cylc.flow.option_parsers import CylcOptionParser as COP
 
 
+USAGE_WITH_COMMENT = "usage \n # comment"
+
+
 @pytest.fixture(scope='module')
 def parser():
     return COP('usage')
@@ -30,14 +33,14 @@ def parser():
 def parser_nocolor():
     argv = sys.argv
     sys.argv = ['cmd', 'arg', '--help', '--color=never']
-    cop = COP('usage \n # comment')
+    cop = COP(USAGE_WITH_COMMENT)
     sys.argv = argv
     return cop
 
 
 @pytest.fixture(scope='module')
 def parser_color():
-    return COP('usage \n # comment')
+    return COP(USAGE_WITH_COMMENT)
 
 
 @pytest.mark.parametrize(
@@ -65,9 +68,9 @@ def test_verbosity(args, verbosity, parser, monkeypatch):
 
 def test_help_color(parser_color):
     """Test for colorized comments in 'cylc cmd --help'."""
-    assert not parser_color.usage.startswith('usage \n # comment')
+    assert not parser_color.usage.startswith(USAGE_WITH_COMMENT)
 
 
 def test_help_nocolor(parser_nocolor):
     """Test for no colorization in 'cylc cmd --help --color=never'."""
-    assert parser_nocolor.usage.startswith('usage \n # comment')
+    assert parser_nocolor.usage.startswith(USAGE_WITH_COMMENT)


### PR DESCRIPTION
This is a small change with no associated Issue.

Some of our command help pages are quite long, so I sometimes like to grep in them, or open them in an editor `cylc play --help | vim -` in which case color control codes in the output are annoying.  This hack makes `--color=never` work with `--help`.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`. (No changes)
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
