### PR TITLE
tests: disable pytest_tornasync

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,3 +107,7 @@ def log_filter():
 @pytest.fixture(scope='session')
 def port_range():
     return glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
+
+
+def pytest_addhooks(pluginmanager):
+    pluginmanager.unregister('tornado')


### PR DESCRIPTION
I don't like the way this plugin invades our tests, nicer to kick it out.