### PR TITLE
Turn off broken flake8-bugbear rule B018 (for now)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ ignore=
     W504
     ; `.next()` is not a thing on Python 3 (it is for TaskActionTimer)
     B305
+    ; useless expression (re-enable when
+    ; https://github.com/PyCQA/flake8-bugbear/issues/208 fixed)
+    B018
 exclude=
     build,
     dist,


### PR DESCRIPTION
This is a small change with no associated Issue. Fixes failing style test on GH Actions.

We should re-enable this rule when https://github.com/PyCQA/flake8-bugbear/issues/208 is fixed
