### PR TITLE
scan: show uninstalled workflows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,9 @@ Third beta release of Cylc 8.
 
 ### Enhancements
 
+[#4286](https://github.com/cylc/cylc-flow/pull/4286) -
+Add an option for displaying source workflows in `cylc scan`.
+
 [#4291](https://github.com/cylc/cylc-flow/pull/4291)
  - Remove obsolete `cylc edit` and `cylc search` commands.
 

--- a/cylc/flow/async_util.py
+++ b/cylc/flow/async_util.py
@@ -396,7 +396,7 @@ def _scandir(future, path, request):
     """Callback helper for scandir()."""
     future.set_result([
         Path(path, directory.name)
-        # request.result can be None (maybe an empty dir in cylc-run)
+        # request.result is None for empty dirs
         for directory in request.result or []
     ])
 

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -41,6 +41,10 @@ Examples:
   # filter workflows by name
   $ cylc scan --name '^f.*'  # show only flows starting with "f"
 
+  # list source workflows in a tree
+  # (looks in the dirs configured by "global.cylc[install]source dirs")
+  $ cylc scan --source -t tree
+
   # get results in JSON format
   $ cylc scan -t json
 """
@@ -52,21 +56,23 @@ from pathlib import Path
 from ansimarkup import ansiprint as cprint
 
 from cylc.flow import LOG
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import UserInputError
 from cylc.flow.network.scan import (
-    scan,
-    is_active,
     contact_info,
+    filter_name,
     graphql_query,
-    filter_name
+    is_active,
+    scan,
+    scan_multi,
 )
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     Options
 )
 from cylc.flow.print_tree import get_tree
-from cylc.flow.workflow_files import ContactFileFields as Cont
 from cylc.flow.terminal import cli_function
+from cylc.flow.workflow_files import ContactFileFields as Cont
 
 
 # default grey colour (do not use "dim", it is not sufficiently portable)
@@ -165,7 +171,7 @@ def get_option_parser():
     parser.add_option(
         '--name', '-n',
         help=(
-            'Filter flows by registered name using a regex.'
+            'Filter workflows by registered name using a regex.'
             ' Can be used multiple times, workflows will be displayed if'
             ' their name matches ANY of the provided regexes.'
         ),
@@ -175,12 +181,22 @@ def get_option_parser():
     parser.add_option(
         '--states',
         help=(
-            'Choose which flows to display by providing a list of states'
+            'Choose which workflows to display by providing a list of states'
             ' or "all" to show everything. See the full `cylc scan` help'
             ' for a list of supported states.'
         ),
         default='running,paused,stopping',
         action='store'
+    )
+
+    parser.add_option(
+        '--source', '-s',
+        help=(
+            'List source workflows from configured source'
+            ' directories (overrides the --states option).'
+        ),
+        default=False,
+        action='store_true'
     )
 
     parser.add_option(
@@ -397,6 +413,12 @@ def get_pipe(opts, formatter, scan_dir=None):
     """Construct a pipe for listing flows."""
     if scan_dir:
         pipe = scan(scan_dir=scan_dir)
+    elif opts.source:
+        pipe = scan_multi(
+            Path(path).expanduser()
+            for path in glbl_cfg().get(['install', 'source dirs'])
+        )
+        opts.states = {'stopped'}
     else:
         pipe = scan
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from shutil import rmtree
+
+import pytest
+
+from cylc.flow.cfgspec.globalcfg import SPEC
+from cylc.flow.parsec.config import ParsecConfig
+
+
+@pytest.fixture
+def mock_glbl_cfg(tmp_path, monkeypatch):
+    """A Pytest fixture for fiddling global config values.
+
+    * Hacks the specified `glbl_cfg` object.
+    * Can be called multiple times within a test function.
+
+    Args:
+        pypath (str):
+            The python-like path to the global configuation object you want
+            to fiddle.
+            E.G. if you want to hack the `glbl_cfg` in
+            `cylc.flow.scheduler` you would provide
+            `cylc.flow.scheduler.glbl_cfg`
+        global_config (str):
+            The globlal configuration as a multi-line string.
+
+    Example:
+        Change the value of `UTC mode` in the global config as seen from
+        `the scheduler` module.
+
+        def test_something(mock_glbl_cfg):
+            mock_glbl_cfg(
+                'cylc.flow.scheduler.glbl_cfg',
+                '''
+                    [scheduler]
+                        UTC mode = True
+                '''
+            )
+
+    """
+    # TODO: modify Parsec so we can use StringIO rather than a temp file.
+    def _mock(pypath, global_config):
+        nonlocal tmp_path, monkeypatch
+        global_config_path = tmp_path / 'global.cylc'
+        global_config_path.write_text(global_config)
+        glbl_cfg = ParsecConfig(SPEC)
+        glbl_cfg.loadcfg(global_config_path)
+
+        def _inner(cached=False):
+            nonlocal glbl_cfg
+            return glbl_cfg
+
+        monkeypatch.setattr(pypath, _inner)
+
+    yield _mock
+    rmtree(tmp_path)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,19 +16,17 @@
 """Standard pytest fixtures for unit tests."""
 
 from pathlib import Path
-import pytest
-from shutil import rmtree
 from typing import Any, Callable, Optional
 from unittest.mock import create_autospec, Mock
 
-from cylc.flow.cfgspec.globalcfg import SPEC
+import pytest
+
 from cylc.flow.cycling.iso8601 import init as iso8601_init
 from cylc.flow.cycling.loader import (
     ISO8601_CYCLING_TYPE,
     INTEGER_CYCLING_TYPE
 )
 from cylc.flow.data_store_mgr import DataStoreMgr
-from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.xtrigger_mgr import XtriggerManager
@@ -99,55 +97,6 @@ def set_cycling_type(monkeypatch: pytest.MonkeyPatch):
         if ctype == ISO8601_CYCLING_TYPE:
             iso8601_init(time_zone=time_zone)
     return _set_cycling_type
-
-
-@pytest.fixture
-def mock_glbl_cfg(tmp_path, monkeypatch):
-    """A Pytest fixture for fiddling global config values.
-
-    * Hacks the specified `glbl_cfg` object.
-    * Can be called multiple times within a test function.
-
-    Args:
-        pypath (str):
-            The python-like path to the global configuation object you want
-            to fiddle.
-            E.G. if you want to hack the `glbl_cfg` in
-            `cylc.flow.scheduler` you would provide
-            `cylc.flow.scheduler.glbl_cfg`
-        global_config (str):
-            The globlal configuration as a multi-line string.
-
-    Example:
-        Change the value of `UTC mode` in the global config as seen from
-        `the scheduler` module.
-
-        def test_something(mock_glbl_cfg):
-            mock_glbl_cfg(
-                'cylc.flow.scheduler.glbl_cfg',
-                '''
-                    [scheduler]
-                        UTC mode = True
-                '''
-            )
-
-    """
-    # TODO: modify Parsec so we can use StringIO rather than a temp file.
-    def _mock(pypath, global_config):
-        nonlocal tmp_path, monkeypatch
-        global_config_path = tmp_path / 'global.cylc'
-        global_config_path.write_text(global_config)
-        glbl_cfg = ParsecConfig(SPEC)
-        glbl_cfg.loadcfg(global_config_path)
-
-        def _inner(cached=False):
-            nonlocal glbl_cfg
-            return glbl_cfg
-
-        monkeypatch.setattr(pypath, _inner)
-
-    yield _mock
-    rmtree(tmp_path)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add the `cylc scan --uninstalled` option.

> **Note:** Source isn't a workflow state because source workflows are orthogonal to run workflows. The lifecycle of the source is not the same as the lifecycle of the run. The UI will have to track source and run workflows separately.

First step towards displaying source workflows in the UI (as the UIS can use the `scan_multi` interface). Next we need to jam source workflows into the schema at the UIS and make them available to the UI.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
