### PR TITLE
Make spawn to max active cylc points obsolete

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@ erroneous use of both `expr => bar` and `expr => !bar` in the same graph.
 
 ### Fixes
 
-[#](https://github.com/cylc/cylc-flow/pull/) -
+[#4310](https://github.com/cylc/cylc-flow/pull/4310 -
 Remove obsolete Cylc 7 `[scheduling]spawn to max active cycle points` config.
 
 -------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,10 @@ Fourth beta release of Cylc 8.
 [#4335](https://github.com/cylc/cylc-flow/pull/4335) - have validation catch
 erroneous use of both `expr => bar` and `expr => !bar` in the same graph.
 
+### Fixes
+
+[#](https://github.com/cylc/cylc-flow/pull/) -
+Remove obsolete Cylc 7 `[scheduling]spawn to max active cycle points` config.
 
 -------------------------------------------------------------------------------
 ## __cylc-8.0b2 (<span actions:bind='release-date'>Released 2021-07-28</span>)__

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1339,6 +1339,7 @@ def upg(cfg, descr):
         ['cylc', 'simulation', 'disable suite event handlers'])
     u.obsolete('8.0.0', ['cylc', 'simulation'])
     u.obsolete('8.0.0', ['visualization'])
+    u.obsolete('8.0.0', ['scheduling', 'spawn to max active cycle points']),
     u.deprecate(
         '8.0.0',
         ['cylc', 'task event mail interval'],


### PR DESCRIPTION

These changes close https://github.com/cylc/cylc-flow/issues/4310
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (why - removing config, covered by test of obsolete).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
