### PR TITLE
Allow nested sub-workflows

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1791,9 +1791,9 @@ def validate_source_dir(source, workflow_name):
     cylc_run_dir = Path(get_cylc_run_dir())
     if (os.path.abspath(os.path.realpath(cylc_run_dir))
             in os.path.abspath(os.path.realpath(source))):
-        raise WorkflowFilesError(
-            f"{workflow_name} installation failed. Source directory "
-            f"should not be in {cylc_run_dir}")
+        LOG.warning(
+            f"{workflow_name} source found in {cylc_run_dir}. This is OK"
+            f" for installed sub-workflow definitions.")
     check_flow_file(source, logger=None)
 
 

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -213,16 +213,14 @@ rm -rf "${ALT_SOURCE}"
 purge_rnd_workflow
 
 # -----------------------------------------------------------------------------
-# Test cylc install can not be run from within the cylc-run directory
+# Test warning if cylc install is run from within the cylc-run directory
 
 TEST_NAME="${TEST_NAME_BASE}-forbid-cylc-run-dir-install"
 BASE_NAME="test-install-${CYLC_TEST_TIME_INIT}"
 mkdir -p "${RUN_DIR}/${BASE_NAME}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME}" && cd "$_" || exit
 touch flow.cylc
 run_fail "${TEST_NAME}" cylc install
-contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: ${TEST_NAME} installation failed. Source directory should not be in ${RUN_DIR}
-__ERR__
+grep_ok "WARNING - ${TEST_NAME} source found in ${RUN_DIR}. This is OK for installed sub-workflow definitions." "${TEST_NAME}.stderr" 
 
 cd "${RUN_DIR}" || exit
 rm -rf "${BASE_NAME}"


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

Allow sub-workflow definitions under the `~/cylc-run` directory.  

This simple change address part of the discussion under #4453. It just changes (and rewords) an exception into a warning, so that `cylc install` does not balk at installing the sub-workflow at runtime, when its `flow.cylc` is found under `~/cylc-run`.

Context: a sub-workflow definition is just another source flie for the main workflow. As such, it should be installed with other main workflow source files into the main workflow run directory.  Then at run-time, the sub-workflow gets "instantiated" anew for each main workflow cycle point (via another `cylc install`) from the *installed* sub-workflow source.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
