### PR TITLE
Cylc Wrapper uses arbitrary env set at CYLC_ENV_NAME

### DIFF
--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -173,6 +173,8 @@ class JobFileWriter:
         for key, value in verbosity_to_env(cylc.flow.flags.verbosity).items():
             handle.write(f'\nexport {key}={value}')
         handle.write("\nexport CYLC_VERSION='%s'" % CYLC_VERSION)
+        handle.write(
+            "\nexport CYLC_ENV_NAME='%s'" % os.getenv('CYLC_ENV_NAME'))
         env_vars = (
             (job_conf['platform']['copyable environment variables'] or [])
             # pass CYLC_COVERAGE into the job execution environment

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -173,8 +173,13 @@ class JobFileWriter:
         for key, value in verbosity_to_env(cylc.flow.flags.verbosity).items():
             handle.write(f'\nexport {key}={value}')
         handle.write("\nexport CYLC_VERSION='%s'" % CYLC_VERSION)
-        handle.write(
-            "\nexport CYLC_ENV_NAME='%s'" % os.getenv('CYLC_ENV_NAME'))
+        try:
+            CYLC_ENV_NAME = os.environ['CYLC_ENV_NAME']
+        except KeyError:
+            pass
+        else:
+            handle.write(
+                "\nexport CYLC_ENV_NAME='%s'" % CYLC_ENV_NAME)
         env_vars = (
             (job_conf['platform']['copyable environment variables'] or [])
             # pass CYLC_COVERAGE into the job execution environment

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -293,12 +293,12 @@ def _construct_ssh_cmd(
 
     # Pass CYLC_VERSION and optionally, CYLC_CONF_PATH & CYLC_UTC through.
     command += ['env', quote(r'CYLC_VERSION=%s' % CYLC_VERSION)]
-    command += [quote(r'CYLC_ENV_NAME=%s' % os.getenv('CYLC_ENV_NAME'))]
 
     for envvar in [
         'CYLC_CONF_PATH',
         'CYLC_COVERAGE',
-        'CLIENT_COMMS_METH'
+        'CLIENT_COMMS_METH',
+        'CYLC_ENV_NAME'
     ]:
         if envvar in os.environ:
             command.append(

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -293,6 +293,7 @@ def _construct_ssh_cmd(
 
     # Pass CYLC_VERSION and optionally, CYLC_CONF_PATH & CYLC_UTC through.
     command += ['env', quote(r'CYLC_VERSION=%s' % CYLC_VERSION)]
+    command += [quote(r'CYLC_ENV_NAME=%s' % os.getenv('CYLC_ENV_NAME'))]
 
     for envvar in [
         'CYLC_CONF_PATH',

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -610,7 +610,6 @@ class Scheduler:
         Lightweight wrapper for convenience.
 
         """
-        LOG.critical("PURPLE GIRAFFES")
         try:
             await self.initialise()
             await self.configure()

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -610,6 +610,7 @@ class Scheduler:
         Lightweight wrapper for convenience.
 
         """
+        LOG.critical("PURPLE GIRAFFES")
         try:
             await self.initialise()
             await self.configure()

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -245,17 +245,28 @@ def test_traps_for_each_job_runner(job_runner: str):
         assert("CYLC_FAIL_SIGNALS='EXIT ERR TERM XCPU" in output)
 
 
-def test_write_prelude(monkeypatch, fixture_get_platform):
+@pytest.mark.parametrize(
+    'set_CYLC_ENV_NAME',
+    [
+        pytest.param(True, id='CYLC_ENV_NAME=True'),
+        pytest.param(False, id='CYLC_ENV_NAME=False'),
+    ]
+)
+def test_write_prelude(monkeypatch, fixture_get_platform, set_CYLC_ENV_NAME):
     """Test the prelude section of job script file is correctly
     written.
     """
+    if set_CYLC_ENV_NAME:
+        monkeypatch.setenv('CYLC_ENV_NAME', 'myenv')
     monkeypatch.setattr('cylc.flow.flags.verbosity', 2)
     expected = ('\nCYLC_FAIL_SIGNALS=\'EXIT ERR TERM XCPU\'\n'
                 'CYLC_VACATION_SIGNALS=\'USR1\'\nexport PATH=moo/baa:$PATH'
                 '\nexport CYLC_VERBOSE=true'
                 '\nexport CYLC_DEBUG=true'
-                '\nexport CYLC_VERSION=\'%s\'\nexport ' % __version__
-                + 'CYLC_WORKFLOW_INITIAL_CYCLE_POINT=\'20200101T0000Z\'')
+                '\nexport CYLC_VERSION=\'%s\'' % __version__)
+    if set_CYLC_ENV_NAME:
+        expected += '\nexport CYLC_ENV_NAME=\'myenv\''
+    expected += '\nexport CYLC_WORKFLOW_INITIAL_CYCLE_POINT=\'20200101T0000Z\''
     job_conf = {
         "platform": fixture_get_platform({
             "job runner": "loadleveler",

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -145,7 +145,7 @@ fi
 # Note: the code above is only needed if still using standalone Rose 2019
 # versions
 
-# CYLC_NAME construction:
+# CYLC_ENV_NAME construction:
 #                           ╔════════════════════════════╗
 #                           ║        CYLC_VERSION        ║
 #                           ╠══════════════════╦═════════╣

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -147,9 +147,16 @@ fi
 
 if [[ -z "${CYLC_HOME}" ]]; then
     # Look for specified or default version under the root locations
+    # Build CYLC_NAME from CYLC_VERSION if you can:
     if [[ -n "${CYLC_VERSION}" ]]; then
         CYLC_NAME="cylc-$CYLC_VERSION"
-    else
+        echo "cylc name is $CYLC_NAME"
+    fi
+    # Build CYLC_NAME from CYLC_ENV_NAME if you can:
+    if [[ -n "${CYLC_ENV_NAME}" ]]; then
+        CYLC_NAME="${CYLC_ENV_NAME}"
+    fi
+    if [[ -z "${CYLC_ENV_NAME}" && -z "${CYLC_VERSION}" ]]; then
         # Default version symlink
         CYLC_NAME="cylc"
     fi

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -64,7 +64,8 @@
 # And create a default version symlink "cylc" to the latest version:
 #   $ ln -s cylc-8.2.0 cylc
 #
-# Alternatively use CYLC_ENV_NAME to use Cylc from an arbitrary Conda environment:
+# Alternatively use CYLC_ENV_NAME to use Cylc from an arbitrary Conda or Python
+# virtual environment:
 #
 # Create environments with arbitrary names and install cylc:
 #   $ conda create cylc-violet-capybara

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -64,15 +64,7 @@
 # And create a default version symlink "cylc" to the latest version:
 #   $ ln -s cylc-8.2.0 cylc
 #
-# Note you can `pip install` from a cylc-flow git clone into a Conda
-# environment and then select it by CYLC_VERSION but that may be misleading
-# if the code is not the true release version. Better to use Python venvs and
-# CYLC_HOME for development and testing.
-#
-# INSTALLING cylc 8+ WITH PIP IN CONDA ENVIRONMENTS WITH ARBITRARY NAMES
-#-----------------------------------------------------------------------
-#
-# You can use CYLC_ENV_NAME to use Cylc from an arbitrary Conda environment:
+# Alternatively use CYLC_ENV_NAME to use Cylc from an arbitrary Conda environment:
 #
 # Create environments with arbitrary names and install cylc:
 #   $ conda create cylc-violet-capybara
@@ -81,7 +73,7 @@
 #   $ conda deactivate
 #
 #   $ CYLC_ENV_NAME=cylc-violet-capybara cylc version --long
-#   > 8.0.whateva (/home/user/miniconda3/envs/cylc-violet-capybara)
+#   > 8.0.0 (/home/user/miniconda3/envs/cylc-violet-capybara)
 #
 # n.b. if CYLC_VERSION and CYLC_ENV_NAME are both set, CYLC_ENV_NAME will be
 # used and CYLC_VERSION ignored.
@@ -146,8 +138,10 @@ CYLC_HOME_ROOT="${CYLC_HOME_ROOT:-/opt}"
 # Prior to Cylc 8, Rose used a standalone installation
 # Note: assumes Cylc 7 is the default version - once Cylc 8 becomes the default
 # the if test below needs to change to
-# if [[ ${CYLC_VERSION:-} =~ ^7 && ${0##*/} =~ ^rose ]]; then
-if [[ ! ${CYLC_VERSION:-} =~ ^8 && ${0##*/} =~ ^rose ]]; then
+# if [[ ${0##*/} =~ ^rose && ${CYLC_VERSION:-} =~ ^7 ]]; then
+if [[ ${0##*/} =~ ^rose && \
+      ((-n "${CYLC_ENV_NAME}" && ${CYLC_VERSION:-} =~ ^7) || \
+       (-z "${CYLC_ENV_NAME}" && ! ${CYLC_VERSION:-} =~ ^8)) ]]; then
     if [[ -z "${ROSE_HOME:-}" ]]; then
         ROSE_HOME_ROOT="${ROSE_HOME_ROOT:-$CYLC_HOME_ROOT}"
         if [[ -n "${ROSE_VERSION:-}" ]]; then
@@ -174,16 +168,18 @@ fi
 # ║               ║ not set ║ Use CYLC_VERSION ║  "cylc" ║
 # ╚═══════════════╩═════════╩══════════════════╩═════════╝
 if [[ -z "${CYLC_HOME}" ]]; then
-    if [[ -n "${CYLC_VERSION}" && -z "${CYLC_ENV_NAME}" ]]; then
-        CYLC_ENV_NAME="cylc-$CYLC_VERSION"
-    elif [[ -z "${CYLC_ENV_NAME}" && -z "${CYLC_VERSION}" ]]; then
-        # Default version symlink
-        CYLC_ENV_NAME="cylc"
+    if [[ -z "${CYLC_ENV_NAME}" ]]; then
+        if [[ -n "${CYLC_VERSION}" ]]; then
+            CYLC_ENV_NAME="cylc-$CYLC_VERSION"
+        else
+            # Default version symlink - export CYLC_ENV_NAME to ensure it
+            # does nott get overridden by CYLC_VERSION
+            export CYLC_ENV_NAME="cylc"
+        fi
     fi
     for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
         if [[ -d "${ROOT}/${CYLC_ENV_NAME}" ]]; then
             CYLC_HOME="${ROOT}/${CYLC_ENV_NAME}"
-            export CYLC_ENV_NAME
             break
         fi
     done

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -46,7 +46,7 @@
 # .bashrc so that task jobs see CYLC_HOME too.
 #
 # CYLC_VERSION does not have to be set by users in their .bashrc because the
-# scheduler propagates its own version to task job scripts. If users do specify 
+# scheduler propagates its own version to task job scripts. If users do specify
 # a version in .bashrc they should make sure it defaults to an existing version
 # to avoid overriding task job version selection (see User Instructions below).
 #
@@ -57,6 +57,7 @@
 #
 # INSTALLING cylc 8+ RELEASES WITH CONDA
 #---------------------------------------
+#
 # Create environments named cylc-$CYLC_VERSION under a root location such as /opt:
 #   $ conda create -p /opt/cylc-8.2.0 cylc=8.2.0
 #
@@ -67,6 +68,23 @@
 # environment and then select it by CYLC_VERSION but that may be misleading
 # if the code is not the true release version. Better to use Python venvs and
 # CYLC_HOME for development and testing.
+#
+# INSTALLING cylc 8+ WITH PIP IN CONDA ENVIRONMENTS WITH ARBITRARY NAMES
+#-----------------------------------------------------------------------
+#
+# You can use CYLC_ENV_NAME to use Cylc from an arbitrary Conda environment:
+#
+# Create environments with arbitrary names and install cylc:
+#   $ conda create cylc-violet-capybara
+#   $ conda activate cylc-violet-capybara
+#   $ pip install -e <path to cylc>
+#   $ conda deactivate
+#
+#   $ CYLC_ENV_NAME=cylc-violet-capybara cylc version --long
+#   > 8.0.whateva (/home/user/miniconda3/envs/cylc-violet-capybara)
+#
+# n.b. if CYLC_VERSION and CYLC_ENV_NAME are both set, CYLC_ENV_NAME will be
+# used and CYLC_VERSION ignored.
 #
 # INSTALLING cylc-flow 8+ WORKING COPIES WITH PIP FOR DEVELOPMENT AND TESTING
 #----------------------------------------------------------------------------

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -173,7 +173,7 @@ if [[ -z "${CYLC_HOME}" ]]; then
             CYLC_ENV_NAME="cylc-$CYLC_VERSION"
         else
             # Default version symlink - export CYLC_ENV_NAME to ensure it
-            # does nott get overridden by CYLC_VERSION
+            # does not get overridden by CYLC_VERSION
             export CYLC_ENV_NAME="cylc"
         fi
     fi

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -156,24 +156,22 @@ fi
 # ║               ║ not set ║ Use CYLC_VERSION ║  "cylc" ║
 # ╚═══════════════╩═════════╩══════════════════╩═════════╝
 if [[ -z "${CYLC_HOME}" ]]; then
-    if [[ -n "${CYLC_ENV_NAME}" ]]; then
-        CYLC_NAME="${CYLC_ENV_NAME}"
-        export CYLC_ENV_NAME
-    elif [[ -n "${CYLC_VERSION}" ]]; then
-        CYLC_NAME="cylc-$CYLC_VERSION"
+    if [[ -n "${CYLC_VERSION}" && -z "${CYLC_ENV_NAME}" ]]; then
+        CYLC_ENV_NAME="cylc-$CYLC_VERSION"
     elif [[ -z "${CYLC_ENV_NAME}" && -z "${CYLC_VERSION}" ]]; then
         # Default version symlink
-        CYLC_NAME="cylc"
+        CYLC_ENV_NAME="cylc"
     fi
     for ROOT in "${CYLC_HOME_ROOT}" "${CYLC_HOME_ROOT_ALT}"; do
-        if [[ -d "${ROOT}/${CYLC_NAME}" ]]; then
-            CYLC_HOME="${ROOT}/${CYLC_NAME}"
+        if [[ -d "${ROOT}/${CYLC_ENV_NAME}" ]]; then
+            CYLC_HOME="${ROOT}/${CYLC_ENV_NAME}"
+            export CYLC_ENV_NAME
             break
         fi
     done
 fi
 if [[ -z "${CYLC_HOME}" ]]; then
-    MSG="ERROR: $CYLC_NAME not found in $CYLC_HOME_ROOT"
+    MSG="ERROR: $CYLC_ENV_NAME not found in $CYLC_HOME_ROOT"
     if [[ -n "${CYLC_HOME_ROOT_ALT}" ]]; then
         MSG="${MSG} or ${CYLC_HOME_ROOT_ALT}"
     fi

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -145,18 +145,23 @@ fi
 # Note: the code above is only needed if still using standalone Rose 2019
 # versions
 
+# CYLC_NAME construction:
+#                           ╔════════════════════════════╗
+#                           ║        CYLC_VERSION        ║
+#                           ╠══════════════════╦═════════╣
+#                           ║        set       ║ not set ║
+# ╔═══════════════╦═════════╬══════════════════╩═════════╣
+# ║ CYLC_ENV_NAME ║   set   ║      Use CYLC_ENV_NAME     ║
+# ║               ╠═════════╬══════════════════╦═════════╣
+# ║               ║ not set ║ Use CYLC_VERSION ║  "cylc" ║
+# ╚═══════════════╩═════════╩══════════════════╩═════════╝
 if [[ -z "${CYLC_HOME}" ]]; then
-    # Look for specified or default version under the root locations
-    # Build CYLC_NAME from CYLC_VERSION if you can:
-    if [[ -n "${CYLC_VERSION}" ]]; then
-        CYLC_NAME="cylc-$CYLC_VERSION"
-        echo "cylc name is $CYLC_NAME"
-    fi
-    # Build CYLC_NAME from CYLC_ENV_NAME if you can:
     if [[ -n "${CYLC_ENV_NAME}" ]]; then
         CYLC_NAME="${CYLC_ENV_NAME}"
-    fi
-    if [[ -z "${CYLC_ENV_NAME}" && -z "${CYLC_VERSION}" ]]; then
+        export CYLC_ENV_NAME
+    elif [[ -n "${CYLC_VERSION}" ]]; then
+        CYLC_NAME="cylc-$CYLC_VERSION"
+    elif [[ -z "${CYLC_ENV_NAME}" && -z "${CYLC_VERSION}" ]]; then
         # Default version symlink
         CYLC_NAME="cylc"
     fi

--- a/usr/bin/cylc
+++ b/usr/bin/cylc
@@ -72,7 +72,7 @@
 #   $ conda activate cylc-violet-capybara
 #   $ pip install -e <path to cylc>
 #   $ conda deactivate
-#
+# (or similarly for a native Python venv)
 #   $ CYLC_ENV_NAME=cylc-violet-capybara cylc version --long
 #   > 8.0.0 (/home/user/miniconda3/envs/cylc-violet-capybara)
 #


### PR DESCRIPTION
These changes address the bulk of #4165 

**Ticket Specific Checklist**
- [x] Use a new variable, `CYLC_ENV_NAME`, to allow fully arbitrary names.
- [ ] Also consider CYLC_ENVIRONMENT_TYPE. Not considered. Mind if I leave it to a future PR?
- [ ] Testing?
  - [x] Manual testing
    - [x] `CYLC_ENV_NAME=foo cylc version --long`
    - [x] `CYLC_ENV_NAME=foo CYLC_VERSION=8.0b3 cylc version --long`
    - [x] `CYLC_VERSION=8.0b3 cylc version --long`
    - [x] Ran a workflow with a remote task and checked the logfiles
  - [ ] Automated testing @hjoliver  - any thoughts? Are there any existing automated tests for this functionality? 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
