### PR TITLE
stop get_platform_from_group reversing the order of the platform list

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -251,7 +251,7 @@ def get_platform_from_group(
         good_platforms = set()
         for platform in group['platforms']:
             if set(platform_from_name(platform)['hosts']) - bad_hosts:
-                good_platforms.add(platform)
+                good_platforms = good_platforms.union({platform})
 
         platform_names = list(good_platforms)
     else:


### PR DESCRIPTION
These changes fix [issue discussed on Element](https://matrix.to/#/!hwZqSYihGPuhDdIzIP:matrix.org/$1642480697178601JWqGF:matrix.org?via=matrix.org).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] No documentation update required.
