### PR TITLE
Fix contact file exists message

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -504,7 +504,7 @@ def detect_old_contact_file(reg: str, contact_data=None) -> None:
             CONTACT_FILE_EXISTS_MSG % {
                 "host": old_host,
                 "port": old_port,
-                "pid": old_cmd,
+                "pid": old_pid,
                 "fname": fname,
                 "workflow": reg,
             }


### PR DESCRIPTION
While investigating healthcheck bug, I noticed the `CONTACT_FILE_EXISITS_MSG` is incorrect. It was being sent the original command rather than the process id.  

To test, 
`cylc play workflow` 
`cylc play workflow`
On master the pid is not passed to the kill command.


This is a small change with no associated Issue.


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why? Documentation).
- [x] No change log entry required (why? trivial change).
- [x] No documentation update required.
