### PR TITLE
graphql: use a common interface for added / updated deltas

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -27,7 +27,7 @@ from typing import AsyncGenerator, Any
 from graphene import (
     Boolean, Field, Float, ID, InputObjectType, Int,
     List, Mutation, ObjectType, Schema, String, Union, Enum,
-    Argument
+    Argument, Interface
 )
 from graphene.types.generic import GenericScalar
 from graphene.utils.str_converters import to_snake_case
@@ -1963,9 +1963,15 @@ class Pruned(ObjectType):
     edges = List(String, default_value=[])
 
 
-class Added(ObjectType):
-    class Meta:
-        description = """Added node/edge deltas."""
+class Delta(Interface):
+    """Interface for delta types.
+
+    Since we usually subscribe to the same fields for both added/updated
+    deltas this interface makes writing fragments easier.
+
+    NOTE: This interface is specialised to the "added" type, other types must
+    override fields as required.
+    """
 
     families = List(
         Family,
@@ -2033,9 +2039,16 @@ class Added(ObjectType):
     )
 
 
+class Added(ObjectType):
+    class Meta:
+        description = """Added node/edge deltas."""
+        interfaces = (Delta,)
+
+
 class Updated(ObjectType):
     class Meta:
         description = """Updated node/edge deltas."""
+        interfaces = (Delta,)
 
     families = List(
         Family,


### PR DESCRIPTION
The added and updated delta types are essentially identical. Usually we subscribe to the same fields for both added and updated.

This PR uses a GraphQL interface to make this slightly nicer, example using `GscanSubscriptionQuery`:

```diff
  fragment GScanTreeDeltas on Deltas {
    id
    added {
-    ...GscanAddedData
+    ...GscanDelta
    }
    updated {
-    ...GscanUpdatedData
+    ...GscanDelta
    }
    pruned {
      workflow
    }
  }

- fragment GscanAddedData on Added {
+ fragment GscanData on Added {
    workflow {
      ...WorkflowData
    }
  }

- fragment GscanUpdatedData on Updated {
-   workflow {
-     ...WorkflowData
-   }
- }

```

Boiler plate "hello world" deltas subscription after this change:

```graphql
fragment ExampleTreeData on Delta {
  workflow {
    id
  }
  cyclePoints: familyProxies(ids: ["root"], ghosts: true) {
    id
  }
  familyProxies(exids: ["root"], sort: {keys: ["name"]}, ghosts: true) {
    id
  }
  taskProxies(sort: {keys: ["cyclePoint"], reverse: false}, ghosts: true) {
    id
  }
  jobs(sort: {keys: ["submit_num"], reverse: true}) {
    id
  }
}

subscription ExampleTreeQuery {
  deltas(stripNull: true) {
    id
    added {
      ...ExampleTreeData
    }
    updated {
      ...ExampleTreeData
    }
    pruned {
      workflow
    }
  }
}
```

This doesn't change the existing types so no changes to the UI subscriptions should be required.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.