### PR TITLE
Fix job polling bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,9 @@ now accepts ``&`` and ``|`` as valid line breaks in the same way as ``=>``.
 
 ### Fixes
 
+[#4443](https://github.com/cylc/cylc-flow/pull/4443) - fix for slow polling
+generating an incorrect submit-failed result.
+
 [#4421](https://github.com/cylc/cylc-flow/pull/4421) -
 Remove use of the `ps` system call (fixes a bug reported with Alpine Linux).
 


### PR DESCRIPTION
Manual cherry-pick 6ea49470dc8f5823e57433f47252b3b35239aacc from #4437 
Credit @wxtim 

Close #4431 

But reproduced on master with this workflow *and `time.sleep(10)` between status file and job runner check in `job_runner_mgr.py`*:
```
[scheduling]
    [[graph]]
        R1 = "poller & fast & waiter"
[runtime]
    [[poller]]
        script = cylc poll $CYLC_WORKFLOW_NAME fast.1
    [[fast]]
        init-script = sleep 5  # fake delayed start
    [[waiter]]
        script = "cylc__job__poll_grep_workflow_log '\(polled\)'"
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.py` and `conda-environment.yml` (none)
- [x] Does not need tests (note testable without bodging the code).
- [ ] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
