### PR TITLE
GH Actions: Do not fail if problem in remote coverage file

### DIFF
--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -258,12 +258,17 @@ jobs:
             --exclude='*' \
             >rsyncout
           cat rsyncout
+
+      - name: Fiddle remote coverage paths
+        if: env.REMOTE_PLATFORM == 'true'
+        run: |
           # fiddle the python source location to match the local system
           for db in $(grep --color=never '.coverage\.' rsyncout); do
             sqlite3 "$db" "
               UPDATE file
               SET path = REPLACE(path, '/cylc/cylc/', '$PWD/cylc/')
-            "
+            " || \
+            (echo "::warning::${db}" && sqlite3 "$db" ".schema" && rm "$db")
           done
 
       - name: Shutdown


### PR DESCRIPTION
This is a small change with no associated Issue.

A lot of the time when `_remote_background_indep_poll` fails it's due to an error in the "Fetch remote coverage" step

> Error: no such table: file

This PR aims to skip such failures and just not upload that particular bit of coverage (there are like 100 remote coverage files, so skipping 1 or 2 shouldn't matter too much)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry required 
- [x] No documentation update required.
