### PR TITLE
Upper pin markupsafe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,18 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.0rc2 (<span actions:bind='release-date'>Upcoming</span>)__
+
+Second Release Candidate for Cylc 8 suitable for acceptance testing.
+
+### Fixes
+
+[#4703](https://github.com/cylc/cylc-flow/pull/4703) - Fix `ImportError` when
+validating/running a Jinja2 workflow (for users who have installed Cylc
+using `pip`.)
+
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0rc1 (<span actions:bind='release-date'>Released 2022-02-17</span>)__
 
 First Release Candidate for Cylc 8 suitable for acceptance testing.

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -18,6 +18,10 @@ dependencies:
   - setuptools >=49
   - urwid >=2,<3
 
+  # https://github.com/pallets/jinja/issues/1585 (remove when upgrading
+  # jinja2 to >= 3.0):
+  - markupsafe <2.1
+
 # optional dependencies
   #- empy >=3.3,<3.4
   #- pandas >=1.0,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,10 @@ install_requires =
     setuptools>=49
     urwid==2.*
 
+    # https://github.com/pallets/jinja/issues/1585 (remove when upgrading
+    # jinja2 to >= 3.0):
+    markupsafe<2.1
+
 [options.packages.find]
 include = cylc*
 


### PR DESCRIPTION
```
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```

Jinja2 @ 2.11.3 has [a dependency `MarkupSafe>=0.23`](https://github.com/pallets/jinja/blob/cf215390d4a4d6f0a4de27e2687eed176878f13d/setup.py#L53 ). Unfortunately Pallets have made a breaking change in the API in MarkupSafe 2.1.0, but have no plans to patch version 2.11 of Jinja2 with an upper pin on MarkupSafe, so we have to do it ourselves.

https://github.com/pallets/jinja/issues/1585

Note: we have discussed moving to version 3.0 of Jinja2, which is the only supported version going forward (see comments from the Pallets team on the issue above). The difficulty is convincing ourselves this will not introduce breaking changes to Cylc workflows that are dependent on Jinja2. It is is unfeasible (and not our job) to write a test spec for Jinja2; however, it might be enough to have a suitably complex test workflow that we can diff with a reference file to see if Jinja2 updates cause changes in output.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests 
- [ ] Appropriate change log entry included.
- [x] (master branch) I have opened a documentation PR: cylc/cylc-doc/pull/408