### PR TITLE
Handle missing optional dependencies better

### DIFF
--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -58,7 +58,7 @@ def iter_entry_points(entry_point_name):
     yield from (
         entry_point
         for entry_point in pkg_resources.iter_entry_points(entry_point_name)
-        # filter out the cylc namespace as it should be empty
-        # all cylc packages should take the form cylc-<name>
+        # Filter out the cylc namespace as it should be empty.
+        # All cylc packages should take the form cylc-<name>
         if entry_point.dist.key != 'cylc'
     )


### PR DESCRIPTION
These changes close #4719 - when optional dependencies are not installed, there is traceback when trying to run `cylc help all` or a command that uses the optional dependency.

Steps to reproduce bug (before checking out this branch):
1. Create a clean conda env
2. `pip install <cylc-flow-dev-location> <cylc-uiserver-dev-location>`
3. `cylc help all`
4. `cylc hubapp`

The last two should give traceback.

Now check out this branch and test the fix:
1. `cylc help all`
2. `cylc hubapp`

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Does not need tests (can't).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
