### PR TITLE
Remove workflow owner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,8 @@ ones in. -->
 
 Fourth beta release of Cylc 8.
 
+`suite owner` and `workflow owner` option option has been removed.
+
 (See note on cylc-8 backward-incompatible changes, above)
 
 ### Enhancements

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -252,13 +252,6 @@ TASK_GLOB matches task or family names at a given cycle point.
                 )
             )
 
-        if self.prep:
-            self.add_std_option(
-                "--workflow-owner",
-                help="Specify workflow owner",
-                metavar="OWNER", action="store", default=None,
-                dest="workflow_owner")
-
         if self.comms:
             self.add_std_option(
                 "--comms-timeout", metavar='SEC',


### PR DESCRIPTION
Removes workflow owner option. 
This is a small change with no associated Issue.

This was supposed to have been removed in https://github.com/cylc/cylc-flow/pull/4194 but this selection of code was missed. 

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (Removing code).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
