### PR TITLE
only show task job state change info is comms method is polling

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -595,7 +595,10 @@ class TaskEventsManager():
         Check whether to process/skip message.
         Return True if `.process_message` should contine, False otherwise.
         """
-        if self.timestamp and itask.platform['communication method'] == 'poll':
+        if (
+            self.timestamp
+            and itask.platform.get('communication method', None) == 'poll'
+        ):
             timestamp = f" at {event_time}"
         else:
             timestamp = ""

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -595,7 +595,7 @@ class TaskEventsManager():
         Check whether to process/skip message.
         Return True if `.process_message` should contine, False otherwise.
         """
-        if self.timestamp:
+        if self.timestamp and itask.platform['communication method'] == 'poll':
             timestamp = f" at {event_time}"
         else:
             timestamp = ""

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -595,13 +595,13 @@ class TaskEventsManager():
         Check whether to process/skip message.
         Return True if `.process_message` should contine, False otherwise.
         """
-        if (
-            self.timestamp
-            and itask.platform.get('communication method', None) == 'poll'
-        ):
+        if self.timestamp:
             timestamp = f" at {event_time}"
         else:
             timestamp = ""
+
+        is_poll = itask.platform.get('communication method', None) == 'poll'
+
         if flag == self.FLAG_RECEIVED and submit_num != itask.submit_num:
             # Ignore received messages from old jobs
             LOG.warning(
@@ -648,7 +648,7 @@ class TaskEventsManager():
 
         LOG.log(
             LOG_LEVELS.get(severity, INFO),
-            f"[{itask}] {flag}{message}{timestamp}"
+            f"[{itask}] {flag}{message}{timestamp if is_poll else ''}"
         )
         return True
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -646,9 +646,14 @@ class TaskEventsManager():
                 )
             return False
 
+        if is_poll:
+            ts_string = timestamp
+        else:
+            ts_string = ''
+
         LOG.log(
             LOG_LEVELS.get(severity, INFO),
-            f"[{itask}] {flag}{message}{timestamp if is_poll else ''}"
+            f"[{itask}] {flag}{message}{ts_string}"
         )
         return True
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -600,8 +600,6 @@ class TaskEventsManager():
         else:
             timestamp = ""
 
-        is_poll = itask.platform.get('communication method', None) == 'poll'
-
         if flag == self.FLAG_RECEIVED and submit_num != itask.submit_num:
             # Ignore received messages from old jobs
             LOG.warning(
@@ -646,14 +644,14 @@ class TaskEventsManager():
                 )
             return False
 
-        if is_poll:
-            ts_string = timestamp
+        if itask.platform.get('communication method', '') == 'poll':
+            ts = ''
         else:
-            ts_string = ''
+            ts = timestamp
 
         LOG.log(
             LOG_LEVELS.get(severity, INFO),
-            f"[{itask}] {flag}{message}{ts_string}"
+            f"[{itask}] {flag}{message}{ts}"
         )
         return True
 

--- a/tests/functional/queues/02-queueorder.t
+++ b/tests/functional/queues/02-queueorder.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-run" \
     cylc play "${WORKFLOW_NAME}" --reference-test --debug --no-detach
 run_ok "${TEST_NAME_BASE}-test" bash -o pipefail -c "
     cylc cat-log '${WORKFLOW_NAME}' |
-    grep 'proc_n.*)submitted' |
+    grep 'proc_n.*(internal)submitted' |
     sort --key=4,4 --check"
 
 purge

--- a/tests/functional/queues/02-queueorder.t
+++ b/tests/functional/queues/02-queueorder.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-run" \
     cylc play "${WORKFLOW_NAME}" --reference-test --debug --no-detach
 run_ok "${TEST_NAME_BASE}-test" bash -o pipefail -c "
     cylc cat-log '${WORKFLOW_NAME}' |
-    grep 'proc_n.*submitted at' |
+    grep 'proc_n.*)submitted' |
     sort --key=4,4 --check"
 
 purge


### PR DESCRIPTION
These changes partially address #3647 

This PR only attempts to address the duplication of timestamps in Cylc Logging output:

```
2022-01-10T12:34:26Z INFO - [t1.1 preparing job:01 flows:1] (internal)submitted at 2022-01-10T12:34:26Z
...
2022-01-10T12:34:28Z INFO - [t1.1 submitted job:01 flows:1] (received)started at 2022-01-10T12:34:27Z
...
2022-01-10T12:34:31Z INFO - [t1.1 running job:01 flows:1] (received)succeeded at 2022-01-10T12:34:30Z
```

Except where the task communication method is 'poll'.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (Change to logging output, removing feature that is not useful).
- [x] No documentation update required.
