### PR TITLE
Remove the suite.rc flow.cylc symlink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,9 @@ First Release Candidate for Cylc 8.
 
 ### Enhancements
 
+[#](https://github.com/cylc/cylc-flow/pull/) -
+Cylc no longer creates a `flow.cylc` symlink to a `suite.rc` file.
+
 [#4526](https://github.com/cylc/cylc-flow/pull/4526) - Prevent runN and run\d+
 being allowed as installation target names.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,7 +56,7 @@ First Release Candidate for Cylc 8.
 
 ### Enhancements
 
-[#](https://github.com/cylc/cylc-flow/pull/) -
+[#4506](https://github.com/cylc/cylc-flow/pull/4506) -
 Cylc no longer creates a `flow.cylc` symlink to a `suite.rc` file.
 
 [#4526](https://github.com/cylc/cylc-flow/pull/4526) - Prevent runN and run\d+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@ First Release Candidate for Cylc 8.
 
 [#4506](https://github.com/cylc/cylc-flow/pull/4506) -
 Cylc no longer creates a `flow.cylc` symlink to a `suite.rc` file.
+This only affects you if you have used a prior Cylc 8 pre-release.
 
 [#4526](https://github.com/cylc/cylc-flow/pull/4526) - Prevent runN and run\d+
 being allowed as installation target names.

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1790,8 +1790,8 @@ def is_forbidden(flow_file: Path) -> bool:
             return True
         return False
     link = flow_file.resolve()
-    if link.parent == flow_file.parent:
-        # link points within dir (permitted)
+    if link == flow_file.parent.resolve() / WorkflowFiles.SUITE_RC:
+        # link points within dir to suite.rc (permitted)
         return False
     # link points elsewhere, check that suite.rc does not also exist in dir
     if flow_file.parent.joinpath(WorkflowFiles.SUITE_RC).exists():

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1686,9 +1686,7 @@ def install_workflow(
             f"An error occurred when copying files from {source} to {rundir}")
         install_log.warning(f" Warning: {stderr}")
     cylc_install = Path(rundir.parent, WorkflowFiles.Install.DIRNAME)
-    check_deprecation(
-        check_flow_file(rundir)
-    )
+    check_deprecation(check_flow_file(rundir))
     if no_run_name:
         cylc_install = Path(rundir, WorkflowFiles.Install.DIRNAME)
     source_link = cylc_install.joinpath(WorkflowFiles.Install.SOURCE)
@@ -1792,9 +1790,13 @@ def is_forbidden(flow_file: Path) -> bool:
             return True
         return False
     link = flow_file.resolve()
-    if Path(link).parent == flow_file.parent:  # link points within dir
+    if link.parent == flow_file.parent:
+        # link points within dir (permitted)
         return False
-    return True
+    # link points elsewhere, check that suite.rc does not also exist in dir
+    if flow_file.parent.joinpath(WorkflowFiles.SUITE_RC).exists():
+        return True
+    return False
 
 
 def detect_flow_exists(
@@ -1823,9 +1825,7 @@ def detect_flow_exists(
     return False
 
 
-def check_flow_file(
-    path: Union[Path, str],
-) -> Path:
+def check_flow_file(path: Union[Path, str]) -> Path:
     """Checks the path for a suite.rc or flow.cylc file.
 
     Raises:

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -545,10 +545,7 @@ def get_contact_file(reg):
 
 
 def get_flow_file(reg: str) -> Path:
-    """Return the path of a workflow's flow.cylc file.
-
-    Creates a flow.cylc symlink to suite.rc if only suite.rc exists.
-    """
+    """Return the path of a workflow's flow.cylc file."""
     run_dir = get_workflow_run_dir(reg)
     path = check_flow_file(run_dir)
     return path
@@ -1851,7 +1848,7 @@ def check_flow_file(
     raise WorkflowFilesError(NO_FLOW_FILE_MSG.format(path))
 
 
-def create_workflow_srv_dir(rundir=None):
+def create_workflow_srv_dir(rundir: Path) -> None:
     """Create workflow service directory"""
 
     workflow_srv_d = rundir.joinpath(WorkflowFiles.Service.DIRNAME)

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow installation
 . "$(dirname "$0")/test_header"
-set_test_number 25
+set_test_number 26
 
 create_test_global_config "" "
 [install]
@@ -71,10 +71,17 @@ make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
-
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
+
+# Test deprecation message is displayed on installing a suite.rc file
+MSG=$(python -c 'from cylc.flow.workflow_files import SUITERC_DEPR_MSG;
+print(SUITERC_DEPR_MSG)')
+
+grep_ok "$MSG" "${TEST_NAME}.stderr"
+
+
 purge_rnd_workflow
 
 # -----------------------------------------------------------------------------

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow installation
 . "$(dirname "$0")/test_header"
-set_test_number 29
+set_test_number 25
 
 create_test_global_config "" "
 [install]
@@ -66,7 +66,6 @@ purge_rnd_workflow
 
 # -----------------------------------------------------------------------------
 # Test cylc install succeeds if suite.rc file in source dir
-# See also tests/functional/deprecations/03-suiterc.t
 TEST_NAME="${TEST_NAME_BASE}-suite.rc"
 make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
@@ -76,20 +75,6 @@ run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
-# test symlink not made in source dir
-exists_fail "flow.cylc"
-# test symlink correctly made in run dir
-pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
-exists_ok "flow.cylc"
-
-TEST_NAME="${TEST_NAME_BASE}-suite.rc-flow.cylc-readlink"
-readlink "flow.cylc" > "${TEST_NAME}.out"
-cmp_ok "${TEST_NAME}.out" <<< "suite.rc"
-
-INSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*.log')"
-grep_ok "Symlink created: flow.cylc -> suite.rc" "${INSTALL_LOG}"
-popd || exit 1
-
 purge_rnd_workflow
 
 # -----------------------------------------------------------------------------

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -64,8 +64,8 @@ TEST_NAME="${TEST_NAME_BASE}-both-suite-and-flow-file"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source \
-directory. Please remove one and try again. For more information visit: \
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in ${RND_WORKFLOW_SOURCE}. \
+Please remove one and try again. For more information visit: \
 https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility
 __ERR__
 

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation
 . "$(dirname "$0")/test_header"
-set_test_number 28
+set_test_number 21
 
 # Test basic cylc reinstall, named run given
 TEST_NAME="${TEST_NAME_BASE}-basic-named-run"
@@ -60,30 +60,8 @@ run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_
 cmp_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
-# test symlink not made in source dir
-exists_fail "flow.cylc"
-# test symlink correctly made in run dir
-pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
-exists_ok "flow.cylc"
-if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "suite.rc" ]] ; then
-    ok "symlink.suite.rc"
-else
-    fail "symlink.suite.rc"
-fi
 
-INSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*.log')"
-grep_ok "Symlink created: flow.cylc -> suite.rc" "${INSTALL_LOG}"
-rm -rf flow.cylc
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
-exists_ok "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc"
-if [[ $(readlink "${RND_WORKFLOW_RUNDIR}/run1/flow.cylc") == "suite.rc" ]] ; then
-    ok "symlink.suite.rc"
-else
-    fail "symlink.suite.rc"
-fi
-REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "Symlink created: flow.cylc -> suite.rc" "${INSTALL_LOG}"
-popd || exit 1
 purge_rnd_workflow
 
 # Test cylc reinstall from within rundir, no args given

--- a/tests/functional/cylc-reinstall/01-file-transfer.t
+++ b/tests/functional/cylc-reinstall/01-file-transfer.t
@@ -21,7 +21,7 @@
 if ! command -v 'tree' >'/dev/null'; then
     skip_all '"tree" command not available'
 fi
-set_test_number 14
+set_test_number 9
 
 # Test cylc install copies files to run dir successfully.
 TEST_NAME="${TEST_NAME_BASE}-basic"
@@ -85,22 +85,6 @@ __OUT__
 # Test cylc reinstall affects only named run, i.e. run1 should be unaffected in this case
 tree -a -v -I "${tree_excludes}" --charset=ascii --noreport "${RND_WORKFLOW_RUNDIR}/run1" > 'after-reinstall-run1-tree.out'
 cmp_ok 'after-reinstall-run1-tree.out' '01-file-transfer-basic-tree.out'
-popd || exit 1
-purge_rnd_workflow
-
-
-# Test cylc reinstall creates flow.cylc given suite.rc.
-TEST_NAME="${TEST_NAME_BASE}-reinstall-creates-flow.cylc-given-suite.rc"
-make_rnd_workflow
-pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-rm -f flow.cylc
-touch suite.rc
-run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_WORKFLOW_NAME}"
-rm -f "${RND_WORKFLOW_RUNDIR}/flow.cylc"
-exists_fail "${RND_WORKFLOW_RUNDIR}/flow.cylc"
-run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
-exists_ok "${RND_WORKFLOW_RUNDIR}/flow.cylc"
-exists_fail "${RND_WORKFLOW_SOURCE}/flow.cylc"
 popd || exit 1
 purge_rnd_workflow
 

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -65,8 +65,8 @@ run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-na
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: Both flow.cylc and suite.rc files are present in the source \
-directory. Please remove one and try again. For more information visit: \
+WorkflowFilesError: Both flow.cylc and suite.rc files are present in ${RND_WORKFLOW_SOURCE}. \
+Please remove one and try again. For more information visit: \
 https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility
 __ERR__
 purge_rnd_workflow

--- a/tests/functional/deprecations/03-suiterc.t
+++ b/tests/functional/deprecations/03-suiterc.t
@@ -18,7 +18,7 @@
 # Test backwards compatibility for suite.rc files
 
 . "$(dirname "$0")/test_header"
-set_test_number 5
+set_test_number 2
 
 init_suiterc() {
     local TEST_NAME="$1"
@@ -44,19 +44,3 @@ print(SUITERC_DEPR_MSG)')
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate .
 grep_ok "$MSG" "${TEST_NAME_BASE}-validate.stderr"
-
-# Test install suite.rc
-# See also tests/functional/cylc-install/00-simple.t
-TEST_NAME="${TEST_NAME_BASE}-install-after-validate"
-run_ok "${TEST_NAME}" cylc install --flow-name="${WORKFLOW_NAME}" --no-run-name
-
-cd "${WORKFLOW_RUN_DIR}" || exit 1
-exists_ok "flow.cylc"
-
-TEST_NAME="flow.cylc-readlink"
-readlink "flow.cylc" > "${TEST_NAME}.out"
-cmp_ok "${TEST_NAME}.out" <<< "suite.rc"
-
-cd "${TEST_DIR}" || exit 1
-rm -rf "${TEST_DIR:?}/${WORKFLOW_NAME}/"
-purge

--- a/tests/functional/deprecations/03-suiterc.t
+++ b/tests/functional/deprecations/03-suiterc.t
@@ -24,7 +24,6 @@ init_suiterc() {
     local TEST_NAME="$1"
     local FLOW_CONFIG="${2:--}"
     WORKFLOW_NAME="${CYLC_TEST_REG_BASE}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME}"
-    WORKFLOW_RUN_DIR="$RUN_DIR/$WORKFLOW_NAME"
     mkdir -p "${TEST_DIR}/${WORKFLOW_NAME}/"
     cat "${FLOW_CONFIG}" >"${TEST_DIR}/${WORKFLOW_NAME}/suite.rc"
     cd "${TEST_DIR}/${WORKFLOW_NAME}" || exit

--- a/tests/functional/optional-outputs/03-c7backcompat.t
+++ b/tests/functional/optional-outputs/03-c7backcompat.t
@@ -35,8 +35,7 @@ grep_ok "${ERR}" "${TEST_NAME}.stderr"
 
 # Rename config to "suite.rc"
 mv "${WORKFLOW_RUN_DIR}/flow.cylc" "${WORKFLOW_RUN_DIR}/suite.rc"
-ln -s "${WORKFLOW_RUN_DIR}/suite.rc" "${WORKFLOW_RUN_DIR}/flow.cylc" 
-
+-ln -s "${WORKFLOW_RUN_DIR}/suite.rc" "${WORKFLOW_RUN_DIR}/flow.cylc"
 # It should now validate, with a deprecation message
 TEST_NAME="${TEST_NAME_BASE}-validate_as_c7"
 run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"

--- a/tests/functional/optional-outputs/03-c7backcompat.t
+++ b/tests/functional/optional-outputs/03-c7backcompat.t
@@ -35,7 +35,7 @@ grep_ok "${ERR}" "${TEST_NAME}.stderr"
 
 # Rename config to "suite.rc"
 mv "${WORKFLOW_RUN_DIR}/flow.cylc" "${WORKFLOW_RUN_DIR}/suite.rc"
--ln -s "${WORKFLOW_RUN_DIR}/suite.rc" "${WORKFLOW_RUN_DIR}/flow.cylc"
+ln -s "${WORKFLOW_RUN_DIR}/suite.rc" "${WORKFLOW_RUN_DIR}/flow.cylc"
 # It should now validate, with a deprecation message
 TEST_NAME="${TEST_NAME_BASE}-validate_as_c7"
 run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1805,8 +1805,8 @@ def test_check_flow_file(
         with pytest.raises(WorkflowFilesError) as exc:
             check_flow_file(tmp_path)
         assert str(exc.value) == (
-            "Both flow.cylc and suite.rc files are present in the "
-            "source directory. Please remove one and try again. "
+            "Both flow.cylc and suite.rc files are present in "
+            f"{tmp_path}. Please remove one and try again. "
             "For more information visit: "
             "https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html"
             "#backward-compatibility"

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1920,19 +1920,14 @@ def test_check_flow_file_symlink(
 
 def test_detect_both_flow_and_suite_symlinked(tmp_path):
     """Test flow.cylc symlinked to suite.rc together in dir is permitted."""
-    Path(tmp_path)
     (tmp_path / WorkflowFiles.SUITE_RC).touch()
     flow_file = tmp_path.joinpath(WorkflowFiles.FLOW_FILE)
     flow_file.symlink_to(WorkflowFiles.SUITE_RC)
-    try:
-        detect_both_flow_and_suite(tmp_path)
-    except WorkflowFilesError:
-        pytest.fail("Unexpected WorkflowFilesError")
+    detect_both_flow_and_suite(tmp_path)
 
 
-def test_flow_symlinked_elsewhere_and_suite_present(tmp_path):
+def test_flow_symlinked_elsewhere_and_suite_present(tmp_path: Path):
     """flow.cylc symlinked to suite.rc elsewhere, and suite.rc in dir raises"""
-    tmp_path = Path(tmp_path)
     tmp_path.joinpath('some_other_dir').mkdir(exist_ok=True)
     suite_file = tmp_path.joinpath('some_other_dir', WorkflowFiles.SUITE_RC)
     suite_file.touch()

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1826,13 +1826,12 @@ def test_detect_both_flow_and_suite(tmp_path):
     assert forbidden is True
     with pytest.raises(WorkflowFilesError) as exc:
         detect_both_flow_and_suite(tmp_path)
-        assert str(exc.value) == (
-            "Both flow.cylc and suite.rc files are present in the "
-            "source directory. Please remove one and try again. "
-            "For more information visit: "
-            "https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html"
-            "#backward-compatibility"
-        )
+    assert str(exc.value) == (
+        f"Both flow.cylc and suite.rc files are present in {tmp_path}. Please "
+        "remove one and try again. For more information visit: "
+        "https://cylc.github.io/cylc-doc/latest/html/7-to-8/"
+        "summary.html#backward-compatibility"
+    )
 
 
 def test_detect_both_flow_and_suite_symlinked(tmp_path):

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1859,8 +1859,8 @@ def test_flow_symlinked_elsewhere_and_suite_present(tmp_path: Path):
     with pytest.raises(WorkflowFilesError) as exc:
         detect_both_flow_and_suite(run_dir)
     assert str(exc.value).startswith(
-        "Both flow.cylc and suite.rc files are present in the "
-        "source directory. Please remove one and try again."
+        "Both flow.cylc and suite.rc files are present in "
+        f"{run_dir}. Please remove one and try again."
     )
 
 


### PR DESCRIPTION
Removes the `flow.cylc` symlink created when using a `suite.rc` file. This also enabled a refactor of duplicate logic from https://github.com/cylc/cylc-flow/pull/4497.
These changes close https://github.com/cylc/cylc-flow/issues/4500

Milestone is 8.0rc1 to give time for any unforeseen problems to surface.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Already covered by existing tests (removed now redundant tests).
- [x] Appropriate change log entry included.
- [x] No documentation update required (I can not find reference in the docs to this symlink being created).
