### PR TITLE
actions: speed up homebrew installs

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')
         run: |
+          # speed up install (https://docs.brew.sh/Manpage#environment)
+          export HOMEBREW_NO_AUTO_UPDATE=1
           brew update
-          brew install shellcheck sqlite3 bash coreutils
+          brew install shellcheck bash coreutils
 
           # add GNU coreutils and sed to the user PATH
           # (see instructions in brew install output)

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -90,6 +90,8 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           # install system deps
+          # speed up install (https://docs.brew.sh/Manpage#environment)
+          export HOMEBREW_NO_AUTO_UPDATE=1
           brew update
           brew install bash coreutils gnu-sed
 


### PR DESCRIPTION
Hopefully speed up homebrew installs.

Homebrew automatically upgrades all formulae on upgrade/install, great for home machines, less good for CI.

GHA installs a fair few packages with homebrew, as the images drift with time the number of packages upgraded will increase.

Found some option which disables this behaviour, lets see how it works out.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
