### PR TITLE
cylc-rose: `cylc list` compatibility

### DIFF
--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -132,7 +132,7 @@ def main(parser, options, reg=None):
         workflow,
         flow_file,
         options,
-        get_template_vars(options, flow_file))
+        get_template_vars(options, flow_file, [reg, workflow]))
 
     config.pcfg.idump(
         options.item,

--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -56,7 +56,8 @@ from cylc.flow.config import WorkflowConfig
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.workflow_files import WorkflowFiles, parse_workflow_arg
-from cylc.flow.templatevars import load_template_vars
+from cylc.flow.scripts.install import add_cylc_rose_options
+from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
 
@@ -97,6 +98,8 @@ def get_option_parser():
             "overrides any settings it shares with those higher up."),
         action="store_true", default=False, dest="print_hierarchy")
 
+    parser = add_cylc_rose_options(parser)
+
     return parser
 
 
@@ -129,7 +132,7 @@ def main(parser, options, reg=None):
         workflow,
         flow_file,
         options,
-        load_template_vars(options.templatevars, options.templatevars_file))
+        get_template_vars(options, flow_file))
 
     config.pcfg.idump(
         options.item,

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -37,8 +37,9 @@ from cylc.flow.config import WorkflowConfig
 from cylc.flow.exceptions import UserInputError
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.workflow_files import parse_workflow_arg
-from cylc.flow.templatevars import load_template_vars
+from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
+from cylc.flow.scripts.install import add_cylc_rose_options
 
 
 def sort_integer_node(item):
@@ -209,6 +210,8 @@ def get_option_parser():
         action='store',
     )
 
+    parser = add_cylc_rose_options(parser)
+
     return parser
 
 
@@ -222,8 +225,7 @@ def main(parser, opts, workflow=None, start=None, stop=None):
             'Only the --reference and --diff use cases are supported'
         )
 
-    template_vars = load_template_vars(
-        opts.templatevars, opts.templatevars_file)
+    template_vars = get_template_vars(opts, workflow)
 
     write = print
     flows = [(workflow, [])]

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -83,6 +83,51 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
+def add_cylc_rose_options(parser):
+    """Add extra options for cylc-rose plugin if it is installed.
+
+    Args:
+        parser: An option parser object
+    """
+    try:
+        __import__('cylc.rose')
+        parser.add_option(
+            "--opt-conf-key", "-O",
+            help=(
+                "Use optional Rose Config Setting"
+                "(If Cylc-Rose is installed)"
+            ),
+            action="append",
+            default=[],
+            dest="opt_conf_keys"
+        )
+        parser.add_option(
+            "--define", '-D',
+            help=(
+                "Each of these overrides the `[SECTION]KEY` setting in a "
+                "`rose-suite.conf` file. "
+                "Can be used to disable a setting using the syntax "
+                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
+            ),
+            action="append",
+            default=[],
+            dest="defines"
+        )
+        parser.add_option(
+            "--rose-template-variable", '-S',
+            help=(
+                "As `--define`, but with an implicit `[SECTION]` for "
+                "workflow variables."
+            ),
+            action="append",
+            default=[],
+            dest="rose_template_vars"
+        )
+    except ImportError:
+        pass
+    return parser
+
+
 def get_option_parser():
     parser = COP(
         __doc__, comms=True, prep=True,
@@ -127,43 +172,7 @@ def get_option_parser():
         default=False,
         dest="no_symlinks")
 
-    # If cylc-rose plugin is available ad the --option/-O config
-    try:
-        __import__('cylc.rose')
-        parser.add_option(
-            "--opt-conf-key", "-O",
-            help=(
-                "Use optional Rose Config Setting"
-                "(If Cylc-Rose is installed)"
-            ),
-            action="append",
-            default=[],
-            dest="opt_conf_keys"
-        )
-        parser.add_option(
-            "--define", '-D',
-            help=(
-                "Each of these overrides the `[SECTION]KEY` setting in a "
-                "`rose-suite.conf` file. "
-                "Can be used to disable a setting using the syntax "
-                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
-            ),
-            action="append",
-            default=[],
-            dest="defines"
-        )
-        parser.add_option(
-            "--rose-template-variable", '-S',
-            help=(
-                "As `--define`, but with an implicit `[SECTION]` for "
-                "workflow variables."
-            ),
-            action="append",
-            default=[],
-            dest="rose_template_vars"
-        )
-    except ImportError:
-        pass
+    parser = add_cylc_rose_options(parser)
 
     return parser
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -94,7 +94,7 @@ def add_cylc_rose_options(parser):
         parser.add_option(
             "--opt-conf-key", "-O",
             help=(
-                "Use optional Rose Config Setting"
+                "Use optional Rose Config Setting "
                 "(If Cylc-Rose is installed)"
             ),
             action="append",

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -89,8 +89,7 @@ def get_option_parser():
 @cli_function(get_option_parser)
 def main(parser, options, reg):
     workflow, flow_file = parse_workflow_arg(options, reg)
-
-    template_vars = get_template_vars(options, flow_file)
+    template_vars = get_template_vars(options, flow_file, [reg, flow_file])
 
     if options.all_tasks and options.all_namespaces:
         parser.error("Choose either -a or -n")

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -81,12 +81,78 @@ def get_option_parser():
         "initial cycle point, by default). Use '-p , ' for the default range.",
         metavar="[START],[STOP]", action="store", default=None, dest="prange")
 
+    # If cylc-rose plugin is available ad the --option/-O config
+    try:
+        __import__('cylc.rose')
+        parser.add_option(
+            "--opt-conf-key", "-O",
+            help=(
+                "Use optional Rose Config Setting"
+                "(If Cylc-Rose is installed)"
+            ),
+            action="append",
+            default=[],
+            dest="opt_conf_keys"
+        )
+        parser.add_option(
+            "--define", '-D',
+            help=(
+                "Each of these overrides the `[SECTION]KEY` setting in a "
+                "`rose-suite.conf` file. "
+                "Can be used to disable a setting using the syntax "
+                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
+            ),
+            action="append",
+            default=[],
+            dest="defines"
+        )
+        parser.add_option(
+            "--rose-template-variable", '-S',
+            help=(
+                "As `--define`, but with an implicit `[SECTION]` for "
+                "workflow variables."
+            ),
+            action="append",
+            default=[],
+            dest="rose_template_vars"
+        )
+    except ImportError:
+        pass
+
     return parser
 
 
 @cli_function(get_option_parser)
 def main(parser, options, reg):
     workflow, flow_file = parse_workflow_arg(options, reg)
+
+    from cylc.flow import iter_entry_points
+    from cylc.flow.exceptions import PluginError
+    from pathlib import Path
+    flow_file = Path(flow_file)
+    source = flow_file.parent
+
+    template_vars = load_template_vars(
+        options.templatevars, options.templatevars_file)
+    if template_vars == {}:
+        for entry_point in iter_entry_points(
+            'cylc.pre_configure'
+        ):
+            try:
+                if source:
+                    ep_result = entry_point.resolve()(srcdir=source, opts=options)
+                else:
+                    from pathlib import Path
+                    ep_result = entry_point.resolve()(srcdir=Path().cwd(), opts=options)
+                template_vars = ep_result['template_variables']
+            except Exception as exc:
+                # NOTE: except Exception (purposefully vague)
+                # this is to separate plugin from core Cylc errors
+                raise PluginError(
+                    'cylc.pre_configure',
+                    entry_point.name,
+                    exc
+                ) from None
 
     if options.all_tasks and options.all_namespaces:
         parser.error("Choose either -a or -n")
@@ -125,7 +191,7 @@ def main(parser, options, reg):
         workflow,
         flow_file,
         options,
-        load_template_vars(options.templatevars, options.templatevars_file))
+        template_vars)
     if options.tree:
         config.print_first_parent_tree(
             pretty=options.box, titles=options.titles)

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -35,6 +35,7 @@ import sys
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.workflow_files import parse_workflow_arg
+from cylc.flow.scripts.install import add_cylc_rose_options
 from cylc.flow.templatevars import load_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -81,44 +82,7 @@ def get_option_parser():
         "initial cycle point, by default). Use '-p , ' for the default range.",
         metavar="[START],[STOP]", action="store", default=None, dest="prange")
 
-    # If cylc-rose plugin is available ad the --option/-O config
-    try:
-        __import__('cylc.rose')
-        parser.add_option(
-            "--opt-conf-key", "-O",
-            help=(
-                "Use optional Rose Config Setting"
-                "(If Cylc-Rose is installed)"
-            ),
-            action="append",
-            default=[],
-            dest="opt_conf_keys"
-        )
-        parser.add_option(
-            "--define", '-D',
-            help=(
-                "Each of these overrides the `[SECTION]KEY` setting in a "
-                "`rose-suite.conf` file. "
-                "Can be used to disable a setting using the syntax "
-                "`--define=[SECTION]!KEY` or even `--define=[!SECTION]`."
-            ),
-            action="append",
-            default=[],
-            dest="defines"
-        )
-        parser.add_option(
-            "--rose-template-variable", '-S',
-            help=(
-                "As `--define`, but with an implicit `[SECTION]` for "
-                "workflow variables."
-            ),
-            action="append",
-            default=[],
-            dest="rose_template_vars"
-        )
-    except ImportError:
-        pass
-
+    parser = add_cylc_rose_options(parser)
     return parser
 
 

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -38,7 +38,7 @@ from cylc.flow.exceptions import (WorkflowConfigError,
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_pool import FlowLabelMgr
 from cylc.flow.loggingutil import CylcLogFormatter
-from cylc.flow.templatevars import load_template_vars
+from cylc.flow.templatevars import get_template_vars
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     Options
@@ -104,7 +104,7 @@ def main(_, options, reg):
         workflow,
         flow_file,
         options,
-        load_template_vars(options.templatevars, options.templatevars_file),
+        get_template_vars(options, flow_file, [reg, workflow]),
         output_fname=options.output, mem_log_func=profiler.log_memory)
 
     # Check bounds of sequences

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -44,6 +44,7 @@ from cylc.flow.option_parsers import (
     Options
 )
 from cylc.flow.workflow_files import parse_workflow_arg
+from cylc.flow.scripts.install import add_cylc_rose_options
 
 
 def get_option_parser():
@@ -70,6 +71,8 @@ def get_option_parser():
         "-u", "--run-mode", help="Validate for run mode.", action="store",
         default="live", dest="run_mode",
         choices=['live', 'dummy', 'dummy-local', 'simulation'])
+
+    parser = add_cylc_rose_options(parser)
 
     parser.set_defaults(is_validate=True)
 

--- a/cylc/flow/templatevars.py
+++ b/cylc/flow/templatevars.py
@@ -118,7 +118,7 @@ def get_template_vars(
                 ep_result = entry_point.resolve()(
                     srcdir=source, opts=options
                 )
-                template_vars.extend(ep_result['template_variables'])
+                template_vars.update(ep_result['template_variables'])
             except Exception as exc:
                 # NOTE: except Exception (purposefully vague)
                 # this is to separate plugin from core Cylc errors

--- a/cylc/flow/templatevars.py
+++ b/cylc/flow/templatevars.py
@@ -91,6 +91,9 @@ def get_template_vars(
             function.
         flow_file: Path to the ``flow.cylc`` (or ``suite.rc``) file defining
             this workflow.
+        names: reg and flow file name from
+            `cylc.flow.workflow_filesparse_workflow_arg`: Used to determine
+            whether flow is installed.
 
     Returns:
         template_vars: Template variables to give to a Cylc config.
@@ -98,8 +101,8 @@ def get_template_vars(
     # We are operating on an installed workflow.
     if (
         names
-        and names[0] == names[1]
-        and not Path(names[0]).is_file()
+        and names[0] == names[1]            # reg == flow_file name
+        and not Path(names[0]).is_file()    # reg is not a path
     ):
         template_vars = load_template_vars(
             options.templatevars, options.templatevars_file)

--- a/cylc/flow/templatevars.py
+++ b/cylc/flow/templatevars.py
@@ -99,7 +99,6 @@ def get_template_vars(
         template_vars: Template variables to give to a Cylc config.
     """
     # We are operating on an installed workflow.
-    template_vars = {}
     if (
         names
         and names[0] == names[1]            # reg == flow_file name
@@ -109,6 +108,8 @@ def get_template_vars(
             options.templatevars, options.templatevars_file)
     # Else we act as if we might be looking at a cylc-src dir.
     else:
+        template_vars = load_template_vars(
+            options.templatevars, options.templatevars_file)
         source = Path(flow_file).parent
         for entry_point in iter_entry_points(
             'cylc.pre_configure'
@@ -117,7 +118,7 @@ def get_template_vars(
                 ep_result = entry_point.resolve()(
                     srcdir=source, opts=options
                 )
-                template_vars = ep_result['template_variables']
+                template_vars.extend(ep_result['template_variables'])
             except Exception as exc:
                 # NOTE: except Exception (purposefully vague)
                 # this is to separate plugin from core Cylc errors

--- a/cylc/flow/templatevars.py
+++ b/cylc/flow/templatevars.py
@@ -99,6 +99,7 @@ def get_template_vars(
         template_vars: Template variables to give to a Cylc config.
     """
     # We are operating on an installed workflow.
+    template_vars = {}
     if (
         names
         and names[0] == names[1]            # reg == flow_file name

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -117,7 +117,8 @@ def test_get_template_vars_installed_flow(monkeypatch):
         lambda templatevars, templatevars_file: {'foo': 'bar'}
     )
     opts = SimpleNamespace(templatevars='', templatevars_file='')
-    assert get_template_vars(opts, '') == {'foo': 'bar'}
+    result = get_template_vars(opts, '', names=('eg/runN', 'eg/runN'))
+    assert result == {'foo': 'bar'}
 
 
 @pytest.fixture(scope='module')

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -14,11 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 import tempfile
 import unittest
 
-from cylc.flow.templatevars import load_template_vars
+from types import SimpleNamespace
 
+from cylc.flow.exceptions import PluginError
+from cylc.flow.templatevars import get_template_vars, load_template_vars
 
 class TestTemplatevars(unittest.TestCase):
 
@@ -102,3 +105,71 @@ class TestTemplatevars(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+def test_get_template_vars_installed_flow(monkeypatch):
+    """It works on an installed flow.
+
+    n.b. Does not attempt to test ``load_template_vars``
+    """
+    monkeypatch.setattr(
+        'cylc.flow.templatevars.load_template_vars',
+        lambda templatevars, templatevars_file: {'foo': 'bar'}
+    )
+    opts = SimpleNamespace(templatevars='', templatevars_file='')
+    assert get_template_vars(opts, '') == {'foo': 'bar'}
+
+
+def test_get_template_vars_src_flow(monkeypatch):
+    """It works on a flow which hasn't been installed.
+    """
+    monkeypatch.setattr(
+        'cylc.flow.templatevars.load_template_vars',
+        lambda templatevars, templatevars_file: {}
+    )
+    def fake_iter_entry_points(_):
+        class fake_ep:
+            name = 'Zaphod'
+            def resolve():
+                def _inner(srcdir, opts):
+                    return {'template_variables': {'MYVAR': 'foo'}}
+                return _inner
+        return [fake_ep]
+
+    monkeypatch.setattr(
+        'cylc.flow.templatevars.iter_entry_points',
+        fake_iter_entry_points
+    )
+    opts = SimpleNamespace(
+        templatevars='', templatevars_file='', opt_conf_keys=[], defines=[],
+        rose_template_vars=[])
+    assert get_template_vars(opts, '') == {'MYVAR': 'foo'}
+
+
+def test_get_template_vars_src_flow_fails(monkeypatch):
+    """It fails if there is a plugin error.
+    """
+    monkeypatch.setattr(
+        'cylc.flow.templatevars.load_template_vars',
+        lambda templatevars, templatevars_file: {}
+    )
+    def fake_iter_entry_points(_):
+        class fake_ep:
+            name = 'Zaphod'
+            def resolve():
+                def _inner(srcdir, opts):
+                    raise TypeError('Utter Drivel.')
+                return _inner
+        return [fake_ep]
+
+    monkeypatch.setattr(
+        'cylc.flow.templatevars.iter_entry_points',
+        fake_iter_entry_points
+    )
+    opts = SimpleNamespace(
+        templatevars='', templatevars_file='', opt_conf_keys=[], defines=[],
+        rose_template_vars=[])
+    with pytest.raises(PluginError) as exc:
+        get_template_vars(opts, '')
+    assert exc.match(
+        'Error in plugin cylc.pre_configure.Zaphod\nUtter Drivel.')


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes address #4288 
These changes are twinned with https://github.com/cylc/cylc-rose/pull/65

Make the following scripts work with cylc-rose:

### Internal Todo List

- [x] Cylc list
- [x] Cylc graph
- [x] Cylc config
- [x] Cylc validate


### Standard checklist

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (tests are in cylc-rose).
- [x] Appropriate change log entry included:  https://github.com/wxtim/cylc/pull/30 (Can be merged before merging this PR, avoids conflict)
- [x] Documented changes in cylc list docstring: Auto documents using the Cylc Rose args.

### How to review:

Create workflows with a `rose-suite.conf` in
- `~/cylc-src/`
-  `~/cylc-run/` (using `cylc install`)
- some other folder somewhere else entirely

You might use jinja2 or empy in the workflow to carry out tests like [these](https://github.com/cylc/cylc-rose/blob/master/tests/functional/06_jinja2_thorough/flow.cylc).

Try each of the four cylc CLI commands with and without the [extra rose options provided by this function](https://github.com/wxtim/cylc/blob/5ec95b29c20fe74a49754f529317f5f10597ab6d/cylc/flow/scripts/install.py#L86)/

Ideally these commands and `cylc install` should behave in a consistent way.
