### PR TITLE
mypy: allow redefinition

### DIFF
--- a/cylc/flow/c3mro.py
+++ b/cylc/flow/c3mro.py
@@ -104,6 +104,7 @@ print_mro(ex_9.Z)
 
 
 from copy import copy
+from typing import Dict, List
 
 
 class C3:
@@ -150,7 +151,7 @@ class C3:
 
 
 if __name__ == "__main__":
-    parents: dict = {}
+    parents: Dict[str, List[str]] = {}
     parents['root'] = []
     parents['a'] = ['root']
     parents['b'] = ['root']
@@ -158,7 +159,7 @@ if __name__ == "__main__":
 
     print('foo', C3(parents).mro('foo'))
 
-    parents = {}
+    parents.clear()
     parents['o'] = []
     parents['a'] = ['o']
     parents['b'] = ['o']

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,5 +9,6 @@ namespace_packages = True
 # Need this because we don't have __init__.py in top-level dir:
 explicit_package_bases = True
 
+allow_redefinition = True
 strict_equality = True
 show_error_codes = True


### PR DESCRIPTION
This is a small change with no associated Issue.

Allowing redefinition of variables as different types seems like a Pythonic practice, and not allowing it (as is currently the case) can be a bit annoying.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-allow-redefinition

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
