### PR TITLE
Remove "directory created" debug messages on workflow restart

### DIFF
--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -130,8 +130,8 @@ def make_workflow_run_tree(workflow):
         get_workflow_run_share_dir(workflow),
         get_workflow_run_work_dir(workflow),
     ):
-        if dir_:
-            os.makedirs(dir_, exist_ok=True)
+        if not Path(dir_).is_dir():
+            os.makedirs(dir_)
             LOG.debug(f'{dir_}: directory created')
 
 


### PR DESCRIPTION
This is a small change with no associated Issue. Identified by @dpmatthews 

These log messages always appear on startup:
```
DEBUG - ~/cylc-run/tempflow/run1/log/workflow: directory created
DEBUG - ~/cylc-run/tempflow/run1/log/job: directory created
DEBUG - ~/cylc-run/tempflow/run1/log/flow-config: directory created
DEBUG - ~/cylc-run/tempflow/run1/share: directory created
DEBUG - ~/cylc-run/tempflow/run1/work: directory created
```
This change stops them from appearing if the directories already exist.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
- [x] Does not need tests.
- [x] No change log entry required
- [x] No documentation update required.
