### PR TITLE
Fix mutation error when stopping workflow in UI

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -91,6 +91,10 @@ class WorkflowEventError(CylcError):
     """Exception for errors in Cylc event handlers."""
 
 
+class CommandFailedError(CylcError):
+    """Exception for when scheduler commands fail."""
+
+
 class ServiceFileError(CylcError):
     """Exception for errors related to workflow service files."""
 

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -21,7 +21,7 @@ from fnmatch import fnmatchcase
 import logging
 import queue
 from time import time
-from typing import Iterable, Tuple, TYPE_CHECKING
+from typing import Iterable, Optional, Tuple, TYPE_CHECKING
 from uuid import uuid4
 
 from graphene.utils.str_converters import to_snake_case
@@ -38,6 +38,7 @@ from cylc.flow.network.schema import (
 if TYPE_CHECKING:
     from cylc.flow.data_store_mgr import DataStoreMgr
     from cylc.flow.scheduler import Scheduler
+    from cylc.flow.workflow_status import StopMode
 
 
 logger = logging.getLogger(__name__)
@@ -733,29 +734,25 @@ class Resolvers(BaseResolvers):
         return (True, 'Command queued')
 
     def stop(
-            self,
-            mode=None,
-            cycle_point=None,
-            clock_time=None,
-            task=None,
-            flow_label=None
-    ):
+        self,
+        mode: 'StopMode',
+        cycle_point: Optional[str] = None,
+        clock_time: Optional[str] = None,
+        task: Optional[str] = None,
+        flow_label: Optional[str] = None
+    ) -> Tuple[bool, str]:
         """Stop the workflow or specific flow from spawning any further.
 
         Args:
-            mode (StopMode.Value): Stop mode to set
-            cycle_point (str): Cycle point after which to stop.
-            clock_time (str): Wallclock time after which to stop.
-            task (str): Stop after this task succeeds.
-            flow_label (str): The flow to sterilise.
+            mode: Stop mode to set
+            cycle_point: Cycle point after which to stop.
+            clock_time: Wallclock time after which to stop.
+            task: Stop after this task succeeds.
+            flow_label: The flow to sterilise.
 
         Returns:
-            tuple: (outcome, message)
-
-            outcome (bool)
-                True if command successfully queued.
-            message (str)
-                Information about outcome.
+            outcome: True if command successfully queued.
+            message: Information about outcome.
 
         """
         self.schd.command_queue.put((

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1446,13 +1446,12 @@ class WorkflowStopMode(Enum):
 
     # NOTE: using a different enum because:
     # * Graphene requires special enums.
-    # * We only want to offer a subset of stop modes.
+    # * We only want to offer a subset of stop modes (REQUEST_* only).
 
-    # Note: contains only the REQUEST_* values from StopMode
-    Clean = StopMode.REQUEST_CLEAN.value
-    Kill = StopMode.REQUEST_KILL.value
-    Now = StopMode.REQUEST_NOW.value
-    NowNow = StopMode.REQUEST_NOW_NOW.value
+    Clean = StopMode.REQUEST_CLEAN
+    Kill = StopMode.REQUEST_KILL
+    Now = StopMode.REQUEST_NOW
+    NowNow = StopMode.REQUEST_NOW_NOW
 
     @property
     def description(self):
@@ -1726,7 +1725,7 @@ class Stop(Mutation):
     class Arguments:
         workflows = List(WorkflowID, required=True)
         mode = WorkflowStopMode(
-            default_value=WorkflowStopMode.Clean.value  # type: ignore
+            default_value=WorkflowStopMode.Clean.value
         )
         cycle_point = CyclePoint(
             description='Stop after the workflow reaches this cycle.'

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -44,6 +44,7 @@ from typing import Optional, TYPE_CHECKING
 from cylc.flow.command_polling import Poller
 from cylc.flow.exceptions import ClientError, ClientTimeout
 from cylc.flow.network.client_factory import get_client
+from cylc.flow.network.schema import WorkflowStopMode
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.task_id import TaskID
 from cylc.flow.terminal import cli_function
@@ -182,11 +183,11 @@ def main(
         # not a task ID, may be a cycle point
         cycle_point = shutdown_arg
     elif options.kill:
-        mode = 'Kill'
+        mode = WorkflowStopMode.Kill.name
     elif options.now > 1:
-        mode = 'NowNow'
+        mode = WorkflowStopMode.NowNow.name
     elif options.now:
-        mode = 'Now'
+        mode = WorkflowStopMode.Now.name
 
     mutation_kwargs = {
         'request_string': MUTATION,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -145,10 +145,14 @@ def set_cycling_type(monkeypatch: pytest.MonkeyPatch):
 def xtrigger_mgr() -> XtriggerManager:
     """A fixture to build an XtriggerManager which uses a mocked proc_pool,
     and uses a mocked broadcast_mgr."""
+    workflow_name = "sample_workflow"
+    user = "john-foo"
     return XtriggerManager(
-        workflow="sample_workflow",
-        user="john-foo",
+        workflow=workflow_name,
+        user=user,
         proc_pool=Mock(put_command=lambda *a, **k: True),
         broadcast_mgr=Mock(put_broadcast=lambda *a, **k: True),
-        data_store_mgr=DataStoreMgr(create_autospec(Scheduler))
+        data_store_mgr=DataStoreMgr(
+            create_autospec(Scheduler, workflow=workflow_name, owner=user)
+        )
     )


### PR DESCRIPTION
This is a small change with no associated Issue. Fixes bug probably introduced by #4331.

#### The bug

Stopping a workflow using the default stop mode in the UI (e.g. pressing the stop button) was resulting in an error

> command failed: stop - Error: Response not successful: Received status code 400 

![image](https://user-images.githubusercontent.com/61982285/131695730-e3abab0a-4671-48e1-8ead-3eb2d73402ad.png)

Inspecting the sent mutation in the devtools console showed that the mode was 
```
mode: "REQUEST(CLEAN)"
```
However, if you clicked on the hamburger and clicked the pencil icon to edit the Stop command, and actively chose "Clean" from the mode dropdown, then it would work fine. The mutation in that case contained
```
mode: "Clean"
```
instead.

#### The fix

In `cylc.flow.network.schema.WorkflowStopMode`, remove the `.value` from `StopMode.REQUEST_*.value`.

I'm not really sure why this works, `graphene.Enum` is confusing and not well documented.

#### Testing it out

Run a workflow in no-detach mode and try stopping it using
- `cylc stop`
- `cylc stop --kill` (or `--now`)
- The web UI using the stop button
- The web UI using the hamburger button > stop (edit) > mode = Clean
- The TUI

#### Requirements check-list
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [ ] Appropriate tests are included (unit and/or functional).
- [x] No change log entry needed (fixes recently introduced change).
- [x] No documentation update required.
