### PR TITLE
Deltas batched post reload

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -435,6 +435,7 @@ class DataStoreMgr:
         self.prune_trigger_nodes = {}
         self.prune_flagged_nodes = set()
         self.updates_pending = False
+        self.publish_pending = False
 
     def initiate_data_model(self, reloaded=False):
         """Initiate or Update data model on start/restart/reload.
@@ -1944,6 +1945,7 @@ class DataStoreMgr:
         result.append(
             (ALL_DELTAS.encode('utf-8'), all_deltas, 'SerializeToString')
         )
+        self.publish_pending = True
         return deepcopy(result)
 
     def get_data_elements(self, element_type):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1552,7 +1552,10 @@ class Scheduler:
                 reloaded=self.is_reloaded)
             self.is_reloaded = False
             # Publish updates:
-            await self.publisher.publish(self.data_store_mgr.publish_deltas)
+            if self.data_store_mgr.publish_pending:
+                self.data_store_mgr.publish_pending = False
+                await self.publisher.publish(
+                    self.data_store_mgr.publish_deltas)
         if has_updated:
             # Database update
             self.workflow_db_mgr.put_task_pool(self.pool)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -209,6 +209,7 @@ class Scheduler:
     is_paused: Optional[bool] = None
     is_updated: Optional[bool] = None
     is_stalled: Optional[bool] = None
+    is_reloaded: Optional[bool] = None
 
     # main loop
     main_loop_intervals: deque = deque(maxlen=10)
@@ -453,6 +454,7 @@ class Scheduler:
             self.task_events_mgr,
             self.data_store_mgr)
 
+        self.is_reloaded = False
         self.data_store_mgr.initiate_data_model()
 
         self.profiler.log_memory("scheduler.py: before load_tasks")
@@ -1414,9 +1416,8 @@ class Scheduler:
                 # Re-initialise data model on reload
                 self.data_store_mgr.initiate_data_model(reloaded=True)
                 self.pool.reload_taskdefs()
+                self.is_reloaded = True
                 self.is_updated = True
-                await self.publisher.publish(
-                    self.data_store_mgr.publish_deltas)
 
             self.process_command_queue()
 
@@ -1541,9 +1542,14 @@ class Scheduler:
             t for t in self.pool.get_tasks() if t.state.is_updated]
         has_updated = self.is_updated or updated_tasks
         # Add tasks that have moved moved from runahead to live pool.
-        if has_updated or self.data_store_mgr.updates_pending:
+        if (
+                (has_updated and not self.is_reloaded)
+                or self.data_store_mgr.updates_pending
+        ):
             # Collect/apply data store updates/deltas
-            self.data_store_mgr.update_data_structure()
+            self.data_store_mgr.update_data_structure(
+                reloaded=self.is_reloaded)
+            self.is_reloaded = False
             # Publish updates:
             await self.publisher.publish(self.data_store_mgr.publish_deltas)
         if has_updated:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1416,6 +1416,10 @@ class Scheduler:
                 # Re-initialise data model on reload
                 self.data_store_mgr.initiate_data_model(reloaded=True)
                 self.pool.reload_taskdefs()
+                # Load jobs from DB
+                self.workflow_db_mgr.pri_dao.select_jobs_for_restart(
+                    self.data_store_mgr.insert_db_job)
+                LOG.info("Reload completed.")
                 self.is_reloaded = True
                 self.is_updated = True
 
@@ -1542,10 +1546,7 @@ class Scheduler:
             t for t in self.pool.get_tasks() if t.state.is_updated]
         has_updated = self.is_updated or updated_tasks
         # Add tasks that have moved moved from runahead to live pool.
-        if (
-                (has_updated and not self.is_reloaded)
-                or self.data_store_mgr.updates_pending
-        ):
+        if has_updated or self.data_store_mgr.updates_pending:
             # Collect/apply data store updates/deltas
             self.data_store_mgr.update_data_structure(
                 reloaded=self.is_reloaded)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -263,14 +263,7 @@ class TaskPool:
             self.main_pool[itask.point][itask.identity] = itask
             self.main_pool_changed = True
 
-            # Register pool node reference data-store with ID_DELIM format
-            self.data_store_mgr.add_pool_node(itask.tdef.name, itask.point)
-            # Create new data-store n-distance graph window about this task
-            self.data_store_mgr.increment_graph_window(itask)
-            self.data_store_mgr.delta_task_state(itask)
-            self.data_store_mgr.delta_task_held(itask)
-            self.data_store_mgr.delta_task_queued(itask)
-            self.data_store_mgr.delta_task_runahead(itask)
+            self.create_data_store_elements(itask)
 
         if is_new:
             # Add row to "task_states" table:
@@ -283,6 +276,17 @@ class TaskPool:
             if itask.state.outputs.has_custom_triggers():
                 self.workflow_db_mgr.put_insert_task_outputs(itask)
         return itask
+
+    def create_data_store_elements(self, itask):
+        """Create the node window elements about given task proxy."""
+        # Register pool node reference data-store with ID_DELIM format
+        self.data_store_mgr.add_pool_node(itask.tdef.name, itask.point)
+        # Create new data-store n-distance graph window about this task
+        self.data_store_mgr.increment_graph_window(itask)
+        self.data_store_mgr.delta_task_state(itask)
+        self.data_store_mgr.delta_task_held(itask)
+        self.data_store_mgr.delta_task_queued(itask)
+        self.data_store_mgr.delta_task_runahead(itask)
 
     def release_runahead_tasks(self):
         """Release runahead tasks.
@@ -845,6 +849,8 @@ class TaskPool:
 
         # Now queue all tasks that are ready to run
         for itask in self.get_tasks():
+            # Recreate data store elements from main pool.
+            self.create_data_store_elements(itask)
             if itask.state.is_queued:
                 # Already queued
                 continue
@@ -854,11 +860,9 @@ class TaskPool:
             if itask.tdef.clocktrigger_offset is not None:
                 self.data_store_mgr.delta_task_clock_trigger(
                     itask, ready_check_items)
-
             if all(ready_check_items) and not itask.state.is_runahead:
                 self.queue_task(itask)
 
-        LOG.info("Reload completed.")
         self.do_reload = False
 
     def set_stop_point(self, stop_point):

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -273,7 +273,6 @@ class TaskProxy:
         reload_successor.state.is_runahead = self.state.is_runahead
         reload_successor.state.is_updated = self.state.is_updated
         reload_successor.state.prerequisites = self.state.prerequisites
-        reload_successor.graph_children = self.graph_children
 
     @staticmethod
     def get_offset_as_seconds(offset):


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-ui/issues/667
Closes #4047

This PR batches all the data-store deltas post reload, and sets the `reloaded` flag on all..

Previously only the definition elements (`workflow`, `tasks`, `families`)would be batched and sent, and then the cycle point nodes/elements (`task_proxies`, `family_proxies`, `jobs`, `edges`) would be sent on the next main loop iteration (after being released from the runahead/spawn pool)..

The reason we want one batch, is to replicate an initial burst for the UI.

Along with the sibling PR: https://github.com/cylc/cylc-uiserver/pull/234
this fixes the freeze issue at the UI..

~~There is still a little delay with the reload, but is likely related to the processing of the newly loaded pool (releasing etc... which is when the data-store receives nodes.)~~

- The n-window elements are created as the task pool is reloaded.
- The job elements are created from the DB thereafter.
- Orphaned tasks are now included post reload.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests.
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
