### PR TITLE
Fix tutorial workflow test

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -10,13 +10,6 @@ on:
       - 'tests/**'
       - '**.md'
   workflow_dispatch:
-    inputs:
-      rose_ref:
-        description: The Rose branch to test against
-        required: false
-      cylc_rose_ref:
-        description: The Cylc branch to test against
-        required: false
 
 jobs:
   test:
@@ -36,15 +29,6 @@ jobs:
 
       - name: install cylc-flow
         run: pip install .[all]
-
-      - name: install libs
-        env:
-          rose_ref: ${{ github.event.inputs.rose_ref || 'master' }}
-          cylc_rose_ref: ${{ github.event.inputs.cylc_rose_ref || 'master' }}
-        run: |
-          pip install  \
-            "cylc-rose @ git+https://github.com/cylc/cylc-rose@${cylc_rose_ref}" \
-            "metomi-rose @ git+https://github.com/metomi/rose@${rose_ref}"
 
       - name: run tutorial workflow
         timeout-minutes: 6

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -43,9 +43,8 @@ jobs:
           cylc_rose_ref: ${{ github.event.inputs.cylc_rose_ref || 'master' }}
         run: |
           pip install  \
-            "cylc-rose @ git+https://github.com/cylc/cylc-rose@${cylc_rose_ref}"
-          git clone --depth 1 --branch "${rose_ref}" https://github.com/metomi/rose ../rose
-          pip install -e ../rose
+            "cylc-rose @ git+https://github.com/cylc/cylc-rose@${cylc_rose_ref}" \
+            "metomi-rose @ git+https://github.com/metomi/rose@${rose_ref}"
 
       - name: run tutorial workflow
         timeout-minutes: 6

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/bin/get-observations
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/bin/get-observations
@@ -37,6 +37,7 @@ from datetime import datetime
 import json
 import os
 import re
+
 import requests
 import urllib3
 

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/bin/get-rainfall
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/bin/get-rainfall
@@ -37,6 +37,7 @@ from datetime import datetime
 import math
 import os
 import shutil
+
 import urllib3
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,7 @@ tests =
     typing-extensions>=4
 tutorials =
     pillow
+    requests
     urllib3
 all =
     %(empy)s


### PR DESCRIPTION
Fixes this error in tutorial tests:
```
ERROR: Could not find a version that satisfies the requirement metomi-rose==2.0rc2.* (from cylc-rose) (from versions: 2.0a1, 2.0b1, 2.0b2, 2.0b3, 2.0rc1)
ERROR: No matching distribution found for metomi-rose==2.0rc2.*
```

Further info:

> The `git clone` approach was used because of that symlink issue where pip install <url> was broken for Rose. Seems like it works fine now though so going back to the simpler approach.

https://github.com/cylc/cylc-rose/pull/114#discussion_r811762468