### PR TITLE
Fix test failing due to expected task failures not using UID.

### DIFF
--- a/tests/functional/directives/slurm/flow.cylc
+++ b/tests/functional/directives/slurm/flow.cylc
@@ -2,7 +2,7 @@
 
 [scheduler]
    [[events]]
-       expected task failures = rem2.1
+       expected task failures = 1/rem2
 
 [scheduling]
     [[graph]]


### PR DESCRIPTION

This is a small change with no associated Issue.

`tests/functional/directives/03-slurm.t` was failing because Cylc didn't seem to understand the non UID format of the task listed as an expected failure.

@oliver-sanders - Is this indicative of a larger hole- should UID cope with the old format in this case?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Itself a change to existing tests.
- [x] No change log entry required (Change to test).
- [x] No documentation update required.
