### PR TITLE
Put `@pytest.mark.asyncio` decorators back in for now

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
   pull_request:
+    paths-ignore:
+      - '.github/workflows/*.ya?ml'
+      - '!.github/workflows/test_tutorial_workflow.yml'
+      - 'tests/**'
+      - '**.md'
   workflow_dispatch:
     inputs:
       rose_ref:

--- a/tests/integration/graphql/test_root.py
+++ b/tests/integration/graphql/test_root.py
@@ -19,6 +19,7 @@ import pytest
 from cylc.flow.network.client import WorkflowRuntimeClient
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run):
     reg = mod_flow({
@@ -57,6 +58,7 @@ async def harness(mod_flow, mod_scheduler, mod_run):
         yield schd, client, _query
 
 
+@pytest.mark.asyncio
 async def test_workflows(harness):
     """It should return True if running."""
     schd, client, query = harness
@@ -68,6 +70,7 @@ async def test_workflows(harness):
     }
 
 
+@pytest.mark.asyncio
 async def test_jobs(harness):
     """It should return True if running."""
     schd, client, query = harness

--- a/tests/integration/test_async_util.py
+++ b/tests/integration/test_async_util.py
@@ -32,6 +32,7 @@ def directory(tmp_path):
     rmtree(tmp_path)
 
 
+@pytest.mark.asyncio
 async def test_scandir(directory):
     """It should list directory contents (including symlinks)."""
     assert await scandir(directory) == [

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -21,6 +21,7 @@ from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.network.server import PB_METHOD_MAP
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run, mod_one_conf):
     reg = mod_flow(mod_one_conf)
@@ -30,6 +31,7 @@ async def harness(mod_flow, mod_scheduler, mod_run, mod_one_conf):
         yield schd, client
 
 
+@pytest.mark.asyncio
 async def test_graphql(harness):
     """It should return True if running."""
     schd, client = harness
@@ -43,6 +45,7 @@ async def test_graphql(harness):
     assert schd.workflow in workflow['id']
 
 
+@pytest.mark.asyncio
 async def test_protobuf(harness):
     """It should return True if running."""
     schd, client = harness

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -85,6 +85,7 @@ def ext_id(schd):
     return f'~{schd.owner}/{schd.workflow}//{int_id(None)}'
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run):
     flow_def = {

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -28,6 +28,7 @@ import pytest
 from cylc.flow import __version__
 
 
+@pytest.mark.asyncio
 async def test_create_flow(flow, run_dir):
     """Use the flow fixture to create workflows on the file system."""
     # Ensure a flow.cylc file gets written out
@@ -48,6 +49,7 @@ async def test_create_flow(flow, run_dir):
     assert flow_file.exists()
 
 
+@pytest.mark.asyncio
 async def test_run(flow, scheduler, run, one_conf):
     """Create a workflow, initialise the scheduler and run it."""
     # Ensure the scheduler can survive for one second without crashing
@@ -57,6 +59,7 @@ async def test_run(flow, scheduler, run, one_conf):
         await asyncio.sleep(1)
 
 
+@pytest.mark.asyncio
 async def test_logging(flow, scheduler, run, one_conf, log_filter):
     """We can capture log records when we run a scheduler."""
     # Ensure that the cylc version is logged on startup.
@@ -67,6 +70,7 @@ async def test_logging(flow, scheduler, run, one_conf, log_filter):
         assert log_filter(log, contains=__version__)
 
 
+@pytest.mark.asyncio
 async def test_scheduler_arguments(flow, scheduler, run, one_conf):
     """We can provide options to the scheduler when we __init__ it.
 
@@ -86,6 +90,7 @@ async def test_scheduler_arguments(flow, scheduler, run, one_conf):
         assert not schd.is_paused
 
 
+@pytest.mark.asyncio
 async def test_shutdown(flow, scheduler, run, one_conf):
     """Shut down a workflow.
 
@@ -102,6 +107,7 @@ async def test_shutdown(flow, scheduler, run, one_conf):
     assert schd.server.socket.closed
 
 
+@pytest.mark.asyncio
 async def test_install(flow, scheduler, one_conf, run_dir):
     """You don't have to run workflows, it's usually best not to!
 
@@ -118,6 +124,7 @@ async def test_install(flow, scheduler, one_conf, run_dir):
     ).exists()
 
 
+@pytest.mark.asyncio
 async def test_task_pool(flow, scheduler, one_conf):
     """You don't have to run the scheduler to play with the task pool."""
     # Ensure that the correct number of tasks get added to the task pool.
@@ -136,6 +143,7 @@ async def test_task_pool(flow, scheduler, one_conf):
     assert len(schd.pool.main_pool) == 1
 
 
+@pytest.mark.asyncio
 async def test_exception(flow, scheduler, run, one_conf, log_filter):
     """Through an exception into the scheduler to see how it will react.
 
@@ -202,6 +210,7 @@ def test_module_two(myflow):
     assert myflow.uuid_str
 
 
+@pytest.mark.asyncio
 async def test_db_select(one, run, db_select):
     """Demonstrate and test querying the workflow database."""
     schd = one

--- a/tests/integration/test_graphql.py
+++ b/tests/integration/test_graphql.py
@@ -69,6 +69,7 @@ def job_db_row():
     ]
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run):
     flow_def = {
@@ -109,6 +110,7 @@ async def harness(mod_flow, mod_scheduler, mod_run):
         yield schd, client, workflow_tokens
 
 
+@pytest.mark.asyncio
 async def test_workflows(harness):
     schd, client, w_tokens = harness
     ret = await client.async_request(
@@ -124,6 +126,7 @@ async def test_workflows(harness):
     }
 
 
+@pytest.mark.asyncio
 async def test_tasks(harness):
     schd, client, w_tokens = harness
 
@@ -155,6 +158,7 @@ async def test_tasks(harness):
         }
 
 
+@pytest.mark.asyncio
 async def test_families(harness):
     schd, client, w_tokens = harness
 
@@ -188,6 +192,7 @@ async def test_families(harness):
         }
 
 
+@pytest.mark.asyncio
 async def test_task_proxies(harness):
     schd, client, w_tokens = harness
 
@@ -222,6 +227,7 @@ async def test_task_proxies(harness):
     }
 
 
+@pytest.mark.asyncio
 async def test_family_proxies(harness):
     schd, client, w_tokens = harness
 
@@ -257,6 +263,7 @@ async def test_family_proxies(harness):
         }
 
 
+@pytest.mark.asyncio
 async def test_edges(harness):
     schd, client, w_tokens = harness
 
@@ -316,6 +323,7 @@ async def test_edges(harness):
     }
 
 
+@pytest.mark.asyncio
 async def test_jobs(harness):
     schd, client, w_tokens = harness
 

--- a/tests/integration/test_id_cli.py
+++ b/tests/integration/test_id_cli.py
@@ -46,6 +46,7 @@ async def harness(
             yield reg_prefix, reg1, reg2, reg3
 
 
+@pytest.mark.asyncio
 async def test_glob_wildcard(harness):
     """It should search for workflows using globs."""
     reg_prefix, reg1, reg2, reg3 = harness
@@ -64,6 +65,7 @@ async def test_glob_wildcard(harness):
     assert sorted(workflows) == sorted([])
 
 
+@pytest.mark.asyncio
 async def test_glob_pattern(harness):
     """It should support fnmatch syntax including square brackets."""
     # [a]* should match workflows starting with "a"
@@ -82,6 +84,7 @@ async def test_glob_pattern(harness):
     assert sorted(workflows) == sorted([])
 
 
+@pytest.mark.asyncio
 async def test_state_filter(harness):
     """It should filter by workflow state."""
     reg_prefix, reg1, reg2, reg3 = harness

--- a/tests/integration/test_publisher.py
+++ b/tests/integration/test_publisher.py
@@ -22,6 +22,7 @@ from cylc.flow.network.subscriber import (
 )
 
 
+@pytest.mark.asyncio
 async def test_publisher(flow, scheduler, run, one_conf, port_range):
     """It should publish deltas when the flow starts."""
     reg = flow(one_conf)

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -93,6 +93,7 @@ async def mock_flow(
     return ret
 
 
+@pytest.mark.asyncio
 async def test_get_workflows(mock_flow, flow_args):
     """Test method returning workflow messages satisfying filter args."""
     flow_args['workflows'].append({
@@ -104,6 +105,7 @@ async def test_get_workflows(mock_flow, flow_args):
     assert len(flow_msgs) == 1
 
 
+@pytest.mark.asyncio
 async def test_get_nodes_all(mock_flow, node_args):
     """Test method returning workflow(s) node message satisfying filter args.
     """
@@ -126,6 +128,7 @@ async def test_get_nodes_all(mock_flow, node_args):
     assert len(nodes) == 1
 
 
+@pytest.mark.asyncio
 async def test_get_nodes_by_ids(mock_flow, node_args):
     """Test method returning workflow(s) node messages
     who's ID is a match to any given."""
@@ -149,6 +152,7 @@ async def test_get_nodes_by_ids(mock_flow, node_args):
     assert len(nodes) > 0
 
 
+@pytest.mark.asyncio
 async def test_get_node_by_id(mock_flow, node_args):
     """Test method returning a workflow node message
     who's ID is a match to that given."""
@@ -170,6 +174,7 @@ async def test_get_node_by_id(mock_flow, node_args):
     assert node in mock_flow.data[TASK_PROXIES].values()
 
 
+@pytest.mark.asyncio
 async def test_get_edges_all(mock_flow, flow_args):
     """Test method returning all workflow(s) edges."""
     edges = [
@@ -180,6 +185,7 @@ async def test_get_edges_all(mock_flow, flow_args):
     assert len(edges) > 0
 
 
+@pytest.mark.asyncio
 async def test_get_edges_by_ids(mock_flow, node_args):
     """Test method returning workflow(s) edge messages
     who's ID is a match to any given edge IDs."""
@@ -194,6 +200,7 @@ async def test_get_edges_by_ids(mock_flow, node_args):
     assert len(edges) > 0
 
 
+@pytest.mark.asyncio
 async def test_mutator(mock_flow, flow_args):
     """Test the mutation method."""
     flow_args['workflows'].append({
@@ -211,6 +218,7 @@ async def test_mutator(mock_flow, flow_args):
     assert response[0]['id'] == mock_flow.id
 
 
+@pytest.mark.asyncio
 async def test_nodes_mutator(mock_flow, flow_args):
     """Test the nodes mutation method."""
     flow_args['workflows'].append({
@@ -226,6 +234,7 @@ async def test_nodes_mutator(mock_flow, flow_args):
     assert response[0]['id'] == mock_flow.id
 
 
+@pytest.mark.asyncio
 async def test_mutation_mapper(mock_flow):
     """Test the mapping of mutations to internal command methods."""
     response = await mock_flow.resolvers._mutation_mapper('pause', {})

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -184,6 +184,7 @@ async def listify(async_gen, field='name'):
     return ret
 
 
+@pytest.mark.asyncio
 async def test_scan(sample_run_dir):
     """It should list all flows."""
     assert await listify(
@@ -197,6 +198,7 @@ async def test_scan(sample_run_dir):
     ]
 
 
+@pytest.mark.asyncio
 async def test_scan_with_files(sample_run_dir):
     """It shouldn't be perturbed by arbitrary files."""
     Path(sample_run_dir, 'abc').touch()
@@ -212,6 +214,7 @@ async def test_scan_with_files(sample_run_dir):
     ]
 
 
+@pytest.mark.asyncio
 async def test_scan_horrible_mess(badly_messed_up_cylc_run_dir):
     """It shouldn't be affected by erroneous cylc files/dirs.
 
@@ -227,6 +230,7 @@ async def test_scan_horrible_mess(badly_messed_up_cylc_run_dir):
     ]
 
 
+@pytest.mark.asyncio
 async def test_scan_symlinks(run_dir_with_symlinks):
     """It should follow symlinks to flows in other dirs."""
     assert await listify(
@@ -237,6 +241,7 @@ async def test_scan_symlinks(run_dir_with_symlinks):
     ]
 
 
+@pytest.mark.asyncio
 async def test_scan_nasty_symlinks(run_dir_with_nasty_symlinks):
     """It should handle strange symlinks because users can be nasty."""
     assert await listify(
@@ -248,6 +253,7 @@ async def test_scan_nasty_symlinks(run_dir_with_nasty_symlinks):
     ]
 
 
+@pytest.mark.asyncio
 async def test_is_active(sample_run_dir):
     """It should filter flows by presence of a contact file."""
     # running flows
@@ -276,6 +282,7 @@ async def test_is_active(sample_run_dir):
     )
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'depth, expected',
     [
@@ -290,6 +297,7 @@ async def test_max_depth(nested_dir, depth: int, expected: List[str]):
     ) == expected
 
 
+@pytest.mark.asyncio
 async def test_max_depth_configurable(nested_dir, mock_glbl_cfg):
     """Default scan depth should be configurable in global.cylc."""
     mock_glbl_cfg(
@@ -307,6 +315,7 @@ async def test_max_depth_configurable(nested_dir, mock_glbl_cfg):
     ]
 
 
+@pytest.mark.asyncio
 async def test_workflow_params(
     flow,
     scheduler,
@@ -341,6 +350,7 @@ async def test_workflow_params(
             assert flow['workflow_params'][uuid_key] == schd.uuid_str
 
 
+@pytest.mark.asyncio
 async def test_source_dirs(source_dirs):
     """It should list uninstalled workflows from configured source dirs."""
     src1, src2 = source_dirs
@@ -355,6 +365,7 @@ async def test_source_dirs(source_dirs):
     ]
 
 
+@pytest.mark.asyncio
 async def test_scan_sigstop(flow, scheduler, run, one_conf, test_dir, caplog):
     """It should log warnings if workflows are un-contactable.
 

--- a/tests/integration/test_scan_api.py
+++ b/tests/integration/test_scan_api.py
@@ -95,6 +95,7 @@ async def flows(mod_flow, mod_scheduler, mod_run, mod_one_conf):
             yield
 
 
+@pytest.mark.asyncio
 async def test_state_filter(flows, mod_test_dir):
     """It should filter flows by state."""
     # one stopped flow
@@ -132,6 +133,7 @@ async def test_state_filter(flows, mod_test_dir):
     assert len(lines) == 4
 
 
+@pytest.mark.asyncio
 async def test_name_filter(flows, mod_test_dir):
     """It should filter flows by name regex."""
     # one stopped flow
@@ -142,6 +144,7 @@ async def test_name_filter(flows, mod_test_dir):
     assert '-paused-' in lines[0]
 
 
+@pytest.mark.asyncio
 async def test_name_sort(flows, mod_test_dir):
     """It should sort flows by name."""
     # one stopped flow
@@ -155,6 +158,7 @@ async def test_name_sort(flows, mod_test_dir):
     assert 'a/b/c' in lines[3]
 
 
+@pytest.mark.asyncio
 async def test_format_json(flows, mod_test_dir):
     """It should dump results in json format."""
     # one stopped flow
@@ -166,6 +170,7 @@ async def test_format_json(flows, mod_test_dir):
     assert data[0]['name']
 
 
+@pytest.mark.asyncio
 async def test_format_tree(flows, run_dir, ses_test_dir, mod_test_dir):
     """It should dump results in an ascii tree format."""
     # one stopped flow
@@ -181,6 +186,7 @@ async def test_format_tree(flows, run_dir, ses_test_dir, mod_test_dir):
     assert '-running-' in lines[2]
 
 
+@pytest.mark.asyncio
 async def test_format_rich(flows, mod_test_dir):
     """It should print results in a long human-friendly format."""
     # one stopped flow (--colour-blind)
@@ -239,6 +245,7 @@ async def test_format_rich(flows, mod_test_dir):
         raise Exception('missing state totals line (colourful)')
 
 
+@pytest.mark.asyncio
 async def test_scan_cleans_stuck_contact_files(
     run,
     scheduler,

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -25,6 +25,7 @@ from cylc.flow.scheduler import Scheduler
 Fixture = Any
 
 
+@pytest.mark.asyncio
 async def test_is_paused_after_stop(
         one_conf: Fixture, flow: Fixture, scheduler: Fixture, run: Fixture,
         db_select: Fixture):
@@ -44,6 +45,7 @@ async def test_is_paused_after_stop(
         assert not schd.is_paused
 
 
+@pytest.mark.asyncio
 async def test_is_paused_after_crash(
         one_conf: Fixture, flow: Fixture, scheduler: Fixture, run: Fixture,
         db_select: Fixture):
@@ -73,6 +75,7 @@ async def test_is_paused_after_crash(
         assert schd.is_paused
 
 
+@pytest.mark.asyncio
 async def test_resume_does_not_release_tasks(one: Scheduler, run: Callable):
     """Test that resuming a workflow does not release any held tasks."""
     schd: Scheduler = one
@@ -89,6 +92,7 @@ async def test_resume_does_not_release_tasks(one: Scheduler, run: Callable):
         assert itask.state.is_held
 
 
+@pytest.mark.asyncio
 async def test_shutdown_CylcError_log(one: Scheduler, run: Callable):
     """Test that if a CylcError occurs during shutdown, it is
     logged in one line."""
@@ -108,6 +112,7 @@ async def test_shutdown_CylcError_log(one: Scheduler, run: Callable):
     assert last_record.levelno == logging.ERROR
 
 
+@pytest.mark.asyncio
 async def test_shutdown_general_exception_log(one: Scheduler, run: Callable):
     """Test that if a non-CylcError occurs during shutdown, it is
     logged with traceback (but not excessive)."""

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -23,6 +23,7 @@ import pytest
 from cylc.flow.network.server import PB_METHOD_MAP
 
 
+@pytest.mark.asyncio
 @pytest.fixture(scope='module')
 async def myflow(mod_flow, mod_scheduler, mod_run, mod_one_conf):
     reg = mod_flow(mod_one_conf)
@@ -78,6 +79,7 @@ def test_pb_entire_workflow(myflow):
     assert data.workflow.id == myflow.id
 
 
+@pytest.mark.asyncio
 @pytest.fixture
 async def accident(flow, scheduler, run, one_conf):
     reg = flow(one_conf)
@@ -86,6 +88,7 @@ async def accident(flow, scheduler, run, one_conf):
         yield schd
 
 
+@pytest.mark.asyncio
 async def test_listener(accident):
     """Test listener."""
     accident.server.queue.put('STOP')

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -114,6 +114,7 @@ async def example_flow(
     return schd
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'items, expected_task_ids, expected_bad_items, expected_warnings',
     [
@@ -192,6 +193,7 @@ async def test_filter_task_proxies(
     assert_expected_log(caplog, expected_warnings)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'items, expected_task_ids, expected_warnings',
     [
@@ -261,6 +263,7 @@ async def test_match_taskdefs(
     assert n_warnings == len(logged_warnings)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'items, expected_tasks_to_hold_ids, expected_warnings',
     [
@@ -330,6 +333,7 @@ async def test_hold_tasks(
     assert get_task_ids(db_held_tasks) == expected_tasks_to_hold_ids
 
 
+@pytest.mark.asyncio
 async def test_release_held_tasks(
     example_flow: Scheduler, db_select: Callable
 ) -> None:
@@ -365,6 +369,7 @@ async def test_release_held_tasks(
     assert get_task_ids(db_tasks_to_hold) == expected_tasks_to_hold_ids
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'hold_after_point, expected_held_task_ids',
     [

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -45,6 +45,7 @@ def test_load_contact_file(myflow):
     assert cont[CFF.HOST] == myflow.host
 
 
+@pytest.mark.asyncio
 async def test_load_contact_file_async(myflow):
     cont = await load_contact_file_async(myflow.workflow)
     assert cont[CFF.HOST] == myflow.host
@@ -54,6 +55,7 @@ async def test_load_contact_file_async(myflow):
     assert cont == cont2
 
 
+@pytest.mark.asyncio
 @pytest.fixture
 async def workflow(flow, scheduler, one_conf, run_dir):
     reg = flow(one_conf)

--- a/tests/integration/utils/test_utils.py
+++ b/tests/integration/utils/test_utils.py
@@ -44,6 +44,7 @@ def test_rm_if_empty(tmp_path):
     assert not path1.exists()
 
 
+@pytest.mark.asyncio
 async def test_poll_file(tmp_path):
     """It should return if the condition is met."""
     path = tmp_path / 'file'

--- a/tests/unit/network/test_scan_nt.py
+++ b/tests/unit/network/test_scan_nt.py
@@ -44,6 +44,7 @@ def test_filter_name_preprocess():
     assert pipe.args[0] == re.compile('(^f|^c)')
 
 
+@pytest.mark.asyncio
 async def test_filter_name():
     """It should filter flows by registration name."""
     pipe = filter_name('^f')
@@ -57,6 +58,7 @@ async def test_filter_name():
     )
 
 
+@pytest.mark.asyncio
 async def test_cylc_version():
     """It should filter flows by cylc version."""
     version = ContactFileFields.VERSION
@@ -74,6 +76,7 @@ async def test_cylc_version():
     )
 
 
+@pytest.mark.asyncio
 async def test_api_version():
     """It should filter flows by api version."""
     version = ContactFileFields.API
@@ -91,6 +94,7 @@ async def test_api_version():
     )
 
 
+@pytest.mark.asyncio
 async def test_contact_info(tmp_path):
     """It should load info from the contact file."""
     # create a dummy flow

--- a/tests/unit/scripts/test_clean.py
+++ b/tests/unit/scripts/test_clean.py
@@ -23,6 +23,7 @@ import pytest
 from cylc.flow.scripts.clean import scan, run
 
 
+@pytest.mark.asyncio
 async def test_scan(tmp_run_dir):
     """It should scan the filesystem to expand partial IDs."""
     # regular workflows pass straight through
@@ -58,6 +59,7 @@ def mute(monkeypatch):
     return items
 
 
+@pytest.mark.asyncio
 async def test_multi(tmp_run_dir, mute):
     """It supports cleaning multiple workflows."""
     # cli opts

--- a/tests/unit/test_async_util.py
+++ b/tests/unit/test_async_util.py
@@ -55,6 +55,7 @@ async def sleepy(x):
     return True
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe(preserve_order):
     """It passes values through the pipe."""
@@ -72,6 +73,7 @@ async def test_pipe(preserve_order):
     ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe_single(preserve_order):
     """It allow single-step pipes."""
@@ -91,6 +93,7 @@ async def test_pipe_single(preserve_order):
     ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe_reusable(preserve_order):
     """It can be re-used once depleted."""
@@ -109,6 +112,7 @@ async def test_pipe_reusable(preserve_order):
         ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe_filter_stop(preserve_order):
     """It yields values early with the filter_stop argument."""
@@ -137,6 +141,7 @@ async def one(x):
     return x
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe_preserve_order(preserve_order):
     """It should control result order according to pipe configuration."""
@@ -152,6 +157,7 @@ async def test_pipe_preserve_order(preserve_order):
     assert (result == list(range(n))) is preserve_order
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize('preserve_order', (True, False))
 async def test_pipe_concurrent(caplog, preserve_order):
     """It runs pipes concurrently.
@@ -223,6 +229,7 @@ def test_rewind():
     assert pipe.fastforward().rewind() == pipe
 
 
+@pytest.mark.asyncio
 async def test_asyncqgen():
     """It should provide an async gen interface to an async queue."""
     queue = asyncio.Queue()

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -46,6 +46,7 @@ def abc_src_dir(tmp_path_factory):
     os.chdir(cwd_before)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -61,6 +62,7 @@ async def test_parse_ids_workflows(ids_in, ids_out):
     assert list(workflows.values()) == [[] for _ in workflows]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -78,6 +80,7 @@ async def test_parse_ids_workflows_src(ids_in, ids_out, abc_src_dir):
     assert list(workflows.values()) == [[] for _ in workflows]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -108,6 +111,7 @@ async def test_parse_ids_tasks(ids_in, ids_out):
     } == ids_out
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -130,6 +134,7 @@ async def test_parse_ids_tasks_src(ids_in, ids_out, abc_src_dir):
     } == ids_out
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -156,6 +161,7 @@ async def test_parse_ids_mixed(ids_in, ids_out):
     } == ids_out
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out',
     [
@@ -173,6 +179,7 @@ async def test_parse_ids_mixed_src(ids_in, ids_out, abc_src_dir):
     } == ids_out
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,errors',
     [
@@ -193,6 +200,7 @@ async def test_parse_ids_max_workflows(ids_in, errors):
             raise Exception('Should have raised UserInputError')
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,errors',
     [
@@ -213,6 +221,7 @@ async def test_parse_ids_max_tasks(ids_in, errors):
             raise Exception('Should have raised UserInputError')
 
 
+@pytest.mark.asyncio
 async def test_parse_ids_infer_run_name(tmp_run_dir):
     """It should infer the run name for auto-numbered installations."""
     # it doesn't do anything for a named run
@@ -257,6 +266,7 @@ def patch_expand_workflow_tokens(monkeypatch):
     return _patch_expand_workflow_tokens
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,ids_out,multi_mode',
     [
@@ -348,6 +358,7 @@ def test_parse_src_path(src_dir, monkeypatch):
     assert src_file_path == src_dir / 'flow.cylc'
 
 
+@pytest.mark.asyncio
 async def test_parse_ids_src_path(src_dir):
     workflows, src_path = await parse_ids_async(
         './a',
@@ -357,6 +368,7 @@ async def test_parse_ids_src_path(src_dir):
     assert workflows == {'a': []}
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'ids_in,error_msg',
     [
@@ -388,6 +400,7 @@ async def test_parse_ids_invalid_ids(ids_in, error_msg):
     assert error_msg in str(exc_ctx.value)
 
 
+@pytest.mark.asyncio
 async def test_parse_ids_file(tmp_run_dir):
     """It should reject IDs that are paths to files."""
     tmp_path = tmp_run_dir('x')
@@ -408,6 +421,7 @@ async def test_parse_ids_file(tmp_run_dir):
     assert 'Workflow ID cannot be a file' in str(exc_ctx.value)
 
 
+@pytest.mark.asyncio
 async def test_parse_ids_constraint():
     """It should validate input against the constraint."""
     # constraint: workflows
@@ -426,6 +440,7 @@ async def test_parse_ids_constraint():
         await parse_ids_async('foo', constraint='bar')
 
 
+@pytest.mark.asyncio
 async def test_parse_ids_src_run(abc_src_dir, tmp_run_dir):
     """It should locate the flow file when src=True."""
     # locate flow file for a src workflow
@@ -504,6 +519,7 @@ def no_scan(monkeypatch):
     monkeypatch.setattr('cylc.flow.id_cli.scan', _scan)
 
 
+@pytest.mark.asyncio
 async def test_expand_workflow_tokens_impl_selector(no_scan):
     """It should reject filters it can't handle."""
     tokens = tokenise('~user/*')

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -376,6 +376,7 @@ def test_clean_check__fail(
     assert err_msg in str(exc.value)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'db_platforms, opts, clean_called, remote_clean_called',
     [
@@ -425,6 +426,7 @@ def test_init_clean(
     assert mock_remote_clean.called is remote_clean_called
 
 
+@pytest.mark.asyncio
 def test_init_clean__no_dir(
     monkeymock: MonkeyMock, tmp_run_dir: Callable,
     caplog: pytest.LogCaptureFixture
@@ -441,6 +443,7 @@ def test_init_clean__no_dir(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__no_db(
     monkeymock: MonkeyMock, tmp_run_dir: Callable,
     caplog: pytest.LogCaptureFixture
@@ -457,6 +460,7 @@ def test_init_clean__no_db(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__remote_only_no_db(
     monkeymock: MonkeyMock, tmp_run_dir: Callable
 ) -> None:
@@ -473,6 +477,7 @@ def test_init_clean__remote_only_no_db(
     assert mock_remote_clean.called is False
 
 
+@pytest.mark.asyncio
 def test_init_clean__running_workflow(
     monkeypatch: pytest.MonkeyPatch, tmp_run_dir: Callable
 ) -> None:
@@ -488,6 +493,7 @@ def test_init_clean__running_workflow(
     assert "Cannot remove running workflow" in str(exc.value)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     'rm_dirs, expected_clean, expected_remote_clean',
     [(None, None, []),


### PR DESCRIPTION
Unfortunately, now getting a conflict with pytest-tornasync after removing `@pytest.mark.asyncio` decorators - https://github.com/eukaryote/pytest-tornasync/issues/13. pytest-tornasync is a dependency of cylc-uiserver, not cylc-flow, so it passed on GH Actions but now flakily fails locally.

This might be fixed by https://github.com/pytest-dev/pytest-asyncio/pull/261 when it makes its way into a release

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
