### PR TITLE
Disallow implicit tasks in Cylc 7 back-compat when `rose-suite.conf` present

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -160,8 +160,9 @@ with Conf(
             ``False`` after finishing the :cylc:conf:`flow.cylc[runtime]`
             section.
 
-           Note it is not possible to disallow implicit tasks in
-            :ref:`Cylc 7 backwards compatiblity mode <BackCompat>`.
+            In :ref:`Cylc 7 backward compatibility mode <BackCompat>`,
+            implicit tasks are still allowed unless you explicitly set
+            this to ``False``.
 
             .. versionadded:: 8.0.0
         ''')

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -43,12 +43,18 @@ from metomi.isodatetime.parsers import DurationParser
 from metomi.isodatetime.exceptions import IsodatetimeError
 from metomi.isodatetime.timezone import get_local_time_zone_format
 from metomi.isodatetime.dumpers import TimePointDumper
-from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
-from cylc.flow.parsec.util import replicate
 
 from cylc.flow import LOG
 from cylc.flow.c3mro import C3
-from cylc.flow.listify import listify
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.cfgspec.workflow import RawWorkflowConfig
+from cylc.flow.cycling.loader import (
+    get_point, get_point_relative, get_interval, get_interval_cls,
+    get_sequence, get_sequence_cls, init_cyclers, get_dump_format,
+    INTEGER_CYCLING_TYPE, ISO8601_CYCLING_TYPE
+)
+from cylc.flow.cycling.integer import IntegerInterval
+from cylc.flow.cycling.iso8601 import ingest_time, ISO8601Interval
 from cylc.flow.exceptions import (
     CylcError,
     WorkflowConfigError,
@@ -57,19 +63,15 @@ from cylc.flow.exceptions import (
     ParamExpandError,
     UserInputError
 )
-from cylc.flow.graph_parser import GraphParser
-from cylc.flow.param_expand import NameExpander
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-from cylc.flow.cfgspec.workflow import RawWorkflowConfig
-from cylc.flow.cycling.loader import (
-    get_point, get_point_relative, get_interval, get_interval_cls,
-    get_sequence, get_sequence_cls, init_cyclers, get_dump_format,
-    INTEGER_CYCLING_TYPE, ISO8601_CYCLING_TYPE)
-from cylc.flow.cycling.integer import IntegerInterval
-from cylc.flow.cycling.iso8601 import ingest_time, ISO8601Interval
 import cylc.flow.flags
+from cylc.flow.graph_parser import GraphParser
+from cylc.flow.listify import listify
 from cylc.flow.option_parsers import verbosity_to_env
 from cylc.flow.graphnode import GraphNodeParser
+from cylc.flow.param_expand import NameExpander
+from cylc.flow.parsec.exceptions import ItemNotFoundError
+from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
+from cylc.flow.parsec.util import replicate
 from cylc.flow.pathutil import (
     get_workflow_run_dir,
     get_workflow_run_log_dir,
@@ -762,20 +764,32 @@ class WorkflowConfig:
         )
         if self.cfg['scheduler']['allow implicit tasks']:
             LOG.debug(msg)
-        else:
-            msg = (
-                f"{msg}\n"
-                "To allow implicit tasks, use "
-                f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'"
-            )
-            # Allow implicit tasks in Cylc 7 back-compat mode (but not if
-            # rose-suite.conf present, to maintain compat with Rose 2019)
-            if (
-                Path(self.run_dir, 'rose-suite.conf').is_file() or
-                not cylc.flow.flags.cylc7_back_compat
-            ):
-                raise WorkflowConfigError(msg)
-            LOG.warning(msg)
+            return
+
+        # Check if implicit tasks explicitly disallowed
+        try:
+            is_disallowed = self.pcfg.get(
+                ['scheduler', 'allow implicit tasks'], sparse=True
+            ) is False
+        except ItemNotFoundError:
+            is_disallowed = False
+        if is_disallowed:
+            raise WorkflowConfigError(msg)
+
+        # Otherwise "[scheduler]allow implicit tasks" is not set
+        msg = (
+            f"{msg}\n"
+            "To allow implicit tasks, use "
+            f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'"
+        )
+        # Allow implicit tasks in Cylc 7 back-compat mode (but not if
+        # rose-suite.conf present, to maintain compat with Rose 2019)
+        if (
+            Path(self.run_dir, 'rose-suite.conf').is_file() or
+            not cylc.flow.flags.cylc7_back_compat
+        ):
+            raise WorkflowConfigError(msg)
+        LOG.warning(msg)
 
     def _check_circular(self):
         """Check for circular dependence in graph."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1084,7 +1084,8 @@ def test_success_after_optional_submit(tmp_flow_config, graph):
     'allow_implicit_tasks',
     [
         pytest.param(True, id="allow implicit tasks = True"),
-        pytest.param(None, id="")
+        pytest.param(None, id="allow implicit tasks not set"),
+        pytest.param(False, id="allow implicit tasks = False")
     ]
 )
 @pytest.mark.parametrize(
@@ -1127,10 +1128,10 @@ def test_implicit_tasks(
         cylc7_compat: Whether Cylc 7 backwards compatibility is turned on.
         rose_suite_conf: Whether a rose-suite.conf file is present in run dir.
         expected_exc: Exception expected to be raised only when
-            [scheduler]allow implicit tasks = False.
+            "[scheduler]allow implicit tasks" is not set.
         expected_log_level: Expected logging severity level for the
             "implicit tasks detected" message only when
-            [scheduler]allow implicit tasks = False.
+            "[scheduler]allow implicit tasks" is not set.
     """
     # Setup
     reg = 'rincewind'
@@ -1148,9 +1149,11 @@ def test_implicit_tasks(
     if rose_suite_conf:
         (flow_file.parent / 'rose-suite.conf').touch()
     caplog.set_level(logging.DEBUG, CYLC_LOG)
-    if allow_implicit_tasks:
+    if allow_implicit_tasks is True:
         expected_exc = None
         expected_log_level = logging.DEBUG
+    elif allow_implicit_tasks is False:
+        expected_exc = WorkflowConfigError
     # Test
     args: dict = {'workflow': reg, 'fpath': flow_file, 'options': None}
     expected_msg = "implicit tasks detected"


### PR DESCRIPTION
These changes finish closing #4385. This is a followup to #4446.

Now:
- `[scheduler]allow implicit tasks = True` will always allow implicit tasks
- `[scheduler]allow implicit tasks = False` (explicitly set) will always disallow implicit tasks, even in Cylc 7 backward compatibility mode
- If `[scheduler]allow implicit tasks` is not set, Cylc 7 back compat mode is on, but `rose-suite.conf` is present in the run dir, implicit tasks will be disallowed

> **Context:** Rose 2019 used to call `cylc validate --strict` which did not allow implicit tasks. Consequently Rose users are used to the idea that Cylc forbids implicit tasks. One of the complex relations between the two we are glad to be rid of!


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit).
- [x] No changelog entry needed (Followup to #4343, not yet released.)
- [x] (master branch) Docs PR ongoing: cylc/cylc-doc/pull/304
