### PR TITLE
data-store n > 0 window DB loads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,19 +56,23 @@ First Release Candidate for Cylc 8.
 
 ### Enhancements
 
-[#3931](https://github.com/cylc/cylc-flow/pull/3931) -
-Convert Cylc to use the new "Universal Identifier".
+[#4581](https://github.com/cylc/cylc-flow/pull/4581) - Job and task history
+is now loaded into the window about active tasks. Reflow future tasks now set
+to waiting.
 
-[#4506](https://github.com/cylc/cylc-flow/pull/4506) -
-Cylc no longer creates a `flow.cylc` symlink to a `suite.rc` file.
+[#3931](https://github.com/cylc/cylc-flow/pull/3931) - Convert Cylc to
+use the new "Universal Identifier".
+
+[#4506](https://github.com/cylc/cylc-flow/pull/4506) - Cylc no longer
+creates a `flow.cylc` symlink to a `suite.rc` file.
 This only affects you if you have used a prior Cylc 8 pre-release.
 
 [#4547](https://github.com/cylc/cylc-flow/pull/4547) - The max scan depth is
 now configurable in `global.cylc[install]max depth`, and `cylc install` will
 fail if the workflow ID would exceed this depth.
 
-[#4534](https://github.com/cylc/cylc-flow/pull/4534)
-- Permit jobs to be run on platforms with no $HOME directory.
+[#4534](https://github.com/cylc/cylc-flow/pull/4534) - Permit jobs
+to be run on platforms with no $HOME directory.
 
 [#4536](https://github.com/cylc/cylc-flow/pull/4536) - `cylc extract-resources`
 renamed `cylc get-resources` and small changes made:

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1084,6 +1084,10 @@ class DataStoreMgr:
                 ]
             )
 
+        # Load jobs from DB.
+        for row in flow_db.select_jobs_for_datastore(cycle_name_pairs):
+            self.insert_db_job(1, row)
+
         self.db_load_task_proxies.clear()
 
     def insert_job(self, name, point_string, status, job_conf):

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -883,6 +883,8 @@ class CylcWorkflowDAO:
         self, cycle_name_pairs
     ):
         """Select state and outputs of specified tasks."""
+        if not cycle_name_pairs:
+            return []
         form_stmt = r"""
             SELECT
                 %(task_states)s.cycle,
@@ -946,6 +948,8 @@ class CylcWorkflowDAO:
         self, cycle_name_pairs
     ):
         """Select jobs of of specified tasks."""
+        if not cycle_name_pairs:
+            return []
         form_stmt = r"""
             SELECT
                 %(task_states)s.cycle,

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -969,8 +969,8 @@ class CylcWorkflowDAO:
                 (%(task_states)s.cycle, %(task_states)s.name) IN (
                     VALUES %(cycle_name_pairs)s
                 )
-            GROUP BY
-                %(task_states)s.cycle, %(task_states)s.name
+            ORDER BY
+                %(task_states)s.submit_num DESC
         """
         form_data = {
             "task_states": self.TABLE_TASK_STATES,

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -436,6 +436,7 @@ class TaskPool:
                     self.workflow_db_mgr.pri_dao.select_task_prerequisites(
                         cycle,
                         name,
+                        flow_nums,
                     )
             ):
                 key = (prereq_cycle, prereq_name, prereq_output)

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -440,7 +440,8 @@ class WorkflowDatabaseManager:
         relevant insert statements for the current tasks in the pool.
         """
         self.db_deletes_map[self.TABLE_TASK_POOL].append({})
-        self.db_deletes_map[self.TABLE_TASK_PREREQUISITES].append({})
+        # We now keep prereq history, no need to do:
+        # self.db_deletes_map[self.TABLE_TASK_PREREQUISITES].append({})
         # No need to do:
         # self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
         # Should already be done by self.put_task_event_timers above.
@@ -451,6 +452,7 @@ class WorkflowDatabaseManager:
                     prereq.satisfied.items()
                 ):
                     self.put_insert_task_prerequisites(itask, {
+                        "flow_nums": json.dumps(list(itask.flow_nums)),
                         "prereq_name": p_name,
                         "prereq_cycle": p_cycle,
                         "prereq_output": p_output,

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -440,8 +440,8 @@ class WorkflowDatabaseManager:
         relevant insert statements for the current tasks in the pool.
         """
         self.db_deletes_map[self.TABLE_TASK_POOL].append({})
-        # We now keep prereq history, no need to do:
-        # self.db_deletes_map[self.TABLE_TASK_PREREQUISITES].append({})
+        # We can comment this out to keep prereq history for the data-store:
+        self.db_deletes_map[self.TABLE_TASK_PREREQUISITES].append({})
         # No need to do:
         # self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
         # Should already be done by self.put_task_event_timers above.

--- a/tests/flakyfunctional/database/00-simple/schema.out
+++ b/tests/flakyfunctional/database/00-simple/schema.out
@@ -9,7 +9,7 @@ CREATE TABLE task_jobs(cycle TEXT, name TEXT, submit_num INTEGER, is_manual_subm
 CREATE TABLE task_late_flags(cycle TEXT, name TEXT, value INTEGER, PRIMARY KEY(cycle, name));
 CREATE TABLE task_outputs(cycle TEXT, name TEXT, outputs TEXT, PRIMARY KEY(cycle, name));
 CREATE TABLE task_pool(cycle TEXT, name TEXT, flow_nums TEXT, status TEXT, is_held INTEGER, PRIMARY KEY(cycle, name, flow_nums));
-CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, prereq_name, prereq_cycle, prereq_output));
+CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, flow_nums, prereq_name, prereq_cycle, prereq_output));
 CREATE TABLE task_states(name TEXT, cycle TEXT, flow_nums TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, PRIMARY KEY(name, cycle, flow_nums));
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));
 CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT);

--- a/tests/functional/job-submission/01-job-nn-localhost/db.sqlite3
+++ b/tests/functional/job-submission/01-job-nn-localhost/db.sqlite3
@@ -6,7 +6,7 @@ CREATE TABLE inheritance(namespace TEXT, inheritance TEXT, PRIMARY KEY(namespace
 INSERT INTO inheritance VALUES('root','["root"]');
 INSERT INTO inheritance VALUES('foo','["foo", "root"]');
 CREATE TABLE workflow_params(key TEXT, value TEXT, PRIMARY KEY(key));
-INSERT INTO workflow_params VALUES('cylc_version', '8.0b2.dev');
+INSERT INTO workflow_params VALUES('cylc_version', '8.0rc1.dev0');
 CREATE TABLE workflow_template_vars(key TEXT, value TEXT, PRIMARY KEY(key));
 CREATE TABLE task_action_timers(cycle TEXT, name TEXT, ctx_key TEXT, ctx TEXT, delays TEXT, num INTEGER, delay TEXT, timeout TEXT, PRIMARY KEY(cycle, name, ctx_key));
 INSERT INTO task_action_timers VALUES('1','foo','"poll_timer"','["tuple", [[99, "running"]]]','[]',0,NULL,NULL);
@@ -21,7 +21,7 @@ INSERT INTO task_pool VALUES('1','foo','["1", "2"]','waiting', 0);
 CREATE TABLE task_states(name TEXT, cycle TEXT, flow_nums TEXT, time_created TEXT,
 time_updated TEXT, submit_num INTEGER, status TEXT, PRIMARY KEY(name, cycle, flow_nums));
 INSERT INTO task_states VALUES('foo','1','["1", "2"]', '2019-06-14T11:30:16+01:00','2019-06-14T11:40:24+01:00',99,'waiting');
-CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, prereq_name, prereq_cycle, prereq_output));
+CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, flow_nums, prereq_name, prereq_cycle, prereq_output));
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));
 CREATE TABLE xtriggers(signature TEXT, results TEXT, PRIMARY KEY(signature));
 COMMIT;

--- a/tests/functional/restart/53-task-prerequisites.t
+++ b/tests/functional/restart/53-task-prerequisites.t
@@ -34,10 +34,10 @@ TEST_NAME="${TEST_NAME_BASE}-db-task-prereq"
 QUERY='SELECT * FROM task_prerequisites ORDER BY cycle, name, prereq_cycle;'
 run_ok "$TEST_NAME" sqlite3 "$DB_FILE" "$QUERY"
 cmp_ok "${TEST_NAME}.stdout" << '__EOF__'
-2|bar|foo|1|succeeded|0
-2|bar|apollo|2|The Eagle has landed|satisfied naturally
-3|bar|foo|2|succeeded|satisfied naturally
-3|bar|apollo|3|The Eagle has landed|0
+2|bar|[1]|foo|1|succeeded|0
+2|bar|[1]|apollo|2|The Eagle has landed|satisfied naturally
+3|bar|[1]|foo|2|succeeded|satisfied naturally
+3|bar|[1]|apollo|3|The Eagle has landed|0
 __EOF__
 
 workflow_run_fail "${TEST_NAME_BASE}-restart" cylc play "${WORKFLOW_NAME}" --stopcp=3 --no-detach

--- a/tests/functional/restart/54-incompatible-db/db.sqlite3
+++ b/tests/functional/restart/54-incompatible-db/db.sqlite3
@@ -27,5 +27,5 @@ INSERT INTO task_pool VALUES('1','bar',0,'held','waiting');
 CREATE TABLE xtriggers(signature TEXT, results TEXT, PRIMARY KEY(signature));
 CREATE TABLE task_action_timers(cycle TEXT, name TEXT, ctx_key TEXT, ctx TEXT, delays TEXT, num INTEGER, delay TEXT, timeout TEXT, PRIMARY KEY(cycle, name, ctx_key));
 CREATE TABLE absolute_outputs(cycle TEXT, name TEXT, output TEXT);
-CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, prereq_name, prereq_cycle, prereq_output));
+CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, flow_nums, prereq_name, prereq_cycle, prereq_output));
 COMMIT;


### PR DESCRIPTION
These changes partially addresses #4036
(prerequisites were always available, but satisfaction not set)

At present history is only populated via the evolution/forward-march of the active pool.
History is not recovered on restart nor on the window appearing/reappearing about a trigger/reflow.

This pull request aims to fill in the history of those n>0 window nodes:
- [x] Load DB task status and other information of the latest submit.
- [x] Load DB prerequisite satisfaction for the flow (`flow_nums`) of the respective tasks.
- [x] Load DB jobs of the respective tasks.
- [x] Set reflow future window task state to waiting (if not in active-pool/data-store).

This PR also fixes a bug where triggered tasks would hang around after completion, and never get pruned.

**Note: Prerequisite DB history has been taken out (only restart prereqs available and loaded)**
So the prereq satisfaction, shown with GraphiQL below, will no longer be correct for historical tasks.
(However, this is just a one line change.. So, I've left it in)

As an example:
```
[scheduling]
    initial cycle point = 20210101T00
    [[special tasks]]
        clock-trigger = foo(PT0H)
    [[graph]]
        P1M = """
foo => bar => qux => qaz
foo[-P1M] => foo
"""
```
With prerequisites, we can't visualize them at the moment.. But they can be confirmed with GraphiQL:
```
query {
  workflows (ids: ["linear/run1"]) {
    id
    taskProxies {
      id
      flowNums
      state
      prerequisites {
        satisfied
        conditions {
          taskId
          satisfied
        }
      }
    }
  }
}
```
**Trigger reflow:**
```$ cylc trigger --reflow linear //20210201T00/foo```
![n-gt-zero-loads-reflow](https://user-images.githubusercontent.com/11400777/150282822-e6c9d435-9366-476a-a9bf-74bde5641477.gif)
Data at start:
```
{
  "data": {
    "workflows": [
      {
        "id": "~sutherlander/linear/run1",
        "taskProxies": [
          {
            "id": "~sutherlander/linear/run1//20220101T00/foo",
            "flowNums": "[1]",
            "state": "succeeded",
            "prerequisites": [
              {
                "satisfied": true,
                "conditions": [
                  {
                    "taskId": "20211201T00/foo",
                    "satisfied": true
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210201T00/bar",
            "flowNums": "[2]",
            "state": "waiting",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20210201T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210301T00/foo",
            "flowNums": "[2]",
            "state": "waiting",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20210201T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20220301T00/foo",
            "flowNums": "[1]",
            "state": "waiting",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20220201T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210201T00/foo",
            "flowNums": "[2]",
            "state": "preparing",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20210101T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210101T00/foo",
            "flowNums": "[1]",
            "state": "succeeded",
            "prerequisites": [
              {
                "satisfied": true,
                "conditions": [
                  {
                    "taskId": "20201201T00/foo",
                    "satisfied": true
                  }
                ]
              }
            ]
          },
          .
          .
          .
        ]
      }
    ]
  }
}
```

(not the past task is loaded in it's previous state, while the future tasks are set to waiting)

**Trigger (noflow):**
```$ cylc trigger linear //20210201T00/bar```
![n-gt-zero-loads-noflow](https://user-images.githubusercontent.com/11400777/150282849-1afd965c-6762-4f5a-b629-396c9143a67a.gif)
Data at start:
```
{
  "data": {
    "workflows": [
      {
        "id": "~sutherlander/linear/run1",
        "taskProxies": [
          {
            "id": "~sutherlander/linear/run1//20220101T00/foo",
            "flowNums": "[1]",
            "state": "succeeded",
            "prerequisites": [
              {
                "satisfied": true,
                "conditions": [
                  {
                    "taskId": "20211201T00/foo",
                    "satisfied": true
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210201T00/bar",
            "flowNums": "[]",
            "state": "submitted",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20210201T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20220301T00/foo",
            "flowNums": "[1]",
            "state": "waiting",
            "prerequisites": [
              {
                "satisfied": false,
                "conditions": [
                  {
                    "taskId": "20220201T00/foo",
                    "satisfied": false
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210201T00/qux",
            "flowNums": "[1]",
            "state": "succeeded",
            "prerequisites": [
              {
                "satisfied": true,
                "conditions": [
                  {
                    "taskId": "20210201T00/bar",
                    "satisfied": true
                  }
                ]
              }
            ]
          },
          {
            "id": "~sutherlander/linear/run1//20210201T00/foo",
            "flowNums": "[1]",
            "state": "succeeded",
            "prerequisites": [
              {
                "satisfied": true,
                "conditions": [
                  {
                    "taskId": "20210101T00/foo",
                    "satisfied": true
                  }
                ]
              }
            ]
          },
          .
          .
          .
        ]
      }
    ]
  }
}
```



**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required (non-interactive changes).
