### PR TITLE
trigger: don't warn if task not already in the pool

### DIFF
--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -134,8 +134,7 @@ def filter_ids(
             id_tokens_map[id_] = Tokens(id_, relative=True)
         except ValueError:
             _not_matched.append(id_)
-            if warn:
-                LOG.warning(f'Invalid ID: {id_}')
+            LOG.warning(f'Invalid ID: {id_}')
 
     for id_, tokens in id_tokens_map.items():
         for lowest_token in reversed(IDTokens):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1396,6 +1396,7 @@ class TaskPool:
         itasks, future_tasks, unmatched = self.filter_task_proxies(
             items,
             future=True,
+            warn=False,
         )
 
         # spawn future tasks


### PR DESCRIPTION
* Small fix probably resulting from the UID change.
* A warning currently shows when you trigger a task not present in the pool.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
