### PR TITLE
remove duplicate timestamps from logging

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -595,15 +595,11 @@ class TaskEventsManager():
         Check whether to process/skip message.
         Return True if `.process_message` should contine, False otherwise.
         """
-        if self.timestamp:
-            timestamp = f" at {event_time}"
-        else:
-            timestamp = ""
         if flag == self.FLAG_RECEIVED and submit_num != itask.submit_num:
             # Ignore received messages from old jobs
             LOG.warning(
                 f"[{itask}] "
-                f"{self.FLAG_RECEIVED_IGNORED}{message}{timestamp} "
+                f"{self.FLAG_RECEIVED_IGNORED}{message}"
                 f"for job({submit_num:02d}) != job({itask.submit_num:02d})"
             )
             return False
@@ -633,19 +629,19 @@ class TaskEventsManager():
             if flag == self.FLAG_RECEIVED:
                 LOG.warning(
                     f"[{itask}] "
-                    f"{self.FLAG_RECEIVED_IGNORED}{message}{timestamp}"
+                    f"{self.FLAG_RECEIVED_IGNORED}{message}"
                 )
 
             else:
                 LOG.warning(
                     f"[{itask}] "
-                    f"{self.FLAG_POLLED_IGNORED}{message}{timestamp}"
+                    f"{self.FLAG_POLLED_IGNORED}{message}"
                 )
             return False
 
         LOG.log(
             LOG_LEVELS.get(severity, INFO),
-            f"[{itask}] {flag}{message}{timestamp}"
+            f"[{itask}] {flag}{message}"
         )
         return True
 


### PR DESCRIPTION
These changes partially address #3647

## TODO
- [ ] Need to keep the time if comms method is poll
- [x] Remove second timestamp if comms method is not poll.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests: I suspect any test grepping for this will pass without change because this change removes redundancy.
- [x] No change log entry required (Small Logging Change).
- [x] No documentation update required.
