### PR TITLE
Fix new job state logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,9 @@ renamed to `CYLC_WORKFLOW_ID`. `CYLC_WORKFLOW_NAME` re-added as
 
 ### Fixes
 
+[#4493](https://github.com/cylc/cylc-flow/pull/4493) - handle late job
+submission message properly.
+
 [#4443](https://github.com/cylc/cylc-flow/pull/4443) - fix for slow polling
 generating an incorrect submit-failed result.
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1037,6 +1037,8 @@ class TaskEventsManager():
 
         # register the newly submitted job with the data base and data store
         self._insert_task_job(itask, event_time, submit_num, 0)
+        self.data_store_mgr.delta_job_attr(job_d, 'job_id',
+                                           itask.summary['submit_method_id'])
 
     def _insert_task_job(self, itask, event_time, submit_num, submit_status):
         job_conf = itask.jobs[submit_num - 1]

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -766,6 +766,7 @@ class TaskJobManager:
                 if line.startswith(prefix):
                     line = line[len(prefix):].strip()
                     try:
+                        # TODO this massive try block should be unpacked.
                         path = line.split("|", 2)[1]  # timestamp, path, status
                         point, name, submit_num = path.split(os.sep, 2)
                         if prefix == self.job_runner_mgr.OUT_PREFIX_SUMMARY:

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1050,10 +1050,8 @@ class TaskJobManager:
         if ctx.ret_code == SubProcPool.RET_CODE_WORKFLOW_STOPPING:
             return
 
-        job_d = get_task_job_id(itask.point, itask.tdef.name, itask.submit_num)
         try:
             itask.summary['submit_method_id'] = items[3]
-            self.data_store_mgr.delta_job_attr(job_d, 'job_id', items[3])
         except IndexError:
             itask.summary['submit_method_id'] = None
         if itask.summary['submit_method_id'] == "None":

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -185,7 +185,7 @@ class TaskProxy:
         if submit_num is None:
             submit_num = 0
         self.submit_num = submit_num
-        self.jobs: List[str] = []
+        self.jobs: List[dict] = []
         if flow_nums is None:
             self.flow_nums = set()
         else:

--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -47,6 +47,7 @@ QUERY = '''
           jobRunnerName
           jobId
           startedTime
+          finishedTime
         }
         task {
           meanElapsedTime

--- a/tests/functional/job-submission/21-late-sub-message.t
+++ b/tests/functional/job-submission/21-late-sub-message.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test that a late job submitted message does not put the task back in the
+# submitted state (it is possible, though unlikely, for the job started 
+# message to arrive first).
+
+# Uses a modified background job runner (defined in the workflow source
+# directory) that sleeps before returning after submitting the job.
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+create_test_global_config "" "
+[platforms]
+  [[wobblygibblets]]
+    hosts = localhost
+    job runner = delayed_background
+    install target = localhost
+"
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+
+workflow_run_ok "${TEST_NAME_BASE}-run" \
+    cylc play --debug --no-detach "${WORKFLOW_NAME}"
+
+sqlite3 "$RUN_DIR/${WORKFLOW_NAME}/log/db" \
+   'SELECT name, cycle, event from task_events;' >'sqlite3.out'
+
+cmp_ok 'sqlite3.out' <<'__OUT__'
+foo|1|submitted
+foo|1|started
+foo|1|succeeded
+bar|1|submitted
+bar|1|started
+bar|1|succeeded
+__OUT__
+
+purge

--- a/tests/functional/job-submission/21-late-sub-message/flow.cylc
+++ b/tests/functional/job-submission/21-late-sub-message/flow.cylc
@@ -1,0 +1,9 @@
+# Test delayed job submission.
+[scheduling]
+    [[graph]]
+        R1 = foo => bar
+[runtime]
+    [[bar]]
+    [[foo]]
+        platform = wobblygibblets
+        script = sleep 20

--- a/tests/functional/job-submission/21-late-sub-message/lib/python/delayed_background.py
+++ b/tests/functional/job-submission/21-late-sub-message/lib/python/delayed_background.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from time import sleep
+from cylc.flow.job_runner_handlers.background import BgCommandHandler
+
+
+class DelayedBgCommandHandler(BgCommandHandler):
+
+    @classmethod
+    def submit(cls, job_file_path, submit_opts):
+        result = super().submit(job_file_path, submit_opts)
+        sleep(10)
+        return result
+
+
+JOB_RUNNER_HANDLER = DelayedBgCommandHandler()


### PR DESCRIPTION
This is a small change with no associated Issue.

Follow up to #4485 which delayed data store job proxy creation until job submit time, but:
- did not update job ID in the job proxy (it was trying to update before the delayed proxy creation)
- did not handle edge case where "started" message can come in before "submitted" 
- it introduced a small bug in accessing job config via the  task proxy

Also:
- gets TUI to display job finish time as well as start time

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
