### PR TITLE
Fix docs build failure.

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -781,6 +781,17 @@ with Conf('global.cylc', desc='''
                 )
         with Conf('localhost', meta=Platform):
             Conf('hosts', VDR.V_STRING_LIST, ['localhost'])
+            with Conf('selection'):
+                Conf(
+                    'method', VDR.V_STRING, default='random',
+                    options=['random', 'definition order'],
+                    desc='''
+                        .. seealso::
+
+                           :cylc:conf:`global.cylc[platforms]
+                           [<platform name>][selection]`
+                    '''
+                )
 
     # Platform Groups
     with Conf('platform groups'):  # noqa: SIM117 (keep same format)

--- a/cylc/flow/parsec/config.py
+++ b/cylc/flow/parsec/config.py
@@ -186,7 +186,7 @@ class ConfigNode(ContextNode):
             This is useful if you want to create a specific instance of
             a generic configuration e.g. ``[elephant]`` from ``[<animal>]``.
 
-            Leaf nodes inherited from the generic config wil have
+            Leaf nodes inherited from the generic config will have
             ``meta=True``.
 
     """


### PR DESCRIPTION
Cause: In cylc.flow.parsec.config.ConfigNode.__doc__
> Leaf nodes inherited from the generic config will have ``meta=True``.

But this doesn't lead to the localhost platform building properly into the docs.

Fix: Explicitly add copy of section to "localhost" platform.

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (Doc change).
- [x] No change log entry required (Only for getting doc build to work).
- [x] _Is_ a documentation update.


Review assigned to @oliver-sanders  as most likely person to be able to suggest a better fix.
