### PR TITLE
Fix start type log formatting

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -678,9 +678,11 @@ class Scheduler:
         released from runhead.)
 
         """
-        LOG.info(
-            f"{'warm' if self.options.startcp else 'cold'} start from"
-            f"{self.config.start_point}.")
+        start_type = (
+            "Warm" if self.config.start_point > self.config.initial_point
+            else "Cold"
+        )
+        LOG.info(f"{start_type} start from {self.config.start_point}")
 
         flow_num = self.flow_mgr.get_new_flow(
             f"original flow from {self.config.start_point}"


### PR DESCRIPTION
This is a small change with no associated Issue. Fixes lack of space in
```
INFO - cold start from1.
```

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
