### PR TITLE
remove the color/no-colour option from cylc cyclepoint

### DIFF
--- a/cylc/flow/scripts/cycle_point.py
+++ b/cylc/flow/scripts/cycle_point.py
@@ -67,6 +67,7 @@ from metomi.isodatetime.exceptions import IsodatetimeError
 def get_option_parser():
     parser = COP(
         __doc__,
+        color=False,
         argdoc=[
             ('[POINT]', 'ISO8601 date-time, default=$CYLC_TASK_CYCLE_POINT')])
 


### PR DESCRIPTION
This is a small change with no associated Issue:

While looking at tutorial workflows I noticed the following use case:
```python
    Popen(
        ['cylc', 'cyclepoint', '--offset-hours', str(int(offset_hours))],
        stdout=PIPE
    ).communicate()
```

In this case the subsequent commands fail because colour information chars are included in the output.
Because this command is likely to used by other scripts this should not have the colour options.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (v. small pre release change).
- [x] No documentation update required.
