### PR TITLE
Client key error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ htmlcov/
 build
 dist
 MANIFEST
-cylc.egg-info
 cylc_flow.egg-info
 .eggs
 

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -211,8 +211,14 @@ class WorkflowRuntimeClient(ZMQSocketBase):
         try:
             return response['data']
         except KeyError:
-            error = response['error']
-            raise ClientError(error['message'], error.get('traceback'))
+            error = response.get(
+                'error',
+                {'message': f'Received invalid response: {response}'},
+            )
+            raise ClientError(
+                error.get('message'),
+                error.get('traceback'),
+            )
 
     def serial_request(
         self,


### PR DESCRIPTION
Not a blocker for RC1.

Fixes a small bug where a `KeyError` could be raised during the process of raising a `ClientError` in the event of an error in the response causing it to not contain an "error" entry.

Also remove a .gitignore file.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] (7.8.x branch) I have updated the documentation in this PR branch.
