### PR TITLE
Fix shell style errors

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -57,9 +57,9 @@ cylc__job__main() {
     if [[ -z "${host}" ]]; then
         if [[ "$(uname)" == 'AIX' ]]; then
             # On AIX the hostname command has no '-f' option
-            typeset host="$(hostname).$(namerslv -sn 2>'/dev/null' | awk '{print $2}')"
+            host="$(hostname).$(namerslv -sn 2>'/dev/null' | awk '{print $2}')"
         else
-            typeset host="$(hostname -f)"
+            host="$(hostname -f)"
         fi
     fi
     # Developer Note:

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -57,7 +57,7 @@ __OUT__
 sed -n 's/\(\[jobs-submit out\]\) .*\(|1\/\)/\1 \2/p' 'log' >'log2'
 N=0
 while read -r; do
-    TAIL="${REPLY#${WORKFLOW_RUN_DIR}/log/job/}"
+    TAIL="${REPLY#"${WORKFLOW_RUN_DIR}"/log/job/}"
     TASK_JOB="${TAIL%/job}"
     contains_ok 'log2' <<<"[jobs-submit out] |${TASK_JOB}|1|None"
     ((N += 1))

--- a/tests/functional/remote/01-file-install.t
+++ b/tests/functional/remote/01-file-install.t
@@ -45,7 +45,7 @@ init_workflow "${TEST_NAME}" <<__FLOW_CONFIG__
     [[foo]]
         platform = $CYLC_TEST_PLATFORM
 __FLOW_CONFIG__
-RUN_DIR_REL="${WORKFLOW_RUN_DIR#$HOME/}"
+RUN_DIR_REL="${WORKFLOW_RUN_DIR#"${HOME}"/}"
 
 create_files
 
@@ -82,7 +82,7 @@ init_workflow "${TEST_NAME}" <<__FLOW_CONFIG__
     [[foo]]
         platform = $CYLC_TEST_PLATFORM
 __FLOW_CONFIG__
-RUN_DIR_REL="${WORKFLOW_RUN_DIR#$HOME/}"
+RUN_DIR_REL="${WORKFLOW_RUN_DIR#"${HOME}"/}"
 
 create_files
 


### PR DESCRIPTION
Latest shellcheck version fails several of our scripts, and seems to have been updated for macos on our CI:
```console
$ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

$ shellcheck cylc/flow/etc/job.sh

In cylc/flow/etc/job.sh line 60:
            typeset host="$(hostname).$(namerslv -sn 2>'/dev/null' | awk '{print $2}')"
                    ^--^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In cylc/flow/etc/job.sh line 62:
            typeset host="$(hostname -f)"
                    ^--^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
```

This is a **very small** change with no associated Issue.

