### PR TITLE
python: Add 3.10 support

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # Don't let a failed MacOS run stop the Ubuntu runs
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: 'macos-latest'
             python-version: '3.7'

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -43,6 +43,13 @@ jobs:
         platform: ['_local_background* _local_at*']
         # NOTE: includes must define ALL of the matrix values
         include:
+          # latest python
+          - name: 'py-3.10'
+            os: 'ubuntu-latest'
+            python-version: '3.10'
+            test-base: 'tests/f'
+            chunk: '1/4'
+            platform: '_local_background*'
           # tests/k
           - name: 'flaky'
             os: 'ubuntu-latest'

--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         manylinux: ['1']
         os: ['ubuntu-18.04']  # run on the oldest linux we have access to
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Atmospheric Science


### PR DESCRIPTION
Add support for Python 3.10.

Note 3.11 is now nearing release but we can't install our deps with it just yet...

> **Note:** We may need to change the conda-forge metadata for the 8.1.0 release.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.