### PR TITLE
Attempt to fix unit test flakiness on Python 3.7

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -2,10 +2,28 @@
 name: bash
 
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/*.ya?ml'
+      - '!.github/workflows/bash.yml'
+      - 'cylc/flow/etc/syntax/**'
+      - 'etc/syntax/**'
+      - 'tests/unit/**'
+      - 'tests/integration/**'
+      - '**.md'
+      - '**/README*/**'
   push:
     branches: [master]
+    paths-ignore:
+      - '.github/workflows/*.ya?ml'
+      - '!.github/workflows/bash.yml'
+      - 'cylc/flow/etc/syntax/**'
+      - 'etc/syntax/**'
+      - 'tests/unit/**'
+      - 'tests/integration/**'
+      - '**.md'
+      - '**/README*/**'
 
 jobs:
   bash-docker:

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -1,8 +1,17 @@
 name: functional tests
 
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/*.ya?ml'
+      - '!.github/workflows/test_functional.yml'
+      - 'cylc/flow/etc/syntax/**'
+      - 'etc/syntax/**'
+      - 'tests/unit/**'
+      - 'tests/integration/**'
+      - '**.md'
+      - '**/README*/**'
   push:
     branches: [master]
     paths-ignore:

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -191,6 +191,7 @@ def test_clean_check__fail(
     assert err_msg in str(exc.value)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'db_platforms, opts, clean_called, remote_clean_called',
     [
@@ -240,6 +241,7 @@ def test_init_clean(
     assert mock_remote_clean.called is remote_clean_called
 
 
+@pytest.mark.asyncio
 def test_init_clean__no_dir(
     monkeymock: MonkeyMock, tmp_run_dir: Callable,
     caplog: pytest.LogCaptureFixture
@@ -256,6 +258,7 @@ def test_init_clean__no_dir(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__no_db(
     monkeymock: MonkeyMock, tmp_run_dir: Callable,
     caplog: pytest.LogCaptureFixture
@@ -272,6 +275,7 @@ def test_init_clean__no_db(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__remote_only_no_db(
     monkeymock: MonkeyMock, tmp_run_dir: Callable
 ) -> None:
@@ -288,6 +292,7 @@ def test_init_clean__remote_only_no_db(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__running_workflow(
     monkeypatch: pytest.MonkeyPatch, tmp_run_dir: Callable
 ) -> None:
@@ -303,6 +308,7 @@ def test_init_clean__running_workflow(
     assert "Cannot remove running workflow" in str(exc.value)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('number_of_runs', [1, 2])
 @pytest.mark.parametrize(
     'force_opt',
@@ -347,6 +353,7 @@ def test_init_clean__multiple_runs(
         ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'rm_dirs, expected_clean, expected_remote_clean',
     [(None, None, []),


### PR DESCRIPTION
This is a small change with no associated Issue.

It seems `asyncio.get_event_loop().run_until_complete()` might be more buggy than `asyncio.run()`? But this is the opposite of expected - https://github.com/cylc/cylc-flow/pull/4289#discussion_r664025464

Traceback from unit tests on GH Actions:

```python
>       workflow_files.init_clean(reg, opts=opts)

tests/unit/test_workflow_files.py:377: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cylc/flow/workflow_files.py:674: in init_clean
    contained_workflows = asyncio.get_event_loop().run_until_complete(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x7ffa73b578d0>

>                              % threading.current_thread().name)
E           RuntimeError: There is no current event loop in thread 'Dummy-1'.

/opt/hostedtoolcache/Python/3.7.11/x64/lib/python3.7/asyncio/events.py:644: RuntimeError
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
