### PR TITLE
GH Actions: Add test workflows badges to release PRs

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -54,5 +54,7 @@ jobs:
 
       - name: Create pull request
         uses: cylc/release-actions/stage-1/create-release-pr@v1
+        with:
+          test-workflows: test_fast.yml, test_functional.yml, bash.yml, test_manylinux.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a small change with no associated Issue.

Depends on https://github.com/cylc/release-actions/pull/22