### PR TITLE
Tweak terminal colour handling.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,9 @@ invocation for remote scheduler host on a shared filesystem.
 large inexact offsets (year, months); restore time check for old-style
 (task-property) clock triggers.
 
+[#4568](https://github.com/cylc/cylc-flow/pull/4568) - Disable all CLI colour
+output if not to a terminal.
+
 [#4553](https://github.com/cylc/cylc-flow/pull/4553) - Add job submit time
 to the datastore.
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -133,9 +133,8 @@ class CylcHelpFormatter(IndentedHelpFormatter):
     def _format(self, text):
         """Format help (usage) text on the fly to handle coloring.
 
-        This has to be done here because help is printed to the terminal before
-        command line parsing is completed, and color initialization for general
-        command output is done after that to make use of parsed options.
+        Help is printed to the terminal before color initialization for general
+        command output.
 
         If coloring is wanted:
           - Add color tags to shell examples
@@ -143,22 +142,11 @@ class CylcHelpFormatter(IndentedHelpFormatter):
           - Strip any hardwired color tags
 
         """
-        # Crudely parse sys.argv for --color options here (see docstring above;
-        # only default option values are available here in self.parser.values).
-        # Join the command line with '=' to unify "--opt=val" and "--opt val":
-        joined_args = '='.join(sys.argv[2:])
         use_color = (
-            '--color=always' in joined_args
-            or
-            '--colour=always' in joined_args
+            self.parser.values.color == "always"
             or (
-                supports_color()
-                and not
-                (
-                    '--color=never' in joined_args
-                    or
-                    '--colour=never' in joined_args
-                )
+                self.parser.values.color == "auto"
+                and supports_color()
             )
         )
         if use_color:

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -142,14 +142,13 @@ class CylcHelpFormatter(IndentedHelpFormatter):
           - Strip any hardwired color tags
 
         """
-        use_color = (
+        if (
             self.parser.values.color == "always"
             or (
                 self.parser.values.color == "auto"
                 and supports_color()
             )
-        )
-        if use_color:
+        ):
             # Add color formatting to examples text.
             text = format_shell_examples(text)
         else:
@@ -160,8 +159,9 @@ class CylcHelpFormatter(IndentedHelpFormatter):
     def format_usage(self, usage):
         return super().format_usage(self._format(usage))
 
-    def format_descrtiption(self, description):
-        return super().format_description(self._format(description))
+    # If we start using "description" as well as "usage" (also epilog):
+    # def format_description(self, description):
+    #     return super().format_description(self._format(description))
 
 
 class CylcOptionParser(OptionParser):

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -36,6 +36,7 @@ from cylc.flow.loggingutil import (
 )
 
 
+# regex to match '<blargh>foo</blargh>' and capture foo:
 TAG_REC = re.compile(r'<(.*?)>(.*?)</\1>')
 
 
@@ -189,14 +190,13 @@ class CylcOptionParser(OptionParser):
             else:
                 argdoc = [('WORKFLOW', 'Workflow ID')]
 
-        joined_args = '='.join(sys.argv[2:])
+        joined_args = '='.join(sys.argv[2:])  # for "--opt=arg" and "--opt arg"
         if (
             '--color=never' not in joined_args
             and
             '--colour=never' not in joined_args
         ):
             # Before option parsing, make comments grey in --help output.
-            # (This catches both '--colo(u)r=never' and '--colo(u)r never'.)
             usage = format_shell_examples(usage)
         else:
             # Strip hardwired colour tags in usage (e.g. "cylc scan --help").
@@ -385,17 +385,18 @@ class CylcOptionParser(OptionParser):
         before color init for general command output.
 
         """
+        joined_args = '='.join(sys.argv[2:])  # for "--opt=arg" and "--opt arg"
         use_color = (
-            '--color=always' in sys.argv
+            '--color=always' in joined_args
             or
-            '--colour=always' in sys.argv
+            '--colour=always' in joined_args
             or (
                 supports_color()
                 and not
                 (
-                    '--color=never' in sys.argv
+                    '--color=never' in joined_args
                     or
-                    '--colour=never' in sys.argv
+                    '--colour=never' in joined_args
                 )
             )
         )

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -646,7 +646,7 @@ def main():
                 # check if this is a command abbreviation or exit
                 command = match_command(command)
             if opts.help_:
-                execute_cmd(command, "--help")
+                execute_cmd(command, *cmd_args, "--help")
             else:
                 if opts.version:
                     cmd_args.append("--version")

--- a/cylc/flow/scripts/play.py
+++ b/cylc/flow/scripts/play.py
@@ -23,6 +23,3 @@ from cylc.flow.scheduler_cli import (  # noqa: F401
 )
 
 # CLI of "cylc play". See cylc.flow.scheduler_cli for details.
-
-if __name__ == "__main__":
-    main()

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -203,7 +203,7 @@ def cli_function(
             wrapped_args, wrapped_kwargs = [], {}
             if parser_function:
                 parser = parser_function()
-                opts, args = parser_function().parse_args(
+                opts, args = parser.parse_args(
                     list(api_args),
                     **parser_kwargs
                 )

--- a/tests/functional/cli/05-colour.t
+++ b/tests/functional/cli/05-colour.t
@@ -26,30 +26,30 @@ ANSI='\e\['
 
 # No redirection.
 script -q -c "cylc scan -t rich" log > /dev/null 2>&1
-grep_ok $ANSI log -P  # color
+grep_ok "$ANSI" log -P  # color
 
 script -q -c "cylc scan -t rich --color=never" log > /dev/null 2>&1
-grep_fail $ANSI log -P  # no color
+grep_fail "$ANSI" log -P  # no color
 
 # Redirected.
 cylc scan -t rich > log
-grep_fail $ANSI log -P  # no color
+grep_fail "$ANSI" log -P  # no color
 
 cylc scan -t rich --color=always > log
-grep_ok $ANSI log -P  # color
+grep_ok "$ANSI" log -P  # color
 
 # Check command help too (gets printed during command line parsing).
 
 # No redirection.
 script -q -c "cylc scan --help" log > /dev/null 2>&1
-grep_ok $ANSI log -P  # color
+grep_ok "$ANSI" log -P  # color
 
 script -q -c "cylc scan --help --color never" log > /dev/null 2>&1
-grep_fail $ANSI log -P  # no color
+grep_fail "$ANSI" log -P  # no color
 
 # Redirected.
 cylc scan --help > log
-grep_fail $ANSI log -P  # no color
+grep_fail "$ANSI" log -P  # no color
 
 cylc scan --help --color=always > log
-grep_ok $ANSI log -P  # color
+grep_ok "$ANSI" log -P  # color

--- a/tests/functional/cli/05-colour.t
+++ b/tests/functional/cli/05-colour.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Test that CLI colour output is disabled if output is not to a terminal.
+# Uses the "script" command to make stdout log file look like a terminal.
+
+. "$(dirname "$0")/test_header"
+set_test_number 8
+
+ANSI='\e\['
+
+# No redirection.
+script -q -c "cylc scan -t rich" log > /dev/null 2>&1
+grep_ok $ANSI log -P  # color
+
+script -q -c "cylc scan -t rich --color=never" log > /dev/null 2>&1
+grep_fail $ANSI log -P  # no color
+
+# Redirected.
+cylc scan -t rich > log
+grep_fail $ANSI log -P  # no color
+
+cylc scan -t rich --color=always > log
+grep_ok $ANSI log -P  # color
+
+# Check command help too (gets printed during command line parsing).
+
+# No redirection.
+script -q -c "cylc scan --help" log > /dev/null 2>&1
+grep_ok $ANSI log -P  # color
+
+script -q -c "cylc scan --help --color never" log > /dev/null 2>&1
+grep_fail $ANSI log -P  # no color
+
+# Redirected.
+cylc scan --help > log
+grep_fail $ANSI log -P  # no color
+
+cylc scan --help --color=always > log
+grep_ok $ANSI log -P  # color

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -31,11 +31,6 @@ def parser():
     return COP('usage')
 
 
-@pytest.fixture(scope='module')
-def parser_usage_with_comment():
-    return COP(USAGE_WITH_COMMENT)
-
-
 @pytest.mark.parametrize(
     'args,verbosity', [
         ([], 0),
@@ -59,25 +54,27 @@ def test_verbosity(args, verbosity, parser, monkeypatch):
     assert cylc.flow.flags.verbosity == verbosity
 
 
-def test_help_color(parser_usage_with_comment):
+def test_help_color(monkeypatch):
     """Test for colorized comments in 'cylc cmd --help --color=always'."""
     # This colorization is done on the fly when help is printed.
-    argv = sys.argv
-    sys.argv = ['cmd', 'arg', '--help', '--color=always']
+    monkeypatch.setattr("sys.argv", ['cmd', 'foo', '--color=always'])
+    parser = COP(USAGE_WITH_COMMENT)
+    parser.parse_args(None)
+    assert parser.values.color == "always"
     f = io.StringIO()
     with redirect_stdout(f):
-        parser_usage_with_comment.print_help()
-    sys.argv = argv
+        parser.print_help()
     assert not (f.getvalue()).startswith("Usage: " + USAGE_WITH_COMMENT)
 
 
-def test_help_nocolor(parser_usage_with_comment):
+def test_help_nocolor(monkeypatch):
     """Test for no colorization in 'cylc cmd --help --color=never'."""
     # This colorization is done on the fly when help is printed.
-    argv = sys.argv
-    sys.argv = ['cmd', 'arg', '--help', '--color=never']
+    monkeypatch.setattr(sys, "argv", ['cmd', 'foo', '--color=never'])
+    parser = COP(USAGE_WITH_COMMENT)
+    parser.parse_args(None)
+    assert parser.values.color == "never"
     f = io.StringIO()
     with redirect_stdout(f):
-        parser_usage_with_comment.print_help()
-    sys.argv = argv
+        parser.print_help()
     assert (f.getvalue()).startswith("Usage: " + USAGE_WITH_COMMENT)


### PR DESCRIPTION
Follow-up to #4562 

- [x] strip colorama markup from command help if not needed
- [x] strip hardwired ansimarkup tags from command help if not needed (`cylc scan --help`)
  
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
