### PR TITLE
tests/i: replace run with start where possible

### DIFF
--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -355,7 +355,14 @@ async def test_source_dirs(source_dirs):
     ]
 
 
-async def test_scan_sigstop(flow, scheduler, run, one_conf, test_dir, caplog):
+async def test_scan_sigstop(
+    flow,
+    scheduler,
+    start,
+    one_conf,
+    test_dir,
+    caplog,
+):
     """It should log warnings if workflows are un-contactable.
 
     Note:
@@ -367,7 +374,7 @@ async def test_scan_sigstop(flow, scheduler, run, one_conf, test_dir, caplog):
     # run a workflow
     reg = flow(one_conf)
     schd = scheduler(reg)
-    async with run(schd):
+    async with start(schd):
         # stop the server to make the flow un-responsive
         schd.server.stop()
         # try scanning the workflow

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -127,7 +127,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
     capture_submission,
     flow,
     one_conf,
-    run,
+    start,
     scheduler,
 ):
     """It should hold tasks irrespective of workflow state.
@@ -138,7 +138,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
     one = scheduler(reg, paused_start=True)
 
     # run the workflow
-    async with run(one):
+    async with start(one):
         # capture any job submissions
         submitted_tasks = capture_submission(one)
         assert one.pre_prep_tasks == []
@@ -175,7 +175,7 @@ async def test_no_poll_waiting_tasks(
     capture_polling,
     flow,
     one_conf,
-    run,
+    start,
     scheduler,
 ):
     """Waiting tasks shouldn't be polled.
@@ -189,7 +189,7 @@ async def test_no_poll_waiting_tasks(
     one = scheduler(reg, paused_start=True)
 
     log: pytest.LogCaptureFixture
-    async with run(one) as log:
+    async with start(one) as log:
 
         # Test assumes start up with a waiting task.
         task = (one.pool.get_all_tasks())[0]

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -424,10 +424,10 @@ async def test_hold_point(
         (TASK_STATUS_SUCCEEDED, True),
     ]
 )
-async def test_trigger_states(status, should_trigger, one, run):
+async def test_trigger_states(status, should_trigger, one, start):
     """It should only trigger tasks in compatible states."""
 
-    async with run(one):
+    async with start(one):
         task = one.pool.filter_task_proxies('1/a')[0][0]
 
         # reset task a to the provided state
@@ -440,7 +440,7 @@ async def test_trigger_states(status, should_trigger, one, run):
         assert task.is_manual_submit == should_trigger
 
 
-async def test_preparing_tasks_on_restart(one_conf, flow, scheduler, run):
+async def test_preparing_tasks_on_restart(one_conf, flow, scheduler, start):
     """Preparing tasks should be reset to waiting on restart.
 
     This forces preparation to be re-done on restart so that it uses the
@@ -453,19 +453,19 @@ async def test_preparing_tasks_on_restart(one_conf, flow, scheduler, run):
 
     # start the workflow, reset a task to preparing
     one = scheduler(id_)
-    async with run(one):
+    async with start(one):
         task = one.pool.filter_task_proxies(['*'])[0][0]
         task.state.reset(TASK_STATUS_PREPARING)
 
     # when we restart the task should have been reset to waiting
     one = scheduler(id_)
-    async with run(one):
+    async with start(one):
         task = one.pool.filter_task_proxies(['*'])[0][0]
         assert task.state(TASK_STATUS_WAITING)
         task.state.reset(TASK_STATUS_SUCCEEDED)
 
     # whereas if we reset the task to succeeded the state is not reset
     one = scheduler(id_)
-    async with run(one):
+    async with start(one):
         task = one.pool.filter_task_proxies(['*'])[0][0]
         assert task.state(TASK_STATUS_SUCCEEDED)


### PR DESCRIPTION
This may reduce the risk of integration test timeouts.

* The run fixture kicks off the main loop which is typically one more moving part than the average integration test requires.
* The start fixture only starts the scheduler and leaves the test to perform any required actions to implement test logic.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
