### PR TITLE
fix new issue identified by flake8-simplify after upgrade to 15.0

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -422,7 +422,7 @@ class CylcOptionParser(OptionParser):
         log_handler = logging.StreamHandler(sys.stderr)
         log_handler.setFormatter(CylcLogFormatter(
             timestamp=options.log_timestamp,
-            dev_info=bool(options.verbosity > 2)
+            dev_info=(options.verbosity > 2)
         ))
         LOG.addHandler(log_handler)
 


### PR DESCRIPTION
# Issue
Upgrade of flake8-simplify to 15.0 has highlighted something new:
```
> flake8
./cylc/flow/option_parsers.py:425:22: SIM901 Use 'options.verbosity > 2' instead of 'bool(options.verbosity > 2)'
```

This is a small change with no associated Issue:

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Does not need tests (Non-functional change to code-style).
<!-- choose one: -->
- [x] No change log entry required (code style change)
<!-- choose one: -->
- [x] No documentation update required.
