### PR TITLE
Added check for templating language setting

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -426,6 +426,13 @@ def hashbang_and_plugin_templating_clash(
             Traceback (most recent call last):
                 ...
             cylc.flow.parsec.exceptions.TemplateVarLanguageClash: ...
+
+        - Function raises if plugin templating engine is generic and hashbang
+          unset:
+            >>> thisfunc('template variables', ['# Some Comment'])
+            Traceback (most recent call last):
+                ...
+            cylc.flow.parsec.exceptions.TemplateVarLanguageClash: ...
     """
     if flines and re.match(r'^#!(.*)\s*', flines[0]):
         hashbang = re.findall(r'^#!(.*)\s*', flines[0])[0].lower()
@@ -440,6 +447,14 @@ def hashbang_and_plugin_templating_clash(
             "Plugins set templating engine = "
             f"{templating}"
             f" which does not match {flines[0]} set in flow.cylc."
+        )
+    elif (
+        hashbang is None
+        and templating == 'template variables'
+    ):
+        raise TemplateVarLanguageClash(
+            'Plugins provided template variables, but workflow definition '
+            'has no hashbang (e.g. #jinja2): Templating will fail.'
         )
     return hashbang
 

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -454,7 +454,7 @@ def hashbang_and_plugin_templating_clash(
     ):
         raise TemplateVarLanguageClash(
             'Plugins provided template variables, but workflow definition '
-            'has no hashbang (e.g. #jinja2): Templating will fail.'
+            'has no hashbang (e.g. #!jinja2): Templating will fail.'
         )
     return hashbang
 


### PR DESCRIPTION
if plugin sets 'template variables' == 'template variables' and
config does not contain a hashbang fail with an explanation that Cylc
cannot work out the correct templating engine.

These changes close https://github.com/cylc/cylc-rose/issues/67

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (Logging change).
- [x] No documentation update required.
