### PR TITLE
GH Actions: Use 1 process for manylinux pytest

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -74,6 +74,6 @@ jobs:
           import cylc.flow.scheduler
 
       - name: Test
-        timeout-minutes: 15
+        timeout-minutes: 10
         run: |
-          pytest -n 5
+          pytest


### PR DESCRIPTION
Hopefully reduce flakiness

