### PR TITLE
Improve logging when a task message is received when the task is retrying

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -586,11 +586,18 @@ class TaskEventsManager():
                 )
 
         ):
-            # Ignore polled messages if task has a retry lined up
-            LOG.warning(
-                logfmt,
-                itask, itask.state, self.FLAG_POLLED_IGNORED, message,
-                timestamp, submit_num, itask.flow_label)
+            # Ignore messages if task has a retry lined up
+            # (caused by polling overlapping with task failure)
+            if flag == self.FLAG_RECEIVED:
+                LOG.warning(
+                    logfmt,
+                    itask, itask.state, self.FLAG_RECEIVED_IGNORED, message,
+                    timestamp, submit_num, itask.flow_label)
+            else:
+                LOG.warning(
+                    logfmt,
+                    itask, itask.state, self.FLAG_POLLED_IGNORED, message,
+                    timestamp, submit_num, itask.flow_label)
             return False
         LOG.log(
             LOG_LEVELS.get(severity, INFO), logfmt, itask, itask.state, flag,


### PR DESCRIPTION
Problem noticed whilst testing with this workflow:

```
[scheduling]
    initial cycle point = now
    [[graph]]
        PT1H = "flakey[-PT1H] => flakey"
[runtime]
    [[flakey]]
        platform = ??? # Use a remote platform to slow down how quickly the polling returns
        script = "sleep 5; ((CYLC_TASK_TRY_NUMBER <= 9)) && exit 1; true"
        execution retry delays = 10*PT5S
        execution polling intervals= PT3S
```

Relevant log entries:
```
2021-08-13T13:47:14+01:00 INFO - [flakey.20210813T1346+0100] -poll now, (next in PT3S (after 2021-08-13T13:47:17+01:00))
2021-08-13T13:47:16+01:00 CRITICAL - [flakey.20210813T1346+0100] status=running: (received)failed/ERR at 2021-08-13T13:47:15+01:00  for job(03) flow(e)
2021-08-13T13:47:16+01:00 INFO - [flakey.20210813T1346+0100] -job(03) failed, retrying in PT5S (after 2021-08-13T13:47:21+01:00)
2021-08-13T13:47:17+01:00 WARNING - [flakey.20210813T1346+0100] status=waiting: (polled-ignored)failed at 2021-08-13T13:47:15+01:00  for job(03) flow(e)
...
2021-08-13T13:49:18+01:00 INFO - [flakey.20210813T1446+0100] -poll now, (next in PT3S (after 2021-08-13T13:49:21+01:00))
2021-08-13T13:49:20+01:00 INFO - [flakey.20210813T1446+0100] status=running: (polled)failed at 2021-08-13T13:49:20+01:00  for job(01) flow(e)
2021-08-13T13:49:20+01:00 INFO - [flakey.20210813T1446+0100] -job(01) failed, retrying in PT5S (after 2021-08-13T13:49:25+01:00)
2021-08-13T13:49:21+01:00 WARNING - [flakey.20210813T1446+0100] status=waiting: (polled-ignored)failed/ERR at 2021-08-13T13:49:20+01:00  for job(01) flow(e)
```

"polled-ignored" is wrong in the second case since it is a task message which is being ignored.
This PR changes the message in this case to "received-ignored".

This is a small change with no associated Issue.

**Requirements check-list**
- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [X] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [X] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [X] No documentation update required.
