### PR TITLE
Do not skip bad site config; raise instead

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -909,15 +909,9 @@ class GlobalConfig(ParsecConfig):
                 fname = os.path.join(conf_dir, self.CONF_BASENAME)
                 try:
                     self._load(fname, conf_type)
-                except ParsecError as exc:
-                    if conf_type == upgrader.SITE_CONFIG:
-                        # Warn on bad site file (users can't fix it).
-                        LOG.warning(
-                            f'ignoring bad {conf_type} {fname}:\n{exc}')
-                    else:
-                        # Abort on bad user file (users can fix it).
-                        LOG.error(f'bad {conf_type} {fname}')
-                        raise
+                except ParsecError:
+                    LOG.error(f'bad {conf_type} {fname}')
+                    raise
 
         self._set_default_editors()
 


### PR DESCRIPTION
This is a small change with no associated Issue. At request of @dpmatthews

During loading of the config hierarchy, if a site global config is bad, do not skip with warning, instead raise error as happens for user global config.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
