### PR TITLE
scan: use natural sort order with --sort opt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@ Fourth beta release of Cylc 8.
 [#4335](https://github.com/cylc/cylc-flow/pull/4335) - have validation catch
 erroneous use of both `expr => bar` and `expr => !bar` in the same graph.
 
+[#4346](https://github.com/cylc/cylc-flow/pull/4346) -
+Use natural sort order for the `cylc scan --sort` option.
+
 ### Fixes
 
 [#4310](https://github.com/cylc/cylc-flow/pull/4310 -

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -72,6 +72,7 @@ from cylc.flow.option_parsers import (
 )
 from cylc.flow.print_tree import get_tree
 from cylc.flow.terminal import cli_function
+from cylc.flow.util import natural_sort_key
 from cylc.flow.workflow_files import ContactFileFields as Cont
 
 
@@ -356,7 +357,7 @@ def sort_function(flow):
         state = 2
     else:
         state = 3
-    return (state, flow['name'])
+    return (state, *natural_sort_key(flow['name']))
 
 
 async def _sorted(pipe, formatter, opts, write):

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import suppress
+from functools import partial
+import re
+from typing import List, Any
+
+
+_NAT_SORT_SPLIT = re.compile(r'([\d\.]+)')
+
+
+def natural_sort_key(key: str, fcns=(int, str)) -> List[Any]:
+    """Returns a key suitable for sorting.
+
+    Splits the key into sortable chunks to preserve numerical order.
+
+    Examples:
+        >>> natural_sort_key('a1b2c3')
+        ['a', 1, 'b', 2, 'c', 3]
+        >>> natural_sort_key('a123b')
+        ['a', 123, 'b']
+        >>> natural_sort_key('a1.23b', fcns=(float, str))
+        ['a', 1.23, 'b']
+        >>> natural_sort_key('a.b')
+        ['a', '.', 'b']
+
+    """
+    ret = []
+    for item in _NAT_SORT_SPLIT.split(key):
+        for fcn in fcns:
+            with suppress(TypeError, ValueError):
+                ret.append(fcn(item))
+                break
+    if ret[-1] == '':
+        ret.pop(-1)
+    return ret
+
+
+def natural_sort(items: List[str], fcns=(int, str)) -> None:
+    """Sorts a list preserving numerical order.
+
+    Note this is an in-place sort.
+
+    Examples:
+        >>> lst = ['a10', 'a1', 'a2']
+        >>> natural_sort(lst)
+        >>> lst
+        ['a1', 'a2', 'a10']
+
+        >>> lst = ['a1', '1a']
+        >>> natural_sort(lst)
+        >>> lst
+        ['1a', 'a1']
+
+    """
+    items.sort(key=partial(natural_sort_key, fcns=fcns))


### PR DESCRIPTION
Use natural sort order with `cylc scan`.

Place function in generic module for easy reuse.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
