### PR TITLE
config: assorted fixes for python template variables supported in various configurations

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -241,7 +241,7 @@ EVENTS_DESCR = {
     ),
     'abort on inactivity timeout': (
         f'''
-        :Default For; :cylc:conf:`flow.cylc \
+        :Default For: :cylc:conf:`flow.cylc \
         [scheduler][events]abort on inactivity timeout`.
 
         Whether to abort if the inactivity timer times out.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -362,6 +362,10 @@ with Conf(
                 ``$PATH`` (in the shell in which the scheduler runs).
                 They should require little resource to run and return
                 quickly.
+
+                Template variables can be used to configure handlers
+                for a full list of supported variables see
+                :ref:`workflow_event_template_variables`.
             ''')
             Conf('handler events', VDR.V_STRING_LIST, None, desc='''
                 Specify the events for which workflow event
@@ -1316,67 +1320,8 @@ with Conf(
                 quickly.
 
                 Each task event handler can be specified as a list of command
-                lines or command line templates. They can contain any or all
-                of the following patterns, which will be substituted with
-                actual values:
-
-                ``%(event)s``
-                   Event name
-                ``%(workflow)s``
-                   Workflow name
-                ``%(workflow_uuid)s``
-                   Workflow UUID string
-                ``%(point)s``
-                   Cycle point
-                ``%(name)s``
-                   Task name
-                ``%(submit_num)s``
-                   Submit number
-                ``%(try_num)s``
-                   Try number
-                ``%(id)s``
-                   Task ID (i.e. %(name)s.%(point)s)
-                ``%(job_runner_name)s``
-                   Job runner name (previously ``%(batch_sys_name)s``)
-                ``%(job_id)s``
-                   Job ID in the job runner
-                   (previously ``%(batch_sys_job_id)s``)
-                ``%(submit_time)s``
-                   Date-time when task job is submitted
-                ``%(start_time)s``
-                   Date-time when task job starts running
-                ``%(finish_time)s``
-                   Date-time when task job exits
-                ``%(platform_name)s``
-                   Name of platform where the task job is submitted
-                ``%(message)s``
-                   Event message, if any
-                Any task [meta] item, e.g.:
-                   ``%(title)s``
-                      Task title
-                   ``%(URL)s``
-                      Task URL
-                   ``%(importance)s``
-                      Example custom task metadata
-                Any workflow ``[meta]`` item, prefixed with ``workflow_``
-                   ``%(workflow_title)s``
-                      Workflow title
-                   ``%(workflow_URL)s``
-                      Workflow URL.
-                   ``%(workflow_rating)s``
-                      Example custom workflow metadata.
-
-                Otherwise, the command line will be called with the following
-                default arguments:
-
-                .. code-block:: none
-
-                   <event-handler> %(event)s %(workflow)s %(id)s %(message)s
-
-                .. note::
-
-                   Substitution patterns should not be quoted in the template
-                   strings.  This is done automatically where required.
+                lines or command line templates. For a full list of supported
+                template variables see :ref:`task_event_template_variables`.
 
                 For an explanation of the substitution syntax, see
                 `String Formatting Operations in the Python

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -372,8 +372,8 @@ with Conf(
                 They should require little resource to run and return
                 quickly.
 
-                Template variables can be used to configure handlers
-                for a full list of supported variables see
+                Template variables can be used to configure handlers.
+                For a full list of supported variables see
                 :ref:`workflow_event_template_variables`.
             ''')
             Conf('handler events', VDR.V_STRING_LIST, None, desc='''
@@ -433,7 +433,7 @@ with Conf(
 
                    {REPLACES} ``[cylc][events]mail footer``.
 
-                Template variables may be used in the mail footer, for a list
+                Template variables may be used in the mail footer. For a list
                 of supported variables see
                 :ref:`_workflow_event_template_variables`.
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -137,7 +137,9 @@ with Conf(
         Conf('URL', VDR.V_STRING, '', desc='''
             A web URL to workflow documentation.
 
-            It can be retrieved at run time with the ``cylc show`` command.
+            The URL can be retrieved at run time with the ``cylc show``
+            command.
+
             The template variable ``%(workflow)s`` will be replaced with the
             actual workflow ID.
 
@@ -409,14 +411,9 @@ with Conf(
 
                    {REPLACES} ``[cylc][events]mail footer``.
 
-                ================ ======================
-                Syntax           Description
-                ================ ======================
-                ``%(host)s``     Workflow host name.
-                ``%(port)s``     Workflow port number.
-                ``%(owner)s``    Workflow owner name.
-                ``%(workflow)s``    Workflow name
-                ================ ======================
+                Template variables may be used in the mail footer, for a list
+                of supported variables see
+                :ref:`_workflow_event_template_variables`.
 
                 Example:
 
@@ -1923,7 +1920,7 @@ def warn_about_depr_event_handler_tmpl(cfg):
             if f'%({EventData.SuiteUUID.value})' in handler:
                 LOG.warning(
                     deprecation_msg.format(EventData.SuiteUUID.value,
-                                           EventData.UUID_str.value)
+                                           EventData.UUID.value)
                 )
 
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -138,8 +138,13 @@ with Conf(
             A web URL to workflow documentation.
 
             It can be retrieved at run time with the ``cylc show`` command.
-            The template ``%(workflow_name)s`` will be replaced with the actual
-            workflow name.
+            The template variable ``%(workflow)s`` will be replaced with the
+            actual workflow ID.
+
+            .. deprecated:: 8.0.0
+
+               The ``%(suite_name)s`` template variable is deprecated, please
+               use ``%(workflow)s``.
 
             .. seealso::
 
@@ -147,7 +152,7 @@ with Conf(
 
             Example:
 
-            ``http://my-site.com/workflows/%(workflow_name)s/index.html``
+            ``http://my-site.com/workflows/%(workflow)s/index.html``
 
         ''')
         Conf('<custom metadata>', VDR.V_STRING, '', desc='''
@@ -1176,16 +1181,24 @@ with Conf(
                         A URL link to task documentation for this task or task
                         family.
 
-                        The templates ``%(workflow_name)s`` and
-                        ``%(task_name)s`` will be replaced with the actual
-                        workflow and task names.
+                        The templates ``%(workflow)s`` and
+                        ``%(task)s`` will be replaced with the actual
+                        workflow ID and task name.
+
+                        .. deprecated:: 8.0.0
+
+                           The ``%(suite_name)s`` template variable is
+                           deprecated, please use ``%(workflow)s``.
+
+                           The ``%(task_name)s`` template variable is
+                           deprecated, please use ``%(task)s``.
 
                         See also :cylc:conf:`[meta]URL <flow.cylc[meta]URL>`.
 
                         Example:
 
-                        ``http://my-site.com/workflows/%(workflow_name)s/'''
-                    '%(task_name)s.html``')
+                        ``http://my-site.com/workflows/%(workflow)s/'''
+                    '%(task)s.html``')
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.
 
@@ -1910,7 +1923,7 @@ def warn_about_depr_event_handler_tmpl(cfg):
             if f'%({EventData.SuiteUUID.value})' in handler:
                 LOG.warning(
                     deprecation_msg.format(EventData.SuiteUUID.value,
-                                           EventData.WorkflowUUID.value)
+                                           EventData.UUID_str.value)
                 )
 
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -506,32 +506,7 @@ class WorkflowConfig:
                     self.feet.append(foot)
         self.feet.sort()  # sort effects get_graph_raw output
 
-        # Replace workflow and task name in workflow and task URLs.
-        self.cfg['meta']['URL'] = self.cfg['meta']['URL'] % {
-            'workflow_name': self.workflow}
-        # BACK COMPAT: CYLC_WORKFLOW_NAME
-        # from:
-        #     Cylc7
-        # to:
-        #     Cylc8
-        # remove at:
-        #     Cylc9
-        self.cfg['meta']['URL'] = RE_WORKFLOW_ID_VAR.sub(
-            self.workflow, self.cfg['meta']['URL'])
-        for name, cfg in self.cfg['runtime'].items():
-            cfg['meta']['URL'] = cfg['meta']['URL'] % {
-                'workflow_name': self.workflow, 'task_name': name}
-            # BACK COMPAT: CYLC_WORKFLOW_NAME, CYLC_TASK_NAME
-            # from:
-            #     Cylc7
-            # to:
-            #     Cylc8
-            # remove at:
-            #     Cylc9
-            cfg['meta']['URL'] = RE_WORKFLOW_ID_VAR.sub(
-                self.workflow, cfg['meta']['URL'])
-            cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(
-                name, cfg['meta']['URL'])
+        self.process_metadata_urls()
 
         if getattr(self.options, 'is_validate', False):
             self.mem_log("config.py: before _check_circular()")
@@ -2263,3 +2238,78 @@ class WorkflowConfig:
                 "Directories can only be from the top level, please "
                 "reconfigure:" + str(illegal_includes)[1:-1])
         return includes
+
+    def process_metadata_urls(self):
+        """Process [meta]URL items."""
+        # workflow metadata
+        url = self.cfg['meta']['URL']
+        try:
+            self.cfg['meta']['URL'] = url % {
+                'workflow': self.workflow,
+            }
+        except (KeyError, ValueError):
+            try:
+                # Replace workflow and task name in workflow and task URLs.
+                # BACK COMPAT: suite_name
+                # url:
+                #     https://github.com/cylc/cylc-flow/pull/4724
+                # from:
+                #     Cylc7
+                # to:
+                #     Cylc8
+                # remove at:
+                #     Cylc9
+                self.cfg['meta']['URL'] = url % {
+                    # cylc 7
+                    'suite_name': self.workflow,
+                    # cylc 8
+                    'workflow': self.workflow,
+                }
+            except (KeyError, ValueError):
+                raise UserInputError(f'Invalid template [meta]URL: {url}')
+            else:
+                LOG.warning(
+                    'Detected deprecated template variables in [meta]URL.'
+                    '\nSee the configuration documentation for details.'
+                )
+
+        # task metadata
+        self.cfg['meta']['URL'] = RE_WORKFLOW_ID_VAR.sub(
+            self.workflow, self.cfg['meta']['URL'])
+        for name, cfg in self.cfg['runtime'].items():
+            try:
+                cfg['meta']['URL'] = cfg['meta']['URL'] % {
+                    'workflow': self.workflow,
+                    'task': name,
+                }
+            except (KeyError, ValueError):
+                # BACK COMPAT: suite_name, task_name
+                # url:
+                #     https://github.com/cylc/cylc-flow/pull/4724
+                # from:
+                #     Cylc7
+                # to:
+                #     Cylc8
+                # remove at:
+                #     Cylc9
+                try:
+                    cfg['meta']['URL'] = cfg['meta']['URL'] % {
+                        # cylc 7
+                        'suite_name': self.workflow,
+                        'task_name': name,
+                        # cylc 8
+                        'workflow': self.workflow,
+                        'task': name,
+                    }
+                except (KeyError, ValueError):
+                    raise UserInputError(f'Invalid template [meta]URL: {url}')
+                else:
+                    LOG.warning(
+                        'Detected deprecated template variables in'
+                        f' [runtime][{name}][meta]URL.'
+                        '\nSee the configuration documentation for details.'
+                    )
+            cfg['meta']['URL'] = RE_WORKFLOW_ID_VAR.sub(
+                self.workflow, cfg['meta']['URL'])
+            cfg['meta']['URL'] = RE_TASK_NAME_VAR.sub(
+                name, cfg['meta']['URL'])

--- a/cylc/flow/log_diagnosis.py
+++ b/cylc/flow/log_diagnosis.py
@@ -18,20 +18,23 @@
 from difflib import unified_diff
 import re
 import os
-
+from typing import TYPE_CHECKING
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import WorkflowEventError
 from cylc.flow.pathutil import get_workflow_test_log_name
 
+if TYPE_CHECKING:
+    from cylc.flow.scheduler import Scheduler
+
 
 RE_TRIG = re.compile(r'(.*? -triggered off \[.*\])$')
 
 
-def run_reftest(config, ctx):
+def run_reftest(schd: 'Scheduler') -> None:
     """Run reference test at shutdown."""
-    reffilename = config.get_ref_log_name()
-    curfilename = get_workflow_test_log_name(ctx.workflow)
+    reffilename = schd.config.get_ref_log_name()
+    curfilename = get_workflow_test_log_name(schd.workflow)
     ref = _load_reflog(reffilename)
     cur = _load_reflog(curfilename)
     if not ref:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -93,8 +93,7 @@ from cylc.flow.profiler import Profiler
 from cylc.flow.resources import get_resources
 from cylc.flow.subprocpool import SubProcPool
 from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
-from cylc.flow.workflow_events import (
-    WorkflowEventContext, WorkflowEventHandler)
+from cylc.flow.workflow_events import WorkflowEventHandler
 from cylc.flow.workflow_status import StopMode, AutoRestartMode
 from cylc.flow import workflow_files
 from cylc.flow.taskdef import TaskDef
@@ -1242,9 +1241,7 @@ class Scheduler:
                 conf.run_mode('simulation', 'dummy')
             ):
                 return
-        self.workflow_event_handler.handle(conf, WorkflowEventContext(
-            event, str(reason), self.workflow, self.uuid_str, self.owner,
-            self.host, self.server.port))
+        self.workflow_event_handler.handle(self, event, str(reason))
 
     def release_queued_tasks(self):
         """Release queued tasks, and submit task jobs.

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -198,7 +198,8 @@ class EventData(Enum):
     TryNum = 'try_num'
     """The job's try number.
 
-    The number of execution attempts. It starts at 1 and increments with automatic
+    The number of execution attempts.
+    It starts at 1 and increments with automatic
     :cylc:conf:`flow.cylc[runtime][<namespace>]execution retry delays`.
     """
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1404,7 +1404,7 @@ class TaskEventsManager():
                         quote(str(itask.summary['submitted_time_string'])),
                     EventData.Workflow.value:
                         quote(self.workflow),
-                    EventData.WorkflowUUID.value:
+                    EventData.UUID_str.value:
                         quote(self.uuid_str),
                     # BACK COMPAT: Suite, SuiteUUID deprecated
                     # url:

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -198,7 +198,7 @@ class EventData(Enum):
     TryNum = 'try_num'
     """The job's try number.
 
-    The number of execution attempts, starts at 1, increments with automatic
+    The number of execution attempts. It starts at 1 and increments with automatic
     :cylc:conf:`flow.cylc[runtime][<namespace>]execution retry delays`.
     """
 
@@ -222,7 +222,7 @@ class EventData(Enum):
     JobID = 'job_id'
     """The job ID in the job runner.
 
-    I.E. The job submission ID, for background jobs this is the process ID.
+    I.E. The job submission ID. For background jobs this is the process ID.
     """
 
     JobID_old = 'batch_sys_job_id'  # deprecated
@@ -234,13 +234,13 @@ class EventData(Enum):
     """
 
     SubmitTime = 'submit_time'
-    """Date-time when the job was submitted in ISO8601 format."""
+    """Date-time when the job was submitted, in ISO8601 format."""
 
     StartTime = 'start_time'
-    """Date-time when the job started in ISO8601 format."""
+    """Date-time when the job started, in ISO8601 format."""
 
     FinishTime = 'finish_time'
-    """Date-time when the job finished in ISO8601 format."""
+    """Date-time when the job finished, in ISO8601 format."""
 
     PlatformName = 'platform_name'
     """The name of the platform where the job is submitted."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,3 +107,29 @@ def log_filter():
 @pytest.fixture(scope='session')
 def port_range():
     return glbl_cfg().get(['scheduler', 'run hosts', 'ports'])
+
+
+@pytest.fixture
+def capcall(monkeypatch):
+    """Capture function calls without running the function.
+    Returns a list of captured calls.
+    For each function call a tuple (args: Tuple, kwargs: Dict) is added
+    to the list.
+    Example:
+        def test_something(capcall):
+            capsys = capcall('sys.exit')
+            sys.exit(1)
+            assert capsys == [(1,), {}]
+    """
+
+    def _capcall(function_string):
+        calls = []
+
+        def _call(*args, **kwargs):
+            nonlocal calls
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(function_string, _call)
+        return calls
+
+    return _capcall

--- a/tests/flakyfunctional/events/41-task-event-template-deprecated.t
+++ b/tests/flakyfunctional/events/41-task-event-template-deprecated.t
@@ -40,7 +40,7 @@ grep_ok 'WARNING - The event handler template variable "%(batch_sys_name)s" is d
     "${TEST_NAME_BASE}-validate.stderr" -F
 grep_ok 'WARNING - The event handler template variable "%(suite)s" is deprecated - use "%(workflow)s" instead' \
     "${TEST_NAME_BASE}-validate.stderr" -F
-grep_ok 'WARNING - The event handler template variable "%(suite_uuid)s" is deprecated - use "%(workflow_uuid)s" instead' \
+grep_ok 'WARNING - The event handler template variable "%(suite_uuid)s" is deprecated - use "%(uuid)s" instead' \
     "${TEST_NAME_BASE}-validate.stderr" -F
 
 workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --no-detach "${WORKFLOW_NAME}"

--- a/tests/functional/events/18-workflow-event-mail.t
+++ b/tests/functional/events/18-workflow-event-mail.t
@@ -49,10 +49,10 @@ workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --reference-test --debug --no-detach ${OPT_SET} "${WORKFLOW_NAME}"
 
 contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
-b'workflow event: startup'
-b'reason: workflow starting'
-b'workflow event: shutdown'
-b'reason: AUTOMATIC'
+b'event: startup'
+b'message: workflow starting'
+b'event: shutdown'
+b'message: AUTOMATIC'
 b'see: http://localhost/stuff/${USER}/${WORKFLOW_NAME}/'
 __LOG__
 

--- a/tests/functional/events/20-workflow-event-handlers.t
+++ b/tests/functional/events/20-workflow-event-handlers.t
@@ -23,7 +23,7 @@ if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
     create_test_global_config "" "
 [scheduler]
     [[events]]
-        handlers = echo 'Your %(workflow)s workflow has a %(event)s event and URL %(workflow_url)s and workflow-priority as %(workflow-priority)s and workflow-UUID as %(workflow_uuid)s.'
+        handlers = echo 'Your %(workflow)s workflow has a %(event)s event and URL %(workflow_url)s and workflow-priority as %(workflow-priority)s and workflow-UUID as %(uuid)s.'
         handler events = startup"
     OPT_SET='-s GLOBALCFG=True'
 fi

--- a/tests/functional/events/20-workflow-event-handlers/flow.cylc
+++ b/tests/functional/events/20-workflow-event-handlers/flow.cylc
@@ -7,7 +7,7 @@
 [scheduler]
     [[events]]
 {% if GLOBALCFG is not defined %}
-        handlers = echo 'Your %(workflow)s workflow has a %(event)s event and URL %(workflow_url)s and workflow-priority as %(workflow-priority)s and workflow-UUID as %(workflow_uuid)s.'
+        handlers = echo 'Your %(workflow)s workflow has a %(event)s event and URL %(workflow_url)s and workflow-priority as %(workflow-priority)s and workflow-UUID as %(uuid)s.'
         handler events = startup
 {% endif %}{# not GLOBALCFG is not defined #}
 

--- a/tests/functional/events/37-workflow-event-bad-custom-template.t
+++ b/tests/functional/events/37-workflow-event-bad-custom-template.t
@@ -26,7 +26,7 @@ workflow_run_ok "${TEST_NAME_BASE}-run1" \
     cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}"
 
 LOG="${WORKFLOW_RUN_DIR}/log/workflow/log"
-MESSAGE="('workflow-event-handler-00', 'startup') bad template: 'rubbish'"
+MESSAGE="('workflow-event-handler-00', 'startup') bad template: echo %(rubbish)s"
 run_ok "${TEST_NAME_BASE}-run1-log" grep -q -F "ERROR - ${MESSAGE}" "${LOG}"
 
 purge

--- a/tests/integration/events/test_task_events.py
+++ b/tests/integration/events/test_task_events.py
@@ -1,0 +1,73 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from types import SimpleNamespace
+
+from .test_workflow_events import TEMPLATES
+
+import pytest
+
+
+@pytest.mark.parametrize('template', TEMPLATES)
+async def test_mail_footer_template(
+    mod_one,  # use the same scheduler for each test
+    start,
+    mock_glbl_cfg,
+    log_filter,
+    capcall,
+    template,
+):
+    """It should handle templating issues with the mail footer."""
+    # prevent emails from being sent
+    mail_calls = capcall(
+        'cylc.flow.task_events_mgr.TaskEventsManager._send_mail'
+    )
+
+    # configure mail footer
+    mock_glbl_cfg(
+        'cylc.flow.workflow_events.glbl_cfg',
+        f'''
+            [scheduler]
+                [[mail]]
+                    footer = 'footer={template}'
+        ''',
+    )
+
+    # start the workflow and get it to send an email
+    ctx = SimpleNamespace(mail_to=None, mail_from=None)
+    id_keys = [((None, 'failed'), '1', 'a', 1)]
+    async with start(mod_one) as one_log:
+        mod_one.task_events_mgr._process_event_email(mod_one, ctx, id_keys)
+
+    # warnings should appear only when the template is invalid
+    should_log = 'workflow' not in template
+
+    # check that template issues are handled correctly
+    assert bool(log_filter(
+        one_log,
+        contains='Ignoring bad mail footer template',
+    )) == should_log
+    assert bool(log_filter(
+        one_log,
+        contains=template,
+    )) == should_log
+
+    # check that the mail is sent even if there are issues with the footer
+    assert len(mail_calls) == 1
+
+
+# NOTE: we do not test custom event handlers here because these are tested
+# as a part of workflow validation (now also performed by cylc play)

--- a/tests/integration/events/test_workflow_events.py
+++ b/tests/integration/events/test_workflow_events.py
@@ -1,0 +1,119 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from cylc.flow.workflow_events import WorkflowEventHandler
+
+import pytest
+
+
+TEMPLATES = [
+    # perfectly valid
+    pytest.param('%(workflow)s', id='good'),
+    # no template variable of that name
+    pytest.param('%(no_such_variable)s', id='bad'),
+    # missing the 's'
+    pytest.param('%(broken_syntax)', id='ugly'),
+]
+
+
+@pytest.mark.parametrize('template', TEMPLATES)
+async def test_mail_footer_template(
+    mod_one,  # use the same scheduler for each test
+    start,
+    mock_glbl_cfg,
+    log_filter,
+    capcall,
+    template,
+):
+    """It should handle templating issues with the mail footer."""
+    # prevent emails from being sent
+    mail_calls = capcall(
+        'cylc.flow.workflow_events.WorkflowEventHandler._send_mail'
+    )
+
+    # configure Cylc to send an email on startup with the configured footer
+    mock_glbl_cfg(
+        'cylc.flow.workflow_events.glbl_cfg',
+        f'''
+            [scheduler]
+                [[mail]]
+                    footer = 'footer={template}'
+                [[events]]
+                    mail events = startup
+        ''',
+    )
+
+    # start the workflow and get it to send an email
+    async with start(mod_one) as one_log:
+        mod_one.run_event_handlers(
+            WorkflowEventHandler.EVENT_STARTUP,
+            'event message'
+        )
+
+    # warnings should appear only when the template is invalid
+    should_log = 'workflow' not in template
+
+    # check that template issues are handled correctly
+    assert bool(log_filter(
+        one_log,
+        contains='Ignoring bad mail footer template',
+    )) == should_log
+    assert bool(log_filter(
+        one_log,
+        contains=template,
+    )) == should_log
+
+    # check that the mail is sent even if there are issues with the footer
+    assert len(mail_calls) == 1
+
+
+@pytest.mark.parametrize('template', TEMPLATES)
+async def test_custom_event_handler_template(
+    mod_one,  # use the same scheduler for each test
+    start,
+    mock_glbl_cfg,
+    log_filter,
+    template,
+):
+    """It should handle templating issues with custom event handlers."""
+    # configure Cylc to send an email on startup with the configured footer
+    mock_glbl_cfg(
+        'cylc.flow.workflow_events.glbl_cfg',
+        f'''
+            [scheduler]
+                [[events]]
+                    startup handlers = echo "{template}"
+        '''
+    )
+
+    # start the workflow and get it to send an email
+    async with start(mod_one) as one_log:
+        mod_one.run_event_handlers(
+            WorkflowEventHandler.EVENT_STARTUP,
+            'event message'
+        )
+
+    # warnings should appear only when the template is invalid
+    should_log = 'workflow' not in template
+
+    # check that template issues are handled correctly
+    assert bool(log_filter(
+        one_log,
+        contains='bad template',
+    )) == should_log
+    assert bool(log_filter(
+        one_log,
+        contains=template,
+    )) == should_log


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/4764
Closes https://github.com/cylc/cylc-flow/issues/4763

> **Note:** Issue has widened in scope since initial post.

> Sibling: https://github.com/cylc/cylc-doc/pull/422

Some assorted fixes for Python template variables supported in various configs.

* `[mail]footer`
  * The "suite" template var is provided for scheduler events but not for task events.
  * (bug) KeyError was being caught for scheduler events but not for task events.
  * (bug) ValueError was not being caught for either (would tear the workflow down for a broken template).
* `[scheudler][events]`
  * Formalised event data into a self-documenting enum.
  * Changed `uuid_str` to `uuid` (was previously `suite_uuid`).
  * (bug) Event handlers configured in the global config were ignored (4764).
* `[runtime][<namespace>][events]`
  * Moved documentation from global config into enum.
  * (bug) `user@host` was replaced by `platform_name` but no deprecated config was left in its place, added it back.
* `[meta]URL`
  * (bug) Restored `suite_name` (had been renamed `workflow_name`), added deprecation notice.
  * Deprecated `task_name` in favour of `task` for consistency with event handlers.
  * (bug) Catch KeyError and ValueError in config load and handle better.

Added some integration tests to ensure template var issues in mail footer and custom event handlers are handled properly.