### PR TITLE
make review-timings work with Cylc 8

### DIFF
--- a/cylc/flow/scripts/report_timings.py
+++ b/cylc/flow/scripts/report_timings.py
@@ -122,7 +122,6 @@ def main(parser, options, workflow):
 
     run_db = _get_dao(workflow)
     row_buf = format_rows(*run_db.select_task_times())
-
     with smart_open(options.output_filename) as output:
         if options.show_raw:
             output.write(row_buf.getvalue())
@@ -210,7 +209,7 @@ class TimingSummary:
         if buf is None:
             buf = sys.stdout
         self.write_summary_header(buf)
-        for group, df in self.by_host_and_runner:
+        for group, df in self.by_host_and_job_runner:
             self.write_group_header(buf, group)
             df_reshape = self._reshape_timings(df)
             df_describe = df.groupby(level='name').describe()


### PR DESCRIPTION
These changes partially address #4351 
**Purpose** Restore some basic functionality to `cylc review-timings` which was broken for even the simplest workflows at Cylc 8.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (Can be manually tested, and lack of tests already noted in #4351 ).
- [x] No change log entry required (Beta restoration of feature not known to be broken).
- [x] No documentation update required.
