### PR TITLE
change back compat reference for docs

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -162,7 +162,7 @@ with Conf(
             ``False`` after finishing the :cylc:conf:`flow.cylc[runtime]`
             section.
 
-            In :ref:`Cylc 7 backward compatibility mode <BackCompat>`,
+            In :ref:`Cylc 7 backward compatibility mode <Cylc_7_compat_mode>`,
             implicit tasks are still allowed unless you explicitly set
             this to ``False``.
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Fixes the build error on https://github.com/cylc/cylc-doc/pull/306.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (link change).
- [x] No change log entry required (why? invisible to users).
- [x] No documentation update required.
