### PR TITLE
cyclers: remove unused get_inferred_child interface

### DIFF
--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -180,8 +180,6 @@ class IntervalBase(metaclass=ABCMeta):
     this type.
      * self.get_null_offset, which is a method to extract a null offset
     relative to a PointBase object.
-     * self.get_inferred_child to generate an offset from an input
-    without units using the current units of the instance (if any).
 
     Subclasses may also provide an overridden self.standardise
     method to reprocess their value into a standard form.
@@ -205,11 +203,6 @@ class IntervalBase(metaclass=ABCMeta):
     @abstractmethod
     def get_null(cls):
         """Return a null interval."""
-        pass
-
-    @abstractmethod
-    def get_inferred_child(self, string):
-        """For a given string, infer the offset given my instance units."""
         pass
 
     @abstractmethod

--- a/cylc/flow/cycling/integer.py
+++ b/cylc/flow/cycling/integer.py
@@ -183,13 +183,6 @@ class IntegerInterval(IntervalBase):
         """Return a null offset."""
         return IntegerInterval("+P0")
 
-    def get_inferred_child(self, string):
-        """For a given string, infer the offset given my instance units."""
-        try:
-            IntegerInterval.from_integer(int(string))
-        except (TypeError, ValueError):
-            return IntegerInterval(string)
-
     def __init__(self, value):
         if (not isinstance(value, str) or
                 not REC_INTERVAL.search(value)):

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 import re
 from typing import List, Optional, TYPE_CHECKING, Tuple
 
-from metomi.isodatetime.data import Calendar, Duration, CALENDAR
+from metomi.isodatetime.data import Calendar, CALENDAR
 from metomi.isodatetime.dumpers import TimePointDumper
 from metomi.isodatetime.timezone import (
     get_local_time_zone, get_local_time_zone_format, TimeZoneFormatMode)
@@ -164,18 +164,6 @@ class ISO8601Interval(IntervalBase):
     def get_null_offset(cls):
         """Return a null offset."""
         return ISO8601Interval("+P0Y")
-
-    def get_inferred_child(self, string):
-        """Return an instance with 'string' amounts of my non-zero units."""
-        interval = interval_parse(self.value)
-        amount_per_unit = int(string)
-        unit_amounts = {}
-        for attribute in ["years", "months", "weeks", "days",
-                          "hours", "minutes", "seconds"]:
-            if getattr(interval, attribute):
-                unit_amounts[attribute] = amount_per_unit
-        interval = Duration(**unit_amounts)
-        return ISO8601Interval(str(interval))
 
     def standardise(self):
         """Format self.value into a standard representation."""


### PR DESCRIPTION
Dunno what it was for, isn't used any more.