### PR TITLE
Revert "docs: fix issue causing docs to fail to build"

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -121,7 +121,7 @@ class WorkflowRuntimeClient(ZMQSocketBase):
         workflow: str,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        context=None,
+        context: Optional[zmq.asyncio.Context] = None,
         timeout: Union[float, str, None] = None,
         srv_public_key_loc: Optional[str] = None
     ):


### PR DESCRIPTION
This reverts commit 21928e6b26dcf6720ce7e38ee0736d8163213c34 (#4692) as superseded by https://github.com/cylc/cylc-doc/pull/406

Needs:
- https://github.com/cylc/cylc-doc/pull/406 

This is a small change with no associated Issue.