### PR TITLE
don't create DB until checks on stopcp are completed

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -46,7 +46,7 @@ from cylc.flow import (
 from cylc.flow.broadcast_mgr import BroadcastMgr
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import WorkflowConfig
-from cylc.flow.cycling.loader import get_point
+from cylc.flow.cycling.loader import get_point, INTEGER_CYCLING_TYPE
 from cylc.flow.data_store_mgr import DataStoreMgr
 from cylc.flow.id import Tokens
 from cylc.flow.flow_mgr import FlowMgr
@@ -120,9 +120,6 @@ from cylc.flow.wallclock import (
     get_time_string_from_unix_time as time2str,
     get_utc_mode)
 from cylc.flow.xtrigger_mgr import XtriggerManager
-
-
-MODE_INT = 'integer'
 
 
 class SchedulerStop(CylcError):
@@ -2010,7 +2007,10 @@ class Scheduler:
     def validate_cyclepoint_str(self, point: str) -> None:
         """Assert that a cyclepoint is valid."""
         try:
-            if self.config.cfg['scheduling']['cycling mode'] == MODE_INT:
+            if (
+                self.config.cfg['scheduling']['cycling mode'] ==
+                INTEGER_CYCLING_TYPE
+            ):
                 int(point)
             else:
                 parser = TimePointParser()

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -445,7 +445,10 @@ class Scheduler:
 
         # Basic validation of --stopcp before we create a database.
         if self.options.stopcp:
-            self.validate_cyclepoint_str(self.options.stopcp)
+            self.validate_cyclepoint_str(
+                self.options.stopcp,
+                self.config.cfg['scheduling']['cycling mode']
+            )
 
         self.workflow_db_mgr.on_workflow_start(self.is_restart)
 
@@ -2004,19 +2007,23 @@ class Scheduler:
                 "effect as it is after the final cycle "
                 f"point '{self.config.final_point}'.")
 
-    def validate_cyclepoint_str(self, point: str) -> None:
+    @staticmethod
+    def validate_cyclepoint_str(
+        point: str,
+        cycling_mode: str,
+        label: str = 'stop cyclepoint (stopcp)'
+    ) -> None:
         """Assert that a cyclepoint is valid."""
+        if point == 'reload':
+            return
         try:
-            if (
-                self.config.cfg['scheduling']['cycling mode'] ==
-                INTEGER_CYCLING_TYPE
-            ):
+            if cycling_mode == INTEGER_CYCLING_TYPE:
                 int(point)
             else:
                 parser = TimePointParser()
-                parser.parse(self.options.stopcp)
+                parser.parse(point)
         except (ValueError, ISO8601SyntaxError):
-            raise UserInputError(f'Invalid stop cyclepoint (stopcp): {point}')
+            raise UserInputError(f'Invalid {label}: {point}')
 
     def update_data_store(self):
         """Sets the update flag on the data store.

--- a/tests/functional/cylc-play/08-invalid-stopcp.t
+++ b/tests/functional/cylc-play/08-invalid-stopcp.t
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Ensure that the Scheduler is able to run in profile mode without falling
+# over. It should produce a profile file at the end.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    initial cycle point = 1066
+    [[graph]]
+        R1 = foo
+__FLOW_CONFIG__
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${WORKFLOW_NAME}"
+
+# Assert malformed stopcp causes failure:
+run_fail "${TEST_NAME_BASE}-run" \
+    cylc play "${WORKFLOW_NAME}" --no-detach --stopcp potato
+
+grep_ok "UserInputError: Invalid stop cyclepoint (stopcp): potato" \
+    "${TEST_NAME_BASE}-run.stderr"
+
+# Check that we haven't got a database ready which appears corrupted:
+run_ok "${TEST_NAME_BASE}-run" \
+    cylc play "${WORKFLOW_NAME}" --no-detach
+
+purge

--- a/tests/functional/cylc-play/09-invalid-stopcp-int-cycling.t
+++ b/tests/functional/cylc-play/09-invalid-stopcp-int-cycling.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Ensure that the Scheduler is able to run in profile mode without falling
+# over. It should produce a profile file at the end.
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 4
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1066
+    [[graph]]
+        R1 = foo
+__FLOW_CONFIG__
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${WORKFLOW_NAME}"
+
+# Assert malformed stopcp causes failure:
+run_fail "${TEST_NAME_BASE}-run" \
+    cylc play "${WORKFLOW_NAME}" --no-detach --stopcp potato
+
+grep_ok "UserInputError: Invalid stop cyclepoint (stopcp): potato" \
+    "${TEST_NAME_BASE}-run.stderr"
+
+# Check that we haven't got a database ready which appears corrupted:
+run_ok "${TEST_NAME_BASE}-run" \
+    cylc play "${WORKFLOW_NAME}" --no-detach
+
+purge

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -25,7 +25,7 @@ from cylc.flow.scheduler import Scheduler
 from cylc.flow.scheduler_cli import RunOptions
 
 Fixture = Any
-
+param = pytest.param
 
 @pytest.mark.parametrize(
     'options, expected',
@@ -147,3 +147,59 @@ def test_check_startup_opts(
         with pytest.raises(UserInputError) as excinfo:
             Scheduler._check_startup_opts(mocked_scheduler)
         assert(err_msg.format(opt) in str(excinfo))
+
+
+@pytest.mark.parametrize(
+    'input_, expect',
+    [
+        param(
+            {
+                'point': 'reload',
+                'cycling_mode': 'integer'
+            },
+            None,
+            id="Point==reload"
+        ),
+        param(
+            {
+                'point': '911',
+                'cycling_mode': 'integer',
+            },
+            None,
+            id="integer-cycling-valid"
+        ),
+        param(
+            {
+                'point': 'foo',
+                'cycling_mode': 'integer'
+            },
+            'Not OK',
+            id="integer-cycling-invalid"
+        ),
+        param(
+            {
+                'point': '2022',
+                'cycling_mode': 'gregorian'
+            },
+            None,
+            id="dt-cycling-valid"
+        ),
+        param(
+            {
+                'point': '2022boo',
+                'cycling_mode': 'gergorian'
+            },
+            'Not OK',
+            id="dt-cycling-invalid"
+        )
+    ]
+)
+def test_validate_cyclepoint_str(input_, expect):
+    """Method correctly checks whether cyclepoint str is valid"""
+    testthis = Scheduler.validate_cyclepoint_str
+    if expect == None:
+        assert testthis(**input_) == expect
+    else:
+        with pytest.raises(UserInputError, match='Invalid'):
+            testthis(**input_)
+


### PR DESCRIPTION
These changes close #4637 

Don't create a workflow database until after validating stopcp.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
