### PR TITLE
Flake8 bugbear fixes

### DIFF
--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -391,7 +391,7 @@ class ISO8601Sequence(SequenceBase):
         if self.exclusions:
             self.value += '!' + str(self.exclusions)
 
-    @lru_cache(100)
+    @lru_cache(100)  # noqa B019 TODO?
     def is_on_sequence(self, point):
         """Return True if point is on-sequence."""
         # Iterate starting at recent valid points, for speed.

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -339,10 +339,10 @@ def load(config, additional_plugins=None):
         # load coroutines
         log = []
         for coro_name, coro in (
-                (coro_name, coro)
-                for coro_name, coro in getmembers(module)
-                if isfunction(coro)
-                if hasattr(coro, 'main_loop')
+                (corou_name, corou)
+                for corou_name, corou in getmembers(module)
+                if isfunction(corou)
+                if hasattr(corou, 'main_loop')
         ):
             log.append(coro_name)
             plugins.setdefault(

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -942,7 +942,7 @@ class TaskJobManager:
                 cmd = construct_ssh_cmd(
                     cmd, platform, host
                 )
-            for itask in sorted(itasks, key=lambda itask: itask.identity):
+            for itask in sorted(itasks, key=lambda jtask: jtask.identity):
                 job_log_dirs.append(
                     itask.tokens.duplicate(
                         job=str(itask.submit_num)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -245,15 +245,15 @@ class TaskPool:
         # At restart all tasks are runahead-limited but finished and manually
         # triggered tasks (incl. --start-task's) can be released immediately.
         for itask in (
-            itask
-            for itask in self.get_tasks()
-            if itask.state.is_runahead
-            if itask.state(
+            jtask
+            for jtask in self.get_tasks()
+            if jtask.state.is_runahead
+            if jtask.state(
                 TASK_STATUS_FAILED,
                 TASK_STATUS_SUCCEEDED,
                 TASK_STATUS_EXPIRED
             )
-            or itask.is_manual_submit
+            or jtask.is_manual_submit
         ):
             self.release_runahead_task(itask)
             released = True


### PR DESCRIPTION
This is a small change with no associated Issue.

With flake8-bugbear 22.3.20:
```console
$ flake8 cylc/flow
cylc/flow/task_pool.py:247:13: 
  B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
cylc/flow/task_job_mgr.py:945:17:
  B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
cylc/flow/cycling/iso8601.py:394:6:
  B019 Use of `functools.lru_cache` or `functools.cache` on class methods can lead to memory leaks. 
  The cache may retain instance references, preventing garbage collection.
cylc/flow/main_loop/__init__.py:341:13:
  B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
cylc/flow/main_loop/__init__.py:341:24:
  B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
```


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
