### PR TITLE
Only poll non-waiting tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,9 @@ access to information on configured platforms.
 
 ### Fixes
 
+[#4658](https://github.com/cylc/cylc-flow/pull/4658) -
+Don't poll waiting tasks (which may have the submit number of a previous job).
+
 [#4620](https://github.com/cylc/cylc-flow/pull/4620) -
 Fix queue interactions with the scheduler paused and task held states.
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1211,9 +1211,10 @@ async def mutator(root, info, command=None, workflows=None,
         workflows = []
     if exworkflows is None:
         exworkflows = []
-    w_args = {}
-    w_args['workflows'] = [Tokens(w_id) for w_id in workflows]
-    w_args['exworkflows'] = [Tokens(w_id) for w_id in exworkflows]
+    w_args = {
+        'workflows': [Tokens(w_id) for w_id in workflows],
+        'exworkflows': [Tokens(w_id) for w_id in exworkflows]
+    }
     if args.get('args', False):
         args.update(args.get('args', {}))
         args.pop('args')

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -960,7 +960,6 @@ class Scheduler:
             return
         itasks, _, bad_items = self.pool.filter_task_proxies(items)
         self.task_job_mgr.poll_task_jobs(self.workflow, itasks)
-        # (Could filter itasks by state here if needed)
         return len(bad_items)
 
     def command_kill_tasks(self, items: List[str]):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -359,3 +359,34 @@ def capture_submission():
         return submitted_tasks
 
     return _disable_submission
+
+
+@pytest.fixture
+def capture_polling():
+    """Suppress job polling and capture polled tasks.
+
+    Provides a function to run on a started Scheduler.
+
+    async with start(schd):
+        polled_tasks = capture_polling(schd)
+
+    or:
+
+    async with run(schd):
+        polled_tasks = capture_polling(schd)
+
+    """
+    def _disable_polling(schd: 'Scheduler') -> 'Set[TaskProxy]':
+        polled_tasks: 'Set[TaskProxy]' = set()
+
+        def run_job_cmd(
+            _1, _2, itasks, _3, _4=None
+        ):
+            nonlocal polled_tasks
+            polled_tasks.update(itasks)
+            return itasks
+
+        schd.task_job_mgr._run_job_cmd = run_job_cmd  # type: ignore
+        return polled_tasks
+
+    return _disable_polling

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -21,6 +21,14 @@ from typing import Any, Callable
 
 from cylc.flow.exceptions import CylcError
 from cylc.flow.scheduler import Scheduler
+from cylc.flow.task_state import (
+    TASK_STATUS_WAITING,
+    TASK_STATUS_SUBMIT_FAILED,
+    TASK_STATUS_SUBMITTED,
+    TASK_STATUS_RUNNING,
+    TASK_STATUS_FAILED
+)
+
 
 Fixture = Any
 
@@ -161,3 +169,56 @@ async def test_holding_tasks_whilst_scheduler_paused(
         one.release_queued_tasks()
         assert len(one.pre_prep_tasks) == 1
         assert len(submitted_tasks) == 1
+
+
+async def test_no_poll_waiting_tasks(
+    capture_polling,
+    flow,
+    one_conf,
+    run,
+    scheduler,
+):
+    """Waiting tasks shouldn't be polled.
+
+    If a waiting task previously it will have the submit number of its previous
+    job, and polling would erroneously return the state of that job.
+
+    See https://github.com/cylc/cylc-flow/issues/4658
+    """
+    reg = flow(one_conf)
+    one = scheduler(reg, paused_start=True)
+
+    log: pytest.LogCaptureFixture
+    async with run(one) as log:
+
+        # Test assumes start up with a waiting task.
+        task = (one.pool.get_all_tasks())[0]
+        assert task.state.status == TASK_STATUS_WAITING
+
+        polled_tasks = capture_polling(one)
+
+        # Waiting tasks should not be polled.
+        one.command_poll_tasks(['*/*'])
+        assert polled_tasks == set()
+
+        # Even if they have a submit number.
+        task.submit_num = 1
+        one.command_poll_tasks(['*/*'])
+        assert len(polled_tasks) == 0
+
+        # But these states should be:
+        for state in [
+            TASK_STATUS_SUBMIT_FAILED,
+            TASK_STATUS_FAILED,
+            TASK_STATUS_SUBMITTED,
+            TASK_STATUS_RUNNING
+        ]:
+            task.state.status = state
+            one.command_poll_tasks(['*/*'])
+            assert len(polled_tasks) == 1
+
+        # Shut down with a running task.
+        task.state.status = TASK_STATUS_RUNNING
+
+    # For good measure, check the faked running task is reported at shutdown.
+    assert "Orphaned task jobs:\n* 1/one (running)" in log.messages

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -216,6 +216,7 @@ async def test_no_poll_waiting_tasks(
             task.state.status = state
             one.command_poll_tasks(['*/*'])
             assert len(polled_tasks) == 1
+            polled_tasks.clear()
 
         # Shut down with a running task.
         task.state.status = TASK_STATUS_RUNNING


### PR DESCRIPTION
Currently we can poll a waiting task (as reloaded from the DB at restart ... and otherwise), and erroneously update it with the state of a previously submitted job of the same task. (This is partly because submit number does not increment until the task reaches the `preparing` state, before which time it matches the previous job ... but I don't think we need to poll non-active tasks anyway??)

[UPDATE] After the discussion below, pending resolution of #4678 this PR now avoids polling waiting tasks, rather than targeting active tasks.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue. 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] New integration test added.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
