### PR TITLE
Log Authenticated User from UI-Server in Workflow Log

### DIFF
--- a/cylc/flow/network/__init__.py
+++ b/cylc/flow/network/__init__.py
@@ -61,20 +61,6 @@ def decode_(message):
     return msg
 
 
-def get_authenticated_user(message):
-    """Returns the authenticated user associated with the message.
-
-    auth_user is sent from ui server in meta data.
-    """
-    return message.get('meta', {}).get('auth_user')
-
-
-def set_authenticated_user(header_message, username):
-    "Sets the authenticated user associated with the message header"
-    header_message['meta']['auth_user'] = username
-    return header_message
-
-
 def get_location(workflow: str):
     """Extract host and port from a workflow's contact file.
 

--- a/cylc/flow/network/__init__.py
+++ b/cylc/flow/network/__init__.py
@@ -61,6 +61,20 @@ def decode_(message):
     return msg
 
 
+def get_authenticated_user(message):
+    """Returns the authenticated user associated with the message.
+
+    auth_user is sent from ui server in meta data.
+    """
+    return message.get('meta', {}).get('auth_user')
+
+
+def set_authenticated_user(header_message, username):
+    "Sets the authenticated user associated with the message header"
+    header_message['meta']['auth_user'] = username
+    return header_message
+
+
 def get_location(workflow: str):
     """Extract host and port from a workflow's contact file.
 

--- a/cylc/flow/network/authorisation.py
+++ b/cylc/flow/network/authorisation.py
@@ -17,8 +17,6 @@
 
 from functools import wraps
 
-from cylc.flow import LOG
-
 
 def authorise():
     """Add authorisation to an endpoint.
@@ -40,16 +38,6 @@ def authorise():
         def _call(self, *args, user='?', meta=None, **kwargs):
             if not meta:
                 meta = {}
-            host = meta.get('host', '?')
-            prog = meta.get('prog', '?')
-            comms_method = meta.get('comms_method', '?')
-
-            # Hardcoded, for new - but much of this functionality can be
-            # removed more swingingly.
-            LOG.debug(
-                '[client-command] %s %s://%s@%s:%s',
-                fcn.__name__, comms_method, user, host, prog
-            )
             return fcn(self, *args, meta=meta, **kwargs)
 
         return _call

--- a/cylc/flow/network/authorisation.py
+++ b/cylc/flow/network/authorisation.py
@@ -50,7 +50,7 @@ def authorise():
                 '[client-command] %s %s://%s@%s:%s',
                 fcn.__name__, comms_method, user, host, prog
             )
-            return fcn(self, *args, **kwargs)
+            return fcn(self, *args, meta=meta, **kwargs)
 
         return _call
     return wrapper

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -742,7 +742,7 @@ class Resolvers(BaseResolvers):
                 (task_job, event_time, severity, message))
         return (True, 'Messages queued: %d' % len(messages))
 
-    def set_graph_window_extent(self, n_edge_distance):
+    def set_graph_window_extent(self, n_edge_distance, meta=None):
         """Set data-store graph window to new max edge distance.
 
         Args:
@@ -810,6 +810,7 @@ class Resolvers(BaseResolvers):
             clock_time: Wallclock time after which to stop.
             task: Stop after this task succeeds.
             flow_num: The flow to stop.
+            meta: Meta data from ui-server
     ):
 
         Returns:

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -649,14 +649,14 @@ class Resolvers(BaseResolvers):
     ) -> Optional[Tuple[bool, str]]:
         """Map between GraphQL resolvers and internal command interface."""
         method = getattr(self, command, None)
+        if not meta:
+            meta = {"auth_user": "unknown user"}
         if method is not None:
             return method(**kwargs, meta=meta)
         try:
             self.schd.get_command_method(command)
         except AttributeError:
             raise ValueError(f"Command '{command}' not found")
-        if not meta:
-            meta = {"auth_user": "unknown user"}
         self.schd.queue_command(
             command,
             kwargs,

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -618,10 +618,10 @@ class Resolvers(BaseResolvers):
         except AttributeError:
             raise ValueError(f"Command '{command}' not found")
         if command != "put_messages":
-            log_msg = f"[command] {command} "
+            log_msg = f"[command] {command}"
             user = meta.get('auth_user', self.schd.owner)
             if user != self.schd.owner:
-                log_msg += (f"(issued by {user})")
+                log_msg += (f" (issued by {user})")
             LOG.info(log_msg)
         self.schd.queue_command(
             command,

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -621,7 +621,7 @@ class Resolvers(BaseResolvers):
             log_msg = f"[command] {command} "
             user = meta.get('auth_user', self.schd.owner)
             if user != self.schd.owner:
-                log_msg += (f"issued by {user}")
+                log_msg += (f"(issued by {user})")
             LOG.info(log_msg)
         self.schd.queue_command(
             command,

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1222,39 +1222,6 @@ async def mutator(root, info, command=None, workflows=None,
     res = await resolvers.mutator(info, command, w_args, args, meta)
     return GenericResponse(result=res)
 
-
-async def nodes_mutator(root, info, command, ids, workflows=None,
-                        exworkflows=None, **args):
-    """Call the resolver method, dealing with multiple node id arguments,
-    which acts on the workflow service via the internal command queue."""
-    tokens_list = [Tokens(n_id, relative=True) for n_id in ids]
-    # if the workflows arg is empty extract from proxy args
-    if workflows is None:
-        workflows = set()
-        for tokens in tokens_list:
-            workflows.add(tokens.workflow_id)
-    if not workflows:
-        return GenericResponse(result="Error: No given Workflow(s)")
-    if exworkflows is None:
-        exworkflows = []
-    w_args = {}
-    w_args['workflows'] = [Tokens(w_id) for w_id in workflows]
-    w_args['exworkflows'] = [Tokens(w_id) for w_id in exworkflows]
-    if args.get('args', False):
-        args.update(args.get('args', {}))
-        args.pop('args')
-    resolvers = info.context.get('resolvers')
-    meta = info.context.get('meta')
-    res = await resolvers.nodes_mutator(
-        info,
-        command,
-        tokens_list,
-        w_args,
-        args,
-        meta
-    )
-    return GenericResponse(result=res)
-
 # Input types:
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1218,7 +1218,8 @@ async def mutator(root, info, command=None, workflows=None,
         args.update(args.get('args', {}))
         args.pop('args')
     resolvers = info.context.get('resolvers')
-    res = await resolvers.mutator(info, command, w_args, args)
+    meta = info.context.get('meta')
+    res = await resolvers.mutator(info, command, w_args, args, meta)
     return GenericResponse(result=res)
 
 
@@ -1243,12 +1244,14 @@ async def nodes_mutator(root, info, command, ids, workflows=None,
         args.update(args.get('args', {}))
         args.pop('args')
     resolvers = info.context.get('resolvers')
+    meta = info.context.get('meta')
     res = await resolvers.nodes_mutator(
         info,
         command,
         tokens_list,
         w_args,
-        args
+        args,
+        meta
     )
     return GenericResponse(result=res)
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -823,13 +823,10 @@ class Scheduler:
         """Return a command processing method or raise AttributeError."""
         return getattr(self, f'command_{command_name}')
 
-    def queue_command(self, command, kwargs, meta):
-        if not meta:
-            meta = {"auth_user": "unknown"}
+    def queue_command(self, command, kwargs):
         self.command_queue.put((
             command,
-            tuple(kwargs.values()), {},
-            meta
+            tuple(kwargs.values()), {}
         ))
 
     def process_command_queue(self) -> None:
@@ -841,15 +838,7 @@ class Scheduler:
         while True:
             try:
                 command = (self.command_queue.get(False))
-                if len(command) == 4:
-                    name, args, kwargs, meta = command
-                else:
-                    name, args, kwargs = command
-                    meta = {}
-                LOG.info(
-                    f"{meta.get('auth_user', 'Owner')} has submitted request "
-                    f"{name}"
-                )
+                name, args, kwargs = command
             except Empty:
                 break
             args_string = ', '.join(str(a) for a in args)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -847,8 +847,8 @@ class Scheduler:
                     name, args, kwargs = command
                     meta = {}
                 LOG.info(
-                    f"Authenticated user {meta.get('auth_user', '?')} "
-                    f"has submitted request {name}"
+                    f"{meta.get('auth_user', 'Owner')} has submitted request "
+                    f"{name}"
                 )
             except Empty:
                 break

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -858,11 +858,6 @@ class Scheduler:
             )
             sep = ', ' if kwargs_string and args_string else ''
             cmdstr = f"{name}({args_string}{sep}{kwargs_string})"
-            # print("moooooo")
-            # if 'tasks' in kwargs:
-            #     import mdb
-            #     print("atttttttatchchhc")
-            #     mdb.debug(ui_server=True)
             try:
                 n_warnings: Optional[int] = self.get_command_method(name)(
                     *args, **kwargs)

--- a/tests/functional/cylc-message/00-ssh.t
+++ b/tests/functional/cylc-message/00-ssh.t
@@ -21,7 +21,7 @@
 export REQUIRE_PLATFORM='loc:remote comms:ssh'
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 3
+set_test_number 2
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" \
@@ -29,8 +29,5 @@ run_ok "${TEST_NAME_BASE}-validate" \
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach --reference-test "${WORKFLOW_NAME}"
 
-grep_ok "\[client-command\] graphql ssh" \
-    "$RUN_DIR/${WORKFLOW_NAME}/log/workflow/log" 
-
-purge
+#purge
 exit

--- a/tests/functional/cylc-message/00-ssh.t
+++ b/tests/functional/cylc-message/00-ssh.t
@@ -29,5 +29,5 @@ run_ok "${TEST_NAME_BASE}-validate" \
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach --reference-test "${WORKFLOW_NAME}"
 
-#purge
+purge
 exit

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -220,22 +220,6 @@ async def test_mutator(mock_flow, flow_args):
     assert response[0]['id'] == mock_flow.id
 
 
-@pytest.mark.asyncio
-async def test_nodes_mutator(mock_flow, flow_args):
-    """Test the nodes mutation method."""
-    flow_args['workflows'].append({
-        'user': mock_flow.owner,
-        'workflow': mock_flow.name,
-        'workflow_sel': None,
-    })
-    ids = [Tokens(n) for n in mock_flow.node_ids]
-    meta = {}
-    response = await mock_flow.resolvers.nodes_mutator(
-        None, 'force_trigger_tasks', ids, flow_args,
-        {"reflow": False, "flow_descr": ""}, meta
-    )
-    assert response[0]['id'] == mock_flow.id
-
 
 @pytest.mark.asyncio
 async def test_mutation_mapper(mock_flow):

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -209,11 +209,13 @@ async def test_mutator(mock_flow, flow_args):
         'workflow_sel': None
     })
     args = {}
+    meta = {}
     response = await mock_flow.resolvers.mutator(
         None,
         'pause',
         flow_args,
-        args
+        args,
+        meta
     )
     assert response[0]['id'] == mock_flow.id
 
@@ -227,9 +229,10 @@ async def test_nodes_mutator(mock_flow, flow_args):
         'workflow_sel': None,
     })
     ids = [Tokens(n) for n in mock_flow.node_ids]
+    meta = {}
     response = await mock_flow.resolvers.nodes_mutator(
         None, 'force_trigger_tasks', ids, flow_args,
-        {"reflow": False, "flow_descr": ""}
+        {"reflow": False, "flow_descr": ""}, meta
     )
     assert response[0]['id'] == mock_flow.id
 
@@ -237,7 +240,8 @@ async def test_nodes_mutator(mock_flow, flow_args):
 @pytest.mark.asyncio
 async def test_mutation_mapper(mock_flow):
     """Test the mapping of mutations to internal command methods."""
-    response = await mock_flow.resolvers._mutation_mapper('pause', {})
+    meta = {}
+    response = await mock_flow.resolvers._mutation_mapper('pause', {}, meta)
     assert response is None
     with pytest.raises(ValueError):
-        await mock_flow.resolvers._mutation_mapper('non_exist', {})
+        await mock_flow.resolvers._mutation_mapper('non_exist', {}, meta)


### PR DESCRIPTION
Log the authenticated user executing the mutation command from the UI.

A test user pausing the workflow of another user, will result in a log message below in the workflow log:
![image](https://user-images.githubusercontent.com/37735232/150127645-698df93d-2d88-4f9b-8336-61b117fa48a7.png)

The owner then resuming the workflow, will result in a log message..
![image](https://user-images.githubusercontent.com/37735232/150127923-1e1e16ab-204b-47ce-a255-1943579c2554.png)
 

These changes close https://github.com/cylc/cylc-flow/issues/4294 and https://github.com/cylc/cylc-uiserver/issues/224 by its sibling:

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Appropriate tests are _not_ included (unit and/or functional). - Only manually tested. This will require multi user testing setup to get this into the automated test battery.
- [x] No change log entry required (why? Logging change).
- [x] No documentation update required.
