### PR TITLE
cycle-point: add note about isodatetime

### DIFF
--- a/cylc/flow/scripts/cycle_point.py
+++ b/cylc/flow/scripts/cycle_point.py
@@ -19,7 +19,9 @@
 
 """cylc cycle-point [OPTIONS] ARGS
 
-Utility for date-time cycle point arithmetic.
+Utility for simple date-time cycle point arithmetic.
+
+For more generic date-time manipulations see the "isodatetime" command.
 
 Filename templating replaces elements of a template string with corresponding
 elements of the current or given cycle point.


### PR DESCRIPTION
I think we should probably advertise the `isodatetime` command more, particularly for `isodatetime R/P1Y/2020` like uses:

https://github.com/cylc/cylc-doc/issues/428

The caveat being that we need to add something about creating a wrapper script for `isodatetime` into the installation docs:

https://github.com/cylc/cylc-doc/issues/429