### PR TITLE
Fix manual triggering of runahead-limited parentless tasks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ access to information on configured platforms.
 
 ### Fixes
 
+[#4640](https://github.com/cylc/cylc-flow/pull/4640) - Fix manual triggering of
+runahead-limited parentless tasks.
+
 [#4566](https://github.com/cylc/cylc-flow/pull/4566) - Fix `cylc scan`
 invocation for remote scheduler host on a shared filesystem.
 

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -267,7 +267,7 @@ def main(_, options: 'Values', workflow_id: str) -> None:
                                 item['name'],
                                 item['cyclePoint'],
                                 item['state']]
-                        values.append('held' if item['isHeld'] else 'unheld')
+                        values.append('held' if item['isHeld'] else 'not-held')
                         values.append('queued' if item['isQueued']
                                       else 'not-queued')
                         values.append('runahead' if item['isRunahead']

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -538,7 +538,9 @@ class TaskPool:
             self.workflow_db_mgr.pri_dao.select_tasks_to_hold()
         )
 
-    def spawn_successor(self, itask: TaskProxy) -> Optional[TaskProxy]:
+    def spawn_successor_if_parentless(
+            self, itask: TaskProxy
+    ) -> Optional[TaskProxy]:
         """Spawn next-cycle instance of itask if parentless.
 
         This includes:
@@ -597,17 +599,15 @@ class TaskPool:
             # implicit prev-instance parent
             return
 
-        if not itask.flow_nums:
-            # No reflow
-            return
-
-        if not runahead_limit_point:
-            return
-
-        # Autospawn successor of itask if parentless.
-        n_task = self.spawn_successor(itask)
-        if n_task and n_task.point <= runahead_limit_point:
-            self.release_runahead_task(n_task, runahead_limit_point)
+        # Autospawn successor of itask if parentless and reflowing.
+        if itask.flow_nums:
+            n_task = self.spawn_successor_if_parentless(itask)
+            if (
+                n_task and
+                runahead_limit_point and
+                n_task.point <= runahead_limit_point
+            ):
+                self.release_runahead_task(n_task, runahead_limit_point)
 
     def remove(self, itask, reason=""):
         """Remove a task from the pool (e.g. after a reload)."""

--- a/tests/flakyfunctional/hold-release/14-hold-kill/flow.cylc
+++ b/tests/flakyfunctional/hold-release/14-hold-kill/flow.cylc
@@ -14,7 +14,7 @@
             sleep 10  # sleep, should still be held after 10 seconds
             cylc dump -s -t "${CYLC_WORKFLOW_ID}" >'cylc-dump.out'
             diff -u 'cylc-dump.out' - <<'__OUT__'
-            1, killer, running, unheld, not-queued, not-runahead
+            1, killer, running, not-held, not-queued, not-runahead
             1, sleeper, waiting, held, not-queued, not-runahead
             __OUT__
             cylc release "${CYLC_WORKFLOW_ID}//1/sleeper"

--- a/tests/functional/spawn-on-demand/13-trigger-runahead.t
+++ b/tests/functional/spawn-on-demand/13-trigger-runahead.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Check correct behaviour if a parentless task is manually triggered whilst
+# runahead-limited. See GitHub #4619.
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+reftest
+exit

--- a/tests/functional/spawn-on-demand/13-trigger-runahead/flow.cylc
+++ b/tests/functional/spawn-on-demand/13-trigger-runahead/flow.cylc
@@ -1,0 +1,21 @@
+# This workflow should behave the same as if foo.1 did not trigger foo.2.
+
+[scheduling]
+   cycling mode = integer
+   initial cycle point = 1
+   final cycle point = 3
+   runahead limit = P1
+   [[graph]]
+      P1 = foo
+[runtime]
+   [[foo]]
+      script = """
+         cylc__job__wait_cylc_message_started
+         if ((CYLC_TASK_CYCLE_POINT == 1)); then
+            expected="foo, 1, running, not-held, not-queued, not-runahead
+foo, 2, waiting, not-held, not-queued, runahead"
+            diff <(cylc dump -t "${CYLC_WORKFLOW_NAME}") <(echo "$expected")
+            # Force trigger next instance while it is runahead limited.
+            cylc trigger $CYLC_WORKFLOW_NAME//2/foo
+         fi
+      """

--- a/tests/functional/spawn-on-demand/13-trigger-runahead/reference.log
+++ b/tests/functional/spawn-on-demand/13-trigger-runahead/reference.log
@@ -1,0 +1,5 @@
+Initial point: 1
+Final point: 3
+1/foo -triggered off []
+2/foo -triggered off []
+3/foo -triggered off []


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4619 

~~Note: this branch is built on top of #4641~~ (now merged; rebased onto master)

The problem was, we were not auto-spawning the successor of a manually-triggered parentless task unless runahead limit had been recomputed, and we don't recompute the limit after manual triggering (the limit is irrelevant for that). We need to auto-spawn the successor task regardless, but only release it from runhead if the limit has been recomputed (and if the task is below below the limit, of course).
 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
