### PR TITLE
have scheduler warn if stopcp > finalcp

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1910,4 +1910,4 @@ class Scheduler:
             LOG.warning(
                 f'Stop Cycle point \'{self.options.stopcp}\' will have no '
                 'effect as it is after the final Cycle '
-                f'point \'{self.options.fcp}\'.')
+                f'point \'{self.config.final_point}\'.')

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1906,10 +1906,7 @@ class Scheduler:
         """
         if self.config.final_point is None:
             return
-        if (
-            get_point(self.options.stopcp, self.config.cycling_type)
-            > get_point(self.config.final_point, self.config.cycling_type)
-        ):
+        if get_point(self.options.stopcp) > self.config.final_point:
             LOG.warning(
                 f'Stop Cycle point \'{self.options.stopcp}\' will have no '
                 'effect as it is after the final Cycle '

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1888,6 +1888,7 @@ class Scheduler:
         if stoppoint is not None:
             self.options.stopcp = str(stoppoint)
             self.pool.set_stop_point(get_point(self.options.stopcp))
+            self.validate_finalcp()
 
     async def handle_exception(self, exc: Exception) -> NoReturn:
         """Gracefully shut down the scheduler given a caught exception.
@@ -1899,3 +1900,17 @@ class Scheduler:
         """
         await self.shutdown(exc)
         raise exc from None
+
+    def validate_finalcp(self):
+        """Warn if Stop Cycle point is on or after the final cycle point
+        """
+        if self.config.final_point is None:
+            return
+        if (
+            get_point(self.options.stopcp, self.config.cycling_type)
+            > get_point(self.config.final_point, self.config.cycling_type)
+        ):
+            LOG.warning(
+                f'Stop Cycle point \'{self.options.stopcp}\' will have no '
+                'effect as it is after the final Cycle '
+                f'point \'{self.options.fcp}\'.')

--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------
+
+# test that cylc play warns if FCP before Stop Point.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 14
+
+# integer cycling
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    initial cycle point = 1
+    final cycle point = 2
+    cycling mode = integer
+    [[dependencies]]
+        P1 = foo
+__FLOW_CONFIG__
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+
+for SCP in 1 2 3; do
+    TEST_NAME="${TEST_NAME_BASE}-play-integer-scp=${SCP}"
+        workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
+        --no-detach --stopcp="${SCP}"
+
+    V=""
+    if [[ "${SCP}" -lt 3 ]]; then
+        V="-v"
+    fi
+    grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "$V"
+done
+
+purge
+
+# Gregorian Cycling
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    initial cycle point = 1348
+    final cycle point = 1349
+    [[dependencies]]
+        P1Y = foo
+__FLOW_CONFIG__
+
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+
+
+for SCP in 1348 1349 1350; do
+    TEST_NAME="${TEST_NAME_BASE}-play-gregorian-scp=${SCP}"
+        workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
+        --no-detach --stopcp="${SCP}"
+
+    V=""
+    if [[ "${SCP}" -lt 1350 ]]; then
+        V="-v"
+    fi
+    grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "$V"
+done
+
+purge

--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -44,10 +44,10 @@ for SCP in 1 2 3; do
         --no-detach --stopcp="${SCP}"
 
     if [[ "${SCP}" -lt 3 ]]; then
-        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "-v"
     else
-        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log"
     fi
 done
@@ -76,10 +76,10 @@ for SCP in 1348 1349 1350; do
         --no-detach --stopcp="${SCP}"
 
     if [[ "${SCP}" -lt 1350 ]]; then
-        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "-v"
     else
-        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log"
     fi
 done

--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -43,12 +43,13 @@ for SCP in 1 2 3; do
         workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
         --no-detach --stopcp="${SCP}"
 
-    V=""
     if [[ "${SCP}" -lt 3 ]]; then
-        V="-v"
+        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+            "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "-v"
+    else
+        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+            "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log"
     fi
-    grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
-        "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "$V"
 done
 
 purge
@@ -74,12 +75,13 @@ for SCP in 1348 1349 1350; do
         workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
         --no-detach --stopcp="${SCP}"
 
-    V=""
     if [[ "${SCP}" -lt 1350 ]]; then
-        V="-v"
+        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+            "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "-v"
+    else
+        grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
+            "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log"
     fi
-    grep_ok "Stop Cycle point '.*'.*after.*final Cycle point '.*'" \
-        "${RUN_DIR}/${WORKFLOW_NAME}/log/workflow/log" "$V"
 done
 
 purge

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -156,25 +156,3 @@ def test_check_startup_opts(
     assert(err in str(excinfo))
 
 from types import SimpleNamespace
-
-
-@pytest.mark.parametrize(
-    'type_, scp, fcp, err',
-    [
-        param('integer', 2, 1, True, id='Integer: stop cp < final cp'),
-        param('integer', 1, 1, False, id='Integer: stop cp = final cp'),
-        param('integer', 1, 2, False, id='Integer: stop cp > final cp'),
-    ]
-)
-def test_validate_finalcp(monkeypatch, caplog, type_, scp, fcp, err):
-    """Scheduler warns is stopcp ≥ finalcp"""
-    mocked_scheduler = Mock()
-    mocked_scheduler.options = SimpleNamespace(stopcp=scp, fcp=fcp)
-    mocked_scheduler.config = SimpleNamespace(
-        final_point=fcp, cycling_type=type_)
-
-    Scheduler.validate_finalcp(mocked_scheduler)
-    if err == True:
-        assert search(f'{scp}.*{fcp}', caplog.records[0].message)
-    else:
-        assert caplog.records == []


### PR DESCRIPTION
These changes close #4226
(CP = Cycle Point)

> If you have a start CP 1, and final CP 2, and define stop CP as 100, your stop CP is just going to be ignored and never used. It would be helpful to users to log a warning.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (Extra logging).
- [x] No documentation update required.
