### PR TITLE
Stop a specific flow with non-active n=0 tasks present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ Second Release Candidate for Cylc 8 suitable for acceptance testing.
 validating/running a Jinja2 workflow (for users who have installed Cylc
 using `pip`.)
 
+[#4743](https://github.com/cylc/cylc-flow/pull/4743) - On stopping a specific
+flow, remove active-waiting tasks with no remaining flow numbers.
 
 -------------------------------------------------------------------------------
 ## __cylc-8.0rc1 (<span actions:bind='release-date'>Released 2022-02-17</span>)__

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1588,10 +1588,19 @@ class TaskPool:
         )
 
     def stop_flow(self, flow_num):
-        """Stop a particular flow_num from spawning any further."""
+        """Stop a given flow within the workflow.
+
+        Remove the flow number from each task, to stop the flow spawning ahead.
+        Remove each task with no remaining flow numbers, if not already active.
+        """
         for itask in self.get_all_tasks():
-            with suppress(KeyError):
+            try:
                 itask.flow_nums.remove(flow_num)
+            except KeyError:
+                continue
+            else:
+                if itask.state(TASK_STATUS_WAITING) and not itask.flow_nums:
+                    self.remove(itask, "flow stopped")
 
     def log_task_pool(self, log_lvl=logging.DEBUG):
         """Log content of task and prerequisite pools in debug mode."""

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1588,10 +1588,10 @@ class TaskPool:
         )
 
     def stop_flow(self, flow_num):
-        """Stop a given flow within the workflow.
+        """Stop a given flow from spawning any further.
 
-        Remove the flow number from each task, to stop the flow spawning ahead.
-        Remove each task with no remaining flow numbers, if not already active.
+        Remove the flow number from every task in the pool, and remove any task
+        with no remaining flow numbers if it is not already active.
         """
         for itask in self.get_all_tasks():
             try:
@@ -1599,7 +1599,11 @@ class TaskPool:
             except KeyError:
                 continue
             else:
-                if itask.state(TASK_STATUS_WAITING) and not itask.flow_nums:
+                if (
+                    not itask.state(
+                        *TASK_STATUSES_ACTIVE, TASK_STATUS_PREPARING)
+                    and not itask.flow_nums
+                ):
                     self.remove(itask, "flow stopped")
 
     def log_task_pool(self, log_lvl=logging.DEBUG):

--- a/tests/functional/spawn-on-demand/15-stop-flow-3.t
+++ b/tests/functional/spawn-on-demand/15-stop-flow-3.t
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Check that stopping the only flow causes the scheduler to shut down cleanly,
+# even if there is an active-waiting task present.
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+reftest
+exit

--- a/tests/functional/spawn-on-demand/15-stop-flow-3/flow.cylc
+++ b/tests/functional/spawn-on-demand/15-stop-flow-3/flow.cylc
@@ -1,0 +1,23 @@
+# This should shut down cleanly without running "never" or "never_again".
+
+# The scheduler must remove flow_num 1 from task "c" to prevent spawning of
+# "never_again" AND remove the n=0 active-waiting task "never" from the pool
+# because it hasn't become active yet (otherwise the inactivity timer will
+# abort the run because the xtrigger never succeeds).
+
+[scheduler]
+    allow implicit tasks = True
+    [[events]]
+        inactivity timeout = PT20S
+        abort on inactivity timeout = True
+[scheduling]
+    [[xtriggers]]
+        x = xrandom("0", "10")  # never succeeds
+    [[graph]]
+        R1 = """
+               @x => never
+               c => never_again 
+             """
+[runtime]
+    [[c]]
+       script = "cylc stop --flow=1 $CYLC_WORKFLOW_ID"

--- a/tests/functional/spawn-on-demand/15-stop-flow-3/reference.log
+++ b/tests/functional/spawn-on-demand/15-stop-flow-3/reference.log
@@ -1,0 +1,3 @@
+Initial point: 1
+Final point: 1
+1/c -triggered off []


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->
<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

Stopping a specific flow should remove non-active tasks in `n=0` (active-waiting, incomplete) if they have no remaining flow numbers, as well as remove the specific flow number from all tasks in `n=0`.

@dpmatthews - this is related to the open question #4741 but only touches the back-end API, so it should be fine to go in.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
