### PR TITLE
Don't do coverage report until CI done

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,10 @@
 # After modifying this file, it might be worth to validate it with:
 # `curl --data-binary @.codecov.yml https://codecov.io/validate`
 
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
 # define the colour bar limits here
 coverage:
   precision: 2


### PR DESCRIPTION
Experimental PR

**Issue**
Codecov runs before the CI has finished, causing a false negative notification.
[Documentation of setting changed](https://docs.codecov.com/docs/common-recipe-list#send-coverage-notifications-even-if-all-ci-statuses-have-not-completed)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.py` and
  `conda-environment.yml`.
- [x] Does not need tests (itself a change to CI setup).
- [x] No change log entry required (developer convienience).
- [x] No documentation update required.
