### PR TITLE
cli: fix --color bug and improve coverage

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -143,10 +143,13 @@ class CylcHelpFormatter(IndentedHelpFormatter):
 
         """
         if (
-            self.parser.values.color == "always"
-            or (
-                self.parser.values.color == "auto"
-                and supports_color()
+            hasattr(self.parser.values, 'color')
+            and (
+                self.parser.values.color == "always"
+                or (
+                    self.parser.values.color == "auto"
+                    and supports_color()
+                )
             )
         ):
             # Add color formatting to examples text.

--- a/cylc/flow/scripts/cycle_point.py
+++ b/cylc/flow/scripts/cycle_point.py
@@ -144,12 +144,9 @@ def main(parser, options, *args):
             parser.error("Provide CYCLE arg, or define $CYLC_TASK_CYCLE_POINT")
         cycle_point_string = os.environ['CYLC_TASK_CYCLE_POINT']
 
-    elif len(args) == 1:
+    else:
         # must be cycle point
         cycle_point_string = args[0]
-
-    else:
-        parser.error("Wrong number of arguments!")
 
     # template string
     template = None

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -374,12 +374,6 @@ def iter_commands():
 
     """
     for cmd, obj in sorted(COMMANDS.items()):
-        if cmd == 'cylc':
-            # don't include this command in the listing
-            continue
-        if not obj:
-            raise ValueError(f'Unrecognised command "{cmd}"')
-        # python command
         module = __import__(obj.module_name, fromlist=[''])
         if getattr(module, 'INTERNAL', False):
             # do not list internal commands
@@ -504,7 +498,7 @@ def list_plugins():
 
 
 @contextmanager
-def pycoverage(cmd_args):
+def pycoverage(cmd_args):  # pragma: no cover
     """Capture code coverage if configured to do so.
 
     This requires Cylc to be installed in editable mode

--- a/tests/functional/cyclepoint/00-time.t
+++ b/tests/functional/cyclepoint/00-time.t
@@ -18,7 +18,7 @@
 # basic jinja2 expansion test
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 29
+set_test_number 45
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-use-env-var
 export CYLC_TASK_CYCLE_POINT=20100102T0300
@@ -82,4 +82,34 @@ cmp_ok "${TEST_NAME}.full.stdout" - <<<'2011-01-01'
 run_ok "${TEST_NAME}-offset-week" cylc cycle-point --offset=P1W '20160301T06Z'
 cmp_ok "${TEST_NAME}-offset-week.stdout" - <<<'20160308T06Z'
 #-------------------------------------------------------------------------------
-unset CYLC_TASK_CYCLE_TIME
+unset CYLC_TASK_CYCLE_POINT
+# Test --equal option
+TEST_NAME="${TEST_NAME_BASE}-equal"
+run_ok "${TEST_NAME}-true" cylc cycle-point 2000 --equal 2000
+run_fail "${TEST_NAME}-true" cylc cycle-point 2000 --equal 2001
+run_fail "${TEST_NAME}-invalid" cylc cycle-point 2000 --equal x
+
+# Test --template option
+TEST_NAME="${TEST_NAME_BASE}-template"
+run_ok "${TEST_NAME}-pass" cylc cycle-point 2010-08 \
+    --offset-years=2 --template=foo-CCYY-MM.nc
+cmp_ok "${TEST_NAME}-pass.stdout" <<< 'foo-2012-08.nc'
+# invalid arg combo
+run_fail "${TEST_NAME}-fail" cylc cycle-point 2000 --template=x --print-year
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-fail"
+# no cycle point
+run_fail "${TEST_NAME}-1" cylc cycle-point
+# invalid cycle point
+run_fail "${TEST_NAME}-2" cylc cycle-point x
+# too many cycle points
+run_fail "${TEST_NAME}-3" cylc cycle-point 2000 2000
+# invalid offsets
+run_ok "${TEST_NAME}-5" cylc cycle-point 2000 --offset-hours=1  # VALID
+run_fail "${TEST_NAME}-6" cylc cycle-point 2000 --offset-hours=x  # INVALID
+run_fail "${TEST_NAME}-7" cylc cycle-point 2000 --offset-days=x
+run_fail "${TEST_NAME}-8" cylc cycle-point 2000 --offset-months=x
+run_fail "${TEST_NAME}-9" cylc cycle-point 2000 --offset-years=x
+# invalid ISO offset
+run_ok "${TEST_NAME}-10" cylc cycle-point 2000 --offset=P1Y  # VALID
+run_fail "${TEST_NAME}-11" cylc cycle-point 2000 --offset=PT1Y  # INVALID


### PR DESCRIPTION
* Fix bug where `cylc <cmd> --help` results in traceback for
  `color=None` commands like `cylc cycle-point`.
* Improve the coverage for `cylc cycle-point` so it catches this error.
* Deal with some minor coverage thinggies found on route.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Already covered by existing tests.
- [x] No change log entry required (why? bug has not been released)
- [x] No documentation update required.