### PR TITLE
Reduce test flakiness on MacOS

### DIFF
--- a/tests/functional/shutdown/02-no-dir.t
+++ b/tests/functional/shutdown/02-no-dir.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Test workflow can shutdown successfully if its run dir is deleted
 . "$(dirname "$0")/test_header"
-set_test_number 3
+set_test_number 4
 
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
@@ -33,7 +33,8 @@ SYM_WORKFLOW_RUND="${WORKFLOW_RUN_DIR}-sym"
 SYM_WORKFLOW_NAME="${WORKFLOW_NAME}-sym"
 ln -s "$(basename "${WORKFLOW_NAME}")" "${SYM_WORKFLOW_RUND}"
 run_fail "${TEST_NAME_BASE}-run" cylc play "${SYM_WORKFLOW_NAME}" --debug --no-detach
-grep_ok 'CRITICAL - Workflow shutting down - unable to open database file' "${WORKFLOW_RUN_DIR}/log/workflow/log".*
+grep_ok 'CRITICAL - Workflow shutting down' "${WORKFLOW_RUN_DIR}/log/workflow/log".*
+grep_ok 'unable to open database file' "${WORKFLOW_RUN_DIR}/log/workflow/log".*
 
 rm -f "${SYM_WORKFLOW_RUND}"
 purge


### PR DESCRIPTION
This is a small change with no associated Issue.

This test has been occasionally failing on the MacOS runner. I had a look at the workflow log and made changes accordingly.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
