### PR TITLE
Rename dummy-local mode to dummy mode.

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -467,7 +467,7 @@ class WorkflowConfig:
 
         self.process_runahead_limit()
 
-        if self.run_mode('simulation', 'dummy', 'dummy-local'):
+        if self.run_mode('simulation', 'dummy'):
             self.configure_sim_modes()
 
         self.configure_workflow_state_polling_tasks()
@@ -1269,7 +1269,7 @@ class WorkflowConfig:
             rtc['script'] = script
 
     def configure_sim_modes(self):
-        """Adjust task defs for simulation mode and dummy modes."""
+        """Adjust task defs for simulation and dummy mode."""
         for tdef in self.taskdefs.values():
             # Compute simulated run time by scaling the execution limit.
             rtc = tdef.rtconfig
@@ -1305,19 +1305,16 @@ class WorkflowConfig:
             scr += "\ncylc__job__dummy_result %s %s || exit 1" % (arg1, arg2)
             rtc['script'] = scr
 
-            # All dummy modes should run on platform localhost
+            # Dummy mode jobs should run on platform localhost
             # All Cylc 7 config items which conflict with platform are removed.
             for section, key, _ in FORBIDDEN_WITH_PLATFORM:
                 if (section in rtc and key in rtc[section]):
                     rtc[section][key] = None
+
             rtc['platform'] = 'localhost'
 
             # Disable environment, in case it depends on env-script.
             rtc['environment'] = {}
-
-            if tdef.run_mode == 'dummy-local':
-                # Run all dummy tasks on the workflow host.
-                rtc['platform'] = 'localhost'
 
             # Simulation mode tasks should fail in which cycle points?
             f_pts = []

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -181,9 +181,9 @@ def get_option_parser(add_std_opts=False):
 
     parser.add_option(
         "-m", "--mode",
-        help="Run mode: live, dummy, dummy-local, simulation (default live).",
+        help="Run mode: live, dummy, simulation (default live).",
         metavar="STRING", action="store", dest="run_mode",
-        choices=["live", "dummy", "dummy-local", "simulation"])
+        choices=["live", "dummy", "simulation"])
 
     parser.add_option(
         "--reference-log",

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -77,7 +77,7 @@ def get_option_parser():
     parser.add_option(
         "-u", "--run-mode", help="Validate for run mode.", action="store",
         default="live", dest="run_mode",
-        choices=['live', 'dummy', 'dummy-local', 'simulation'])
+        choices=['live', 'dummy', 'simulation'])
 
     parser.add_cylc_rose_options()
 

--- a/tests/flakyfunctional/modes/03-dummy-env.t
+++ b/tests/flakyfunctional/modes/03-dummy-env.t
@@ -15,8 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test that user environment is disabled along with env-script in dummy mode.
-# And that remote host is disabled in dummy local mode.
+# Test that in dummy mode:
+# - user environment is disabled.
+# - env-script is disabled.
+# - remote host is disabled.
 . "$(dirname "$0")/test_header"
 set_test_number 5
 

--- a/tests/flakyfunctional/modes/03-dummy-env.t
+++ b/tests/flakyfunctional/modes/03-dummy-env.t
@@ -25,10 +25,10 @@ install_workflow "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}"\
-        --mode=dummy-local
+        --mode=dummy
 
 # Check that each of pre, main and post script do not leave a trace in the
-# job out when --mode=dummy-local.
+# job out when --mode=dummy.
 declare -a GREPFOR=('MY-PRE-SCRIPT' 'MY-SCRIPT' 'MY-POST-SCRIPT')
 for BAD_PHRASE in "${GREPFOR[@]}"; do
     cp "${WORKFLOW_RUN_DIR}/log/job/1/oxygas/NN/job.out" "${BAD_PHRASE}"

--- a/tests/functional/platforms/06-host-to-platform-upgrade-dummy-mode.t
+++ b/tests/functional/platforms/06-host-to-platform-upgrade-dummy-mode.t
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.    If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Check that setting the platform to localhost for dummy-local mode doesn't
+# Check that setting the platform to localhost for dummy mode doesn't
 # cause conflicts with Cylc 7 settings
 # TODO Remove test at Cylc 9.
 . "$(dirname "$0")/test_header"
@@ -28,7 +28,7 @@ run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate "${WORKFLOW_NAME}"
 
 run_ok "${TEST_NAME_BASE}-run" \
-    cylc play "${WORKFLOW_NAME}" --no-detach --mode=dummy-local
+    cylc play "${WORKFLOW_NAME}" --no-detach --mode=dummy
 
 # Check that the upgradeable config has been run on a sensible host.
 grep_ok \


### PR DESCRIPTION
Small tidy-up to reflect the fact that dummy mode is now the same as dummy-local mode, and there's no need for the distinction anymore.


<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address cylc/cylc-doc#297

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] (master branch) I have opened a documentation PR at https://github.com/cylc/cylc-doc/pull/384.
