### PR TITLE
actions: bump manylinux to the oldest ubuntu available

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         manylinux: ['1']
-        os: ['ubuntu-16.04']  # run on the oldest linux we have access to
+        os: ['ubuntu-18.04']  # run on the oldest linux we have access to
         python-version: ['3.7', '3.8', '3.9']
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# coding=utf-8
-
 # THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
 # Copyright (C) NIWA & British Crown (Met Office) & Contributors.
 #


### PR DESCRIPTION
Ubuntu 16.04 is dead, long live Ubuntu 18.04.

Note, we are purposefully using the oldest Linux available to us as this is the version most likely to flag issues.

Note, includes setup.py change to force the manylinux test to run.