### PR TITLE
client: suppress IOError when removing defunct contact files

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -466,10 +466,8 @@ def detect_old_contact_file(reg: str, contact_data=None) -> None:
 
     Raises:
         CylcError:
-            * If it is not possible to tell for sure if the workflow is running
-              or not.
-            * If the workflow is not, however, the contact file cannot be
-              removed.
+            If it is not possible to tell for sure if the workflow is running
+            or not.
         ServiceFileError(CylcError):
             If old contact file exists and the workflow process still alive.
 
@@ -513,15 +511,21 @@ def detect_old_contact_file(reg: str, contact_data=None) -> None:
         # ... the process isn't running so the contact file is out of date
         # remove it
         try:
-            LOG.info(
-                f'Removing contact file for {reg}'
-                ' (workflow no longer running).'
-            )
             os.unlink(fname)
-            return
+        except FileNotFoundError:
+            # contact file has been removed by another process
+            # (likely by another cylc client, no problem, safe to ignore)
+            pass
         except OSError as exc:
-            raise CylcError(
-                f'Failed to remove old contact file: "{fname}"\n{exc}'
+            # unexpected error removing the contact file
+            # (note the FileNotFoundError incorporated errno.ENOENT)
+            LOG.error(
+                f'Failed to remove contact file for {reg}:\n{exc}'
+            )
+        else:
+            LOG.info(
+                f'Removed contact file for {reg}'
+                ' (workflow no longer running).'
             )
 
 


### PR DESCRIPTION
Fixes possible traceback reported [here](https://github.com/cylc/cylc-uiserver/pull/324#issuecomment-1059078983).

* If we can prove that a workflow isn't running but still has a contact file we remove it.
* It is possible that the contact file will already have been removed, e.g. if there are lots of jobs running any one of their clients could remove the contact file, potentially whilst other clients are active.
* Consequently IOError can be rasied, can't remove the contact file if it has already been removed.
* Silence this error.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.