### PR TITLE
Change formating and info on no workflow mutation error

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -519,7 +519,9 @@ class Resolvers(BaseResolvers):
         w_ids = [flow[WORKFLOW].id
                  for flow in await self.get_workflows_data(w_args)]
         if not w_ids:
-            return 'Error: No matching Workflow'
+            flows = list(self.data_store_mgr.data.keys())
+            return [{
+                'response': (False, f'No matching workflow in {flows}')}]
         w_id = w_ids[0]
         result = await self._mutation_mapper(command, args)
         if result is None:
@@ -532,7 +534,9 @@ class Resolvers(BaseResolvers):
         w_ids = [flow[WORKFLOW].id
                  for flow in await self.get_workflows_data(w_args)]
         if not w_ids:
-            return 'Error: No matching Workflow'
+            flows = list(self.data_store_mgr.data.keys())
+            return [{
+                'response': (False, f'No matching workflow in {flows}')}]
         w_id = w_ids[0]
         # match proxy ID args with workflows
         items = []


### PR DESCRIPTION
These changes partially address a formatting issue in an error response found in:
https://github.com/cylc/cylc-uiserver/issues/250
https://github.com/cylc/cylc-uiserver/issues/269

Now has some formatting, and information on store workflows (which is just one at Scheduler):
![mutation_error_from_schd](https://user-images.githubusercontent.com/11400777/140878941-8edf452f-4b95-4aab-8865-949f319cb473.png)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Already covered by existing tests (if covered at all).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
