### PR TITLE
Add link to list of job script env vars in `[runtime][X]script` docs

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1040,6 +1040,9 @@ with Conf(
                 The main custom script invoked from the task job script.
 
                 It can be an external command or script, or inlined scripting.
+
+                See :ref:`Task Job Script Variables` for the list of variables
+                available in the task execution environment.
             ''') + get_script_common_text(
                 this='script', example='my_script.sh'
             ))

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -977,6 +977,16 @@ with Conf(
 
                 If no parents are listed default is ``root``.
             ''')
+            Conf('script', VDR.V_STRING, desc=dedent('''
+                The main custom script invoked from the task job script.
+
+                It can be an external command or script, or inlined scripting.
+
+                See :ref:`Task Job Script Variables` for the list of variables
+                available in the task execution environment.
+            ''') + get_script_common_text(
+                this='script', example='my_script.sh'
+            ))
             Conf('init-script', VDR.V_STRING, desc=dedent('''
                 Custom script invoked by the task job script before the task
                 execution environment is configured.
@@ -1035,16 +1045,6 @@ with Conf(
             ''') + get_script_common_text(
                 this='pre-script',
                 example='echo "Hello from workflow ${CYLC_WORKFLOW_ID}!"'
-            ))
-            Conf('script', VDR.V_STRING, desc=dedent('''
-                The main custom script invoked from the task job script.
-
-                It can be an external command or script, or inlined scripting.
-
-                See :ref:`Task Job Script Variables` for the list of variables
-                available in the task execution environment.
-            ''') + get_script_common_text(
-                this='script', example='my_script.sh'
             ))
             Conf('post-script', VDR.V_STRING, desc=dedent('''
                 Custom script invoked by the task job script immediately


### PR DESCRIPTION
This is a small change with no associated Issue. Sibling to cylc/cylc-doc#390

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required
- [x] No documentation update required.
