### PR TITLE
Codecov: carry forward previous reports 

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,5 +26,9 @@ ignore:
   - "tests/**"
   - "ws_messages_pb2.py"
 
+flag_management:
+  default_rules:
+    carryforward: true
+
 # turn off comments to pull requests
 comment: false

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -81,4 +81,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           name: '"${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}"'
+          flags: fast-tests
           fail_ci_if_error: true

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -281,4 +281,5 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           name: '"${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}"'
+          flags: functional-tests
           fail_ci_if_error: true


### PR DESCRIPTION
This is a small change with no associated Issue.

As GH Actions is now configured to skip the functional tests on PRs when only irrelevant files are modified (e.g. `.md` files, unit test files), this can lead to Codecov failing due to only receiving the limited coverage report of the fast tests.

This PR aims to make it carry forward the previous coverage if the functional tests report is not uploaded, hopefully preventing false coverage failures. I'm not entirely sure this will work, but at least it can't hurt.

Docs (warning: clear as mud): https://docs.codecov.com/docs/flags

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
