### PR TITLE
Trigger mutation fix

### DIFF
--- a/cylc/flow/flow_mgr.py
+++ b/cylc/flow/flow_mgr.py
@@ -16,7 +16,7 @@
 
 """Manage flow counter and flow metadata."""
 
-from typing import Dict, Set
+from typing import Dict, Set, Optional
 import datetime
 
 from cylc.flow import LOG
@@ -32,15 +32,16 @@ class FlowMgr:
         self.flows: Dict[int, Dict[str, str]] = {}
         self.counter: int = 0
 
-    def get_new_flow(self, description: str) -> int:
+    def get_new_flow(self, description: Optional[str] = None) -> int:
         """Increment flow counter, record flow metadata."""
         self.counter += 1
         # record start time to nearest second
         now = datetime.datetime.now()
         now_sec: str = str(
             now - datetime.timedelta(microseconds=now.microsecond))
+        description = description or "no description"
         self.flows[self.counter] = {
-            "description": description or "no description",
+            "description": description,
             "start_time": now_sec
         }
         LOG.info(

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -779,7 +779,7 @@ class Resolvers(BaseResolvers):
         ))
         return (True, 'Command queued')
 
-    def force_trigger_tasks(self, tasks, reflow, flow_descr):
+    def force_trigger_tasks(self, tasks, reflow=False, flow_descr=None):
         """Trigger submission of task jobs where possible.
 
         Args:

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -76,7 +76,7 @@ def get_option_parser():
 
     parser.add_option(
         "--meta", metavar="DESCRIPTION", action="store",
-        dest="flow_descr", default="",
+        dest="flow_descr", default=None,
         help="(with --reflow) a descriptive string for the new flow."
     )
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1413,7 +1413,7 @@ class TaskPool:
     def force_trigger_tasks(
         self, items: Iterable[str],
         reflow: bool = False,
-        flow_descr: str = "no description"
+        flow_descr: Optional[str] = None
     ) -> int:
         """Trigger matching tasks, with or without reflow.
 

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -237,18 +237,13 @@ class TaskProxy:
         return f"<{self.__class__.__name__} '{self.identity}'>"
 
     def __str__(self) -> str:
-        """Stringify using identity, state, submit_num, and flow_nums.
-
-        Ignore flow_nums if only the original flow is present.
-        """
-        res = (
+        """Stringify with identity, state, submit_num, and flow_nums."""
+        return (
             f"{self.identity} "
             f"{self.state} "
             f"job:{self.submit_num:02d}"
+            f" flows:{','.join(str(i) for i in self.flow_nums) or 'none'}"
         )
-        if self.flow_nums:
-            res += f" flows:{','.join(str(i) for i in self.flow_nums)}"
-        return res
 
     def copy_to_reload_successor(self, reload_successor):
         """Copy attributes to successor on reload of this task proxy."""


### PR DESCRIPTION
This is a small change with no associated Issue.

Fix bug in manual triggering, recently introduced by #4300.

Default triggering (i.e. with no reflow) is failing from the GUI and TUI, because missing reflow args (which are not needed for this use case) were not optional.


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and  `conda-environment.yml`. (None)
- [x] Already covered by existing tests.
- [x] Does not need tests (would need end-to-end testing?).
- [x] No change log entry required (fix for unreleased bug).
- [x] No documentation update required.
