### PR TITLE
Workflow name validation: prevent reserved dir names in workflow name

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1401,8 +1401,8 @@ def infer_latest_run(
 
 
 def check_nested_dirs(
-    run_dir: Union[Path, str],
-    install_dir: Union[Path, str, None] = None
+    run_dir: Path,
+    install_dir: Optional[Path] = None
 ) -> None:
     """Disallow nested dirs:
 
@@ -1419,7 +1419,6 @@ def check_nested_dirs(
         WorkflowFilesError if reg dir is nested inside a run dir, or an
             install dirs are nested.
     """
-    run_dir = Path(os.path.normpath(run_dir))
     if install_dir is not None:
         install_dir = Path(os.path.normpath(install_dir))
     # Check parents:
@@ -1658,9 +1657,9 @@ def install_workflow(
     relink, run_num, rundir = get_run_dir_info(
         run_path_base, run_name, no_run_name)
     check_nested_dirs(rundir, run_path_base)
-    if Path(rundir).exists():
+    if rundir.exists():
         raise WorkflowFilesError(
-            f"\"{rundir}\" exists.\n"
+            f'"{rundir}" exists.\n'
             " To install a new run use `cylc install --run-name`,"
             " or to reinstall use `cylc reinstall`."
         )
@@ -1870,7 +1869,10 @@ def create_workflow_srv_dir(rundir: Path) -> None:
 
 
 def validate_source_dir(source, workflow_name):
-    """Ensure the source directory is valid.
+    """Ensure the source directory is valid:
+        - has flow file
+        - does not contain reserved dir names
+        - is not inside ~/cylc-run.
 
     Args:
         source (path): Path to source directory

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1309,8 +1309,15 @@ def _parse_src_reg(reg: Path, cur_dir_only: bool = False) -> Tuple[Path, Path]:
     return (reg, abs_path)
 
 
-def validate_workflow_name(name: str, runNcheck=False) -> None:
-    """Check workflow name is valid and not an absolute path.
+def validate_workflow_name(
+    name: str, check_reserved_names: bool = False
+) -> None:
+    """Check workflow name/ID is valid and not an absolute path.
+
+    Args:
+        name: Workflow name or ID.
+        check_reserved_names: If True, check that the name does not
+            contain reserved dir names.
 
     Raise WorkflowFilesError if not valid.
     """
@@ -1329,14 +1336,21 @@ def validate_workflow_name(name: str, runNcheck=False) -> None:
             "Workflow name cannot be a path that points to the cylc-run "
             "directory or above"
         )
-    if runNcheck and any(
-        re.match(r'^run(N|\d+)$', dir_name)
-        for dir_name in Path(name).parts
-    ):
-        raise WorkflowFilesError(
-            "Workflow name cannot contain a folder called 'runN' or "
-            "'run<number>'."
-        )
+    if check_reserved_names:
+        check_reserved_dir_names(name)
+
+
+def check_reserved_dir_names(name: Union[Path, str]) -> None:
+    """Check workflow/run name does not contain reserved dir names."""
+    err_msg = (
+        "Workflow/run name cannot contain a directory named '{}' "
+        "(that filename is reserved)"
+    )
+    for dir_name in Path(name).parts:
+        if dir_name in WorkflowFiles.RESERVED_NAMES:
+            raise WorkflowFilesError(err_msg.format(dir_name))
+        if re.match(r'^run\d+$', dir_name):
+            raise WorkflowFilesError(err_msg.format('run<number>'))
 
 
 def infer_latest_run(
@@ -1632,14 +1646,13 @@ def install_workflow(
     source = Path(expand_path(source))
     if not workflow_name:
         workflow_name = source.name
-    validate_workflow_name(workflow_name, runNcheck=True)
-    if run_name in WorkflowFiles.RESERVED_NAMES:
-        raise WorkflowFilesError(
-            f'Run name cannot be "{run_name}": That name is reserved.')
-    if run_name is not None and len(Path(run_name).parts) != 1:
-        raise WorkflowFilesError(
-            f'Run name cannot be a path. (You used {run_name})'
-        )
+    validate_workflow_name(workflow_name, check_reserved_names=True)
+    if run_name is not None:
+        if len(Path(run_name).parts) != 1:
+            raise WorkflowFilesError(
+                f'Run name cannot be a path. (You used {run_name})'
+            )
+        check_reserved_dir_names(run_name)
     validate_source_dir(source, workflow_name)
     run_path_base = Path(get_workflow_run_dir(workflow_name))
     relink, run_num, rundir = get_run_dir_info(

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -95,8 +95,8 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-run-name-forbidden"
 run_fail "${TEST_NAME}" cylc install --run-name=_cylc-install -C "${RND_WORKFLOW_SOURCE}"
-contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: Run name cannot be "_cylc-install": That name is reserved.
+cmp_ok "${TEST_NAME}.stderr" <<__ERR__
+WorkflowFilesError: Workflow/run name cannot contain a directory named '_cylc-install' (that filename is reserved)
 __ERR__
 
 # Test cylc install invalid flow-name

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,16 +50,14 @@ def monkeymock(monkeypatch: pytest.MonkeyPatch):
         something()  # calls workflow_files.clean
         assert mock_clean.called is True
     """
-    def inner(pypath: str, **kwargs: Any) -> Mock:
+    def _monkeymock(pypath: str, **kwargs: Any) -> Mock:
         _mock = Mock(**kwargs)
         monkeypatch.setattr(pypath, _mock)
         return _mock
-    return inner
+    return _monkeymock
 
 
-def tmp_run_dir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Callable[[Optional[str]], Path]:
+def tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Fixture that patches the cylc-run dir to the tests's
     {tmp_path}/cylc-run, and optionally creates a workflow run dir inside.
 


### PR DESCRIPTION
This is a small change follow-up to #4394

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit)
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
