### PR TITLE
Limit when tutorial workflow test runs for PRs

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
   pull_request:
+    paths-ignore:
+      - '.github/workflows/*.ya?ml'
+      - '!.github/workflows/test_tutorial_workflow.yml'
+      - 'tests/**'
+      - '**.md'
   workflow_dispatch:
     inputs:
       rose_ref:


### PR DESCRIPTION
The `test_tutorial_workflow` GH Actions workflow is a bit flaky, so why not exclude it from PRs that couldn't affect the tutorial workflows in any way


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry needed
- [x] No documentation update required.
