### PR TITLE
queues: fix interactions with the scheduler paused and task held states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ access to information on configured platforms.
 
 ### Fixes
 
+[#4620](https://github.com/cylc/cylc-flow/pull/4620) -
+Fix queue interactions with the scheduler paused and task held states.
+
 [#4566](https://github.com/cylc/cylc-flow/pull/4566) - Fix `cylc scan`
 invocation for remote scheduler host on a shared filesystem.
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -598,10 +598,9 @@ class Scheduler:
             LOG.info("Quiet mode on")
             LOG.setLevel(log_level)
 
-    async def start_scheduler(self):
+    async def run_scheduler(self):
         """Start the scheduler main loop."""
         try:
-            self._configure_contact()
             if self.is_restart:
                 self.restart_remote_init()
             self.run_event_handlers(self.EVENT_STARTUP, 'workflow starting')
@@ -641,15 +640,10 @@ class Scheduler:
         finally:
             self.profiler.stop()
 
-    async def run(self):
-        """Run the startup sequence.
+    async def start(self):
+        """Run the startup sequence but don't set the main loop running.
 
-        * initialise
-        * configure
-        * start_servers
-        * start_scheduler
-
-        Lightweight wrapper for convenience.
+        Lightweight wrapper for testing convenience.
 
         """
         try:
@@ -657,11 +651,19 @@ class Scheduler:
             await self.configure()
             await self.start_servers()
             await self.log_start()
+            self._configure_contact()
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             await self.handle_exception(exc)
-        else:
-            # note start_scheduler handles its own shutdown logic
-            await self.start_scheduler()
+
+    async def run(self):
+        """Run the startup sequence and set the main loop running.
+
+        Lightweight wrapper for testing convenience.
+
+        """
+        await self.start()
+        # note run_scheduler handles its own shutdown logic
+        await self.run_scheduler()
 
     def _load_pool_from_tasks(self):
         """Load task pool with specified tasks, for a new run."""

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -707,15 +707,24 @@ class TaskPool:
             self.data_store_mgr.delta_task_queued(itask)
             self.task_queue_mgr.push_task(itask)
 
-    def release_queued_tasks(self):
+    def release_queued_tasks(self, pre_prep_tasks):
         """Return list of queue-released tasks for job prep."""
         released = self.task_queue_mgr.release_tasks(
             Counter(
                 [
-                    t.tdef.name for t in self.get_tasks()
-                    if t.state(TASK_STATUS_PREPARING,
-                               TASK_STATUS_SUBMITTED,
-                               TASK_STATUS_RUNNING)
+                    # active tasks
+                    t.tdef.name
+                    for t in self.get_tasks()
+                    if t.state(
+                        TASK_STATUS_PREPARING,
+                        TASK_STATUS_SUBMITTED,
+                        TASK_STATUS_RUNNING
+                    )
+                ] + [
+                    # tasks await job preparation which have not yet
+                    # entered the preparing state
+                    itask.tdef.name
+                    for itask in pre_prep_tasks
                 ]
             )
         )

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -118,8 +118,20 @@ async def test_install(flow, scheduler, one_conf, run_dir):
     ).exists()
 
 
-async def test_task_pool(flow, scheduler, one_conf):
-    """You don't have to run the scheduler to play with the task pool."""
+async def test_task_pool(flow, scheduler, one_conf, start):
+    """You don't have to run the scheduler to play with the task pool.
+
+    There are two fixtures to start a scheduler:
+
+    `start`
+       Takes a scheduler through the startup sequence.
+    `run`
+       Takes a scheduler through the startup sequence, then sets the main loop
+       going.
+
+    Unless you need the Scheduler main loop running, use `start`.
+
+    """
     # Ensure that the correct number of tasks get added to the task pool.
 
     # create the flow
@@ -127,13 +139,10 @@ async def test_task_pool(flow, scheduler, one_conf):
     schd = scheduler(reg)
 
     # take it as far through the startup sequence as needed
-    await schd.install()
-    await schd.initialise()
-    await schd.configure()
-
-    # pump the scheduler's heart manually
-    schd.pool.release_runahead_tasks()
-    assert len(schd.pool.main_pool) == 1
+    async with start(schd):
+        # pump the scheduler's heart manually
+        schd.pool.release_runahead_tasks()
+        assert len(schd.pool.main_pool) == 1
 
 
 async def test_exception(flow, scheduler, run, one_conf, log_filter):

--- a/tests/integration/test_queues.py
+++ b/tests/integration/test_queues.py
@@ -1,0 +1,118 @@
+import pytest
+
+
+@pytest.fixture
+def param_workflow(flow, scheduler):
+    def _schd(paused_start, queue_limit):
+        id_ = flow({
+            'scheduler': {
+                'allow implicit tasks': True,
+            },
+            'task parameters': {
+                'x': '1..10',
+            },
+            'scheduling': {
+                'queues': {
+                    'default': {
+                        'limit': queue_limit,
+                    },
+                },
+                'graph': {
+                    'R1': '''
+                        <x>
+                    ''',
+                },
+            },
+        })
+        return scheduler(id_, paused_start=paused_start)
+    return _schd
+
+
+@pytest.mark.parametrize(
+    'start_paused,queue_limit',
+    [
+        (False, 1),
+        (False, 5),
+        (True, 1),
+        (True, 5),
+    ]
+)
+async def test_queue_release(
+    param_workflow,
+    run,
+    capture_submission,
+    start_paused,
+    queue_limit,
+):
+    """Tasks should be released up to the limit if the scheduler is not paused.
+
+    When the scheudler is paused the scheduler should not release tasks from
+    queues because tasks may subsequently be held by the user and we don't
+    want them clogging up the queue limit.
+
+    https://github.com/cylc/cylc-flow/issues/4627
+    """
+    expected_submissions = queue_limit if not start_paused else 0
+
+    schd = param_workflow(start_paused, queue_limit)
+
+    async with run(schd):
+        # capture task submissions (prevents real submissions)
+        submitted_tasks = capture_submission(schd)
+
+        # release runahead/queued tasks
+        # (if scheduler is paused we should not have any submissions)
+        # (otherwise a number of tasks up to the limit should be released)
+        schd.pool.release_runahead_tasks()
+        schd.release_queued_tasks()
+        assert len(schd.pre_prep_tasks) == expected_submissions
+        assert len(submitted_tasks) == expected_submissions
+
+        for _ in range(3):
+            # release runahead/queued tasks
+            # (no further tasks should be released)
+            schd.release_queued_tasks()
+            assert len(schd.pre_prep_tasks) == expected_submissions
+            assert len(submitted_tasks) == expected_submissions
+
+
+async def test_queue_held_tasks(
+    param_workflow,
+    run,
+    capture_submission
+):
+    """Held tasks should not be released from queues.
+
+    Users can hold tasks whilst they are queued. These held tasks should not
+    be released from their queues.
+
+    https://github.com/cylc/cylc-flow/issues/4628
+    """
+    schd = param_workflow(paused_start=True, queue_limit=1)
+
+    async with run(schd):
+        # capture task submissions (prevents real submissions)
+        submitted_tasks = capture_submission(schd)
+
+        # release runahead tasks to their queues
+        schd.pool.release_runahead_tasks()
+
+        # hold all tasks and resume the workflow
+        # (nothing should have run yet because the workflow started paused)
+        schd.command_hold('*/*')
+        schd.resume_workflow()
+
+        # release queued tasks
+        # (no tasks should be released from the queues because they are held)
+        schd.release_queued_tasks()
+        assert len(schd.pre_prep_tasks) == 0
+        assert len(submitted_tasks) == 0
+
+        # un-hold tasks
+        schd.command_release('*/*')
+
+        # release queued tasks
+        # (tasks should now be released from the queues)
+        schd.release_queued_tasks()
+        assert len(schd.pre_prep_tasks) == 1
+        assert len(submitted_tasks) == 1

--- a/tests/integration/test_queues.py
+++ b/tests/integration/test_queues.py
@@ -39,7 +39,7 @@ def param_workflow(flow, scheduler):
 )
 async def test_queue_release(
     param_workflow,
-    run,
+    start,
     capture_submission,
     start_paused,
     queue_limit,
@@ -54,9 +54,9 @@ async def test_queue_release(
     """
     expected_submissions = queue_limit if not start_paused else 0
 
+    # start the scheduler (but don't set the main loop running)
     schd = param_workflow(start_paused, queue_limit)
-
-    async with run(schd):
+    async with start(schd):
         # capture task submissions (prevents real submissions)
         submitted_tasks = capture_submission(schd)
 
@@ -78,7 +78,7 @@ async def test_queue_release(
 
 async def test_queue_held_tasks(
     param_workflow,
-    run,
+    start,
     capture_submission
 ):
     """Held tasks should not be released from queues.
@@ -90,7 +90,7 @@ async def test_queue_held_tasks(
     """
     schd = param_workflow(paused_start=True, queue_limit=1)
 
-    async with run(schd):
+    async with start(schd):
         # capture task submissions (prevents real submissions)
         submitted_tasks = capture_submission(schd)
 

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -310,7 +310,7 @@ async def test_max_depth_configurable(nested_dir, mock_glbl_cfg):
 async def test_workflow_params(
     flow,
     scheduler,
-    run,
+    start,
     one_conf,
     run_dir,
     mod_test_dir
@@ -323,7 +323,7 @@ async def test_workflow_params(
     """
     reg = flow(one_conf)
     schd = scheduler(reg)
-    async with run(schd):
+    async with start(schd):
         pipe = (
             # scan just this workflow
             scan(scan_dir=mod_test_dir)

--- a/tests/integration/test_scan_api.py
+++ b/tests/integration/test_scan_api.py
@@ -240,7 +240,7 @@ async def test_format_rich(flows, mod_test_dir):
 
 
 async def test_scan_cleans_stuck_contact_files(
-    run,
+    start,
     scheduler,
     flow,
     one_conf,
@@ -256,7 +256,7 @@ async def test_scan_cleans_stuck_contact_files(
     cont = srv_dir / WorkflowFiles.Service.CONTACT
 
     # run the flow, copy the contact, stop the flow, copy back the contact
-    async with run(schd):
+    async with start(schd):
         copytree(srv_dir, tmp_dir)
     rmtree(srv_dir)
     copytree(tmp_dir, srv_dir)

--- a/tests/integration/utils/__init__.py
+++ b/tests/integration/utils/__init__.py
@@ -31,28 +31,3 @@ def _rm_if_empty(path):
     except OSError:
         return False
     return True
-
-
-async def _poll_file(path, timeout=2, step=0.1, exists=True):
-    """Poll a file to wait for its creation or removal.
-
-    Arguments:
-        timeout (number):
-            Maximum time to wait in seconds.
-        step (number):
-            Polling interval in seconds.
-        exists (bool):
-            Set to True to check if a file exists, otherwise False.
-
-    Raises:
-        Exception:
-            If polling hits the timeout.
-
-    """
-    elapsed = 0
-    while path.exists() != exists:
-        await asyncio.sleep(step)
-        elapsed += step
-        if elapsed > timeout:
-            raise Exception(f'Timeout waiting for file creation: {path}')
-    return True

--- a/tests/integration/utils/test_utils.py
+++ b/tests/integration/utils/test_utils.py
@@ -23,11 +23,8 @@ And yes, these are unit-tests inside a functional test framework thinggy.
 
 from pathlib import Path
 
-import pytest
-
 from . import (
     _rm_if_empty,
-    _poll_file,
 )
 
 
@@ -42,11 +39,3 @@ def test_rm_if_empty(tmp_path):
     assert not path2.exists()
     _rm_if_empty(path1)
     assert not path1.exists()
-
-
-async def test_poll_file(tmp_path):
-    """It should return if the condition is met."""
-    path = tmp_path / 'file'
-    await _poll_file(path, exists=False)
-    path.touch()
-    await _poll_file(path, exists=True)

--- a/tests/unit/test_indep_task_queues.py
+++ b/tests/unit/test_indep_task_queues.py
@@ -16,9 +16,11 @@
 #
 # Tests for the task queue manager module
 
-import pytest
-from unittest.mock import Mock
 from collections import Counter
+from unittest.mock import Mock
+
+import pytest
+
 from cylc.flow.task_queues.independent import IndepQueueManager
 from cylc.flow.task_state import TASK_STATUS_PREPARING
 


### PR DESCRIPTION
> [edit] pushed up a new commit with a new approach after discovering the problem went deeper than initially thought.
>
> There are now three issues each has its own steps to reproduce and integration test.
> The new integration tests run on master but you will need to overwite `tests/integration/conftest.py` and `sed -i 's/pre_submit_tasks/prep_submit_tasks/' cylc/flow/scheduler.py`.

* Closes:        
  * https://github.com/cylc/cylc-flow/issues/4278        
  * https://github.com/cylc/cylc-flow/issues/4627        
  * https://github.com/cylc/cylc-flow/issues/4628        
* Makes the following changes:        
  * Held tasks are no longer be released from queues.        
  * `pre_prep_tasks` (previously `pre_submit_tasks`) are now included        
    with active tasks for the computation of queue limits.        
  * Queues are no longer processed whilst the workflow is paused.        
* User's should now be able to safely hold/release tasks:        
  * When they are not in the pool (future tasks).        
  * When they are in the pool but not yet queued.        
  * When they are queued.        
  * When they are in `pre_prep_tasks` (previously `pre_submit_tasks`) which        
    is an intermediary state tasks pass through *after* they have been        
    released form the queue but *before* they are passed into the job        
    preparation pipeline (and acquired the preparing job status).        
* Tasks can also be held whilst they are preparing, submitted & running,        
  however, this will continue to have no effect (except on automatic        
  retries, note `cylc kill`).     


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
