### PR TITLE
docs: fix issue causing docs to fail to build

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -121,7 +121,7 @@ class WorkflowRuntimeClient(ZMQSocketBase):
         workflow: str,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        context: Optional[zmq.asyncio.Context] = None,
+        context=None,
         timeout: Union[float, str, None] = None,
         srv_public_key_loc: Optional[str] = None
     ):


### PR DESCRIPTION
Docs are failing to build with the following message:

```
~/cylc-flow/cylc/flow/network/client.py:docstring of cylc.flow.network.client.WorkflowRuntimeClient:: WARNING: py:class reference target not found: zmq.asyncio.Context
```

* Confirmed ZMQ is installed correctly in the build environment.
* Replicated locally.
* Tried quoting the type, not good enough
* Removing the hint.