### PR TITLE
tests/f: add a skip for non GNU/Linux platforms for a non-posix test

### DIFF
--- a/tests/functional/cli/05-colour.t
+++ b/tests/functional/cli/05-colour.t
@@ -20,6 +20,9 @@
 # Uses the "script" command to make stdout log file look like a terminal.
 
 . "$(dirname "$0")/test_header"
+if [[ ! "$OSTYPE" == "linux-gnu"* ]]; then
+    skip_all "Tests not compatibile with $OSTYPE"
+fi
 set_test_number 8
 
 ANSI='\e\['


### PR DESCRIPTION
Test fails with BSD `script`, I don't think the test's usage is POSIX.

I don't think we need to test this everywhere so adding a skip.

> **Note:** The Mac OS tests only run `CHUNK=1/4` so won't necessarily hit this, for now...

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
