### PR TITLE
Fix remote psutil invocation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,9 @@ are now sparse, i.e. they will no longer be fleshed-out with defaults.
 
 ### Fixes
 
+[#4566](https://github.com/cylc/cylc-flow/pull/4566) - Fix `cylc scan`
+invocation for remote scheduler host on a shared filesystem.
+
 [#4526](https://github.com/cylc/cylc-flow/pull/4526),
 [#4549](https://github.com/cylc/cylc-flow/pull/4549) - Prevent installing
 workflows with directory names that include reserved filenames such as

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -407,10 +407,12 @@ def _is_process_running(
 
     """
     # See if the process is still running or not.
-    cmd = ['cylc', 'psutil']
     metric = f'[["Process", {pid}]]'
     if is_remote_host(host):
+        cmd = ['psutil']
         cmd = _construct_ssh_cmd(cmd, host)
+    else:
+        cmd = ['cylc', 'psutil']
     proc = Popen(  # nosec
         cmd,
         stdin=PIPE,


### PR DESCRIPTION
Remote check for a running workflow (e.g. for `cylc scan - t rich` ~~or any scheduler-targetting `cylc` command~~) is failing, because it tries to execute `cylc cylc psutil` (too many `cylc`s!) on the workflow host.

This is the quick fix as deployed at NIWA.

TODO: check:
- [x] the fix doesn't break anything else 
- [x] a similar problem does not occur for other remote commands

(off-topic: the `construct_ssh_cmd` methods could use some refactoring - e.g. there's one specifically for `cylc` commands, but it isn't used in this case).
 

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] ~~Does not need tests (why?)~~ can't think of how to test this; it requires a shared FS but the shared swarm container won't work because `cylc scan` needs the source dir as well as the run dir to be shared)
- [x] Appropriate change log entry included.
- [x] No documentation update required.
