### PR TITLE
graph: make workflow_id a required argument

### DIFF
--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -190,7 +190,7 @@ def get_option_parser():
         jset=True,
         prep=True,
         argdoc=[
-            ('[WORKFLOW_ID]', 'Workflow ID or path to source'),
+            ('WORKFLOW_ID', 'Workflow ID or path to source'),
             ('[START]', 'Graph start; defaults to initial cycle point'),
             (
                 '[STOP]',


### PR DESCRIPTION
Fixes a minor bug where `cylc graph` would result in traceback due to WORKFLOW_ID erroneously being marked as optional.