### PR TITLE
host_select: fix docs and improve error message

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -453,7 +453,7 @@ with Conf('global.cylc', desc='''
                    cpu_percent() < 70
 
                    # filter out hosts with less than 1GB of RAM available
-                   virtual_memory.available > 1000000000
+                   virtual_memory().available > 1000000000
 
                    # filter out hosts with less than 1GB of disk space
                    # available on the "/" mount


### PR DESCRIPTION
Documented example was missing brackets.

Will hotfix the 8.0.0 docs.

Improved the error message a little, could be better but admin facing rather than user facing so not worth the time investment ATM. If you try testing this with the originally documented example you will see the word "RESULT" appear in the error which is an artefact of the expression processing which cannot easily be removed.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
