### PR TITLE
Preparing job status

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -76,7 +76,6 @@ from cylc.flow.task_job_logs import JOB_LOG_OPTS, get_task_job_log
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import (
     TASK_STATUS_WAITING,
-    TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_RUNNING,
@@ -146,7 +145,6 @@ DELTAS_MAP = {
 DELTA_FIELDS = {DELTA_ADDED, DELTA_UPDATED, DELTA_PRUNED}
 
 JOB_STATUSES_ALL = [
-    TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_RUNNING,

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -997,7 +997,7 @@ class DataStoreMgr:
         elif child_fam not in fp_parent.child_families:
             fp_parent.child_families.append(child_fam)
 
-    def insert_job(self, name, point_string, job_conf):
+    def insert_job(self, name, point_string, status, job_conf):
         """Insert job into data-store.
 
         Args:
@@ -1023,30 +1023,30 @@ class DataStoreMgr:
             stamp=f'{j_id}@{update_time}',
             id=j_id,
             submit_num=sub_num,
-            state=JOB_STATUSES_ALL[0],
+            state=status,
             task_proxy=tp_id,
-            job_runner_name=job_conf['job_runner_name'],
-            env_script=job_conf['env-script'],
-            err_script=job_conf['err-script'],
-            exit_script=job_conf['exit-script'],
-            execution_time_limit=job_conf['execution_time_limit'],
-            platform=job_conf['platform']['name'],
-            init_script=job_conf['init-script'],
-            post_script=job_conf['post-script'],
-            pre_script=job_conf['pre-script'],
-            script=job_conf['script'],
-            work_sub_dir=job_conf['work_d'],
             name=tproxy.name,
             cycle_point=tproxy.cycle_point,
-            directives=json.dumps(job_conf['directives']),
-            environment=json.dumps(job_conf['environment']),
-            param_var=json.dumps(job_conf['param_var'])
+            job_runner_name=job_conf.get('job_runner_name'),
+            env_script=job_conf.get('env-script'),
+            err_script=job_conf.get('err-script'),
+            exit_script=job_conf.get('exit-script'),
+            execution_time_limit=job_conf.get('execution_time_limit'),
+            platform=job_conf.get('platform')['name'],
+            init_script=job_conf.get('init-script'),
+            post_script=job_conf.get('post-script'),
+            pre_script=job_conf.get('pre-script'),
+            script=job_conf.get('script'),
+            work_sub_dir=job_conf.get('work_d'),
+            directives=json.dumps(job_conf.get('directives')),
+            environment=json.dumps(job_conf.get('environment')),
+            param_var=json.dumps(job_conf.get('param_var'))
         )
 
         # Add in log files.
         j_buf.job_log_dir = get_task_job_log(
             self.schd.workflow, tproxy.cycle_point, tproxy.name, sub_num)
-        j_buf.extra_logs.extend(job_conf['logfiles'])
+        j_buf.extra_logs.extend(job_conf.get('logfiles', []))
 
         self.added[JOBS][j_id] = j_buf
         getattr(self.updated[WORKFLOW], JOBS).append(j_id)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -249,7 +249,7 @@ class TaskJobManager:
         Return (list): list of tasks that attempted submission.
         """
         if is_simulation:
-            return self._simulation_submit_task_jobs(itasks)
+            return self._simulation_submit_task_jobs(itasks, workflow)
         # Prepare tasks for job submission
         prepared_tasks, bad_tasks = self.prep_submit_task_jobs(
             workflow, itasks)
@@ -422,7 +422,6 @@ class TaskJobManager:
             ):
                 host = get_host()
 
-            now_str = get_current_time_string()
             done_tasks.extend(itasks)
             for itask in itasks:
                 # Log and persist
@@ -430,7 +429,7 @@ class TaskJobManager:
                 self.workflow_db_mgr.put_insert_task_jobs(itask, {
                     'is_manual_submit': itask.is_manual_submit,
                     'try_num': itask.get_try_num(),
-                    'time_submit': now_str,
+                    'time_submit': get_current_time_string(),
                     'platform_name': itask.platform['name'],
                     'job_runner_name': itask.summary['job_runner_name'],
                 })
@@ -981,17 +980,23 @@ class TaskJobManager:
                 except KeyError:
                     itask.try_timers[key] = TaskActionTimer(delays=delays)
 
-    def _simulation_submit_task_jobs(self, itasks):
+    def _simulation_submit_task_jobs(self, itasks, workflow):
         """Simulation mode task jobs submission."""
         for itask in itasks:
             itask.waiting_on_job_prep = False
             self._set_retry_timers(itask)
-            itask.platform = 'SIMULATION'
+            itask.platform = {'name': 'SIMULATION'}
             itask.summary['job_runner_name'] = 'SIMULATION'
             itask.summary[self.KEY_EXECUTE_TIME_LIMIT] = (
-                itask.tdef.rtconfig['job']['simulated run length'])
+                itask.tdef.rtconfig['job']['simulated run length']
+            )
+            itask.jobs.append(
+                self.get_simulation_job_conf(itask, workflow)
+            )
             self.task_events_mgr.process_message(
-                itask, INFO, TASK_OUTPUT_SUBMITTED)
+                itask, INFO, TASK_OUTPUT_SUBMITTED
+            )
+
         return itasks
 
     def _submit_task_jobs_callback(self, ctx, workflow, itasks):
@@ -1123,7 +1128,8 @@ class TaskJobManager:
             self._create_job_log_path(workflow, itask)
             self._set_retry_timers(itask, rtconfig)
             self._prep_submit_task_job_error(
-                workflow, itask, '(remote host select)', exc)
+                workflow, itask, '(remote host select)', exc
+            )
             return False
         else:
             # host/platform select not ready
@@ -1161,8 +1167,7 @@ class TaskJobManager:
                 self._create_job_log_path(workflow, itask)
                 self._set_retry_timers(itask, rtconfig, False)
                 self._prep_submit_task_job_error(
-                    workflow, itask, '(platform not defined)', exc
-                )
+                    workflow, itask, '(platform not defined)', exc)
                 return False
             else:
                 itask.platform = platform
@@ -1172,20 +1177,25 @@ class TaskJobManager:
                 self._set_retry_timers(itask, rtconfig)
 
         try:
-            job_conf = self._prep_submit_task_job_impl(
-                workflow, itask, rtconfig)
-
-            # Job pool insertion
-            job_config = deepcopy(job_conf)
-            job_config['logfiles'] = deepcopy(itask.summary['logfiles'])
-            itask.jobs.append(job_config['job_d'])
-            self.data_store_mgr.insert_job(
-                itask.tdef.name, itask.point, job_config)
+            job_conf = {
+                **self._prep_submit_task_job_impl(
+                    workflow, itask, rtconfig
+                ),
+                'logfiles': deepcopy(itask.summary['logfiles']),
+            }
+            itask.jobs.append(job_conf)
 
             local_job_file_path = get_task_job_job_log(
-                workflow, itask.point, itask.tdef.name, itask.submit_num)
-            self.job_file_writer.write(local_job_file_path, job_conf,
-                                       check_syntax=check_syntax)
+                workflow,
+                itask.point,
+                itask.tdef.name,
+                itask.submit_num,
+            )
+            self.job_file_writer.write(
+                local_job_file_path,
+                job_conf,
+                check_syntax=check_syntax,
+            )
         except Exception as exc:
             # Could be a bad command template, IOError, etc
             itask.waiting_on_job_prep = False
@@ -1205,14 +1215,29 @@ class TaskJobManager:
             itask.tdef.name,
             submit_num=itask.submit_num
         )
-        # Persist
-        self.workflow_db_mgr.put_insert_task_jobs(itask, {
-            'is_manual_submit': itask.is_manual_submit,
-            'try_num': itask.get_try_num(),
-            'time_submit': get_current_time_string(),
-            'job_runner_name': itask.summary.get('job_runner_name'),
-        })
         itask.is_manual_submit = False
+        # job failed in preparation i.e. is really preparation-failed rather
+        # than submit-failed
+        # provide a dummy job config - this info will be added to the data
+        # store
+        itask.jobs.append({
+            'task_id': itask.identity,
+            'platform': itask.platform,
+            'submit_num': itask.submit_num,
+            'try_num': itask.get_try_num(),
+        })
+        # create a DB entry for the submit-failed job
+        self.workflow_db_mgr.put_insert_task_jobs(
+            itask,
+            {
+                'job_id': itask.summary.get('submit_method_id'),
+                'is_manual_submit': itask.is_manual_submit,
+                'try_num': itask.get_try_num(),
+                'time_submit': get_current_time_string(),
+                'platform_name': itask.platform['name'],
+                'job_runner_name': itask.summary['job_runner_name'],
+            }
+        )
         self.task_events_mgr.process_message(
             itask, CRITICAL, self.task_events_mgr.EVENT_SUBMIT_FAILED)
 
@@ -1228,15 +1253,37 @@ class TaskJobManager:
                 rtconfig['execution time limit']
             )
 
-        scripts = self._get_job_scripts(itask, rtconfig)
-
         # Location of job file, etc
         self._create_job_log_path(workflow, itask)
         job_d = get_task_job_id(
             itask.point, itask.tdef.name, itask.submit_num)
         job_file_path = get_remote_workflow_run_job_dir(
             workflow, job_d, JOB_LOG_JOB)
+
+        return self.get_job_conf(
+            workflow,
+            itask,
+            rtconfig,
+            job_file_path=job_file_path,
+            job_d=job_d
+        )
+
+    def get_job_conf(
+        self,
+        workflow,
+        itask,
+        rtconfig,
+        job_file_path=None,
+        job_d=None,
+    ):
+        """Return a job config.
+
+        Note that rtconfig should have any broadcasts applied.
+        """
+        scripts = self._get_job_scripts(itask, rtconfig)
         return {
+            # NOTE: these fields should match get_simulation_job_conf
+            # TODO: turn this into a namedtuple or similar
             'job_runner_name': itask.platform['job runner'],
             'job_runner_command_template': (
                 itask.platform['job runner command template']
@@ -1264,4 +1311,39 @@ class TaskJobManager:
             'try_num': itask.get_try_num(),
             'uuid_str': self.task_remote_mgr.uuid_str,
             'work_d': rtconfig['work sub-directory'],
+            # this field is populated retrospectively for regular job subs
+            'logfiles': [],
+        }
+
+    def get_simulation_job_conf(self, itask, workflow):
+        """Return a job config for a simulated task."""
+        return {
+            # NOTE: these fields should match _prep_submit_task_job_impl
+            'job_runner_name': 'SIMULATION',
+            'job_runner_command_template': '',
+            'dependencies': itask.state.get_resolved_dependencies(),
+            'directives': {},
+            'environment': {},
+            'execution_time_limit': itask.summary[self.KEY_EXECUTE_TIME_LIMIT],
+            'env-script': 'SIMULATION',
+            'err-script': 'SIMULATION',
+            'exit-script': 'SIMULATION',
+            'platform': itask.platform,
+            'init-script': 'simulation',
+            'job_file_path': 'simulation',
+            'job_d': 'SIMULATION',
+            'namespace_hierarchy': itask.tdef.namespace_hierarchy,
+            'param_var': itask.tdef.param_var,
+            'post-script': 'SIMULATION',
+            'pre-script': 'SIMULATION',
+            'script': 'SIMULATION',
+            'submit_num': itask.submit_num,
+            'flow_nums': itask.flow_nums,
+            'workflow_name': workflow,
+            'task_id': itask.identity,
+            'try_num': itask.get_try_num(),
+            'uuid_str': self.task_remote_mgr.uuid_str,
+            'work_d': 'SIMULATION',
+            # this field is populated retrospectively for regular job subs
+            'logfiles': [],
         }

--- a/cylc/flow/tui/__init__.py
+++ b/cylc/flow/tui/__init__.py
@@ -97,7 +97,6 @@ JOB_ICON = '\u25A0'
 
 # job colour coding
 JOB_COLOURS = {
-    'preparing': 'brown',
     'submitted': 'dark cyan',
     'running': 'light blue',
     'succeeded': 'dark green',

--- a/tests/functional/remote/05-remote-init.t
+++ b/tests/functional/remote/05-remote-init.t
@@ -24,9 +24,6 @@ export REQUIRE_PLATFORM='loc:remote fs:indep comms:tcp'
 set_test_number 6
 create_test_global_config "" "
 [platforms]
-    [[ariel]]
-        hosts = ${CYLC_TEST_HOST}
-        install target = ${CYLC_TEST_INSTALL_TARGET}
     [[belle]]
         hosts = ${CYLC_TEST_HOST}
         install target = ${CYLC_TEST_INSTALL_TARGET}
@@ -48,10 +45,10 @@ sqlite3 "${DB_FILE}" \
      FROM task_jobs ORDER BY name' \
     >"${NAME}"
 cmp_ok "${NAME}" <<__SELECT__
-a|1||
-b|1||
-e|0|0|ariel
-f|0|0|ariel
+a|1||belle
+b|1||belle
+e|0|0|${CYLC_TEST_PLATFORM}
+f|0|0|${CYLC_TEST_PLATFORM}
 g|0|0|localhost
 __SELECT__
 

--- a/tests/functional/remote/05-remote-init/flow.cylc
+++ b/tests/functional/remote/05-remote-init/flow.cylc
@@ -1,3 +1,5 @@
+#!Jinja2
+
 [scheduler]
     [[events]]
         abort on stall timeout = true
@@ -18,23 +20,25 @@
     [[task]]
         script="sleep 1; echo hello"
     [[a]]
-        inherit=task
-        platform=belle
+        inherit = task
+        platform = belle
     [[b]]
-        inherit=task
-        platform=belle
+        inherit = task
+        platform = belle
     [[c]]
-        inherit=task
-        platform=belle
+        inherit = task
+        platform = belle
     [[d]]
         inherit=task
-        platform= belle
+        platform = belle
     [[e]]
         inherit=task
-        platform=ariel
+        # ariel
+        platform = {{ environ['CYLC_TEST_PLATFORM'] }}
     [[f]]
         inherit=task
-        platform=ariel
+        # ariel
+        platform = {{ environ['CYLC_TEST_PLATFORM'] }}
     [[g]]
         inherit=task
-        platform=localhost
+        platform = localhost

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -202,7 +202,7 @@ def test_insert_job(harness):
     """Test method that adds a new job to the store."""
     schd, data = harness
     assert len(schd.data_store_mgr.added[JOBS]) == 0
-    schd.data_store_mgr.insert_job('foo', '1', job_config(schd))
+    schd.data_store_mgr.insert_job('foo', '1', 'submitted', job_config(schd))
     assert len(schd.data_store_mgr.added[JOBS]) == 1
     assert ext_id(schd) in schd.data_store_mgr.added[JOBS]
 


### PR DESCRIPTION
Removes the legacy of the Cylc 7 "ready" job state and fixes some issues discovered along the way.

Fixes #4484 
Addresses https://github.com/cylc/cylc-admin/pull/47

Cylc job items are now created in the data store on submission rather than on preparation.

**Misc Fixes:**

* Jobs which failed during preparation (before job-submit) are now added to the data store.
  * Before the task failed with no jobs, technically correct, but unhelpful.
  * Now we get a submit-failed job with the platform information provided so users can debug.
* Tasks now have jobs when running in simulation mode.
* Fixes a bug where the job platform in the data store may be incorrect.
  * This can happen if the platform it has changed during the preparation process as a result of intelligent host selection.

**Note:**

The "submitting" job is still written to the database so that Cylc can reconnect with it if the workflow is restarted resulting in a small discontinuity between the DB and data store for this edge case. The discontinuity for "prep-failed" tasks has been removed.

**Testing Suggestions:**

* Configure a workflow with a task running on a non-existent *platform*, run it, view it in Tui/Gui, you should *now* see a submit-failed job.
* Configure a workflow with a task running on a platform with a non-existant *host*, run it, view it in Tui/Gui, you should *still* see a submit-failed job.
* Run a workflow in simulation mode, view in Tui/Gui, you should now see simulated jobs.
* Run a regular workflow, check the job information in Tui/Gui matches expectations.

**Question:**

This PR currently relies on the receipt of the "submitted" message. In extreme cases I think it might be possible for the "started" (or even "succeeded") message to be received *before* the "submitted" message? Can't remember if we built some logic in to protect against this? Note that the messages are coming from different ZMQ clients so re cannot rely on any ZMQ message order guarantees.

Should we use some sort of flag or check the data store manually for all messages to cover for this eventuality or is there another layer of protection **(y/n)**?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
