### PR TITLE
clean up interim obselete message

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1356,7 +1356,6 @@ def upg(cfg, descr):
         ['runtime', '__MANY__', 'remote', 'suite definition directory']
     )
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
-    u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])
     u.obsolete('8.0.0', ['cylc', 'disable automatic shutdown'])
     u.obsolete('8.0.0', ['cylc', 'environment'])
     u.obsolete('8.0.0', ['cylc', 'reference test'])

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1356,7 +1356,6 @@ def upg(cfg, descr):
         ['runtime', '__MANY__', 'remote', 'suite definition directory']
     )
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
-    u.obsolete('8.0.0', ['cylc', 'events', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'events', 'mail retry delays'])
     u.obsolete('8.0.0', ['cylc', 'disable automatic shutdown'])
     u.obsolete('8.0.0', ['cylc', 'environment'])


### PR DESCRIPTION
This is a small change with no associated Issue.
An obseletion warning referring to a config item which only ever existed (if at all) in Cylc 8 alpha or beta and not Cylc 7.  

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
