### PR TITLE
Forbid case where both `suite.rc` and `flow.cylc` files are found in src/run dir

### DIFF
--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -92,7 +92,7 @@ def main(parser: COP, opts: 'Values', reg: Optional[str] = None) -> None:
                 "The current working directory is not a workflow run directory"
             )
     else:
-        reg, _ = parse_reg(reg)
+        reg, _ = parse_reg(reg, warn_depr=False)
     run_dir = Path(get_workflow_run_dir(reg))
     if not run_dir.is_dir():
         raise WorkflowFilesError(

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1705,7 +1705,8 @@ def detect_both_flow_and_suite(path):
     """
     msg = (f"Both {WorkflowFiles.FLOW_FILE} and {WorkflowFiles.SUITE_RC} "
            "files are present in the run directory. Please remove one and"
-           " try again.")
+           " try again. For more information visit: https://cylc.github.io/"
+           "cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility")
     if path.resolve().name == WorkflowFiles.SUITE_RC:
         flow_cylc = path.parent / WorkflowFiles.FLOW_FILE
         if flow_cylc.is_file() and not flow_cylc.is_symlink():
@@ -1767,7 +1768,9 @@ def check_flow_file(
             raise WorkflowFilesError(
                 f"Both {WorkflowFiles.FLOW_FILE} and "
                 f"{WorkflowFiles.SUITE_RC} files are present in the source "
-                "directory. Please remove one and try again."
+                "directory. Please remove one and try again. For more "
+                "information visit: https://cylc.github.io/cylc-doc/latest/"
+                "html/7-to-8/summary.html#backward-compatibility"
             )
         if flow_file_path.resolve() == suite_rc_path.resolve():
             # A symlink that points to existing suite.rc

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1220,7 +1220,7 @@ def parse_reg(reg: str, src: bool = False, warn_depr=True) -> Tuple[str, Path]:
                 f"Workflow name must refer to a directory, not a file: {reg}"
             )
         abs_path, reg = infer_latest_run(abs_path)
-
+    detect_both_flow_and_suite(abs_path)
     check_deprecation(abs_path, warn=warn_depr)
     return (str(reg), abs_path)
 
@@ -1698,6 +1698,24 @@ def get_run_dir_info(
     return relink, run_num, rundir
 
 
+def detect_both_flow_and_suite(path):
+    """Detects if both suite.rc and flow.cylc are in directory.
+    Raises:
+        WorkflowFilesError: If both flow.cylc and suite.rc are in directory
+    """
+    msg = (f"Both {WorkflowFiles.FLOW_FILE} and {WorkflowFiles.SUITE_RC} "
+           "files are present in the run directory. Please remove one and"
+           " try again.")
+    if path.resolve().name == WorkflowFiles.SUITE_RC:
+        flow_cylc = path.parent / WorkflowFiles.FLOW_FILE
+        if flow_cylc.is_file() and not flow_cylc.is_symlink():
+            raise WorkflowFilesError(msg)
+    elif (path / WorkflowFiles.SUITE_RC).is_file():
+        flow_cylc = path / WorkflowFiles.FLOW_FILE
+        if flow_cylc.is_file() and not flow_cylc.is_symlink():
+            raise WorkflowFilesError(msg)
+
+
 def detect_flow_exists(
     run_path_base: Union[Path, str], numbered: bool
 ) -> bool:
@@ -1744,7 +1762,13 @@ def check_flow_file(
     suite_rc_path = Path(expand_path(path), WorkflowFiles.SUITE_RC)
     if flow_file_path.is_file():
         if not flow_file_path.is_symlink():
-            return flow_file_path
+            if not suite_rc_path.is_file():
+                return flow_file_path
+            raise WorkflowFilesError(
+                f"Both {WorkflowFiles.FLOW_FILE} and "
+                f"{WorkflowFiles.SUITE_RC} files are present in the source "
+                "directory. Please remove one and try again."
+            )
         if flow_file_path.resolve() == suite_rc_path.resolve():
             # A symlink that points to existing suite.rc
             return flow_file_path

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -66,7 +66,9 @@ TEST_NAME="${TEST_NAME_BASE}-both-suite-and-flow-file"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source directory. Please remove one and try again.
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source \
+directory. Please remove one and try again. For more information visit: \
+https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility
 __ERR__
 
 # Test fail no workflow source dir

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -20,7 +20,7 @@
 
 
 . "$(dirname "$0")/test_header"
-set_test_number 45
+set_test_number 47
 
 # Test source directory between runs that are not consistent result in error
 
@@ -55,6 +55,18 @@ rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: no flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
+__ERR__
+
+# -----------------------------------------------------------------------------
+# Test fail both flow.cylc and suite.rc file
+
+make_rnd_workflow
+
+TEST_NAME="${TEST_NAME_BASE}-both-suite-and-flow-file"
+touch "${RND_WORKFLOW_SOURCE}/suite.rc"
+run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+contains_ok "${TEST_NAME}.stderr" <<__ERR__
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source directory. Please remove one and try again.
 __ERR__
 
 # Test fail no workflow source dir
@@ -188,6 +200,7 @@ run_fail "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-
 cmp_ok "${TEST_NAME}-install.stderr" <<__ERR__
 WorkflowFilesError: Nested run directories not allowed - cannot install workflow in '${RND_WORKFLOW_RUNDIR}/nested/run1' as '${RND_WORKFLOW_RUNDIR}' is already a valid run directory.
 __ERR__
+
 # Test moving source dir results in error
 
 TEST_NAME="${TEST_NAME_BASE}-install-moving-src-dir"

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -65,7 +65,9 @@ run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-na
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source directory. Please remove one and try again.
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source \
+directory. Please remove one and try again. For more information visit: \
+https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility
 __ERR__
 purge_rnd_workflow
 

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow reinstallation expected failures
 . "$(dirname "$0")/test_header"
-set_test_number 23
+set_test_number 26
 
 # Test fail no workflow source dir
 
@@ -54,6 +54,18 @@ rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: no flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
+__ERR__
+purge_rnd_workflow
+
+# Test fail both flow.cylc and suite.rc file
+
+TEST_NAME="${TEST_NAME_BASE}-both-flow-and-suite-file"
+make_rnd_workflow
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}" --no-run-name
+touch "${RND_WORKFLOW_SOURCE}/suite.rc"
+run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
+cmp_ok "${TEST_NAME}.stderr" <<__ERR__
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source directory. Please remove one and try again.
 __ERR__
 purge_rnd_workflow
 

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -663,7 +663,6 @@ def test_init_clean__runN(
     assert "contains the following workflows" in str(exc_info.value)
 
 
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize('number_of_runs', [1, 2])
 @pytest.mark.parametrize(
@@ -1724,7 +1723,7 @@ def test_search_install_source_dirs_empty(mock_glbl_cfg: Callable):
 @pytest.mark.parametrize(
     'flow_file_exists, suiterc_exists, expected_file',
     [(True, False, WorkflowFiles.FLOW_FILE),
-     (True, True, WorkflowFiles.FLOW_FILE),
+     (True, True, None),
      (False, True, WorkflowFiles.SUITE_RC)]
 )
 def test_check_flow_file(
@@ -1742,8 +1741,16 @@ def test_check_flow_file(
         tmp_path.joinpath(WorkflowFiles.FLOW_FILE).touch()
     if suiterc_exists:
         tmp_path.joinpath(WorkflowFiles.SUITE_RC).touch()
+    if expected_file is None:
+        with pytest.raises(WorkflowFilesError) as exc:
+            check_flow_file(tmp_path)
+        assert str(exc.value) == (
+            "Both flow.cylc and suite.rc files are present in the "
+            "source directory. Please remove one and try again."
+        )
 
-    assert check_flow_file(tmp_path) == tmp_path.joinpath(expected_file)
+    else:
+        assert check_flow_file(tmp_path) == tmp_path.joinpath(expected_file)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -43,6 +43,7 @@ from cylc.flow.workflow_files import (
     check_flow_file,
     check_nested_run_dirs,
     clean,
+    detect_both_flow_and_suite,
     get_rsync_rund_cmd,
     get_symlink_dirs,
     get_workflow_source_dir,
@@ -1746,12 +1747,29 @@ def test_check_flow_file(
             check_flow_file(tmp_path)
         assert str(exc.value) == (
             "Both flow.cylc and suite.rc files are present in the "
-            "source directory. Please remove one and try again."
+            "source directory. Please remove one and try again. "
+            "For more information visit: "
+            "https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html"
+            "#backward-compatibility"
         )
 
     else:
         assert check_flow_file(tmp_path) == tmp_path.joinpath(expected_file)
 
+def test_detect_both_flow_and_suite(tmp_path):
+    """Test flow.cylc and suite.rc together in dir raises error."""
+    tmp_path.joinpath(WorkflowFiles.FLOW_FILE).touch()
+    tmp_path.joinpath(WorkflowFiles.SUITE_RC).touch()
+
+    with pytest.raises(WorkflowFilesError) as exc:
+        detect_both_flow_and_suite(tmp_path)
+        assert str(exc.value) == (
+            "Both flow.cylc and suite.rc files are present in the "
+            "source directory. Please remove one and try again. "
+            "For more information visit: "
+            "https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html"
+            "#backward-compatibility"
+        )
 
 @pytest.mark.parametrize(
     'flow_file_target, suiterc_exists, err, expected_file',


### PR DESCRIPTION
Currently if you have both `flow.cylc` and `suite.rc` files in the run directory and cylc play. You get a log message warning that `suite.rc` has been detected and back compatibility mode has been activated. The workflow proceeds to run ignoring the `suite.rc` file and using the `flow.cylc` file.

This could cause some confusion for users and so we should raise an error if both files are detected (discussed UK end), forcing the user to decide which one should be used, rather than assuming either way.
 
Ideally this would be included in upcoming beta release, apologies, I understand this is frozen.

This is a small change with no associated Issue, bit of a quick fix. Looking at the code, I think there is potential for some refactoring but that would be a bigger job for another day.

To test on master:
```
$ tree `~/cylc-src/workflow`
├── flow.cylc
└── suite.rc
$ cylc install
Installed....
```
Then run `cylc play` on newly installed workflow.
Deprecation warnings occur and back compat mode is enabled, `flow.cylc` is used.

On this branch:

Cylc install/reinstall will raise an error.
Cylc play on a workflow containing `flow.cylc` and `suite.rc` will also raise error.


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/313
