### PR TITLE
graph: fix cylc graph output

### DIFF
--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -324,7 +324,7 @@ def dot(opts, lines):
                 ]
             )
         dot.extend(
-            rf'    "{task}.{cycle}" [label="{task}\n{cycle}"]'
+            rf'    "{cycle}/{task}" [label="{task}\n{cycle}"]'
             for task in tasks
         )
         dot.append('  }' if opts.cycles else '')


### PR DESCRIPTION
Fixes a single `task.cycle` format line the was causing `cylc graph` to render strangely.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Does not need tests (why?).
- [x] No change log entry required (why? unreleased bug)
- [x] No documentation update required.
