### PR TITLE
Moor spilling foxes

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -166,7 +166,7 @@ EVENTS_DESCR = {
 
         A workflow will stall if there are no tasks ready to run and no
         waiting external triggers, but the presence of incomplete
-        tasks or unsatisified prerequisites shows the workflow did not run to
+        tasks or unsatisfied prerequisites shows the workflow did not run to
         completion. The stall timer turns off on any post-stall task activity.
         It resets on restarting a stalled workflow.
 

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -370,7 +370,7 @@ class WorkflowRuntimeServer(ZMQSocketBase):
                 Task identifier for the dependency of
                 an edge.
             right (str):
-                Task identifier for the dependant task
+                Task identifier for the dependent task
                 of an edge.
             is_suicide (bool):
                 True if edge represents a suicide trigger.


### PR DESCRIPTION

This is a small change with no associated Issue: I have found a couple more spelling mistakes.


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Does not need tests (why? Internal docs spelling fixes).
<!-- choose one: -->
- [x] No change log entry required (why? spelling errors).
<!-- choose one: -->
- [x] No documentation update required.
