### PR TITLE
Do not assume that generic template vars and no hashbang is error.

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -426,13 +426,6 @@ def hashbang_and_plugin_templating_clash(
             Traceback (most recent call last):
                 ...
             cylc.flow.parsec.exceptions.TemplateVarLanguageClash: ...
-
-        - Function raises if plugin templating engine is generic and hashbang
-          unset:
-            >>> thisfunc('template variables', ['# Some Comment'])
-            Traceback (most recent call last):
-                ...
-            cylc.flow.parsec.exceptions.TemplateVarLanguageClash: ...
     """
     if flines and re.match(r'^#!(.*)\s*', flines[0]):
         hashbang = re.findall(r'^#!(.*)\s*', flines[0])[0].lower()
@@ -452,9 +445,9 @@ def hashbang_and_plugin_templating_clash(
         hashbang is None
         and templating == 'template variables'
     ):
-        raise TemplateVarLanguageClash(
+        LOG.warning(
             'Plugins provided template variables, but workflow definition '
-            'has no hashbang (e.g. #!jinja2): Templating will fail.'
+            'has no hashbang (e.g. #!jinja2): Any templating will fail.'
         )
     return hashbang
 


### PR DESCRIPTION
if flow.cylc
```
[scheduling]
    initial cycle point = 2020
    [[graph]]
        R1 = pointless
[runtime]
    [[pointless]]
        script = myscript
```
and rose-suite.conf is empty:

The user may be using cylc rose to do something inside myscript or want it for some other reason, but validation will fail becuase at the moment Parsec raises an error if `[template variables]` are present without either a hashbang in `flow.cylc` or `[*:suite.rc]` in the `rose-suite.conf`.

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (relevent tests in Cylc-rose).
- [x] No change log entry required (beta fix).
- [x] No documentation update required.
