### PR TITLE
Preparing vs active

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -737,6 +737,8 @@ class Scheduler:
             itask.platform['install target'] = (
                 get_install_target_from_platform(itask.platform))
             if (
+                # we don't need to remote-init for preparing tasks because
+                # they will be reset to waiting on restart
                 itask.state(*TASK_STATUSES_ACTIVE)
                 and not (
                     is_platform_with_target_in_list(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -822,7 +822,7 @@ class TaskPool:
                 itask.copy_to_reload_successor(new_task)
                 self._swap_out(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
-                if itask.state(*TASK_STATUSES_ACTIVE):
+                if itask.state(*TASK_STATUSES_ACTIVE, TASK_STATUS_PREPARING):
                     LOG.warning(
                         f"[{itask}] active with pre-reload settings"
                     )
@@ -898,6 +898,8 @@ class TaskPool:
                 and itask.state(*TASK_STATUSES_ACTIVE)
                 and not itask.state.kill_failed
             )
+            # we don't need to check for preparing tasks because they will be
+            # reset to waiting on restart
             for itask in self.get_tasks()
         )
 


### PR DESCRIPTION
> Built on #4667

* RC2 with no associated issues.
* Follow on from https://github.com/cylc/cylc-flow/pull/4667.

Found three instances where `TASK_STATUS_PREPARING` might be missing from a `TASK_STATUSES_ACTIVE` state check.

If we agree the check should be extended I'll add a test to enforce it.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Logging change only - no changelog.
- [x] No documentation update required.
