### PR TITLE
Include workflow name in `cylc clean` logging/error messages

### DIFF
--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -59,7 +59,7 @@ Examples:
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, List, Tuple
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import UserInputError
@@ -124,7 +124,8 @@ def get_option_parser():
 CleanOptions = Options(get_option_parser())
 
 
-def prompt(workflows):
+def prompt(workflows: Iterable[str]) -> None:
+    """Ask user if they want to clean the given set of workflows."""
     print("Would clean the following workflows:")
     for workflow in workflows:
         print(f'  {workflow}')
@@ -144,12 +145,15 @@ def prompt(workflows):
         sys.exit(1)
 
 
-async def scan(workflows, multi_mode):
+async def scan(
+    workflows: Iterable[str], multi_mode: bool
+) -> Tuple[List[str], bool]:
     """Expand tuncated workflow IDs
 
     For example "one" might expand to "one/run1" & "one/run2"
     or "one/two/run1".
 
+    Returns (workflows, multi_mode)
     """
     ret = []
     for workflow in list(workflows):
@@ -162,7 +166,7 @@ async def scan(workflows, multi_mode):
     return ret, multi_mode
 
 
-async def run(*ids, opts=None):
+async def run(*ids: str, opts: 'Values') -> None:
     # parse ids from the CLI
     workflows, multi_mode = await parse_ids_async(
         *ids,

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -344,7 +344,7 @@ def test_infer_latest_run__bad(
          "cannot be a path that points to the cylc-run directory or above"),
         ('foo/../..', True, WorkflowFilesError,
          "cannot be a path that points to the cylc-run directory or above"),
-        ('foo', False, ServiceFileError, "Cannot remove running workflow"),
+        ('foo', False, ServiceFileError, "Cannot clean running workflow"),
     ]
 )
 def test_clean_check__fail(
@@ -454,7 +454,9 @@ def test_init_clean__no_db(
     mock_remote_clean = monkeymock('cylc.flow.workflow_files.remote_clean')
 
     init_clean('bespin', opts=CleanOptions())
-    assert "No workflow database - will only clean locally" in caplog.text
+    assert (
+        "No workflow database for bespin - will only clean locally"
+    ) in caplog.text
     assert mock_clean.called is True
     assert mock_remote_clean.called is False
 
@@ -469,8 +471,9 @@ def test_init_clean__remote_only_no_db(
 
     with pytest.raises(ServiceFileError) as exc:
         init_clean('hoth', opts=CleanOptions(remote_only=True))
-    assert ("No workflow database - cannot perform remote clean"
-            in str(exc.value))
+    assert (
+        "No workflow database for hoth - cannot perform remote clean"
+    ) in str(exc.value)
     assert mock_clean.called is False
     assert mock_remote_clean.called is False
 
@@ -487,7 +490,7 @@ def test_init_clean__running_workflow(
 
     with pytest.raises(ServiceFileError) as exc:
         init_clean('yavin', opts=CleanOptions())
-    assert "Cannot remove running workflow" in str(exc.value)
+    assert "Cannot clean running workflow" in str(exc.value)
 
 
 @pytest.mark.parametrize(
@@ -1242,7 +1245,7 @@ PLATFORMS = {
             {'enterprise': 255, 'stargazer': 255},
             ['enterprise', 'stargazer', 'voyager'],
             True,
-            ["Could not clean on install target: picard"],
+            ["Could not clean foo on install target: picard"],
             id="Install target with all failed platforms"
         ),
         pytest.param(
@@ -1253,8 +1256,8 @@ PLATFORMS = {
             {'enterprise': 255, 'voyager': 255},
             ['enterprise', 'voyager'],
             True,
-            ["Could not clean on install target: picard",
-             "Could not clean on install target: janeway"],
+            ["Could not clean foo on install target: picard",
+             "Could not clean foo on install target: janeway"],
             id="All install targets have all failed platforms"
         ),
         pytest.param(
@@ -1264,7 +1267,7 @@ PLATFORMS = {
             {'enterprise': 1},
             ['enterprise'],
             True,
-            ["Could not clean on install target: picard"],
+            ["Could not clean foo on install target: picard"],
             id=("Remote clean cmd fails on a platform for non-SSH reason - "
                 "does not retry")
         ),


### PR DESCRIPTION
This is a small change with no associated Issue.

When doing a multi workflow clean, there was no way of knowing which workflow a particular message was about

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (very minor change)
- [x] No documentation update required.
