### PR TITLE
Reduce flakiness of remote func tests on GH Actions

### DIFF
--- a/etc/conf/global.cylc
+++ b/etc/conf/global.cylc
@@ -20,14 +20,14 @@
         hosts = _remote_background_indep_poll
         communication method = poll
         execution polling intervals = 5*PT1S, PT5S
-        submission polling intervals = PT1S
+        submission polling intervals = PT3S
     [[_remote_at_indep_poll]]
         # NOTE: at submission uses the same container as background
         job runner = at
         hosts = _remote_background_indep_poll
         communication method = poll
         execution polling intervals = 5*PT1S, PT5S
-        submission polling intervals = PT1S
+        submission polling intervals = PT3S
     #[[_remote_background_shared_tcp]]
     #    hosts = _remote_background_shared_tcp
     #[[_remote_background_shared_ssh]]

--- a/tests/functional/remote/06-poll.t
+++ b/tests/functional/remote/06-poll.t
@@ -53,7 +53,7 @@ log_scan \
     10 \
     1 \
     '\[foo\.1 submitted .* (polled)foo' \
-    '\[foo\.1 succeeded .* (polled)succeeded'
+    '\[foo\.1 submitted .* (polled)succeeded'
 
 purge
 exit


### PR DESCRIPTION
These changes close #4433

It seems the flakiness of the remote tests on GH Actions was caused by too much polling for the VM to handle?

With this PR we are down to 1 (from 5) of the `_remote_background_indep_poll` tests consistently failing on the first go (`tests/k/cylc-poll/16-execution-time-limit.t`), and this has also reduced the time taken to run the tests from ~21 mins to ~14 mins.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
