### PR TITLE
Actions: skip certain tests on MacOS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - 'dependencies'
+      - 'infrastructure'

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
+      fail-fast: false # Don't let a failed MacOS run stop the Ubuntu runs
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9']
@@ -32,13 +33,15 @@ jobs:
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')
         run: |
+          # speed up install (https://docs.brew.sh/Manpage#environment)
+          export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
+          echo "[command]brew update"
           brew update
-          brew install shellcheck sqlite3 bash coreutils
-
+          echo "[command]brew install ..."
+          brew install bash coreutils
           # add GNU coreutils and sed to the user PATH
           # (see instructions in brew install output)
-          echo \
-            "$(brew --prefix)/opt/coreutils/libexec/gnubin" \
+          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" \
             >> "${GITHUB_PATH}"
 
       - name: Apt-Get Install
@@ -55,18 +58,22 @@ jobs:
         uses: cylc/release-actions/configure-git@v1
 
       - name: Style
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           flake8
           etc/bin/shellchecker
 
       - name: Typing
+        if: startsWith(matrix.os, 'ubuntu')
         run: mypy
 
       - name: Doctests
+        timeout-minutes: 4
         run: |
           pytest cylc/flow
 
       - name: Unit Tests
+        timeout-minutes: 4
         run: |
           pytest tests/unit
 
@@ -77,6 +84,7 @@ jobs:
           bandit -r --ini .bandit cylc/flow
 
       - name: Integration Tests
+        timeout-minutes: 6
         run: |
           pytest tests/integration
 
@@ -88,6 +96,6 @@ jobs:
       - name: Codecov upload
         uses: codecov/codecov-action@v2
         with:
-          name: '"${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}"'
+          name: '${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}'
           flags: fast-tests
           fail_ci_if_error: true

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -88,6 +88,13 @@ jobs:
         run: |
           pytest tests/integration
 
+      - name: Upload artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cylc-run (${{ matrix.os }} py-${{ matrix.python-version }})
+          path: ~/cylc-run/
+
       - name: Coverage report
         run: |
           coverage xml

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload artifact
         if: failure() && steps.test.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cylc-run (${{ steps.uploadname.outputs.uploadname }})
           path: ~/cylc-run/

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -280,6 +280,6 @@ jobs:
       - name: Codecov upload
         uses: codecov/codecov-action@v2
         with:
-          name: '"${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}"'
+          name: '${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}'
           flags: functional-tests
           fail_ci_if_error: true


### PR DESCRIPTION
~Turn off xdist in the hope it makes the integration tests stop hanging flakily on GH Actions~

Reduce homebrew installation and skip style, mypy, in order to speed up MacOS runs