### PR TITLE
Fix warnings and tidy

### DIFF
--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -48,7 +48,7 @@ Main loop plugins can be activated either by:
 
      $ # run a workflow using the "health check" and "auto restart" plugins:
      $ cylc play my-workflow --main-loop 'health check' \
-       --main-loop 'auto restart'
+--main-loop 'auto restart'
 
 * Adding them to the default list of plugins in
   :cylc:conf:`global.cylc[scheduler][main loop]plugins` e.g:

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -324,7 +324,7 @@ class WorkflowRuntimeServer(ZMQSocketBase):
             executed: ExecutionResult = schema.execute(
                 request_string,
                 variable_values=variables,
-                context={
+                context_value={
                     'resolvers': self.resolvers,
                     'meta': meta or {},
                 },

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -211,10 +211,10 @@ def test_module_two(myflow):
     assert myflow.uuid_str
 
 
-async def test_db_select(one, run, db_select):
+async def test_db_select(one, start, db_select):
     """Demonstrate and test querying the workflow database."""
     schd = one
-    async with run(schd):
+    async with start(schd):
         # Note: can't query database here unfortunately
         pass
     # Now we can query the DB

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -185,8 +185,8 @@ async def test_no_poll_waiting_tasks(
 
     See https://github.com/cylc/cylc-flow/issues/4658
     """
-    reg = flow(one_conf)
-    one = scheduler(reg, paused_start=True)
+    reg: str = flow(one_conf)
+    one: Scheduler = scheduler(reg, paused_start=True)
 
     log: pytest.LogCaptureFixture
     async with start(one) as log:

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -31,7 +31,7 @@ from uuid import uuid1
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.workflow_files import WorkflowFiles
-from cylc.flow.scheduler import Scheduler
+from cylc.flow.scheduler import Scheduler, SchedulerStop
 from cylc.flow.scheduler_cli import RunOptions
 from cylc.flow.workflow_status import StopMode
 
@@ -93,7 +93,7 @@ async def _start_flow(
     # stop
     finally:
         async with timeout(5):
-            await schd.shutdown(Exception("that'll do"))
+            await schd.shutdown(SchedulerStop("that'll do"))
 
 
 @asynccontextmanager
@@ -117,7 +117,7 @@ async def _run_flow(
             await schd.shutdown(exc)
     # run
     try:
-        task = asyncio.get_event_loop().create_task(schd.run_scheduler())
+        task = asyncio.create_task(schd.run_scheduler())
         yield caplog
 
     # stop

--- a/tests/unit/main_loop/test_main_loop.py
+++ b/tests/unit/main_loop/test_main_loop.py
@@ -247,6 +247,10 @@ def test_get_runners_periodic_debounce(basic_plugins):
     assert len(runners) == 1
     assert calls[-1] == ('scheduler object', {'a': 1})
 
+    # Clean up coroutines we didn't run
+    for coro in runners:
+        coro.close()
+
 
 def test_state(basic_plugins):
     """It should pass the same state object with each function call.

--- a/tests/unit/network/test_publisher.py
+++ b/tests/unit/network/test_publisher.py
@@ -16,9 +16,6 @@
 
 from time import sleep
 
-import pytest
-
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.network.publisher import WorkflowPublisher, serialize_data
 
 


### PR DESCRIPTION
This is a small change with no associated Issue. In light of the markupsafe incident, I thought it would be a good idea to address the warnings that currently occur during pytest runs (although actually there were no warnings coming through for the markupsafe breaking change). Only exception is the `pytest.PytestUnhandledThreadExceptionWarning` which is tracked in #4706 

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
