### PR TITLE
Check job not in prep already before triggering.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ access to information on configured platforms.
 
 ### Fixes
 
+[#4667](https://github.com/cylc/cylc-flow/pull/4667) - Check manually triggered
+tasks are not already preparing for job submission.
+
 [#4640](https://github.com/cylc/cylc-flow/pull/4640) - Fix manual triggering of
 runahead-limited parentless tasks.
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1425,9 +1425,9 @@ class TaskPool:
                 # In pool already
                 itasks.append(itask)
 
-        # trigger tasks
+        # trigger tasks if not already preparing or active
         for itask in itasks:
-            if itask.state(*TASK_STATUSES_ACTIVE):
+            if itask.state(TASK_STATUS_PREPARING, *TASK_STATUSES_ACTIVE):
                 LOG.warning(f"[{itask}] ignoring trigger - already active")
                 continue
             itask.is_manual_submit = True


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4665

Don't retrigger a task that is already preparing for job submission.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Added test.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
