### PR TITLE
GH Actions: Cache pip dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,7 @@ This is a small change with no associated Issue.
 - [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
 - [ ] Contains logically grouped changes (else tidy your branch by rebase).
 - [ ] Does not contain off-topic changes (use other PRs for other changes).
-- [ ] Applied any dependency changes to both `setup.py` and
-  `conda-environment.yml`.
+- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
 <!-- choose one: -->
 - [ ] Appropriate tests are included (unit and/or functional).
 - [ ] Already covered by existing tests.

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
 
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -85,6 +85,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
 
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
 
       - name: Configure Manylinux Compatibility
         # Make this platform look older than it is. For info see:


### PR DESCRIPTION
This is a small change with no associated Issue. Hopefully will shave some time off GH Actions checks [Update: not really 🤷‍♂️]

https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry required 
- [x] No documentation update required.
