### PR TITLE
Cylc review show any *.cylc file with synatax highlighting

### DIFF
--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -590,7 +590,7 @@ class CylcReviewService(object):
                         break
         if (
             fnmatch(os.path.basename(path), "suite*.rc*")
-            or fnmatch(os.path.basename(path), "flow.cylc*")
+            or fnmatch(os.path.basename(path), "*.cylc")
         ):
             file_content = "cylc-suite-rc"
         elif fnmatch(os.path.basename(path), "rose*.conf"):


### PR DESCRIPTION
This is a small change with no associated Issue.

RE: Cylc 7 Review: Make any file ending in .cylc appear highlighted as a .cylc file. `flow-processed.cylc` and `<timestamp>-start.cylc` were not previously highlighted.

V. small change on legacy system hence 1 reviewer only.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (small manually testable change to legacy system).
- [x] No change log entry required (change will only affect Cylc8 beta users).
- [x] No documentation update required.
