### PR TITLE
`cylc clean`: rename `--force` to `--yes`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,14 +54,23 @@ First Release Candidate for Cylc 8.
 
 (See note on cylc-8 backward-incompatible changes, above)
 
+Also note: you will not be able to restart workflows run with previous
+Cylc 8 pre-releases due to changes in the workflow database structure
+([#4581](https://github.com/cylc/cylc-flow/pull/4581))
+
 ### Enhancements
 
-[#4581](https://github.com/cylc/cylc-flow/pull/4581) - Job and task history
-is now loaded into the window about active tasks. Reflow future tasks now set
-to waiting.
+[#4581](https://github.com/cylc/cylc-flow/pull/4581) - Improvements allowing
+the UI & TUI to remember more info about past tasks and jobs:
+- Job and task history is now loaded into the window about active tasks.
+- Reflow future tasks now set to waiting.
 
 [#3931](https://github.com/cylc/cylc-flow/pull/3931) - Convert Cylc to
 use the new "Universal Identifier".
+
+[#3931](https://github.com/cylc/cylc-flow/pull/3931),
+[#4675](https://github.com/cylc/cylc-flow/pull/4675) - `cylc clean` now
+interactively prompts if trying to clean multiple run dirs.
 
 [#4506](https://github.com/cylc/cylc-flow/pull/4506) - Cylc no longer
 creates a `flow.cylc` symlink to a `suite.rc` file.
@@ -72,7 +81,7 @@ now configurable in `global.cylc[install]max depth`, and `cylc install` will
 fail if the workflow ID would exceed this depth.
 
 [#4534](https://github.com/cylc/cylc-flow/pull/4534) - Permit jobs
-to be run on platforms with no $HOME directory.
+to be run on platforms with no `$HOME` directory.
 
 [#4536](https://github.com/cylc/cylc-flow/pull/4536) - `cylc extract-resources`
 renamed `cylc get-resources` and small changes made:

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -103,12 +103,12 @@ def get_option_parser():
     )
 
     parser.add_option(
-        '--force',
-        help=("Allow cleaning of directories that contain workflow run dirs "
-              "(e.g. 'cylc clean foo' when foo contains run1, run2 etc.). "
-              "Warning: this might lead to remote installations and "
-              "symlink dir targets not getting removed."),
-        action='store_true', dest='force'
+        '--yes', '-y',
+        help=(
+            "Skip interactive prompt if trying to clean multiple "
+            "run directories at once."
+        ),
+        action='store_true', dest='skip_interactive'
     )
 
     parser.add_option(
@@ -137,7 +137,10 @@ def prompt(workflows):
             if ret.lower() == 'n':
                 sys.exit(1)
     else:
-        print('Use --force to remove multiple workflows.', file=sys.stderr)
+        print(
+            "Use --yes to remove multiple workflows in non-interactive mode.",
+            file=sys.stderr
+        )
         sys.exit(1)
 
 
@@ -173,7 +176,7 @@ async def run(*ids, opts=None):
     workflows, multi_mode = await scan(workflows, multi_mode)
 
     workflows.sort()
-    if multi_mode and not opts.force:
+    if multi_mode and not opts.skip_interactive:
         prompt(workflows)  # prompt for approval or exit
 
     for workflow in sorted(workflows):

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -32,7 +32,7 @@ Examples:
   # Remove the workflow at ~/cylc-run/foo/bar
   $ cylc clean foo/bar
 
-  # Remove multiple workflows
+  # Remove multiple workflows
   $ cylc clean one two three
 
   # Remove the workflow's log directory
@@ -86,7 +86,7 @@ def get_option_parser():
         '--rm', metavar='DIR[:DIR:...]',
         help=("Only clean the specified subdirectories (or files) in the "
               "run directory, rather than the whole run directory. "
-              "Accepts quoted globs. Implies --verbose."),
+              "Accepts quoted globs."),
         action='append', dest='rm_dirs', default=[]
     )
 
@@ -125,7 +125,7 @@ CleanOptions = Options(get_option_parser())
 
 
 def prompt(workflows):
-    print('Would remove the following workflows:')
+    print("Would clean the following workflows:")
     for workflow in workflows:
         print(f'  {workflow}')
 


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #4673 and #4618 

The `--force` behaviour is more of a `--yes` than `--force`, so rename it.

`--force` can come back later if we want to allow users to override the current "cannot clean" scenarios - see #4450

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Appropriate tests included
- [x] Appropriate change log entry included.
- [x] Docs PR: https://github.com/cylc/cylc-doc/pull/403
