### PR TITLE
tui: bug fixes

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -196,6 +196,9 @@ class WorkflowRuntimeClient(ZMQSocketBase):
         else:
             if callable(self.timeout_handler):
                 self.timeout_handler()
+            host, port, _ = get_location(self.workflow)
+            if host != self.host or port != self.port:
+                raise WorkflowStopped(self.workflow)
             raise ClientTimeout(
                 'Timeout waiting for server response.'
                 ' This could be due to network or server issues.'

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -319,6 +319,7 @@ class TuiApp:
             })
         except (ClientError, ClientTimeout) as exc:
             # catch network / client errors
+            self.client = None
             self.set_header([('workflow_error', str(exc))])
             return False
 

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -309,7 +309,7 @@ class TuiApp:
                     }
                 }
             )
-        except WorkflowStopped:
+        except (WorkflowStopped):
             self.client = None
             return dummy_flow({
                 'name': self.reg,
@@ -319,7 +319,6 @@ class TuiApp:
             })
         except (ClientError, ClientTimeout) as exc:
             # catch network / client errors
-            self.client = None
             self.set_header([('workflow_error', str(exc))])
             return False
 

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -309,7 +309,7 @@ class TuiApp:
                     }
                 }
             )
-        except (WorkflowStopped):
+        except WorkflowStopped:
             self.client = None
             return dummy_flow({
                 'name': self.reg,

--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -204,6 +204,9 @@ def offline_mutate(mutation, selection):
             # tui only supports single-workflow display ATM so
             # clean should shut down the program
             sys.exit()
+        elif mutation in list_mutations(selection):  # noqa: SIM106
+            # this is an "online" mutation -> ignore
+            pass
         else:
             raise Exception(f'Invalid mutation: {mutation}')
 

--- a/cylc/flow/tui/overlay.py
+++ b/cylc/flow/tui/overlay.py
@@ -231,7 +231,11 @@ def context(app):
                     mutation,
                     on_press=partial(_mutate, mutation)
                 )
-                for mutation in list_mutations(selection)
+                for mutation in (
+                    list_mutations(selection)
+                    if app.client
+                    else []
+                )
             ]
         )
     )

--- a/cylc/flow/tui/overlay.py
+++ b/cylc/flow/tui/overlay.py
@@ -218,6 +218,8 @@ def context(app):
     widget = urwid.ListBox(
         urwid.SimpleFocusListWalker(
             [
+                urwid.Text(f'id: {value["id_"]}'),
+                urwid.Divider(),
                 urwid.Text('Action'),
                 urwid.Button(
                     '(cancel)',
@@ -236,5 +238,5 @@ def context(app):
 
     return (
         widget,
-        {'width': 30, 'height': 12}
+        {'width': 30, 'height': 15}
     )

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -276,7 +276,7 @@ class NaturalSort:
 def dummy_flow(data):
     return add_node(
         'workflow',
-        '',
+        data['id'],
         {},
         data
     )

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -93,10 +93,12 @@ def idpop(id_):
     """Remove the last element of a node id.
 
     Examples:
+        >>> idpop('w//c/t/j')
+        'w//c/t'
         >>> idpop('c/t/j')
-        'c/t'
+        '//c/t'
         >>> idpop('c/t')
-        'c'
+        '//c'
         >>> idpop('c')
         Traceback (most recent call last):
         ValueError: No tokens provided
@@ -108,7 +110,7 @@ def idpop(id_):
     relative = '//' not in id_
     tokens = Tokens(id_, relative=relative)
     tokens.pop_token()
-    return tokens.relative_id
+    return tokens.id
 
 
 def compute_tree(flow):

--- a/tests/unit/tui/test_util.py
+++ b/tests/unit/tui/test_util.py
@@ -261,7 +261,7 @@ def test_compute_tree():
     # the cycle point node
     cycle = tree['children'][0]
     assert cycle['type_'] == 'cycle'
-    assert cycle['id_'] == '1'
+    assert cycle['id_'] == '//1'
     assert list(cycle['data']) == [
         'id',
         'cyclePoint'


### PR DESCRIPTION
tui: add offline commands

* Add support for the play and clean commands.

zmq client: raise WorkflowStoped not ClientTimeout

* WorkflowClient could raise ClientTimeout for stopped workflows.
* Closes https://github.com/cylc/cylc-flow/issues/4654

tui: disable mutations for stopped workflows

* Closes https://github.com/cylc/cylc-flow/issues/4647

tui: fix context menu for cycle points

* Closes https://github.com/cylc/cylc-flow/issues/4629.
* Also adds the node ID to the context menu.


> **Note:** This PR includes a sneaky enhancement (offline) which shouldn't really be going into a
> RC release.
> It's small enough and Tui as an experimental interface is supplementary enough I think its ok, but happy to cherry-pick and delay to 8.0.1.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tui has no test framework for live testing at the moment
- [ ] Appropriate change log entry included.
- [ ] No documentation update required.
