### PR TITLE
Change VCS info file format to JSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,8 +73,11 @@ renamed `cylc get-resources` and small changes made:
 - Metadata as well as names from ``--list`` option.
 - Files extracted to to ``target/source_name`` rather than ``target/full/source/path``.
 
+[#4548](https://github.com/cylc/cylc-flow/pull/4548) - Changed the
+workflow version control info log file format from modified-INI to JSON.
+
 [#4521](https://github.com/cylc/cylc-flow/pull/4521) - The workflow config
-logs (that get written in `log/flow-config/` on start/restart/reload) 
+logs (that get written in `log/flow-config/` on start/restart/reload)
 are now sparse, i.e. they will no longer be fleshed-out with defaults.
 
 ### Fixes

--- a/tests/functional/post-install/00-log-vc-info.t
+++ b/tests/functional/post-install/00-log-vc-info.t
@@ -37,10 +37,10 @@ git commit -am 'Initial commit'
 
 run_ok "${TEST_NAME_BASE}-install" cylc install
 
-VCS_INFO_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/vcs.conf"
+VCS_INFO_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/vcs.json"
 exists_ok "$VCS_INFO_FILE"
 # Basic check, unit tests cover this in more detail:
-contains_ok "$VCS_INFO_FILE" <<< 'version control system = "git"'
+grep_ok '"version control system": "git"' "$VCS_INFO_FILE" -F
 
 DIFF_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/uncommitted.diff"
 exists_ok "$DIFF_FILE"  # Expected to be empty but should exist


### PR DESCRIPTION
These changes close #4546

Change the workflow version control info file format from modified INI to JSON. This is still easily human readable but is much easier to parse by programs that can't use parsec (e.g. see https://github.com/metomi/rose/pull/2520).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included 
- [x] Appropriate change log entry included.
- [x] No documentation update required (updated the relevant auto-doc material)
