### PR TITLE
Add link to migration guide in implicit tasks warning

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -789,7 +789,9 @@ class WorkflowConfig:
         msg = (
             f"{msg}\n"
             "To allow implicit tasks, use "
-            f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'"
+            f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'\n"
+            "See https://cylc.github.io/cylc-doc/latest/html/"
+            "7-to-8/summary.html#backward-compatibility"
         )
         # Allow implicit tasks in Cylc 7 back-compat mode (but not if
         # rose-suite.conf present, to maintain compat with Rose 2019)

--- a/tests/functional/validate/37-special-implicit-task.t
+++ b/tests/functional/validate/37-special-implicit-task.t
@@ -34,5 +34,6 @@ cmp_ok "${TEST_NAME_BASE}.stderr" << '__ERR__'
 WorkflowConfigError: implicit tasks detected (no entry under [runtime]):
     * foo
 To allow implicit tasks, use 'flow.cylc[scheduler]allow implicit tasks'
+See https://cylc.github.io/cylc-doc/latest/html/7-to-8/summary.html#backward-compatibility
 __ERR__
 exit


### PR DESCRIPTION
These changes partially address https://github.com/cylc/cylc-doc/issues/170

> `allow implicit tasks` (note: doesn't affect Rose2019 users) (note: **add link to migration page in warning message**)
