### PR TITLE
mailmap: associate dangling bot commit with github-actions[bot] account

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
+Alex Reinecke              <alex.reinecke@nrlmry.navy.mil>
+Alex Reinecke              <alex.reinecke@nrlmry.navy.mil>      P. A. Reinecke      <alex.reinecke@nrlmry.navy.mil>
 Alexander Paulsell         <alexander.paulsell@nrlmry.navy.mil> AlexanderPaulsell   <alexander.paulsell@nrlmry.navy.mil>
 Ben Fitzpatrick            <ben.fitzpatrick@metoffice.gov.uk>   benfitzpatrick      <ben.fitzpatrick@metoffice.gov.uk>
 Bruno Kinoshita            <bruno.kinoshita@niwa.co.nz>
@@ -16,7 +18,7 @@ Hilary Oliver              <hilary.j.oliver@gmail.com>
 Hilary Oliver              <hilary.oliver@niwa.co.nz>
 Hilary Oliver              <hilary@Megan-Olivers-MacBook-Pro.local>
 Hilary Oliver              <hilary@localhost.localdomain>
-Hilary Oliver             <holiver@eld084.desktop.frd.metoffice.com>
+Hilary Oliver              <holiver@eld084.desktop.frd.metoffice.com>
 Ivor Blockley              <ivor.blockley@bom.gov.au>           Ivor Blockley       <ivorblockley@users.noreply.github.com>
 Jonathan Thomas            <jonathan.thomas@bom.gov.au>         Jonathan Thomas     <jonty_q@yahoo.com.sg>
 Jonathan Thomas            <jonathan.thomas@bom.gov.au>         Jonathan Thomas     <jthomas@dev-laptop14.bom.gov.au>
@@ -35,8 +37,6 @@ Matt Shin                  <matthew.shin@metoffice.gov.uk>      matthewrmshin   
 Matt Shin                  <matthew.shin@metoffice.gov.uk>      matthewrmshin       <matthewrmshin@yahoo.co.uk>
 Mel Hall                   <37735232+datamel@users.noreply.github.com>
 Oliver Sanders             <oliver.sanders@metoffice.gov.uk>    Oliver sanders      <oliver.sanders@metoffice.gov.uk>
-Alex Reinecke           <alex.reinecke@nrlmry.navy.mil>
-Alex Reinecke           <alex.reinecke@nrlmry.navy.mil>      P. A. Reinecke      <alex.reinecke@nrlmry.navy.mil>
 Prasanna Challuri          <Prasanna.Challuri@niwa.co.nz>       challurip           <Prasanna.Challuri@niwa.co.nz>
 Ronnie Dutta               <61982285+MetRonnie@users.noreply.github.com>
 Rosalyn Hatcher            <r.s.hatcher@reading.ac.uk>          RosalynHatcher      <r.s.hatcher@reading.ac.uk>
@@ -50,3 +50,4 @@ Tim Whitcomb               <tim.whitcomb@nrlmry.navy.mil>       Tim Whitcomb    
 Tim Whitcomb               <tim.whitcomb@nrlmry.navy.mil>       trwhitcomb          <twhitcomb@gmail.com>
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   Tomek Trzeciak      <TomekTrzeciak@users.noreply.github.com>
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak       <tomasz.trzeciak@metoffice.gov.uk>
+github-actions[bot]        <41898282+github-actions[bot]@users.noreply.github.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Issue](https://github.com/cylc/cylc-flow/issues) as the team may not be able to
 consider large changes that appear out of the blue. New contributors should
 add their details to the [Code Contributors](#code-contributors) section of
 this file as part of their first Pull Request, and reviewers are responsible
-for checking this before merging the new branch into *master*.
+for checking this before merging the new branch.
 
 ## Code Contributors
 


### PR DESCRIPTION
One github-actions[bot] commit had set the author differently to the others which caused the shortlog action to fail.

~I'm not sure why this happened, one of the actions not using the standard release-action for configuring the author~

I've edited the contributor file to force the shortlog test to run.
