### PR TITLE
Fix host selection bug for deprecated `[runtime][<task>][remote]host` syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,9 @@ of workflows inside other installed workflows.
 [#4540](https://github.com/cylc/cylc-flow/pull/4540) - Handle the `/` character
 in job names, for PBS 19.2.1+.
 
+[#4570](https://github.com/cylc/cylc-flow/pull/4570) - Fix incorrect fallback
+to localhost if `[runtime][<task>][remote]host` is unreachable.
+
 [#4543](https://github.com/cylc/cylc-flow/pull/4543) -
 `cylc play --stopcp=reload` now takes its value from
 `[scheduling]stop after cycle point` instead of using the final cycle point.

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -65,14 +65,18 @@ def log_platform_event(
 
 @overload
 def get_platform(
-    task_conf: Union[str, None] = None, task_id: str = UNKNOWN_TASK
+    task_conf: Union[str, None] = None,
+    task_id: str = UNKNOWN_TASK,
+    bad_hosts: Optional[Set[str]] = None
 ) -> Dict[str, Any]:
     ...
 
 
 @overload
 def get_platform(
-    task_conf: Dict[str, Any], task_id: str = UNKNOWN_TASK
+    task_conf: Dict[str, Any],
+    task_id: str = UNKNOWN_TASK,
+    bad_hosts: Optional[Set[str]] = None
 ) -> Optional[Dict[str, Any]]:
     ...
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -288,17 +288,18 @@ class TaskJobManager:
 
                     # Get another platform, if task config platform is a group
                     use_next_platform_in_group = False
-                    try:
-                        platform = get_platform(
-                            itask.tdef.rtconfig['platform'],
-                            bad_hosts=self.bad_hosts
-                        )
-                    except NoPlatformsError:
-                        pass
-                    else:
-                        # If were able to select a new platform;
-                        if platform and platform != itask.platform:
-                            use_next_platform_in_group = True
+                    if itask.tdef.rtconfig['platform']:
+                        try:
+                            platform = get_platform(
+                                itask.tdef.rtconfig['platform'],
+                                bad_hosts=self.bad_hosts
+                            )
+                        except NoPlatformsError:
+                            pass
+                        else:
+                            # If were able to select a new platform;
+                            if platform and platform != itask.platform:
+                                use_next_platform_in_group = True
 
                     if use_next_platform_in_group:
                         # store the previous platform's hosts so that when

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1154,7 +1154,7 @@ class TaskJobManager:
                 rtconfig['remote']['host'] = host_n
 
             try:
-                platform = get_platform(rtconfig, self.bad_hosts)
+                platform = get_platform(rtconfig, bad_hosts=self.bad_hosts)
 
             except PlatformLookupError as exc:
                 # Submit number not yet incremented

--- a/tests/functional/intelligent-host-selection/07-cylc7-badhost.t
+++ b/tests/functional/intelligent-host-selection/07-cylc7-badhost.t
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+# Test task does not run on localhost if Cylc 7 syntax
+# [runtime][<task>][remote]host is unreachable -
+# https://github.com/cylc/cylc-flow/issues/4569
+
+. "$(dirname "$0")/test_header"
+set_test_number 4
+
+# Host name picked for unlikelihood of matching any real host
+BAD_HOST="f65b965bb914"
+
+create_test_global_config "" "
+[platforms]
+    [[badhostplatform]]
+        hosts = ${BAD_HOST}
+"
+
+init_workflow "${TEST_NAME_BASE}" << __FLOW__
+[scheduler]
+    [[events]]
+        stall timeout = PT0M
+        abort on stall timeout = True
+[scheduling]
+    cycling mode = integer
+    [[graph]]
+        R1 = sattler
+[runtime]
+    [[sattler]]
+        [[[remote]]]
+            host = ${BAD_HOST}
+__FLOW__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+
+workflow_run_fail "${TEST_NAME_BASE}-run" \
+    cylc play --no-detach "${WORKFLOW_NAME}"
+
+grep_workflow_log_ok "${TEST_NAME_BASE}-grep-1" \
+    "platform: badhostplatform - initialisation did not complete (no hosts were reachable)"
+
+grep_workflow_log_ok "${TEST_NAME_BASE}-grep-2" "CRITICAL - Workflow stalled"
+
+purge


### PR DESCRIPTION
These changes close #4569

Prevent Cylc from incorrectly falling back to localhost if a host specified by `[runtime][<task>][remote]host` is unreachable.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
