### PR TITLE
Add `versionchanged` admonitions to certain config items

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -133,6 +133,10 @@ with Conf('global.cylc', desc='''
             Maximum number of concurrent processes used to execute external job
             submission, event handlers, and job poll and kill commands - see
             :ref:`Managing External Command Execution`.
+
+            .. versionchanged:: 8.0.0
+
+               Moved here from the top level.
         ''')
         Conf('process pool timeout', VDR.V_INTERVAL, DurationFloat(600),
              desc='''
@@ -142,6 +146,10 @@ with Conf('global.cylc', desc='''
             .. note::
                The default is set quite high to avoid killing important
                processes when the system is under load.
+
+            .. versionchanged:: 8.0.0
+
+               Moved here from the top level.
         ''')
         Conf('auto restart delay', VDR.V_INTERVAL, desc='''
             Relates to Cylc's auto stop-restart mechanism (see
@@ -365,6 +373,10 @@ with Conf('global.cylc', desc='''
             The workflow event log, held under the workflow run directory, is
             maintained as a rolling archive. Logs are rolled over (backed up
             and started anew) when they reach a configurable limit size.
+
+            .. versionchanged:: 8.0.0
+
+               This section was previously ``[suite logging]``.
         '''):
             Conf('rolling archive length', VDR.V_INTEGER, 5, desc='''
                 How many rolled logs to retain in the archive.
@@ -374,7 +386,9 @@ with Conf('global.cylc', desc='''
                 file size.
             ''')
 
-    with Conf('install'):
+    with Conf('install', desc='''
+        .. versionadded:: 8.0.0
+    '''):
         Conf('source dirs', VDR.V_STRING_LIST, default=['~/cylc-src'], desc='''
             A list of paths where ``cylc install <flow_name>`` will look for
             a workflow of that name. All workflow source directories in these

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -266,6 +266,11 @@ with Conf(
                It is not recommended to write the time zone with a ":"
                (e.g. ``+05:30``), given that the time zone is used as part of
                task output filenames.
+
+            .. versionchanged:: 7.8.9/7.9.4
+
+               The value set here now persists over reloads/restarts after a
+               system time zone change.
         ''')
 
         with Conf('main loop'):  # noqa: SIM117 (keep same format)
@@ -430,6 +435,10 @@ with Conf(
             specified. Unlike for the final cycle point, the workflow will not
             shut down once all tasks have passed this point. If this item
             is provided you can override it on the command line.
+
+            .. versionchanged:: 8.0.0
+
+               This setting was previously called ``hold after point``.
         ''')
         Conf('stop after cycle point', VDR.V_CYCLE_POINT, desc='''
             Set stop point. Shut down after all tasks have PASSED
@@ -480,6 +489,11 @@ with Conf(
                The runahead limit may be automatically raised if this is
                necessary to allow a future task to be triggered, preventing
                the workflow from stalling.
+
+            .. versionchanged:: 8.0.0
+
+               The ``max active cycle points`` setting was merged into this
+               one.
         ''')
 
         with Conf('queues', desc='''
@@ -1245,6 +1259,12 @@ with Conf(
                        MYNUM = %(i)d
                        MYITEM = %(item)s
                        MYFILE = /path/to/%(i)03d/%(item)s
+
+                    .. versionchanged:: 7.8.7/7.9.2
+
+                       Parameter environment templates (previously in
+                       ``[runtime][X][parameter environment templates]``) have
+                       moved here.
                 ''')
 
             with Conf('directives', desc='''
@@ -1288,17 +1308,18 @@ with Conf(
                 ''')
 
             with Conf('parameter environment templates', desc='''
-                .. note::
+                .. deprecated:: 7.8.7/7.9.2
 
-                   This section is deprecated and will be removed in Cylc 9.
                    Parameter environment templates have moved to
                    :cylc:conf:`flow.cylc[runtime][<namespace>][environment]`.
-                   This was done to allow users to control the order of
-                   definition of the variables.
 
-                   For the time being, the contents of this section will be
-                   prepended to the ``[environment]`` section when running
-                   a workflow.
+                This was done to allow users to control the order of
+                definition of the variables. This section will be removed
+                in Cylc 9.
+
+                For the time being, the contents of this section will be
+                prepended to the ``[environment]`` section when running
+                a workflow.
             '''):
                 Conf('<parameter>', VDR.V_STRING)
 


### PR DESCRIPTION
These changes partially address #4342 

**Requirements check-list**
- [x] I have built cylc-doc locally to make sure the build passes
