### PR TITLE
added a note about platform regexes working in  reverse order

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -846,7 +846,7 @@ with Conf('global.cylc', desc='''
             of the definition order to allow user defined platforms
             to override site defined platforms. This means, for example, that 
             if ``[[a.*]]`` were set near the bottom of a configuration any 
-            platform name beginning "a" would retrn that platform.
+            platform name beginning with "a" would return that platform.
 
             .. note::
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -842,13 +842,19 @@ with Conf('global.cylc', desc='''
             ``desktop0000, .., desktop9999`` one would define platforms with
             names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{4}]]``.
 
+            Cylc searches through the list of platform regexes in the reverse
+            of the definition order to allow user defined platforms
+            to override site defined platforms. This means, for example, that
+            if were set ``[[a.*]]`` near the bottom of a configuration any
+            platform name beginning "a" would retrn that platform.
+
             .. note::
 
                Each possible match to the definition regular expression is
                considered a separate platform.
 
                If you had a supercomputer with multiple login nodes this would
-               be a single platform with multiple :cylc:conf:`hosts`
+               be a single platform with multiple :cylc:conf:`hosts`.
 
             .. seealso::
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -844,8 +844,8 @@ with Conf('global.cylc', desc='''
 
             Cylc searches through the list of platform regexes in the reverse
             of the definition order to allow user defined platforms
-            to override site defined platforms. This means, for example, that
-            if were set ``[[a.*]]`` near the bottom of a configuration any
+            to override site defined platforms. This means, for example, that 
+            if ``[[a.*]]`` were set near the bottom of a configuration any 
             platform name beginning "a" would retrn that platform.
 
             .. note::

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -842,10 +842,10 @@ with Conf('global.cylc', desc='''
             ``desktop0000, .., desktop9999`` one would define platforms with
             names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{4}]]``.
 
-            Cylc searches through the list of platform regexes in the reverse
+            Cylc searches for a matching platform in the reverse
             of the definition order to allow user defined platforms
             to override site defined platforms. This means, for example, that
-            if ``[[a.*]]`` were set near the bottom of a configuration any
+            if ``[[a.*]]`` were set at the bottom of a configuration any
             platform name beginning with "a" would return that platform.
 
             .. note::

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -844,8 +844,8 @@ with Conf('global.cylc', desc='''
 
             Cylc searches through the list of platform regexes in the reverse
             of the definition order to allow user defined platforms
-            to override site defined platforms. This means, for example, that 
-            if ``[[a.*]]`` were set near the bottom of a configuration any 
+            to override site defined platforms. This means, for example, that
+            if ``[[a.*]]`` were set near the bottom of a configuration any
             platform name beginning with "a" would return that platform.
 
             .. note::

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1211,9 +1211,10 @@ async def mutator(root, info, command=None, workflows=None,
         workflows = []
     if exworkflows is None:
         exworkflows = []
-    w_args = {}
-    w_args['workflows'] = [Tokens(w_id) for w_id in workflows]
-    w_args['exworkflows'] = [Tokens(w_id) for w_id in exworkflows]
+    w_args = {
+        'workflows': [Tokens(w_id) for w_id in workflows],
+        'exworkflows': [Tokens(w_id) for w_id in exworkflows]
+    }
     if args.get('args', False):
         args.update(args.get('args', {}))
         args.pop('args')


### PR DESCRIPTION
This is a small change with no associated issue

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (Doc change).
- [x] No change log entry required (Internal doc change)
- [x] No documentation update required.
