### PR TITLE
Log attempts to spawn off-sequence.

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1429,6 +1429,9 @@ class TaskPool:
         # Spawn if on-sequence and within recurrence bounds.
         taskdef = self.config.get_taskdef(name)
         if not taskdef.is_valid_point(point):
+            LOG.debug(
+                f"Not spawning attempt {name}.{point}: invalid cycle point"
+            )
             return None
 
         itask = TaskProxy(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1429,8 +1429,8 @@ class TaskPool:
         # Spawn if on-sequence and within recurrence bounds.
         taskdef = self.config.get_taskdef(name)
         if not taskdef.is_valid_point(point):
-            LOG.debug(
-                f"Not spawning attempt {name}.{point}: invalid cycle point"
+            LOG.warning(
+                f"Not spawning {point}/{name}: invalid cycle point for {name}"
             )
             return None
 

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -52,6 +52,11 @@ def generate_graph_children(tdef, point):
                     #   PT6H = "waz"
                     #   T06 = "waz[-PT6H] => foo"
                     graph_children[output].append((name, child_point, is_abs))
+                else:
+                    LOG.warning(
+                        f"{tdef.name}.{point}: ignoring child on invalid"
+                        f" cycle point: {name}.{child_point}"
+                    )
 
     if tdef.sequential:
         # Add next-instance child.

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -54,8 +54,8 @@ def generate_graph_children(tdef, point):
                     graph_children[output].append((name, child_point, is_abs))
                 else:
                     LOG.warning(
-                        f"{tdef.name}.{point}: ignoring child on invalid"
-                        f" cycle point: {name}.{child_point}"
+                        f"Not spawning {point}/{tdef.name}: invalid cycle"
+                        f" point for {tdef.name}"
                     )
 
     if tdef.sequential:


### PR DESCRIPTION

Log attempts to spawn at invalid cycle points.  This make it easier to understand the examples of #4514, pending decisions on what to do about that issue.

These changes partially address ###
These changes close #xxxx
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
