### PR TITLE
uid: tolerate trailing slashes in IDs on the CLI

### DIFF
--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -362,15 +362,11 @@ async def test_parse_ids_src_path(src_dir):
     [
         (
             ['/home/me/whatever'],
-            'Invalid Cylc identifier: /home/me/whatever',
+            'Invalid ID: /home/me/whatever',
         ),
         (
             ['foo/..'],
             'cannot be a path that points to the cylc-run directory or above',
-        ),
-        (
-            ['foo/'],
-            'Invalid Cylc identifier',
         ),
         (
             ['~alice/foo'],


### PR DESCRIPTION
Closes #4583

* Trailing slashes in universal IDs are invalid.
* However, they are harmless and user's may add them due to CLI auto-completion.
* We should tolerate them in the context of user input.
* Note this strips the `/` at the CLI, it doesn't propagate into the code.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? part of bigger change already documented)
- [x] No documentation update required.
