### PR TITLE
cli: add option for viewing the license file

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 PLAY_DOC = r"""cylc play [OPTIONS] ARGS
 
-Start a new workflow, restart a stopped workflow, or resume a paused workflow.
+Start, resume, or restart a workflow.
 
 The scheduler will run as a daemon unless you specify --no-detach.
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -54,12 +54,14 @@ Version:
   {get_version(True)}
 
 Usage:
+  $ cylc help license             # view the Cylc license (GPL-3.0)
   $ cylc help all                 # list all commands
-  $ cylc validate FLOW            # validate a workflow configuration
-  $ cylc play FLOW                # run/resume a workflow
+  $ cylc validate <workflow>      # validate a workflow configuration
+  $ cylc install <workflow>       # install a workflow
+  $ cylc play <workflow>          # run/resume a workflow
   $ cylc scan                     # list all running workflows (by default)
-  $ cylc tui FLOW                 # view a running workflow in the terminal
-  $ cylc stop FLOW                # stop a running workflow
+  $ cylc tui <workflow>           # view/control workflows in the terminal
+  $ cylc stop <workflow>          # stop a running workflow
 
 Command Abbreviation:
   # Commands can be abbreviated as long as there is no ambiguity in
@@ -214,6 +216,8 @@ DEAD_ENDS = {
     'checkpoint':
         'DB checkpoints have been removed, use a reflow to '
         '"rewind" a workflow.',
+    'conditions':
+        'cylc conditions has been replaced by cylc help license',
     'documentation':
         'Cylc documentation is now at http://cylc.org',
     'edit':
@@ -261,7 +265,9 @@ DEAD_ENDS = {
     'submit':
         'cylc submit has been removed',
     'start':
-        'cylc start & cylc restart have been replaced by cylc play'
+        'cylc start & cylc restart have been replaced by cylc play',
+    'warranty':
+        'cylc warranty has been replaced by cylc help license',
 }
 # fmt: on
 
@@ -386,6 +392,14 @@ def print_id_help():
     print(ID_HELP)
 
 
+def print_license():
+    print(
+        pkg_resources.get_distribution('cylc-flow').get_resource_string(
+            __name__, 'COPYING'
+        ).decode()
+    )
+
+
 def print_command_list(commands=None, indent=0):
     """Print list of Cylc commands.
 
@@ -418,6 +432,7 @@ def cli_help():
         # print a short list of the main cylc commands
         commands=[
             'hold',
+            'install',
             'kill',
             'pause',
             'play',
@@ -624,6 +639,9 @@ def main():
                     sys.exit(0)
                 elif cmd_args == ['id']:
                     print_id_help()
+                    sys.exit(0)
+                if cmd_args in (['license'], ['licence']):
+                    print_license()
                     sys.exit(0)
                 else:
                     command = cmd_args.pop(0)

--- a/tests/functional/rnd/04-conditions.t
+++ b/tests/functional/rnd/04-conditions.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+# check `cylc help license`
+run_ok "${TEST_NAME_BASE}" cylc help license
+# remove trailing newlines
+sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "${TEST_NAME_BASE}.stdout"
+# check `cylc help license` output matches the COPYING file
+cmp_ok "${CYLC_REPO_DIR}/COPYING" "${TEST_NAME_BASE}.stdout"


### PR DESCRIPTION
We removed the dedicated commands for viewing the license file.

This adds in a help option that dumps the packaged COPYING file.

(note the COPYING file gets auto packaged into the dist-info thinggy)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tested.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.