### PR TITLE
Allow `~user` in universal ID if it's the current user

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -26,6 +26,7 @@ from cylc.flow.exceptions import (
     UserInputError,
     WorkflowFilesError,
 )
+from cylc.flow.hostuserutil import get_user
 from cylc.flow.id import (
     Tokens,
     contains_multiple_workflows,
@@ -46,6 +47,7 @@ from cylc.flow.workflow_files import (
     infer_latest_run_from_id,
     validate_workflow_name,
 )
+
 
 FN_CHARS = re.compile(r'[\*\?\[\]\!]')
 
@@ -380,9 +382,9 @@ def _validate_constraint(*tokens_list, constraint=None):
 
 def _validate_workflow_ids(*tokens_list, src_path):
     for ind, tokens in enumerate(tokens_list):
-        if tokens['user']:
+        if tokens['user'] and (tokens['user'] != get_user()):
             raise UserInputError(
-                "Operating on others users' workflows is not supported"
+                "Operating on other users' workflows is not supported"
             )
         if not src_path:
             validate_workflow_name(tokens['workflow'])

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -370,18 +370,27 @@ async def test_parse_ids_src_path(src_dir):
         ),
         (
             ['~alice/foo'],
-            "Operating on others users' workflows is not supported",
+            "Operating on other users' workflows is not supported",
         ),
     ]
 )
-async def test_parse_ids_invalid_ids(ids_in, error_msg):
+async def test_parse_ids_invalid_ids(
+    ids_in, error_msg, monkeypatch: pytest.MonkeyPatch
+):
     """It should error for invalid IDs."""
+    monkeypatch.setattr('cylc.flow.id_cli.get_user', lambda: 'rincewind')
     with pytest.raises(Exception) as exc_ctx:
         await parse_ids_async(
             *ids_in,
             constraint='workflows',
         )
     assert error_msg in str(exc_ctx.value)
+
+
+async def test_parse_ids_current_user(monkeypatch: pytest.MonkeyPatch):
+    """It should work if the user in the ID is the current user."""
+    monkeypatch.setattr('cylc.flow.id_cli.get_user', lambda: 'rincewind')
+    await parse_ids_async('~rincewind/luggage', constraint='workflows')
 
 
 async def test_parse_ids_file(tmp_run_dir):


### PR DESCRIPTION
This is a small change with no associated Issue.

Recently I encountered this
```
$ cylc stop '~rdutta/myworkflow'
UserInputError: Operating on others users' workflows is not supported
```
This PR makes it so you can pass in a full ID if the username is yours.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit)
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
