### PR TITLE
Better handling of Cylc 8 workflows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,31 @@ management and does not bundle Jinja2.
 
 
 -------------------------------------------------------------------------------
+## __cylc-7.8.9 (upcoming, 2021)__
+
+### Enhancements
+
+[#4264](https://github.com/cylc/cylc-flow/pull/4264) - Syntax highlighting
+for Cylc 8 `flow.cylc` files in Cylc Review.
+
+[#4320](https://github.com/cylc/cylc-flow/pull/4320) - Prevent Cylc 7 from
+trying to run Cylc 8 workflows.
+
+### Fixes
+
+[#4233](https://github.com/cylc/cylc-flow/pull/4233) - Fix bug in Cylc Review
+caused by Cylc 8 workflows (change in terminology from 'suite' to 'workflow').
+
+[#4276](https://github.com/cylc/cylc-flow/pull/4276) - Fix failure to show
+certain log files in Cylc Review.
+
+[#4280](https://github.com/cylc/cylc-flow/pull/4280) - Fix failure to show
+Cylc 8 workflow status in Cylc Review.
+
+[#4299](https://github.com/cylc/cylc-flow/pull/4299) -
+Fix a GUI bug which can cause extra log files to be listed multiple times.
+
+-------------------------------------------------------------------------------
 ## __cylc-7.8.8 (2021-03-24)__
 
 ### Enhancements
@@ -32,6 +57,7 @@ management and does not bundle Jinja2.
 to display information about Cylc 8 workflows.
 
 
+-------------------------------------------------------------------------------
 ## __cylc-7.8.7 (2020-12-04)__
 
 ### Enhancements
@@ -41,8 +67,8 @@ heteregeneous jobs through an artificial "hetjob_<N>_" or "packjob_<N>_"
 directive prefix.
 
 [#3784](https://github.com/cylc/cylc-flow/pull/3784) - Deprecate the
-[runtime][X][parameter environment templates] section and instead allow
-templates in [runtime][X][environment].
+`[runtime][X][parameter environment templates]` section and instead allow
+templates in `[runtime][X][environment]`.
 
 ### Fixes
 
@@ -60,14 +86,6 @@ labels to prevent runtime bugs when exporting environment variables.
 [#3814](https://github.com/cylc/cylc-flow/pull/3814) - Fixes a minor bug in the
 auto-restart functionality which caused suites to wait for local jobs running
 on *any* host to complete before restarting.
-
--------------------------------------------------------------------------------
-## __cylc-7.8.7 (2020-??-??)__
-
-### Fixes
-
-[#4299](https://github.com/cylc/cylc-flow/pull/4299) -
-Fix a GUI bug which can cause extra log files to be listed multiple times.
 
 -------------------------------------------------------------------------------
 ## __cylc-7.8.6 (2020-05-14)__

--- a/bin/cylc-get-suite-contact
+++ b/bin/cylc-get-suite-contact
@@ -27,7 +27,7 @@ if remrun():
 
 from cylc.option_parsers import CylcOptionParser as COP
 from cylc.suite_srv_files_mgr import (
-    SuiteSrvFilesManager, SuiteServiceFileError)
+    SuiteSrvFilesManager, SuiteServiceFileError, SuiteCylcVersionError)
 
 
 def main():
@@ -38,6 +38,8 @@ def main():
         data = SuiteSrvFilesManager().load_contact_file(reg)
     except SuiteServiceFileError:
         sys.exit("%s: cannot get contact info, suite not running?" % (reg,))
+    except SuiteCylcVersionError as exc:
+        sys.exit("{0}: {1}".format(reg, exc))
     else:
         for key, value in sorted(data.items()):
             print("%s=%s" % (key, value))

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -34,7 +34,7 @@ import cylc.flags
 from cylc.network import NO_PASSPHRASE
 from cylc.hostuserutil import get_host, get_fqdn_by_host, get_user
 from cylc.suite_srv_files_mgr import (
-    SuiteSrvFilesManager, SuiteServiceFileError)
+    SuiteSrvFilesManager, SuiteServiceFileError, SuiteCylcVersionError)
 from cylc.unicode_util import utf8_enforce
 from cylc.version import CYLC_VERSION
 from cylc.wallclock import get_current_time_string
@@ -646,6 +646,8 @@ class SuiteRuntimeServiceClient(object):
             self.port = int(self.comms1.get(self.srv_files_mgr.KEY_PORT))
         except (IOError, ValueError, SuiteServiceFileError):
             raise ClientInfoError(self.suite)
+        except SuiteCylcVersionError as exc:
+            sys.exit("ERROR: {}".format(exc))
         else:
             # Check mismatch suite UUID
             env_suite = os.getenv(self.srv_files_mgr.KEY_NAME)
@@ -668,6 +670,8 @@ class SuiteRuntimeServiceClient(object):
                 SuiteSrvFilesManager.FILE_BASE_CONTACT2))
         except SuiteServiceFileError:
             pass
+        except SuiteCylcVersionError as exc:
+            sys.exit("ERROR: {}".format(exc))
 
 
 def get_exception_from_html(html_text):

--- a/lib/cylc/network/port_scan.py
+++ b/lib/cylc/network/port_scan.py
@@ -34,7 +34,7 @@ from cylc.hostuserutil import is_remote_host, get_host_ip_by_name
 from cylc.network.httpclient import (
     SuiteRuntimeServiceClient, ClientError, ClientTimeout)
 from cylc.suite_srv_files_mgr import (
-    SuiteSrvFilesManager, SuiteServiceFileError)
+    SuiteSrvFilesManager, SuiteServiceFileError, SuiteCylcVersionError)
 from cylc.suite_status import (KEY_NAME, KEY_OWNER, KEY_STATES)
 
 CONNECT_TIMEOUT = 5.0
@@ -311,14 +311,13 @@ def get_scan_items_from_fs(owner_pattern=None, updater=None):
                 contact_data = srv_files_mgr.load_contact_file(reg, owner)
             except (SuiteServiceFileError, IOError, TypeError, ValueError):
                 continue
+            except SuiteCylcVersionError as exc:
+                LOG.debug(
+                    "Suite {0} is running in Cylc version {1} and "
+                    "will not be displayed.".format(reg, exc.cylc_version)
+                )
+                continue
             else:
-                cylc_ver = contact_data[srv_files_mgr.KEY_VERSION]
-                major_ver = int(cylc_ver.split(".", 1)[0])
-                if (major_ver > 7):
-                    LOG.debug("Suite %s is running in Cylc version %s "
-                              "and will not be displayed." % (reg, cylc_ver)
-                              )
-                    continue
                 items.append((
                     contact_data[srv_files_mgr.KEY_HOST],
                     contact_data[srv_files_mgr.KEY_PORT]))

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -234,6 +234,8 @@ class Scheduler(object):
 
     def start(self):
         """Start the server."""
+        SuiteSrvFilesManager.check_for_cylc8_flow_file(self.suite_run_dir)
+
         self._start_print_blurb()
 
         glbl_cfg().create_cylc_run_tree(self.suite)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -61,7 +61,7 @@ from cylc.suite_db_mgr import SuiteDatabaseManager
 from cylc.suite_events import (
     SuiteEventContext, SuiteEventError, SuiteEventHandler)
 from cylc.suite_srv_files_mgr import (
-    SuiteSrvFilesManager, SuiteServiceFileError)
+    SuiteSrvFilesManager, SuiteServiceFileError, SuiteCylcVersionError)
 from cylc.suite_status import (
     KEY_DESCRIPTION, KEY_GROUP, KEY_META, KEY_NAME, KEY_OWNER, KEY_STATES,
     KEY_TASKS_BY_STATE, KEY_TITLE, KEY_UPDATE_TIME, KEY_VERSION)
@@ -1558,7 +1558,7 @@ conditions; see `cylc conditions`.
                 if contact_data != self.contact_data:
                     raise AssertionError('contact file modified')
             except (AssertionError, IOError, ValueError,
-                    SuiteServiceFileError) as exc:
+                    SuiteServiceFileError, SuiteCylcVersionError) as exc:
                 LOG.error(
                     "%s: contact file corrupted/modified and may be left",
                     self.suite_srv_files_mgr.get_contact_file(self.suite))

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -28,13 +28,18 @@ This module provides the logic to:
 import json
 import os
 from shutil import copy, rmtree
+from sqlite3 import OperationalError
 from subprocess import call
+import sys
 from tempfile import mkstemp
 
 
 from cylc import LOG
 from cylc.broadcast_report import get_broadcast_change_iter
 from cylc.rundb import CylcSuiteDAO
+from cylc.suite_srv_files_mgr import (
+    SuiteCylcVersionError, SuiteServiceFileError
+)
 from cylc.version import CYLC_VERSION
 from cylc.wallclock import get_current_time_string, get_utc_mode
 
@@ -522,6 +527,30 @@ class SuiteDatabaseManager(object):
             pri_dao = self.get_pri_dao()
             pri_dao.upgrade_pickle_to_json()
 
+        try:
+            self.check_forward_compatibility(pri_dao)
+        except (SuiteServiceFileError, SuiteCylcVersionError) as exc:
+            sys.exit("ERROR: {}".format(exc))
+
         # Vacuum the primary/private database file
         pri_dao.vacuum()
         pri_dao.close()
+
+    @staticmethod
+    def check_forward_compatibility(pri_dao):
+        """Raises if the existing suite database is incompatible with the
+        current version of Cylc."""
+        # Check for Cylc 8 workflow_params table:
+        try:
+            last_run_ver = pri_dao.connect().execute(
+                'SELECT value FROM workflow_params WHERE key == "cylc_version"'
+            ).fetchone()
+        except OperationalError:
+            # Ok - no workflow_params table
+            return
+        pri_dao.close()
+        if last_run_ver is None:
+            last_run_ver = '(unknown)'
+        else:
+            last_run_ver = last_run_ver[0]
+        raise SuiteCylcVersionError(last_run_ver)

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -23,6 +23,7 @@ import os
 import re
 from uuid import uuid4
 from string import ascii_letters, digits
+import sys
 
 from cylc import LOG
 from cylc.cfgspec.glbl_cfg import glbl_cfg
@@ -36,6 +37,16 @@ from cylc.hostuserutil import (
 class SuiteServiceFileError(Exception):
     """Raise on error related to suite service files."""
     pass
+
+
+class SuiteCylcVersionError(Exception):
+    MESSAGE = "Suite Cylc version {} is incompatible with Cylc 7"
+
+    def __init__(self, version):
+        self.cylc_version = version
+
+    def __str__(self):
+        return self.MESSAGE.format(self.cylc_version)
 
 
 class SuiteSrvFilesManager(object):
@@ -134,6 +145,8 @@ class SuiteSrvFilesManager(object):
         except (IOError, ValueError, SuiteServiceFileError):
             # Contact file does not exist or corrupted, should be OK to proceed
             return
+        except SuiteCylcVersionError as exc:
+            sys.exit("ERROR: {}".format(exc))
         if check_host_port and check_host_port != (old_host, int(old_port)):
             raise AssertionError("%s != (%s, %s)" % (
                 check_host_port, old_host, old_port))
@@ -403,6 +416,7 @@ To start a new run, stop the old one first with one or more of these:
         for line in file_content.splitlines():
             key, value = [item.strip() for item in line.split("=", 1)]
             data[key] = value
+        self.check_cylc_version(data[self.KEY_VERSION])
         return data
 
     def parse_suite_arg(self, options, arg):
@@ -787,3 +801,15 @@ To start a new run, stop the old one first with one or more of these:
         fname = os.path.join(path, item)
         if os.path.exists(fname):
             return fname
+
+    @staticmethod
+    def check_cylc_version(version_str):
+        major_version = version_str.split('.')[0]
+        try:
+            major_version = int(major_version)
+        except (TypeError, ValueError):
+            raise SuiteServiceFileError(
+                "Unable to parse suite Cylc version in contact file"
+            )
+        if major_version > 7:
+            raise SuiteCylcVersionError(version_str)

--- a/lib/cylc/suite_srv_files_mgr.py
+++ b/lib/cylc/suite_srv_files_mgr.py
@@ -477,6 +477,7 @@ To start a new run, stop the old one first with one or more of these:
 
         # suite.rc must exist so we can detect accidentally reversed args.
         source = os.path.abspath(source)
+        self.check_for_cylc8_flow_file(source)
         if not os.path.isfile(os.path.join(source, self.FILE_BASE_SUITE_RC)):
             raise SuiteServiceFileError("ERROR: no suite.rc in %s" % source)
 
@@ -548,6 +549,7 @@ To start a new run, stop the old one first with one or more of these:
         """Create or renew passphrase and SSL files for suite 'reg'."""
         # Suite service directory.
         srv_d = self.get_suite_srv_dir(reg)
+        self.check_for_cylc8_flow_file(os.path.dirname(srv_d))
         mkdir_p(srv_d)
 
         # Create a new passphrase for the suite if necessary.
@@ -813,3 +815,12 @@ To start a new run, stop the old one first with one or more of these:
             )
         if major_version > 7:
             raise SuiteCylcVersionError(version_str)
+
+    @staticmethod
+    def check_for_cylc8_flow_file(run_dir):
+        flow_file_path = os.path.join(run_dir, 'flow.cylc')
+        if os.path.isfile(flow_file_path):
+            sys.exit(
+                "ERROR: Cannot run - flow.cylc (Cylc 8) file detected in "
+                "suite run dir. "
+            )

--- a/lib/cylc/tests/test_suite_db_mgr.py
+++ b/lib/cylc/tests/test_suite_db_mgr.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python2
+
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import sqlite3
+from mock import Mock
+
+from cylc.suite_db_mgr import SuiteDatabaseManager
+from cylc.suite_srv_files_mgr import SuiteCylcVersionError
+
+db_params_dump = """
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE {table}(key TEXT, value TEXT, PRIMARY KEY(key));
+INSERT INTO "{table}" VALUES('uuid_str','60271845-6e61-4208-83fd-0cc705a01903');
+INSERT INTO "{table}" VALUES('cylc_version','{version}');
+INSERT INTO "{table}" VALUES('UTC_mode','0');
+INSERT INTO "{table}" VALUES('cycle_point_tz','+0100');
+COMMIT;
+"""
+
+
+@pytest.fixture
+def tmp_dao():
+    """Provides an sqlite3 connection and a mock CylcSuiteDAO."""
+    conn = sqlite3.connect(':memory:')
+    mock_dao = Mock(connect=lambda: conn)
+    yield (conn, mock_dao)
+    conn.close()
+
+
+def test_check_forward_compatibility__cylc_7_ok(tmp_dao):
+    """SuiteDatabaseManager.check_forward_compatibility() should not raise for
+    a Cylc version < 7.7.0 suite database."""
+    conn, mock_dao = tmp_dao
+    conn.executescript(
+        """
+        PRAGMA foreign_keys=OFF;
+        BEGIN TRANSACTION;
+        CREATE TABLE suite_params(key TEXT, value TEXT, PRIMARY KEY(key));
+        INSERT INTO "suite_params" VALUES('UTC_mode','0');
+        COMMIT;
+        """
+    )
+    SuiteDatabaseManager.check_forward_compatibility(mock_dao)
+    mock_dao.close.assert_not_called()
+
+def test_check_forward_compatibility__cylc_7_7_0_ok(tmp_dao):
+    """SuiteDatabaseManager.check_forward_compatibility() should not raise for
+    a Cylc 7.7.0+ database."""
+    conn, mock_dao = tmp_dao
+    conn.executescript(db_params_dump.format(
+        table='suite_params', version='7.7.0'
+    ))
+    SuiteDatabaseManager.check_forward_compatibility(mock_dao)
+    mock_dao.close.assert_not_called()
+
+
+def test_check_forward_compatibility__cylc_8_fail(tmp_dao):
+    """SuiteDatabaseManager.check_forward_compatibility() should raise for
+    a Cylc 8 database."""
+    conn, mock_dao = tmp_dao
+    conn.executescript(db_params_dump.format(
+        table='workflow_params', version='8.0b2.dev'
+    ))
+    with pytest.raises(SuiteCylcVersionError):
+        SuiteDatabaseManager.check_forward_compatibility(mock_dao)
+    mock_dao.close.assert_called()

--- a/lib/cylc/tests/test_suite_srv_files_mgr.py
+++ b/lib/cylc/tests/test_suite_srv_files_mgr.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import errno
 import os
 import pytest
-import unittest
 
 import mock
 
@@ -29,19 +29,30 @@ from cylc.suite_srv_files_mgr import (
 )
 
 
-def get_register_test_cases():
-    """Test cases for suite_srv_files_mgr.register function."""
-    return [
+def makedirs(path, exist_ok=False):
+    if not exist_ok:
+        os.makedirs(path)
+    else:
+        try:
+            os.makedirs(path)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise exc
+
+
+@pytest.mark.parametrize(
+    ('reg', 'source', 'redirect', 'cwd', 'suiterc_exists', 'suite_srv_dir',
+     'readlink', 'expected_symlink', 'expected', 'e_expected', 'e_message'),
+    [
         # 1 no parameters provided, current directory is not a symlink,
         # and contains a valid suite.rc
         (None,  # reg
          None,  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite1",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite1/.service",  # suite_srv_dir
-         "/home/user/cylc-run/suite1",  # readlink
+         "{home}/user/cylc-run/suite1",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite1/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suite1",  # readlink
          None,  # expected symlink
          "suite1",  # expected return value
          None,  # expected exception
@@ -52,11 +63,10 @@ def get_register_test_cases():
         ("super-suite-2",  # reg
          None,  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite2",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite2/.service",  # suite_srv_dir
-         "/home/user/cylc-run/suite2",  # readlink
+         "{home}/user/cylc-run/suite2",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite2/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suite2",  # readlink
          None,  # expected symlink
          "super-suite-2",  # expected return value
          None,  # expected exception
@@ -65,13 +75,12 @@ def get_register_test_cases():
         # 3 suite name and directory location of suite.rc provided,
         # current directory is not a symlink, and contains a valid suite.rc
         ("suite3",  # reg
-         "/home/user/cylc-run/suite3/suite.rc",  # source
+         "{home}/user/cylc-run/suite3/suite.rc",  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite3",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite3/.service",  # suite_srv_dir
-         "/home/user/cylc-run/suite3",  # readlink
+         "{home}/user/cylc-run/suite3",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite3/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suite3",  # readlink
          None,  # expected symlink
          "suite3",  # expected return value
          None,  # expected exception
@@ -81,13 +90,12 @@ def get_register_test_cases():
         # current directory is not a symlink, but the suite.rc does not
         # exist
         ("suite4",  # reg
-         "/home/user/cylc-run/suite4/suite.txt",  # source
+         "{home}/user/cylc-run/suite4/suite.txt",  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite4",  # cwd
-         False,  # isabs
-         False,  # isfile
-         "/home/user/cylc-run/suite4/.service",  # suite_srv_dir
-         "/home/user/cylc-run/suite4",  # readlink
+         "{home}/user/cylc-run/suite4",  # cwd
+         False,  # suiterc_exists
+         "{home}/user/cylc-run/suite4/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suite4",  # readlink
          None,  # expected symlink
          "suite4",  # expected return value
          SuiteServiceFileError,  # expected exception
@@ -97,14 +105,13 @@ def get_register_test_cases():
         # $SOURCE/.service are not the same directory. No redirect
         # specified, so it must raise an error
         ("suite5",  # reg
-         "/home/user/cylc-run/suite5/suite.txt",  # source
+         "{home}/user/cylc-run/suite5",  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite5",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite5/.service",  # suite_srv_dir
-         "/home/hercules/cylc-run/suite5",  # readlink
-         "/home/user/cylc-run/suite5",  # expected symlink
+         "{home}/user/cylc-run/suite5",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite5/.service",  # suite_srv_dir
+         "{home}/hercules/cylc-run/suite5",  # readlink
+         "{home}/user/cylc-run/suite5",  # expected symlink
          "suite5",  # expected return value
          SuiteServiceFileError,  # expected exception
          "already points to"  # expected part of exception message
@@ -113,14 +120,13 @@ def get_register_test_cases():
         # $SOURCE/.service are not the same directory. The redirect
         # flag is true, so it must simply delete the old source link
         ("suite6",  # reg
-         "/home/user/cylc-run/suite6/suite.rc",  # source
+         "{home}/user/cylc-run/suite6/suite.rc",  # source
          True,  # redirect,
-         "/home/user/cylc-run/suite6",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/hercules/cylc-run/suite6/.service",  # suite_srv_dir
-         "/home/hercules/cylc-run/suite6",  # readlink
-         "/home/user/cylc-run/suite6",  # expected symlink
+         "{home}/user/cylc-run/suite6",  # cwd
+         True,  # suiterc_exists
+         "{home}/hercules/cylc-run/suite6/.service",  # suite_srv_dir
+         "{home}/hercules/cylc-run/suite6",  # readlink
+         "{home}/user/cylc-run/suite6",  # expected symlink
          "suite6",  # expected return value
          None,  # expected exception
          None  # expected part of exception message
@@ -130,13 +136,12 @@ def get_register_test_cases():
         # flag is true. But the resolved orig_source's parent directory,
         # is the source directory. So the symlink must be '..'
         ("suite7",  # reg
-         "/home/user/cylc-run/suite7/suite.rc",  # source
+         "{home}/user/cylc-run/suite7/suite.rc",  # source
          True,  # redirect,
-         "/home/user/cylc-run/suite7",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite7/.service",  # suite_srv_dir
-         "/home/user/cylc-run/suites/suite7",  # readlink
+         "{home}/user/cylc-run/suite7",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite7/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suites/suite7",  # readlink
          "..",  # expected symlink
          "suite7",  # expected return value
          None,  # expected exception
@@ -144,12 +149,11 @@ def get_register_test_cases():
          ),
         # 8 fails to readlink, resulting in a new symlink created
         ("suite8",  # reg
-         "/home/user/cylc-run/suite8/suite.rc",  # source
+         "{home}/user/cylc-run/suite8/suite.rc",  # source
          False,  # redirect,
-         "/home/user/cylc-run/suite8",  # cwd
-         False,  # isabs
-         True,  # isfile
-         "/home/user/cylc-run/suite8/.service",  # suite_srv_dir
+         "{home}/user/cylc-run/suite8",  # cwd
+         True,  # suiterc_exists
+         "{home}/user/cylc-run/suite8/.service",  # suite_srv_dir
          OSError,  # readlink
          "..",  # expected symlink
          "suite8",  # expected return value
@@ -161,8 +165,7 @@ def get_register_test_cases():
          None,  # source
          False,  # redirect,
          None,  # cwd
-         True,  # isabs
-         True,  # isfile
+         True,  # suiterc_exists
          None,  # suite_srv_dir
          None,  # readlink
          None,  # expected symlink
@@ -171,55 +174,67 @@ def get_register_test_cases():
          "cannot be an absolute path"  # expected part of exception message
          )
     ]
-
-
-class TestSuiteSrvFilesManager(unittest.TestCase):
-
-    def setUp(self):
-        self.suite_srv_files_mgr = SuiteSrvFilesManager()
-
-    @mock.patch('cylc.suite_srv_files_mgr.mkdir_p')
-    @mock.patch('cylc.suite_srv_files_mgr.os')
-    def test_register(self, mocked_os, mocked_mkdir_p):
-        """Test the SuiteSrvFilesManager register function."""
-        # we do not need to mock these functions
-        mocked_os.path.basename.side_effect = os.path.basename
-        mocked_os.path.join = os.path.join
-        mocked_os.path.normpath = os.path.normpath
-        mocked_os.path.dirname = os.path.dirname
-        mocked_mkdir_p.side_effect = lambda (x): True
-        mocked_os.path.abspath.side_effect = lambda (x): x
-
-        for reg, source, redirect, cwd, isabs, isfile, \
-            suite_srv_dir, readlink, expected_symlink, \
-            expected, e_expected, e_message \
-                in get_register_test_cases():
-            mocked_os.getcwd.side_effect = lambda: cwd
-            mocked_os.path.isabs.side_effect = lambda (x): isabs
-
-            mocked_os.path.isfile = lambda (x): isfile
-            self.suite_srv_files_mgr.get_suite_srv_dir = mock.MagicMock(
-                return_value=suite_srv_dir
+)
+@mock.patch('cylc.suite_srv_files_mgr.mkdir_p')
+def test_register(
+    mocked_mkdir_p,
+    reg, source, redirect, cwd, suiterc_exists, suite_srv_dir,
+    readlink, expected_symlink, expected, e_expected, e_message,
+    monkeypatch, tmp_path
+):
+    """Test the SuiteSrvFilesManager register function."""
+    # --- Setup ---
+    mocked_mkdir_p.side_effect = lambda x: True
+    if cwd:
+        cwd = cwd.format(home=tmp_path)
+        makedirs(cwd)
+    else:
+        cwd = str(tmp_path)
+    monkeypatch.chdir(cwd)
+    if source:
+        source = source.format(home=tmp_path)
+        if '.' in os.path.basename(source):
+            source_dir = os.path.dirname(source)
+        else:
+            source_dir = source
+        makedirs(source_dir, exist_ok=True)
+    if suiterc_exists:
+        if not source:
+            source_dir = cwd
+        suiterc_file = os.path.join(source_dir, 'suite.rc')
+        with open(suiterc_file, 'w'):
+            pass
+    if suite_srv_dir:
+        suite_srv_dir = suite_srv_dir.format(home=tmp_path)
+        makedirs(suite_srv_dir, exist_ok=True)
+        if readlink and readlink != OSError:
+            readlink = readlink.format(home=tmp_path)
+            makedirs(readlink, exist_ok=True)
+            source_link = os.path.join(
+                suite_srv_dir, SuiteSrvFilesManager.FILE_BASE_SOURCE
             )
-            if readlink == OSError:
-                mocked_os.readlink.side_effect = readlink
-            else:
-                mocked_os.readlink.side_effect = lambda (x): readlink
-
-            if e_expected is None:
-                reg = self.suite_srv_files_mgr.register(reg, source, redirect)
-                self.assertEqual(expected, reg)
-                if mocked_os.symlink.call_count > 0:
-                    # first argument, of the first call
-                    arg0 = mocked_os.symlink.call_args[0][0]
-                    self.assertEqual(expected_symlink, arg0)
-            else:
-                with self.assertRaises(e_expected) as cm:
-                    self.suite_srv_files_mgr.register(reg, source, redirect)
-                if e_message is not None:
-                    the_exception = cm.exception
-                    self.assertTrue(e_message in str(the_exception),
-                                    str(the_exception))
+            os.symlink(readlink, source_link)
+    if expected_symlink:
+        expected_symlink = expected_symlink.format(home=tmp_path)
+    mock_os_symlink = mock.Mock()
+    monkeypatch.setattr('cylc.suite_srv_files_mgr.os.symlink', mock_os_symlink)
+    suite_srv_files_mgr = SuiteSrvFilesManager()
+    suite_srv_files_mgr.get_suite_srv_dir = mock.MagicMock(
+        return_value=suite_srv_dir
+    )
+    # --- Test ---
+    if e_expected is None:
+        reg = suite_srv_files_mgr.register(reg, source, redirect)
+        assert expected == reg
+        if mock_os_symlink.call_count > 0:
+            # first argument, of the first call
+            arg0 = mock_os_symlink.call_args[0][0]
+            assert arg0 == expected_symlink
+    else:
+        with pytest.raises(e_expected) as excinfo:
+            suite_srv_files_mgr.register(reg, source, redirect)
+        if e_message is not None:
+            assert e_message in str(excinfo.value)
 
 
 @pytest.mark.parametrize(
@@ -239,7 +254,3 @@ def test_check_cylc_version(version, expected_err):
             SuiteSrvFilesManager.check_cylc_version(version)
     else:
         SuiteSrvFilesManager.check_cylc_version(version)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/lib/cylc/tests/test_suite_srv_files_mgr.py
+++ b/lib/cylc/tests/test_suite_srv_files_mgr.py
@@ -17,12 +17,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import pytest
 import unittest
 
 import mock
 
-from cylc.suite_srv_files_mgr import SuiteSrvFilesManager, \
-    SuiteServiceFileError
+from cylc.suite_srv_files_mgr import (
+    SuiteSrvFilesManager,
+    SuiteServiceFileError,
+    SuiteCylcVersionError
+)
 
 
 def get_register_test_cases():
@@ -216,6 +220,25 @@ class TestSuiteSrvFilesManager(unittest.TestCase):
                     the_exception = cm.exception
                     self.assertTrue(e_message in str(the_exception),
                                     str(the_exception))
+
+
+@pytest.mark.parametrize(
+    'version, expected_err',
+    [
+        ('6.11.3', None),
+        ('7.8.8-26-g03abf-dirty', None),
+        ('8.0.0', SuiteCylcVersionError),
+        ('8.0b2.dev', SuiteCylcVersionError),
+        ('9', SuiteCylcVersionError),
+        ('foo', SuiteServiceFileError)
+    ]
+)
+def test_check_cylc_version(version, expected_err):
+    if expected_err:
+        with pytest.raises(expected_err):
+            SuiteSrvFilesManager.check_cylc_version(version)
+    else:
+        SuiteSrvFilesManager.check_cylc_version(version)
 
 
 if __name__ == '__main__':

--- a/tests/cylc8/00-run.t
+++ b/tests/cylc8/00-run.t
@@ -1,0 +1,41 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Cylc 7 should not run a Cylc 8 workflow
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+SUITE_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}"
+SUITE_RUN_DIR="$(cylc get-global-config --print-run-dir)/${SUITE_NAME}"
+mkdir -p "$SUITE_RUN_DIR"
+cat > "${SUITE_RUN_DIR}/flow.cylc" << __FLOW__
+# Darmok and Jalad at Tanagra
+__FLOW__
+
+TEST_NAME="${TEST_NAME_BASE}-fail"
+suite_run_fail "$TEST_NAME" cylc run "$SUITE_NAME"
+
+CYLC_TEST_DIFF_CMD="diff -u -Z" cmp_ok "${TEST_NAME}.stderr" << __EOF__
+ERROR: Cannot run - flow.cylc (Cylc 8) file detected in suite run dir.
+__EOF__
+
+exists_fail "${SUITE_RUN_DIR}/.service"
+
+rm -r "$SUITE_RUN_DIR"
+rm -d "$TEST_SOURCE_DIR_BASE" 2> /dev/null || true
+exit

--- a/tests/cylc8/test_header
+++ b/tests/cylc8/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header

--- a/tests/lib/bash/test_header
+++ b/tests/lib/bash/test_header
@@ -539,7 +539,7 @@ __PYTHON__
 
 mock_smtpd_init() {  # Logic borrowed from Rose
     local SMTPD_PORT=
-    for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do 
+    for SMTPD_PORT in 8025 8125 8225 8325 8425 8525 8625 8725 8825 8925; do
         local SMTPD_HOST="localhost:${SMTPD_PORT}"
         local SMTPD_LOG="${TEST_DIR}/smtpd.log"
         python2 -m 'smtpd' -c 'DebuggingServer' -d -n "${SMTPD_HOST}" \
@@ -603,7 +603,7 @@ set_test_remote_host() {
   # For remote job tests, define CYLC_TEST_HOST from global config '[test
   # battery]remote host', skipping tests if not defined. Call immediately after
   # sourcing the test header, for skip_all to work.
-  # TODO - these tests should be modified to use set_test_remote() instead, to 
+  # TODO - these tests should be modified to use set_test_remote() instead, to
   # allow full remote job tests with another user account on the suite host.
   CYLC_TEST_HOST="$( \
       cylc get-global-config -i '[test battery]remote host' 2>'/dev/null')"


### PR DESCRIPTION
These changes close #4315

Give better errors and be safer with the contact file and DB when trying to use Cylc 7 commands on Cylc 8 workflows.

#### Manual tests I have tried

First create a **suite.rc** workflow that is compatible with both Cylc 7 and 8:
```ini
# ~/cylc-run/myflow/suite.rc
[cylc]
    cycle point format = %Y
[scheduling]
    initial cycle point = 2012
    [[dependencies]]
        [[[P1Y]]]
            graph = foo
[runtime]
    [[foo]]
```

Run in Cylc 8:
```shell
# cylc8 conda env
$ cylc play myflow -n --pause
```
Then open a new terminal for Cylc 7:

1. `cylc hold myflow`
2. `cylc scan --debug`
3. `cylc run myflow`
4. `cylc restart myflow`
5. `cylc stop myflow`
6. `cylc get-suite-contact myflow` (Should this work?)
7. `cylc get-suite-version` (I think this ought to work, but it doesn't and I'm not sure it's worth getting it to work. At least the error prints the version anyway!)
8. `cd some_other_flow && cylc register myflow`

(have I missed any important ones?)

Now stop the workflow:
```shell
# cylc8 conda env
$ cylc stop myflow
```

Then run those same Cylc 7 commands again.

#### Requirements check-list
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] (Some) appropriate tests are included (unit & functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
