### PR TITLE
actions: pin manylinux to pip<22

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -48,6 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Downgrade PIP
+        run: |
+          # pip v22+ will fail on error rather than falling back to the
+          # previous release
+          # the old behaviour is better for this check
+          if (( $(pip --version | sed 's/pip \([0-9]*\).*/\1/') >= 22 ))
+          then
+            pip install 'pip<22'
+          fi
+
       - name: Configure Manylinux Compatibility
         # Make this platform look older than it is. For info see:
         # https://stackoverflow.com/questions/37231799/


### PR DESCRIPTION
> The manylinux failure is due to a combination of kiwisolver dropping manylinux1 support and pip22 failing on error (so no longer falling back to the previous version as it used to).
> 
> The (transient) kiwisolver dep is `kiwisolver>=1.0.1`, manylinux support was only dropped at the most recent `1.3.2` release so we are good here, for now...
 
This might be enough to patch things over for now 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
