### PR TITLE
log removal of contact file

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -513,6 +513,10 @@ def detect_old_contact_file(reg: str, contact_data=None) -> None:
         # ... the process isn't running so the contact file is out of date
         # remove it
         try:
+            LOG.info(
+                f'Removing contact file for {reg}'
+                ' (workflow no longer running).'
+            )
             os.unlink(fname)
             return
         except OSError as exc:


### PR DESCRIPTION
If a client fails to connect and the workflow can be proven not to be running, then the contact file will be removed.

This PR logs when contact files are removed which seems like sensible logging to have.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Already covered by existing tests.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
