### PR TITLE
Store cycle point tz in DB for restart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,31 @@ management and does not bundle Jinja2.
 
 
 -------------------------------------------------------------------------------
+## __cylc-7.8.9 (upcoming, 2021)__
+
+### Enhancements
+
+[#4264](https://github.com/cylc/cylc-flow/pull/4264) - Syntax highlighting
+for Cylc 8 `flow.cylc` files in Cylc Review.
+
+### Fixes
+
+[#4233](https://github.com/cylc/cylc-flow/pull/4233) - Fix bug in Cylc Review
+caused by Cylc 8 workflows (change in terminology from 'suite' to 'workflow').
+
+[#4276](https://github.com/cylc/cylc-flow/pull/4276) - Fix failure to show
+certain log files in Cylc Review.
+
+[#4280](https://github.com/cylc/cylc-flow/pull/4280) - Fix failure to show
+Cylc 8 workflow status in Cylc Review.
+
+[#4299](https://github.com/cylc/cylc-flow/pull/4299) -
+Fix a GUI bug which can cause extra log files to be listed multiple times.
+
+[#4327](https://github.com/cylc/cylc-flow/pull/4327) - Ensure the suite always
+restarts using the same time zone as the last `cylc run`.
+
+-------------------------------------------------------------------------------
 ## __cylc-7.8.8 (2021-03-24)__
 
 ### Enhancements
@@ -32,6 +57,7 @@ management and does not bundle Jinja2.
 to display information about Cylc 8 workflows.
 
 
+-------------------------------------------------------------------------------
 ## __cylc-7.8.7 (2020-12-04)__
 
 ### Enhancements
@@ -41,8 +67,8 @@ heteregeneous jobs through an artificial "hetjob_<N>_" or "packjob_<N>_"
 directive prefix.
 
 [#3784](https://github.com/cylc/cylc-flow/pull/3784) - Deprecate the
-[runtime][X][parameter environment templates] section and instead allow
-templates in [runtime][X][environment].
+`[runtime][X][parameter environment templates]` section and instead allow
+templates in `[runtime][X][environment]`.
 
 ### Fixes
 
@@ -60,14 +86,6 @@ labels to prevent runtime bugs when exporting environment variables.
 [#3814](https://github.com/cylc/cylc-flow/pull/3814) - Fixes a minor bug in the
 auto-restart functionality which caused suites to wait for local jobs running
 on *any* host to complete before restarting.
-
--------------------------------------------------------------------------------
-## __cylc-7.8.7 (2020-??-??)__
-
-### Fixes
-
-[#4299](https://github.com/cylc/cylc-flow/pull/4299) -
-Fix a GUI bug which can cause extra log files to be listed multiple times.
 
 -------------------------------------------------------------------------------
 ## __cylc-7.8.6 (2020-05-14)__

--- a/doc/src/appendices/suiterc-config-ref.rst
+++ b/doc/src/appendices/suiterc-config-ref.rst
@@ -199,11 +199,6 @@ This number defaults to 0 (no sign or extra digits used).
 [cylc] ``->`` cycle point time zone
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you set UTC mode to True (:ref:`UTC-mode`) then this will default to
-``Z``. If you use a custom cycle point format
-(:ref:`cycle-point-format`), you should specify the timezone choice (or null
-timezone choice) here as well.
-
 You may set your own time zone choice here, which will be used for all
 date-time cycle point dumping. Time zones should be expressed as ISO 8601 time
 zone offsets from UTC, such as ``+13``, ``+1300``,
@@ -211,10 +206,20 @@ zone offsets from UTC, such as ``+13``, ``+1300``,
 special ``+0000`` case. Cycle points will be converted to the time
 zone you give and will be represented with this string at the end.
 
+If you set UTC mode to True (:ref:`UTC-mode`) then this will default to
+``Z``. If you use a custom cycle point format
+(:ref:`cycle-point-format`), you should specify the timezone choice (or null
+timezone choice) here as well.
+
 Cycle points that are input without time zones (e.g. as an initial cycle
 point
 setting) will use this time zone if set. If this isn't set (and UTC mode is
 also not set), then they will default to the current local time zone.
+
+This setting will persist over local time zone
+changes (e.g. if the suite is run during winter time, then stopped,
+then restarted after summer time has begun, the cycle points will
+remain in winter time).
 
 .. note::
 

--- a/lib/cylc/config.py
+++ b/lib/cylc/config.py
@@ -36,7 +36,9 @@ import re
 import traceback
 
 from isodatetime.data import Calendar
+from isodatetime.dumpers import TimePointDumper
 from isodatetime.parsers import DurationParser
+from isodatetime.timezone import get_local_time_zone_format
 from parsec.OrderedDict import OrderedDictWithDefaults
 from parsec.util import replicate
 
@@ -379,16 +381,14 @@ class SuiteConfig(object):
         self.cfg = self.pcfg.get(sparse=False)
         self.mem_log("config.py: after get(sparse=False)")
 
+        # These 2 must be called before init_cyclers(self.cfg):
+        self.process_utc_mode()
+        self.process_cycle_point_tz()
+
         # after the call to init_cyclers, we can start getting proper points.
         init_cyclers(self.cfg)
         self.cycling_type = get_interval_cls().get_null().TYPE
         self.cycle_point_dump_format = get_dump_format(self.cycling_type)
-
-        # Running in UTC time? (else just use the system clock)
-        if self.cfg['cylc']['UTC mode'] is None:
-            set_utc_mode(glbl_cfg().get(['cylc', 'UTC mode']))
-        else:
-            set_utc_mode(self.cfg['cylc']['UTC mode'])
 
         # Initial point from suite definition (or CLI override above).
         orig_icp = self.cfg['scheduling']['initial cycle point']
@@ -761,6 +761,65 @@ class SuiteConfig(object):
             self.mem_log("config.py: after _check_circular()")
 
         self.mem_log("config.py: end init config")
+
+    def process_utc_mode(self):
+        """Set UTC mode from config or from stored value on restart.
+
+        Sets:
+            - self.cfg['cylc']['UTC mode']
+            - The UTC mode flag
+        """
+        cfg_utc_mode = self.cfg['cylc']['UTC mode']
+        # Get the original UTC mode if restart:
+        orig_utc_mode = getattr(self.options, 'utc_mode', None)
+        if orig_utc_mode is None:
+            # Not a restart - will save config value
+            if cfg_utc_mode is not None:
+                orig_utc_mode = cfg_utc_mode
+            else:
+                orig_utc_mode = glbl_cfg().get(['cylc', 'UTC mode'])
+        elif cfg_utc_mode is not None and cfg_utc_mode != orig_utc_mode:
+            LOG.warning(
+                "UTC mode = {0} specified in configuration, but it is stored "
+                "as {1} from the initial run. The suite will continue to use "
+                "UTC mode = {1}"
+                .format(cfg_utc_mode, orig_utc_mode)
+            )
+        self.cfg['cylc']['UTC mode'] = orig_utc_mode
+        set_utc_mode(orig_utc_mode)
+
+    def process_cycle_point_tz(self):
+        """Set the cycle point time zone from config or from stored value
+        on restart.
+
+        Ensure suites restart with the same cycle point time zone even after
+        system time zone changes e.g. DST (the value is put in db by
+        Scheduler).
+
+        Sets self.cfg['cylc']['cycle point time zone']
+        """
+        cfg_cp_tz = self.cfg['cylc'].get('cycle point time zone')
+        # Get the original suite run time zone if restart:
+        orig_cp_tz = getattr(self.options, 'cycle_point_tz', None)
+        if orig_cp_tz is None:
+            # Not a restart
+            if cfg_cp_tz is None:
+                if get_utc_mode() is True:
+                    orig_cp_tz = 'Z'
+                else:
+                    orig_cp_tz = get_local_time_zone_format()
+            else:
+                orig_cp_tz = cfg_cp_tz
+        elif cfg_cp_tz is not None:
+            dmp = TimePointDumper()
+            if dmp.get_time_zone(cfg_cp_tz) != dmp.get_time_zone(orig_cp_tz):
+                LOG.warning(
+                    "cycle point time zone = {0} specified in configuration, "
+                    "but there is a stored value of {1} from the initial run. "
+                    "The suite will continue to run in {1}"
+                    .format(cfg_cp_tz, orig_cp_tz)
+                )
+        self.cfg['cylc']['cycle point time zone'] = orig_cp_tz
 
     def _check_circular(self):
         """Check for circular dependence in graph."""

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -1129,7 +1129,7 @@ conditions; see `cylc conditions`.
         elif key == 'stop_task':
             self.stop_task = value
             LOG.info('+ stop task = %s', value)
-        elif key == 'utc_mode':
+        elif key == 'UTC_mode':
             value = bool(int(value))
             self.options.utc_mode = value
             LOG.info('+ UTC mode = %s' % value)

--- a/lib/cylc/scheduler.py
+++ b/lib/cylc/scheduler.py
@@ -400,6 +400,13 @@ conditions; see `cylc conditions`.
         if reqmode and not self.config.run_mode(reqmode):
             raise ValueError('this suite requires the %s run mode' % reqmode)
 
+        if not self.is_restart:
+            # Set suite params that would otherwise be loaded from database:
+            self.options.utc_mode = get_utc_mode()
+            self.options.cycle_point_tz = (
+                self.config.cfg['cylc']['cycle point time zone']
+            )
+
         self.broadcast_mgr.linearized_ancestors.update(
             self.config.get_linearized_ancestors())
         self.task_events_mgr.mail_interval = self._get_cylc_conf(
@@ -902,6 +909,10 @@ conditions; see `cylc conditions`.
         """Reload suite configuration."""
         LOG.info("Reloading the suite definition.")
         old_tasks = set(self.config.get_task_name_list())
+        # Things that can't change on suite reload:
+        pri_dao = self.suite_db_mgr.get_pri_dao()
+        pri_dao.select_suite_params(self._load_suite_params)
+
         self.suite_db_mgr.checkpoint("reload-init")
         self.load_suiterc(is_reload=True)
         self.broadcast_mgr.linearized_ancestors = (
@@ -1050,38 +1061,39 @@ conditions; see `cylc conditions`.
         })
 
     def _load_suite_params(self, row_idx, row):
-        """Load a row in the "suite_params" table in a restart.
+        """Load a row in the "suite_params" table in a restart/reload.
 
         This currently includes:
         * Initial/Final cycle points.
         * Start/Stop Cycle points.
         * Suite UUID.
         * A flag to indicate if the suite should be held or not.
+        * Original suite run time zone.
         """
         if row_idx == 0:
             LOG.info('LOADING suite parameters')
         key, value = row
         if key in ['icp', 'initial_point']:
-            if self.options.ignore_icp:
+            if self.is_restart and self.options.ignore_icp:
                 LOG.debug('- initial point = %s (ignored)' % value)
             elif self.options.icp is None:
                 self.options.icp = value
                 LOG.info('+ initial point = %s' % value)
         elif key in ['startcp', 'start_point', 'warm_point']:
             # 'warm_point' for back compat <= 7.6.X
-            if self.options.ignore_startcp:
+            if self.is_restart and self.options.ignore_startcp:
                 LOG.debug('- start point = %s (ignored)' % value)
             elif self.options.startcp is None:
                 self.options.startcp = value
                 LOG.info('+ start point = %s' % value)
         elif key in ['fcp', 'final_point']:
-            if self.options.ignore_fcp:
+            if self.is_restart and self.options.ignore_fcp:
                 LOG.debug('- override final point = %s (ignored)' % value)
             elif self.options.fcp is None:
                 self.options.fcp = value
                 LOG.info('+ override final point = %s' % value)
         elif key == 'stopcp':
-            if self.options.ignore_stopcp:
+            if self.is_restart and self.options.ignore_stopcp:
                 LOG.debug('- stop point = %s (ignored)' % value)
             elif self.options.stopcp is None:
                 self.options.stopcp = value
@@ -1117,6 +1129,13 @@ conditions; see `cylc conditions`.
         elif key == 'stop_task':
             self.stop_task = value
             LOG.info('+ stop task = %s', value)
+        elif key == 'utc_mode':
+            value = bool(int(value))
+            self.options.utc_mode = value
+            LOG.info('+ UTC mode = %s' % value)
+        elif key == 'cycle_point_tz':
+            self.options.cycle_point_tz = value
+            LOG.info('+ cycle point time zone = %s' % value)
 
     def _load_template_vars(self, _, row):
         """Load suite start up template variables."""

--- a/lib/cylc/suite_db_mgr.py
+++ b/lib/cylc/suite_db_mgr.py
@@ -270,12 +270,6 @@ class SuiteDatabaseManager(object):
             schd (cylc.scheduler.Scheduler): scheduler object.
         """
         self.db_deletes_map[self.TABLE_SUITE_PARAMS].append({})
-        if schd.config.final_point is None:
-            # Store None as proper null value in database. No need to do this
-            # for initial cycle point, which should never be None.
-            final_point_str = None
-        else:
-            final_point_str = str(schd.config.final_point)
         self.db_inserts_map[self.TABLE_SUITE_PARAMS].extend([
             {"key": "uuid_str", "value": str(schd.uuid_str)},
             {"key": "run_mode", "value": schd.config.run_mode()},
@@ -289,7 +283,10 @@ class SuiteDatabaseManager(object):
         if schd.pool.is_held:
             self.db_inserts_map[self.TABLE_SUITE_PARAMS].append({
                 "key": "is_held", "value": 1})
-        for key in ('icp', 'fcp', 'startcp', 'stopcp', 'no_auto_shutdown'):
+        for key in (
+            'icp', 'fcp', 'startcp', 'stopcp', 'no_auto_shutdown',
+            'cycle_point_tz'
+        ):
             value = getattr(schd.options, key, None)
             if value is not None:
                 self.db_inserts_map[self.TABLE_SUITE_PARAMS].append({

--- a/tests/cyclers/20-multidaily_local.t
+++ b/tests/cyclers/20-multidaily_local.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -25,8 +25,6 @@ install_suite $TEST_NAME_BASE $CHOSEN_SUITE
 CURRENT_TZ_UTC_OFFSET=$(date +%z)
 if [[ $CURRENT_TZ_UTC_OFFSET == '+0000' ]]; then
     CURRENT_TZ_UTC_OFFSET="Z"
-else
-    CURRENT_TZ_UTC_OFFSET=${CURRENT_TZ_UTC_OFFSET%00}
 fi
 sed -i "s/Z/$CURRENT_TZ_UTC_OFFSET/g" reference.log
 #-------------------------------------------------------------------------------

--- a/tests/cylc-show/03-clock-triggered-non-utc-mode.t
+++ b/tests/cylc-show/03-clock-triggered-non-utc-mode.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -31,8 +31,7 @@ fi
 if [[ "${TZ_OFFSET_EXTENDED}" == "+00:00" ]]; then
     TZ_OFFSET_EXTENDED=Z
 fi
-TZ_OFFSET_BASIC=${TZ_OFFSET_EXTENDED/:00/}
-TZ_OFFSET_BASIC=${TZ_OFFSET_BASIC/:/}
+TZ_OFFSET_BASIC=${TZ_OFFSET_EXTENDED/:/}
 #-------------------------------------------------------------------------------
 TEST_NAME=$TEST_NAME_BASE-validate
 run_ok $TEST_NAME cylc validate \

--- a/tests/database/00-simple.t
+++ b/tests/database/00-simple.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -21,7 +21,7 @@ set_test_number 21
 install_suite "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
-suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug --no-detach "${SUITE_NAME}"
+TZ=XXX-01:30 suite_run_ok "${TEST_NAME_BASE}-run" cylc run --debug --no-detach "${SUITE_NAME}"
 
 if ! which sqlite3 > /dev/null; then
     skip 7 "sqlite3 not installed?"

--- a/tests/database/00-simple/select-suite-params.out
+++ b/tests/database/00-simple/select-suite-params.out
@@ -1,3 +1,4 @@
 UTC_mode|0
+cycle_point_tz|+0130
 cylc_version|<SOME-VERSION>
 run_mode|live

--- a/tests/database/03-remote.t
+++ b/tests/database/03-remote.t
@@ -1,7 +1,7 @@
 #!/bin/bash
 # THIS FILE IS PART OF THE CYLC SUITE ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/tests/restart/52-cycle-point-time-zone.t
+++ b/tests/restart/52-cycle-point-time-zone.t
@@ -1,0 +1,64 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test saving and loading of cycle point time zone to/from database on a run
+# followed by a restart. Important for restarting a suite after a system
+# time zone change.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 7
+
+init_suite "${TEST_NAME_BASE}" << '__FLOW__'
+[cylc]
+    UTC mode = False
+[scheduling]
+    initial cycle point = now
+    [[dependencies]]
+        [[[T23]]]
+            graph = stopper
+[runtime]
+    [[stopper]]
+        script = cylc stop "$CYLC_SUITE_NAME"
+__FLOW__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
+
+# Set time zone to +02:15
+export TZ=XXX-02:15
+
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --no-detach
+
+sqlite3 "${SUITE_RUN_DIR}/log/db" \
+    'SELECT * FROM suite_params WHERE key=="cycle_point_tz" OR key=="UTC_mode";' > 'dump.out'
+cmp_ok 'dump.out' << __EOF__
+UTC_mode|0
+cycle_point_tz|+0215
+__EOF__
+
+# Simulate DST change
+export TZ=UTC
+
+suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --no-detach
+
+log_scan "${TEST_NAME_BASE}-log-scan" "${SUITE_RUN_DIR}/log/suite/log" 1 0 \
+    'LOADING suite parameters' \
+    '+ UTC mode = False' \
+    '+ cycle point time zone = +0215'
+
+purge_suite "${SUITE_NAME}"
+exit


### PR DESCRIPTION
These changes close #3462

Save the cycle point time zone to the suite database upon `cylc run` (setting it to the local time zone if it isn't set in `suite.rc`), and make sure the suite always reloads & restarts using the same cycle point time zone and UTC mode value.

Backport of #3614

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and functional).
- [x] Appropriate change log entry included.
- [x] (7.8.x branch) I have updated the documentation in this PR branch.

