### PR TITLE
subscription async-gen yield coordination & delta clash fix

### DIFF
--- a/cylc/flow/network/graphql.py
+++ b/cylc/flow/network/graphql.py
@@ -421,7 +421,6 @@ class IgnoreFieldMiddleware:
                                 and not field_value.ListFields()
                             )
                     ):
-                        root[field_name] = None
                         return None
                 if (
                         info.operation.operation in self.ASYNC_OPS

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -17,6 +17,7 @@
 """GraphQL resolvers for use in data accessing and mutation of workflows."""
 
 import asyncio
+from contextlib import suppress
 from fnmatch import fnmatchcase
 import logging
 import queue
@@ -44,6 +45,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DELTA_SLEEP_INTERVAL = 0.5
+# Delay before carrying on with the next delta,
+# rougly DELTA_PROC_WAIT*DELTA_SLEEP_INTERVAL seconds (if queue is empty).
+DELTA_PROC_WAIT = 10
 
 
 def filter_none(dictionary):
@@ -186,10 +190,11 @@ def get_flow_data_from_ids(data_store, native_ids):
 
 def get_data_elements(flow, nat_ids, element_type):
     """Return data elements by id."""
+    flow_element = flow[element_type]
     return [
-        flow[element_type][n_id]
+        flow_element[n_id]
         for n_id in nat_ids
-        if n_id in flow[element_type]
+        if n_id in flow_element
     ]
 
 
@@ -198,7 +203,12 @@ class BaseResolvers:  # noqa: SIM119 (no real gain + mutable default)
 
     def __init__(self, data_store_mgr):
         self.data_store_mgr = data_store_mgr
+        # Used with subscriptions for a temporary delta-store,
+        # [sub_id][w_id] = store
         self.delta_store = {}
+        # Used to serialised deltas from a single workflow, needed for
+        # the management of a common data object.
+        self.delta_processing_flows = {}
 
     # Query resolvers
     async def get_workflow_by_id(self, args):
@@ -375,8 +385,21 @@ class BaseResolvers:  # noqa: SIM119 (no real gain + mutable default)
         sub_id = uuid4()
         info.variable_values['backend_sub_id'] = sub_id
         self.delta_store[sub_id] = {}
+
+        op_id = root
+        if 'ops_queue' not in info.context:
+            info.context['ops_queue'] = {}
+        info.context['ops_queue'][op_id] = queue.Queue()
+        op_queue = info.context['ops_queue'][op_id]
+        self.delta_processing_flows[sub_id] = set()
+        delta_processing_flows = self.delta_processing_flows[sub_id]
+
         delta_queues = self.data_store_mgr.delta_queues
         deltas_queue = queue.Queue()
+
+        counters = {}
+        delta_yield_queue = queue.Queue()
+        flow_delta_queues = {}
         try:
             # Iterate over the queue yielding deltas
             w_ids = workflow_ids
@@ -400,27 +423,50 @@ class BaseResolvers:  # noqa: SIM119 (no real gain + mutable default)
                                     workflow_id=w_id)
                                 delta_store[DELTA_ADDED] = (
                                     self.data_store_mgr.data[w_id])
-                                self.delta_store[sub_id][w_id] = delta_store
-                                if sub_resolver is None:
-                                    yield delta_store
-                                else:
-                                    result = await sub_resolver(
-                                        root, info, **args)
-                                    if result:
-                                        yield result
+                                deltas_queue.put(
+                                    (w_id, 'initial_burst', delta_store))
                     elif w_id in self.delta_store[sub_id]:
                         del self.delta_store[sub_id][w_id]
                 try:
-                    w_id, topic, delta_store = deltas_queue.get(False)
-                    if topic != 'shutdown':
+                    with suppress(queue.Empty):
+                        w_id, topic, delta_store = deltas_queue.get(False)
+
+                        if w_id not in flow_delta_queues:
+                            counters[w_id] = 0
+                            flow_delta_queues[w_id] = queue.Queue()
+                        flow_delta_queues[w_id].put((topic, delta_store))
+
+                    # Only yield deltas from the same workflow if previous
+                    # delta has finished processing.
+                    for flow_id, flow_queue in flow_delta_queues.items():
+                        if flow_queue.empty():
+                            continue
+                        elif flow_id in delta_processing_flows:
+                            if counters[flow_id] < DELTA_PROC_WAIT:
+                                if delta_yield_queue.empty():
+                                    counters[flow_id] += 1
+                                    await asyncio.sleep(DELTA_SLEEP_INTERVAL)
+                                continue
+                            delta_processing_flows.remove(flow_id)
+                        counters[flow_id] = 0
+                        topic, delta_store = flow_queue.get()
+                        delta_yield_queue.put((flow_id, topic, delta_store))
+
+                    w_id, topic, delta_store = delta_yield_queue.get(False)
+
+                    # Handle shutdown delta, don't ignore.
+                    if topic == 'shutdown':
+                        delta_store['shutdown'] = True
+                    else:
+                        # ignore deltas that are more frequent than interval.
                         new_time = time()
                         elapsed = new_time - old_time
-                        # ignore deltas that are more frequent than interval.
                         if elapsed <= interval:
                             continue
                         old_time = new_time
-                    else:
-                        delta_store['shutdown'] = True
+
+                    delta_processing_flows.add(w_id)
+                    op_queue.put((sub_id, w_id))
                     self.delta_store[sub_id][w_id] = delta_store
                     if sub_resolver is None:
                         yield delta_store
@@ -442,6 +488,12 @@ class BaseResolvers:  # noqa: SIM119 (no real gain + mutable default)
             if sub_id in self.delta_store:
                 del self.delta_store[sub_id]
             yield None
+
+    async def flow_delta_processed(self, context, op_id):
+        if 'ops_queue' in context:
+            with suppress(queue.Empty, KeyError):
+                sub_id, w_id = context['ops_queue'][op_id].get(False)
+                self.delta_processing_flows[sub_id].remove(w_id)
 
 
 class Resolvers(BaseResolvers):

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -650,7 +650,7 @@ class TimeZone(ObjectType):
 class Workflow(ObjectType):
     class Meta:
         description = """Global workflow info."""
-    id = ID(required=True)  # noqa: A003 (required for definition)
+    id = ID()  # noqa: A003 (required for definition)
     name = String()
     status = String()
     status_msg = String()
@@ -754,7 +754,7 @@ class Workflow(ObjectType):
 class Job(ObjectType):
     class Meta:
         description = """Jobs."""
-    id = ID(required=True)  # noqa: A003 (required for definition)
+    id = ID()  # noqa: A003 (required for definition)
     submit_num = Int()
     state = String()
     # name and cycle_point for filtering/sorting
@@ -793,7 +793,7 @@ class Job(ObjectType):
 class Task(ObjectType):
     class Meta:
         description = """Task definition, static fields"""
-    id = ID(required=True)  # noqa: A003 (required for definition)
+    id = ID()  # noqa: A003 (required for definition)
     name = String()
     meta = Field(NodeMeta)
     mean_elapsed_time = Float()
@@ -828,9 +828,9 @@ class Task(ObjectType):
 class PollTask(ObjectType):
     class Meta:
         description = """Polling task edge"""
-    local_proxy = ID(required=True)
+    local_proxy = ID()
     workflow = String()
-    remote_proxy = ID(required=True)
+    remote_proxy = ID()
     req_state = String()
     graph_string = String()
 
@@ -896,7 +896,7 @@ class XTrigger(ObjectType):
 class TaskProxy(ObjectType):
     class Meta:
         description = """Task cycle instance."""
-    id = ID(required=True)  # noqa: A003 (required for schema definition)
+    id = ID()  # noqa: A003 (required for schema definition)
     task = Field(
         Task,
         description="""Task definition""",
@@ -985,7 +985,7 @@ class TaskProxy(ObjectType):
 class Family(ObjectType):
     class Meta:
         description = """Task definition, static fields"""
-    id = ID(required=True)  # noqa: A003 (required for schema definition)
+    id = ID()  # noqa: A003 (required for schema definition)
     name = String()
     meta = Field(NodeMeta)
     depth = Int()
@@ -1034,7 +1034,7 @@ class Family(ObjectType):
 class FamilyProxy(ObjectType):
     class Meta:
         description = """Family composite."""
-    id = ID(required=True)  # noqa: A003 (required for schema definition)
+    id = ID()  # noqa: A003 (required for schema definition)
     cycle_point = String()
     # name & namespace for filtering/sorting
     name = String()
@@ -1107,7 +1107,7 @@ class Node(Union):
 class Edge(ObjectType):
     class Meta:
         description = """Dependency edge task/family proxies"""
-    id = ID(required=True)  # noqa: A003 (required for schema definition)
+    id = ID()  # noqa: A003 (required for schema definition)
     source = ID()
     source_node = Field(
         Node,
@@ -2108,7 +2108,7 @@ class Updated(ObjectType):
 class Deltas(ObjectType):
     class Meta:
         description = """Grouped deltas of the WFS publish"""
-    id = ID(required=True)  # noqa: A003 (required for schema definition)
+    id = ID()  # noqa: A003 (required for schema definition)
     shutdown = Boolean(default_value=False)
     added = Field(
         Added,


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-uiserver/issues/247
Sibling to https://github.com/cylc/cylc-uiserver/pull/266

**Yield coordination**

This is needed because the async generator yields data, and the resolvers return an Observable and Promises to the server implementation.

The PR a feature into the GraphQL subscription resolvers that requires the subscription server to flag when the processing of a delta is complete. This is a compulsory feature due to the common delta-store reference of a subscription and workflow.

The only other way to avoid this type coordination is to have a reference that changes, which would still require some coordination..

**Delta clash fix**
This PR fixes the following sort of errors appearing at the UIS:
```
ERROR:graphql.execution.utils:Traceback (most recent call last):
  File "/home/sutherlander/.envs/uiserver/lib/python3.8/site-packages/promise/promise.py", line 844, in handle_future_result
    resolve(future.result())
  File "/home/sutherlander/cylc/cylc-flow/cylc/flow/network/graphql.py", line 446, in async_null_setter
    result = await next_(root, info, **args)
  File "/home/sutherlander/cylc/cylc-flow/cylc/flow/network/schema.py", line 407, in get_workflow_by_id
    args['workflow'] = args['id']
graphql.error.located_error.GraphQLLocatedError: 'id'
```
```
ERROR:graphql.execution.utils:Traceback (most recent call last):
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/promise/promise.py", line 844, in handle_future_result
    resolve(future.result())
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/graphql.py", line 446, in async_null_setter
    result = await next_(root, info, **args)
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/schema.py", line 468, in get_nodes_by_ids
    return await resolvers.get_nodes_by_ids(node_type, args)
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/resolvers.py", line 265, in get_nodes_by_ids
    [node
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/resolvers.py", line 268, in <listcomp>
    for node in get_data_elements(flow, nat_ids, node_type)
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/resolvers.py", line 189, in get_data_elements
    return [
  File "/home/oliverh/cylc/cylc-uiserver/venv/lib/python3.9/site-packages/cylc/flow/network/resolvers.py", line 192, in <listcomp>
    if n_id in flow[element_type]
graphql.error.located_error.GraphQLLocatedError: argument of type 'NoneType' is not iterable
```

The cause for these errors was from the delta store, common to all subscriptions, being modified by a the stripping by one or more subscriptions. The PR responsible is:
https://github.com/cylc/cylc-flow/pull/4410

This has been undone, and the ID field in the GraphQL schema is no longer set as a hard requirement.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Cannot test, as would require cross project (at present), no `cylc-flow` subscription implementation.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
