### PR TITLE
Change `[selection]method` to `host selection method` in  `global.cylc[platforms][<name>]`

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -24,11 +24,17 @@ from cylc.flow import LOG
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.hostuserutil import get_user_home
 from cylc.flow.network.client_factory import CommsMeth
-from cylc.flow.parsec.config import ParsecConfig, ConfigNode as Conf
+from cylc.flow.parsec.config import (
+    ConfigNode as Conf,
+    ParsecConfig,
+)
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.parsec.upgrade import upgrader
 from cylc.flow.parsec.validate import (
-    DurationFloat, CylcConfigValidator as VDR, cylc_config_validate)
+    CylcConfigValidator as VDR,
+    DurationFloat,
+    cylc_config_validate,
+)
 
 # Nested dict of spec items.
 # Spec value is [value_type, default, allowed_2, allowed_3, ...]
@@ -709,8 +715,7 @@ with Conf('global.cylc', desc='''
             Conf('install target', VDR.V_STRING, desc='''
                 This defaults to the platform name. This will be used as the
                 target for remote file installation.
-                For example, to indicate to Cylc that Platform_A shares a file
-                system with localhost, we would configure as follows:
+                For example, if Platform_A shares a file system with localhost:
 
                 .. code-block:: cylc
 
@@ -745,13 +750,15 @@ with Conf('global.cylc', desc='''
             Conf('job submission environment pass-through', VDR.V_STRING_LIST,
                  desc='''
                 Minimal list of environment variable names to pass through to
-                job submission subprocesses. $HOME is passed automatically.
+                job submission subprocesses. ``$HOME`` is passed automatically.
                 You are unlikely to need this.
             ''')
-            Conf('job submission executable paths', VDR.V_STRING_LIST, desc='''
+            Conf('job submission executable paths', VDR.V_STRING_LIST,
+                 desc=f'''
                 Additional executable locations to pass to the job
-                submission subprocess beyond the standard locations''' +
-                 ', '.join(SYSPATH) + '''. You are unlikely to need this.
+                submission subprocess beyond the standard locations
+                {", ".join(f"``{i}``" for i in SYSPATH)}.
+                You are unlikely to need this.
             ''')
             Conf('max batch submit size', VDR.V_INTEGER, default=100, desc='''
                 Limits the maximum number of jobs that can be submitted at

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -763,22 +763,20 @@ with Conf('global.cylc', desc='''
                 systems so for safety there is an upper limit on the number
                 of job submissions which can be batched together.
             ''')
-            with Conf('selection'):
-                Conf(
-                    'method', VDR.V_STRING, default='random',
-                    options=['random', 'definition order'],
-                    desc='''
-                        Host selection method for the platform. Available
-                        options:
+            Conf('host selection method', VDR.V_STRING, default='random',
+                 options=['random', 'definition order'],
+                 desc='''
+                Method for choosing the job host from the platform.
+                Available options:
 
-                        - random: Suitable for an identical pool of hosts.
-                        - definition order: Take the first host in the list
-                          unless that host has been unreachable. In many cases
-                          this is likely to cause load imbalances, but might
-                          be appropriate if your hosts were
-                          ``main, backup, failsafe``.
-                    '''
-                )
+                - ``random``: Choose randomly from the list of hosts.
+                  This is suitable for a pool of identical hosts.
+                - ``definition order``: Take the first host in the list
+                  unless that host was unreachable. In many cases
+                  this is likely to cause load imbalances, but might
+                  be appropriate if following the pattern
+                  ``hosts = main, backup, failsafe``.
+            ''')
         with Conf('localhost', meta=Platform):
             Conf('hosts', VDR.V_STRING_LIST, ['localhost'])
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -391,7 +391,7 @@ def get_host_from_platform(
         goodhosts = platform['hosts']
 
     # Get the selection method
-    method = platform['selection']['method']
+    method: str = platform['host selection method']
     if not goodhosts:
         raise NoHostsError(platform)
     else:

--- a/tests/functional/intelligent-host-selection/00-mixedhost.t
+++ b/tests/functional/intelligent-host-selection/00-mixedhost.t
@@ -35,8 +35,7 @@ create_test_global_config "" "
         hosts = unreachable_host, ${CYLC_TEST_HOST}
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
-        [[[selection]]]
-            method = 'definition order'
+        host selection method = 'definition order'
     "
 #-------------------------------------------------------------------------------
 

--- a/tests/functional/intelligent-host-selection/01-periodic-clear-badhosts.t
+++ b/tests/functional/intelligent-host-selection/01-periodic-clear-badhosts.t
@@ -44,8 +44,8 @@ cat >>'global.cylc' <<__HERE__
             hosts = unreachable_host, ${CYLC_TEST_HOST}
             install target = ${CYLC_TEST_INSTALL_TARGET}
             retrieve job logs = True
-            [[[selection]]]
-                method = 'definition order'
+            host selection method = 'definition order'
+
 __HERE__
 
 export CYLC_CONF_PATH="${PWD}"

--- a/tests/functional/intelligent-host-selection/02-badhosts.t
+++ b/tests/functional/intelligent-host-selection/02-badhosts.t
@@ -30,8 +30,7 @@ create_test_global_config "" "
     [[badhostplatform]]
         hosts = e9755ca30f5, 3c0b4799402
         install target = ${CYLC_TEST_INSTALL_TARGET}
-        [[[selection]]]
-            method = definition order
+        host selection method = 'definition order'
 
     [[goodhostplatform]]
         hosts = ${CYLC_TEST_HOST}
@@ -42,8 +41,7 @@ create_test_global_config "" "
         hosts = unreachable_host, ${CYLC_TEST_HOST}
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
-        [[[selection]]]
-            method = 'definition order'
+        host selection method = 'definition order'
     "
 #-------------------------------------------------------------------------------
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/intelligent-host-selection/03-polling.t
+++ b/tests/functional/intelligent-host-selection/03-polling.t
@@ -46,8 +46,7 @@ create_test_global_config "" "
         communication method = poll
         execution polling intervals = PT0S, PT14M
         submission polling intervals = PT0S, PT41M
-        [[[selection]]]
-            method = 'definition order'
+        host selection method = 'definition order'
     "
 #-------------------------------------------------------------------------------
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"

--- a/tests/functional/intelligent-host-selection/04-kill.t
+++ b/tests/functional/intelligent-host-selection/04-kill.t
@@ -39,8 +39,7 @@ create_test_global_config "" "
     [[mixedhostplatform]]
         hosts = unreachable_host, ${CYLC_TEST_HOST}
         install target = ${CYLC_TEST_INSTALL_TARGET}
-        [[[selection]]]
-            method = 'definition order'
+        host selection method = 'definition order'
     "
 #-------------------------------------------------------------------------------
 

--- a/tests/unit/test_platforms_get_host.py
+++ b/tests/unit/test_platforms_get_host.py
@@ -24,7 +24,7 @@ from cylc.flow.exceptions import CylcError
 TEST_PLATFORM = {
     'name': 'Elephant',
     'hosts': ['nellie', 'dumbo', 'jumbo'],
-    'selection': {'method': 'definition order'}
+    'host selection method': 'definition order'
 }
 
 
@@ -52,7 +52,7 @@ def test_get_host_from_platform_fails_no_goodhosts():
 
 def test_get_host_from_platform_fails_bad_method():
     platform = TEST_PLATFORM.copy()
-    platform['selection']['method'] = 'roulette'
+    platform['host selection method'] = 'roulette'
     with pytest.raises(CylcError) as err:
         get_host_from_platform(platform, {'Elephant'})
     assert err.exconly() == (

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -57,7 +57,7 @@ def test_construct_rsync_over_ssh_cmd():
         {
             'hosts': ['miklegard'],
             'ssh command': 'strange_ssh',
-            'selection': {'method': 'definition order'},
+            'host selection method': 'definition order',
             'name': 'testplat'
         }
     )

--- a/tests/unit/test_task_remote_mgr.py
+++ b/tests/unit/test_task_remote_mgr.py
@@ -45,7 +45,7 @@ def test_remote_init_skip(
         'install target': install_target,
         'communication method': CommsMeth.POLL,
         'hosts': ['localhost'],
-        'selection': {'method': 'random'},
+        'host selection method': 'random',
         'name': 'foo'
     }
     mock_task_remote_mgr = MagicMock(remote_init_map={}, bad_hosts=[])

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1146,7 +1146,7 @@ def test_remote_clean_cmd(
         'name': 'enterprise',
         'install target': 'mars',
         'hosts': ['Trill'],
-        'selection': {'method': 'definition order'}
+        'host selection method': 'definition order'
     }
     mock_construct_ssh_cmd = monkeymock(
         'cylc.flow.workflow_files.construct_ssh_cmd', return_value=['blah'])


### PR DESCRIPTION
Something about  `global.cylc[platforms][<name>][selection]` was causing the [docs build to fail](https://github.com/cylc/cylc-doc/pull/276#issuecomment-889730698).
> Could not reference "global.cylc[platforms][localhost][selection]True" from the context "global.cylc[platforms][localhost][selection]" in file "reference/config/global".

Simple solution: change the section into a single setting.

Unless we are going to be putting more stuff in a `[selection]` method later?

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests.
- [ ] Appropriate change log entry included.
- [x] No documentation update required (can't find any reference to  `global.cylc[platforms][<name>][selection]` in the docs).
