### PR TITLE
Task "preparing" state bug fixes

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -76,6 +76,7 @@ from cylc.flow.task_job_logs import JOB_LOG_OPTS, get_task_job_log
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import (
     TASK_STATUS_WAITING,
+    TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_RUNNING,
@@ -145,6 +146,7 @@ DELTAS_MAP = {
 DELTA_FIELDS = {DELTA_ADDED, DELTA_UPDATED, DELTA_PRUNED}
 
 JOB_STATUSES_ALL = [
+    TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_RUNNING,

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -221,7 +221,7 @@ class TaskJobManager:
         prepared_tasks = []
         bad_tasks = []
         for itask in itasks:
-            if itask.state.reset(TASK_STATUS_PREPARING):
+            if itask.state_reset(TASK_STATUS_PREPARING):
                 self.data_store_mgr.delta_task_state(itask)
                 self.workflow_db_mgr.put_update_task_state(itask)
             prep_task = self._prep_submit_task_job(

--- a/cylc/flow/tui/__init__.py
+++ b/cylc/flow/tui/__init__.py
@@ -72,7 +72,7 @@ WORKFLOW_COLOURS = {
 # unicode task icons
 TASK_ICONS = {
     f'{TASK_STATUS_WAITING}': '\u25cb',
-    f'{TASK_STATUS_PREPARING}': '\u25cb',
+    f'{TASK_STATUS_PREPARING}': '\u229D',
     f'{TASK_STATUS_SUBMITTED}': '\u2299',
     f'{TASK_STATUS_RUNNING}': '\u2299',
     f'{TASK_STATUS_RUNNING}:0': '\u2299',
@@ -97,15 +97,12 @@ JOB_ICON = '\u25A0'
 
 # job colour coding
 JOB_COLOURS = {
+    'preparing': 'brown',
     'submitted': 'dark cyan',
     'running': 'light blue',
     'succeeded': 'dark green',
     'failed': 'light red',
     'submit-failed': 'light magenta',
-
-    # TODO: update with https://github.com/cylc/cylc-admin/pull/47
-    'ready': 'brown'
-    # TODO: update with https://github.com/cylc/cylc-admin/pull/47
 }
 
 

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -392,10 +392,9 @@ class TuiApp:
         snapshot = self.get_snapshot()
         if snapshot is False:
             return False
-        data = snapshot['data']
 
         # update the workflow status message
-        header = [get_workflow_status_str(data)]
+        header = [get_workflow_status_str(snapshot['data'])]
         status_summary = get_task_status_summary(snapshot['data'])
         if status_summary:
             header.extend([' ('] + status_summary + [' )'])


### PR DESCRIPTION
This is a small change with no associated Issue.

Fixes:
- the datastore was creating job proxies for tasks in the `preparing` state, but labeling them as `submitted`
- the task state change to `preparing` was not being logged
- TUI had not been updated for the change from `ready` to `preparing`

Also:
- new icon to distinguish `preparing` from `waiting` in TUI

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [x] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [x] No documentation update required.
