### PR TITLE
scheduler: process DB after configure complete

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -539,6 +539,8 @@ class Scheduler:
             self.previous_profile_point = 0
             self.count = 0
 
+        self.process_workflow_db_queue()
+
         self.profiler.log_memory("scheduler.py: end configure")
 
     async def start_servers(self):


### PR DESCRIPTION
> Result of test instability spotted by @MetRonnie, posted on Element
>
>> While trying to debug the flakiness of the integration tests on GH Actions MacOS, I noticed that running the integration tests with -n 0 --dist=no to turn off pytest-xdist results in tests/integration/test_[scan.py](http://scan.py/)::test_workflow_params failing 100% of the time (on linux)

I think this is a bug because if the workflow bails during the first main loop iteration the workflow will be left in a state we cannot restart from.

If it's an issue RC2, otherwise 8.1.0.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.