### PR TITLE
CLI: don't color if stdout redirected.

### DIFF
--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -42,8 +42,15 @@ EXC_EXIT = cparse('<red><bold>{name}: </bold>{exc}</red>')
 
 
 def is_terminal():
-    """Determine if running in a terminal."""
-    return hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()
+    """Determine if running in (and printing to) a terminal."""
+    # Return False if stdout or stderr not going to a terminal.
+    return (
+        (
+            hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()
+        ) and (
+            hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
+        )
+    )
 
 
 def get_width(default=80):


### PR DESCRIPTION
These changes close #4552  and supersede #4559 

Current colour output disabling is a bit broken.

On master, this correctly generates colour output in the terminal:

```console
$ cylc cat-log test 
```

But these cases (for example) get unnecessary color-code pollution:

```console
$ cylc cat-log test | vim -   # IN YOUR FACE emacs!!! (can't read from stdin)
$ cylc cat-log test > log
```

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->



<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).

- [x] No documentation update required.
