### PR TITLE
Update usage text

### DIFF
--- a/bin/cylc-broadcast
+++ b/bin/cylc-broadcast
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [control] broadcast|bcast [OPTIONS] REG
+"""cylc [control] broadcast|bcast [OPTIONS] ARGS
 
 Override [runtime] config in targeted namespaces in a running suite.
 

--- a/bin/cylc-cat-state
+++ b/bin/cylc-cat-state
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [info] cat-state [OPTIONS] REG
+"""cylc [info] cat-state [OPTIONS] ARGS
 
 Print the suite state in the old state dump file format to stdout.
 This command is deprecated; use "cylc ls-checkpoints" instead."""

--- a/bin/cylc-diff
+++ b/bin/cylc-diff
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [prep] diff|compare [OPTIONS] SUITE1 SUITE2
+"""cylc [prep] diff|compare [OPTIONS] ARGS
 
 Compare two suite definitions and display any differences.
 

--- a/bin/cylc-get-directory
+++ b/bin/cylc-get-directory
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [prep] get-directory REG
+"""cylc [prep] get-directory [OPTIONS] ARGS
 
 Retrieve and print the source directory location of suite REG.
 Here's an easy way to move to a suite source directory:

--- a/bin/cylc-gscan
+++ b/bin/cylc-gscan
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc gscan [OPTIONS]
+"""cylc gscan [OPTIONS] ARGS
 
 This is the cylc scan gui for monitoring running suites on a set of
 hosts.

--- a/bin/cylc-gui
+++ b/bin/cylc-gui
@@ -16,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc gui [OPTIONS] [REG] [USER_AT_HOST]
-gcylc [OPTIONS] [REG] [USER_AT_HOST]
+"""cylc gui [OPTIONS] ARGS
+gcylc [OPTIONS] ARGS
 
 This is the cylc Graphical User Interface.
 

--- a/bin/cylc-insert
+++ b/bin/cylc-insert
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [control] insert [OPTIONS] TASK_GLOB [...]
+"""cylc [control] insert [OPTIONS] ARGS
 
 Insert new task proxies into the task pool of a running suite, e.g. to allow
 re-triggering of an earlier task that has already been removed from the pool.

--- a/bin/cylc-jobs-kill
+++ b/bin/cylc-jobs-kill
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""cylc [control] jobs-kill JOB-LOG-ROOT [JOB-LOG-DIR ...]
+"""cylc [control] jobs-kill ARGS
 
 (This command is for internal use. Users should use "cylc kill".) Read job
 status files to obtain the names of the batch systems and the job IDs in the

--- a/bin/cylc-jobs-poll
+++ b/bin/cylc-jobs-poll
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""cylc [control] jobs-poll JOB-LOG-ROOT [JOB-LOG-DIR ...]
+"""cylc [control] jobs-poll ARGS
 
 (This command is for internal use. Users should use "cylc poll".) Read job
 status files to obtain the statuses of the jobs. If necessary, Invoke the

--- a/bin/cylc-jobs-submit
+++ b/bin/cylc-jobs-submit
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""cylc [control] jobs-submit JOB-LOG-ROOT [JOB-LOG-DIR ...]
+"""cylc [control] jobs-submit ARGS
 
 (This command is for internal use. Users should use "cylc submit".) Submit task
 jobs to relevant batch systems. On a remote job host, this command reads the

--- a/bin/cylc-print
+++ b/bin/cylc-print
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [prep] print [OPTIONS] [REGEX]
+"""cylc [prep] print [OPTIONS] ARGS
 
 Print registered (installed) suites.
 

--- a/bin/cylc-report-timings
+++ b/bin/cylc-report-timings
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [util] report-timings [OPTIONS] REG
+"""cylc [util] report-timings [OPTIONS] ARGS
 
 Retrieve suite timing information for wait and run time performance analysis.
 Raw output and summary output (in text or HTML format) are available.  Output

--- a/bin/cylc-scan
+++ b/bin/cylc-scan
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc [discovery] scan [OPTIONS] [HOSTS ...]
+"""cylc [discovery] scan [OPTIONS] ARGS
 
 Print information about running suites.
 

--- a/bin/cylc-suite-state
+++ b/bin/cylc-suite-state
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""cylc suite-state REG [OPTIONS]
+"""cylc suite-state [OPTIONS] ARGS
 
 Print task states retrieved from a suite database; or (with --task,
 --point, and --status) poll until a given task reaches a given state; or (with


### PR DESCRIPTION
Use opt parser to fill in `ARGS` automatically. Fixes incorrect usage text for `cylc insert`, as noticed by someone on Yammer and @dpmatthews 

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required (tiny change).
- [x] No documentation update required.
