### PR TITLE
job_runner_mgr: make paths in directives relative to ~

### DIFF
--- a/cylc/flow/job_runner_handlers/loadleveler.py
+++ b/cylc/flow/job_runner_handlers/loadleveler.py
@@ -84,7 +84,7 @@ class LoadlevelerHandler():
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = re.sub(r"\$HOME/", "", job_conf["job_file_path"])
+        job_file_path = job_conf['job_file_path']
         directives = job_conf["directives"].__class__()
         directives["job_name"] = (
             job_conf["workflow_name"] + "." + job_conf["task_id"])

--- a/cylc/flow/job_runner_handlers/lsf.py
+++ b/cylc/flow/job_runner_handlers/lsf.py
@@ -72,7 +72,7 @@ class LSFHandler():
     @classmethod
     def format_directives(cls, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = re.sub(r"\$HOME/", "", job_conf["job_file_path"])
+        job_file_path = job_conf['job_file_path']
         directives = job_conf["directives"].__class__()
         directives["-J"] = (
             job_conf["task_id"] + "." + job_conf["workflow_name"]

--- a/cylc/flow/job_runner_handlers/moab.py
+++ b/cylc/flow/job_runner_handlers/moab.py
@@ -79,7 +79,7 @@ class MoabHandler:
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = job_conf["job_file_path"].replace(r"$HOME/", "")
+        job_file_path = job_conf['job_file_path']
         directives = job_conf["directives"].__class__()  # an ordereddict
 
         directives["-N"] = (

--- a/cylc/flow/job_runner_handlers/pbs.py
+++ b/cylc/flow/job_runner_handlers/pbs.py
@@ -85,7 +85,7 @@ class PBSHandler:
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = job_conf["job_file_path"].replace(r"$HOME/", "")
+        job_file_path = job_conf['job_file_path']
         directives = job_conf["directives"].__class__()  # an ordereddict
         directives["-N"] = (
             job_conf["task_id"] + "." + job_conf["workflow_name"]

--- a/cylc/flow/job_runner_handlers/sge.py
+++ b/cylc/flow/job_runner_handlers/sge.py
@@ -77,7 +77,7 @@ class SGEHandler:
 
     def format_directives(self, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = re.sub(r'\$HOME/', '', job_conf['job_file_path'])
+        job_file_path = job_conf['job_file_path']
         directives = job_conf['directives'].__class__()
         directives['-N'] = (
             job_conf['workflow_name'] + '.' + job_conf['task_id']

--- a/cylc/flow/job_runner_handlers/slurm.py
+++ b/cylc/flow/job_runner_handlers/slurm.py
@@ -102,8 +102,6 @@ The resulting formatted directives are:
 import re
 import shlex
 
-from cylc.flow.pathutil import expand_path
-
 
 class SLURMHandler():
     """SLURM job submission and manipulation."""
@@ -149,7 +147,7 @@ class SLURMHandler():
     @classmethod
     def format_directives(cls, job_conf):
         """Format the job directives for a job file."""
-        job_file_path = expand_path(job_conf['job_file_path'])
+        job_file_path = job_conf['job_file_path']
         directives = job_conf['directives'].__class__()
         directives['--job-name'] = (
             job_conf['task_id'] + '.' + job_conf['workflow_name'])

--- a/tests/unit/job_runner_handlers/test_loadleveler.py
+++ b/tests/unit/job_runner_handlers/test_loadleveler.py
@@ -27,7 +27,7 @@ from cylc.flow.job_runner_handlers.loadleveler import LoadlevelerHandler
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
@@ -48,7 +48,7 @@ from cylc.flow.job_runner_handlers.loadleveler import LoadlevelerHandler
                     '-l mem': '256gb',
                 },
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },

--- a/tests/unit/job_runner_handlers/test_lsf.py
+++ b/tests/unit/job_runner_handlers/test_lsf.py
@@ -26,7 +26,7 @@ from cylc.flow.job_runner_handlers.lsf import JOB_RUNNER_HANDLER
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
@@ -45,7 +45,7 @@ from cylc.flow.job_runner_handlers.lsf import JOB_RUNNER_HANDLER
                     '-ar': '',
                 },
                 'execution_time_limit': 200,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },

--- a/tests/unit/job_runner_handlers/test_moab.py
+++ b/tests/unit/job_runner_handlers/test_moab.py
@@ -26,7 +26,7 @@ from cylc.flow.job_runner_handlers.moab import JOB_RUNNER_HANDLER
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
@@ -45,7 +45,7 @@ from cylc.flow.job_runner_handlers.moab import JOB_RUNNER_HANDLER
                     '-l mem': '256gb',
                 },
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },

--- a/tests/unit/job_runner_handlers/test_pbs.py
+++ b/tests/unit/job_runner_handlers/test_pbs.py
@@ -26,7 +26,7 @@ from cylc.flow.job_runner_handlers.pbs import JOB_RUNNER_HANDLER
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
                 'platform': {
@@ -45,7 +45,7 @@ from cylc.flow.job_runner_handlers.pbs import JOB_RUNNER_HANDLER
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
                 'platform': {
@@ -68,7 +68,7 @@ from cylc.flow.job_runner_handlers.pbs import JOB_RUNNER_HANDLER
                     '-l mem': '256gb',
                 },
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
                 'platform': {

--- a/tests/unit/job_runner_handlers/test_slurm.py
+++ b/tests/unit/job_runner_handlers/test_slurm.py
@@ -15,11 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-import os
 
 from cylc.flow.job_runner_handlers.slurm import JOB_RUNNER_HANDLER
-
-home = os.path.expandvars('$HOME/')
 
 
 @pytest.mark.parametrize(
@@ -29,19 +26,19 @@ home = os.path.expandvars('$HOME/')
             {
                 'directives': {},
                 'execution_time_limit': 180,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
             [
                 '#SBATCH --job-name=axe.1.chop',
                 (
-                    f'#SBATCH --output='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.out'
+                    '#SBATCH --output='
+                    'cylc-run/chop/log/job/1/axe/01/job.out'
                 ),
                 (
-                    f'#SBATCH --error='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.err'
+                    '#SBATCH --error='
+                    'cylc-run/chop/log/job/1/axe/01/job.err'
                 ),
                 '#SBATCH --time=3:00',
             ],
@@ -51,7 +48,7 @@ home = os.path.expandvars('$HOME/')
                 'directives': {},
                 'execution_time_limit': 180,
                 'job_file_path': (
-                    '$HOME/cylc-run/chop/log/job/1/axe%40HEAD/01/job'
+                    'cylc-run/chop/log/job/1/axe%40HEAD/01/job'
                 ),
                 'workflow_name': 'chop',
                 'task_id': 'axe%40HEAD.1',
@@ -59,12 +56,12 @@ home = os.path.expandvars('$HOME/')
             [
                 '#SBATCH --job-name=axe%40HEAD.1.chop',
                 (
-                    f'#SBATCH --output'
-                    f'={home}cylc-run/chop/log/job/1/axe%%40HEAD/01/job.out'
+                    '#SBATCH --output'
+                    '=cylc-run/chop/log/job/1/axe%%40HEAD/01/job.out'
                 ),
                 (
-                    f'#SBATCH --error'
-                    f'={home}cylc-run/chop/log/job/1/axe%%40HEAD/01/job.err'
+                    '#SBATCH --error'
+                    '=cylc-run/chop/log/job/1/axe%%40HEAD/01/job.err'
                 ),
                 '#SBATCH --time=3:00',
             ],
@@ -77,19 +74,19 @@ home = os.path.expandvars('$HOME/')
                     '--mem': '256gb',
                 },
                 'execution_time_limit': 200,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
             [
                 '#SBATCH --job-name=axe.1.chop',
                 (
-                    f'#SBATCH --output='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.out'
+                    '#SBATCH --output='
+                    'cylc-run/chop/log/job/1/axe/01/job.out'
                 ),
                 (
-                    f'#SBATCH --error='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.err'
+                    '#SBATCH --error='
+                    'cylc-run/chop/log/job/1/axe/01/job.err'
                 ),
                 '#SBATCH --time=3:20',
                 '#SBATCH -p=middle',
@@ -105,19 +102,19 @@ home = os.path.expandvars('$HOME/')
                     'hetjob_1_--mem': '256gb',
                 },
                 'execution_time_limit': 200,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
             [
                 '#SBATCH --job-name=axe.1.chop',
                 (
-                    f'#SBATCH --output='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.out'
+                    '#SBATCH --output='
+                    'cylc-run/chop/log/job/1/axe/01/job.out'
                 ),
                 (
-                    f'#SBATCH --error='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.err'
+                    '#SBATCH --error='
+                    'cylc-run/chop/log/job/1/axe/01/job.err'
                 ),
                 '#SBATCH --time=3:20',
                 '#SBATCH -p=middle',

--- a/tests/unit/job_runner_handlers/test_slurm_packjob.py
+++ b/tests/unit/job_runner_handlers/test_slurm_packjob.py
@@ -19,8 +19,6 @@ import os
 
 from cylc.flow.job_runner_handlers.slurm_packjob import JOB_RUNNER_HANDLER
 
-home = os.path.expandvars('$HOME/')
-
 
 @pytest.mark.parametrize(
     'job_conf,lines',
@@ -33,19 +31,19 @@ home = os.path.expandvars('$HOME/')
                     'packjob_1_--mem': '256gb',
                 },
                 'execution_time_limit': 200,
-                'job_file_path': '$HOME/cylc-run/chop/log/job/1/axe/01/job',
+                'job_file_path': 'cylc-run/chop/log/job/1/axe/01/job',
                 'workflow_name': 'chop',
                 'task_id': 'axe.1',
             },
             [
                 '#SBATCH --job-name=axe.1.chop',
                 (
-                    f'#SBATCH --output='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.out'
+                    '#SBATCH --output='
+                    'cylc-run/chop/log/job/1/axe/01/job.out'
                 ),
                 (
-                    f'#SBATCH --error='
-                    f'{home}cylc-run/chop/log/job/1/axe/01/job.err'
+                    '#SBATCH --error='
+                    'cylc-run/chop/log/job/1/axe/01/job.err'
                 ),
                 '#SBATCH --time=3:20',
                 '#SBATCH -p=middle',


### PR DESCRIPTION
* paths in directives (e.g. out/err files) should be evaluated
  relative to $HOME on the platform where the job submission command
  was run.
* for remote job submissions this was working fine.
* for local job submissions (excluding at/background/slurm) this was broken.
* slurm was working because it was expanding the path when writing the
  directives (incorrectly).
* closes https://github.com/cylc/cylc-flow/issues/4247

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Covered by existing tests where local platforms are present, requires more work to run in CI
- [x] No documentation update required.
