### PR TITLE
actually load contact info before sending a task message.

### DIFF
--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -259,7 +259,7 @@ class SuiteRuntimeServiceClient(object):
                 event_time (str): Event time as string.
                 messages (list): List in the form [[severity, message], ...].
         """
-        self._load_contact_info()
+        func_name = self._compat('put_messages')
         retry_intvl = float(self.comms1.get(
             self.srv_files_mgr.KEY_TASK_MSG_RETRY_INTVL,
             self.MSG_RETRY_INTVL))
@@ -271,7 +271,8 @@ class SuiteRuntimeServiceClient(object):
             if self.timeout is None:
                 self.timeout = self.MSG_TIMEOUT
             try:
-                func_name = self._compat('put_messages')
+                if not func_name:
+                    func_name = self._compat('put_messages')
                 if func_name == 'put_messages':
                     results = self._call_server(func_name, payload=payload)
                 elif func_name == 'put_message':  # API 1, 7.5.0 compat
@@ -315,6 +316,8 @@ class SuiteRuntimeServiceClient(object):
                 return results
             finally:
                 self.timeout = orig_timeout
+                self.comms1 = {}
+                func_name = None
 
     def reset(self):
         """Compat method, does nothing."""

--- a/lib/cylc/network/httpclient.py
+++ b/lib/cylc/network/httpclient.py
@@ -259,6 +259,7 @@ class SuiteRuntimeServiceClient(object):
                 event_time (str): Event time as string.
                 messages (list): List in the form [[severity, message], ...].
         """
+        self._load_contact_info()
         retry_intvl = float(self.comms1.get(
             self.srv_files_mgr.KEY_TASK_MSG_RETRY_INTVL,
             self.MSG_RETRY_INTVL))


### PR DESCRIPTION
**This is a small change with no associated Issue - description of issue here:**

@dpmatthews  noticed that a remote platform was not picking up custom settings for task messaging. It appears that these settings aren't loaded from the contact file before they are set for the task messaging app.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (to be manually tested?).
- [x] Appropriate change log entry included.
- [x] No documentation update required: Part of a soon to be deprecated branch of Cylc.
