### PR TITLE
graph: handle potential failure of PIL.Image.show

### DIFF
--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -344,10 +344,12 @@ def dot(opts, lines):
 
 def gui(filename):
     """Open the rendered image file."""
+    print(f'Graph rendered to {filename}')
     try:
         from PIL import Image
     except ModuleNotFoundError:
-        print(f'Graph rendered to {filename}')
+        # dependencies required to display images not present
+        pass
     else:
         img = Image.open(filename)
         img.show()


### PR DESCRIPTION
Hopefully closes https://github.com/cylc/cylc-doc/issues/375

* We use Pillow to display images (when installed).
* Pillow uses other systems to handle the display itself and includes
  functionality to detect which of these systems are present.
  https://github.com/python-pillow/Pillow/blob/82541b6dec8452cb612067fcebba1c5a1a2bfdc8/src/PIL/ImageShow.py#L117-L263
* We have had reports that this detection has failed for one system
  causing the image not to show with no error displayed.
  https://github.com/cylc/cylc-doc/issues/375
* This change always prints the image file name incase the display
  command fails so that the user is never left high and dry.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.