### PR TITLE
fix broken Cylc doc issue

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -955,13 +955,14 @@ with Conf('global.cylc', desc='''
                 sourcing ``~/.bashrc`` (or ``~/.cshrc``) to set up the
                 environment.
             ''')
-            Conf('cylc path', VDR.V_STRING, desc=f'''
+            Conf('cylc path', VDR.V_STRING, desc='''
                 The path containing the ``cylc`` executable on a remote
                 platform.
 
                 .. versionchanged:: 8.0.0
 
-                   {MOVEDFROMJOB}``cylc executable``.
+                   Moved from ``suite.rc[runtime][<namespace>][job]
+                   cylc executable``.
 
                 This may be necessary if the ``cylc`` executable is not in the
                 ``$PATH`` for an ``ssh`` call.


### PR DESCRIPTION
This is a small change with no associated Issue: [Cylc Docs overnight build failed](https://github.com/cylc/cylc-doc/runs/4137779097?check_suite_focus=true#step:12:127).

Effectively a follow on to #4473 .

Causes
- badly formed rst.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (tested by tests for cylc-doc).
- [x] No change log entry required (itself a documentation change).
- [x] No documentation update required.
