### PR TITLE
config: convert ports from list to min..max pair

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -34,6 +34,7 @@ from cylc.flow.parsec.upgrade import upgrader
 from cylc.flow.parsec.validate import (
     CylcConfigValidator as VDR,
     DurationFloat,
+    Range,
     cylc_config_validate,
 )
 
@@ -368,13 +369,18 @@ with Conf('global.cylc', desc='''
                (Unless an explicit host is provided as an option to the
                ``cylc play --host=<myhost>`` command.)
             ''')
-            Conf('ports', VDR.V_INTEGER_LIST, list(range(43001, 43101)),
+            Conf('ports', VDR.V_RANGE, Range((43001, 43101)),
                  desc=f'''
-                A list of allowed ports for Cylc to use to run workflows.
+                The range of ports for Cylc to use to run workflows.
+
+                The minimum and maximum port numbers in the format
+                ``min .. max``.
 
                 .. versionchanged:: 8.0.0
 
-                   {REPLACES}``[suite servers]run ports``
+                   {REPLACES}``[suite servers]run ports``.
+                   It can no longer be used to definine a non-contiguous port
+                   range.
             ''')
             Conf('condemned', VDR.V_ABSOLUTE_HOST_LIST, desc=f'''
                 These hosts will not be used to run jobs.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -539,9 +539,9 @@ class Scheduler:
 
     async def start_servers(self):
         """Start the TCP servers."""
-        port_range = glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
-        self.server.start(port_range[0], port_range[-1])
-        self.publisher.start(port_range[0], port_range[-1])
+        min_, max_ = glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
+        self.server.start(min_, max_)
+        self.publisher.start(min_, max_)
         # wait for threads to setup socket ports before continuing
         self.barrier.wait()
         self.port = self.server.port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple
 
 import pytest
 
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.parsec.config import ParsecConfig
 
@@ -101,3 +102,8 @@ def log_filter():
             and (regex is None or re.match(regex, log_message))
         ]
     return _log_filter
+
+
+@pytest.fixture(scope='session')
+def port_range():
+    return glbl_cfg().get(['scheduler', 'run hosts', 'ports'])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -213,12 +213,6 @@ def mod_one(mod_one_conf, mod_flow, mod_scheduler):
     return schd
 
 
-@pytest.fixture(scope='session')
-def port_range():
-    ports = glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
-    return min(ports), max(ports)
-
-
 @pytest.fixture(scope='module')
 def event_loop():
     """This fixture defines the event loop used for each test.

--- a/tests/unit/network/test_publisher.py
+++ b/tests/unit/network/test_publisher.py
@@ -22,12 +22,6 @@ from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network.publisher import WorkflowPublisher, serialize_data
 
 
-@pytest.fixture(scope='session')
-def port_range():
-    ports = glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
-    return min(ports), max(ports)
-
-
 def test_serialize_data():
     str1 = 'hello'
     assert serialize_data(str1, None) == str1


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/4586
* Sibling https://github.com/cylc/cylc-sphinx-extensions/pull/66
* At Cylc 7 we could configure a list of ports to choose from.
* At Cylc 8 we use ZMQ to pick an available port for us which it does
  using min/max values.
* As a result we were only considering the first and last items in the
  configured list which could cause the port range to be smaller than
  configured.
* The config has now been reduced to a min..max pair in a format that is
  back compatible with the old format (providing that there is only one
  range).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? back compatible)
- [x] No documentation update required.