### PR TITLE
Commented out line in cylc report-timings causing flaky behaviour.

### DIFF
--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -205,7 +205,6 @@ class TimingSummary(object):
                 df['succeed_time'] - df['submit_time']).apply(self._dt_to_s),
         })
 
-        # self.df = self.df.rename('timing_category', axis='columns')
         self.by_host_and_batch = self.df.groupby(
             level=['host', 'batch_system']
         )

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -204,7 +204,8 @@ class TimingSummary(object):
             'total_time': (
                 df['succeed_time'] - df['submit_time']).apply(self._dt_to_s),
         })
-        self.df = self.df.rename_axis('timing_category', axis='columns')
+
+        # self.df = self.df.rename('timing_category', axis='columns')
         self.by_host_and_batch = self.df.groupby(
             level=['host', 'batch_system']
         )


### PR DESCRIPTION
This is a small change with no associated Issue.
### Bug description
```
> cylc report-timings -s ~me/cylc-run/myworkflow
...traceback...
"str" object is not callable
```

Unwilling to devote too much time to this because we are hoping to replace report-timings in Cylc 8, but had a quick look. 
It looks like `pandas.DataFrame.rename` may have changed interfaces and not be reliable for all python/pandas versions: @trwhitcomb  - what version of Python/Pandas did you write this with? Commenting this out fixes the problem,  at the cost of making a slightly less well labelled table. 

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (Legacy code bugfx).
- [x] No documentation update required.
