### PR TITLE
fixed missing symlink for tutorial workflow

### DIFF
--- a/cylc/flow/etc/tutorial/runtime-tutorial/etc/met-office-sites.dat
+++ b/cylc/flow/etc/tutorial/runtime-tutorial/etc/met-office-sites.dat
@@ -1,0 +1,1 @@
+../../cylc-forecasting-workflow/etc/met-office-sites.dat


### PR DESCRIPTION
This is a small change with no associated Issue.

Small change to tutorial workflow discovered during work on https://github.com/cylc/cylc-doc/pull/383

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (ancilliary data).
<!-- choose one: -->
- [x] No documentation update required.
