### PR TITLE
job: don't use $HOME to source the job script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,9 @@ Fourth beta release of Cylc 8.
 
 ### Enhancements
 
+[#4501](https://github.com/cylc/cylc-flow/pull/4501) -
+Allow job scripts to run in environments without access to `$HOME`.
+
 [#4367](https://github.com/cylc/cylc-flow/pull/4367) -
 Make the central wrapper work with arbitrary virtual environment names.
 

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -338,6 +338,11 @@ class JobFileWriter:
     @staticmethod
     def _write_epilogue(handle, job_conf, run_d):
         """Write epilogue."""
-        handle.write(f'\n\n. "{run_d}/.service/etc/job.sh"\ncylc__job__main')
+        # NOTE: don't use $HOME to locate the job.sh file as some systems might
+        # not have acess to $HOME on compute nodes
+        handle.write(
+            '\n\n. "$(dirname "$0")/../../../../../.service/etc/job.sh"'
+            '\ncylc__job__main'
+        )
         handle.write("\n\n%s%s\n" % (
             JobRunnerManager.LINE_PREFIX_EOF, job_conf['job_d']))

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -423,8 +423,15 @@ def test_write_runtime_environment():
 def test_write_epilogue():
     """Test epilogue is correctly written in jobscript"""
 
-    expected = ('\n\n. \"cylc-run/farm_noises/.service/etc/job.sh\"\n'
-                'cylc__job__main\n\n#EOF: 1/moo/01\n')
+    expected = (
+        '\n\n'
+        '. "$(dirname "$0")/../../../../../.service/etc/job.sh"'
+        '\n'
+        'cylc__job__main'
+        '\n\n'
+        '#EOF: 1/moo/01'
+        '\n'
+    )
     job_conf = {'job_d': "1/moo/01"}
     run_d = "cylc-run/farm_noises"
     with io.StringIO() as fake_file:


### PR DESCRIPTION
The archer2 machine does not have access to `$HOME` on the compute nodes.

On the whole we have handled this use case ok, however, one sticking point remains.

Because Cylc 8 sources the job script from the `cylc-run` directory jobs cannot run in this environment at the moment:

```bash
. "$HOME/cylc-run/two/.service/etc/job.sh"
```

This PR uses `$0` to locate the job script rather than `$HOME` to avoid this issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.