### PR TITLE
Fix tests/cylc-poll/02 wrt optional outputs

### DIFF
--- a/tests/functional/cylc-poll/02-task-submit-failed/flow.cylc
+++ b/tests/functional/cylc-poll/02-task-submit-failed/flow.cylc
@@ -7,8 +7,8 @@
 [scheduling]
     [[graph]]
         R1 = """
-            foo:submit => kill_foo_submit => poll_foo
-            foo:submit-fail => stop
+            foo:submit? => kill_foo_submit => poll_foo
+            foo:submit-fail? => stop
         """
 
 [runtime]


### PR DESCRIPTION
This is a small change with no associated Issue.

This test was found to be broken: It contained a non-valid workflow definition.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (Change _is_ a test).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
