### PR TITLE
flake8: fix B019 issue

### DIFF
--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -365,6 +365,8 @@ class SequenceBase(metaclass=ABCMeta):
         """Deprecated: alter state to offset the entire sequence."""
         pass
 
+    # NOTE: not using @abstractmethod because we need to
+    # patch this method for caching purposes
     def is_on_sequence(self, point):
         """Is point on-sequence, disregarding bounds?"""
         raise NotImplementedError

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -365,10 +365,9 @@ class SequenceBase(metaclass=ABCMeta):
         """Deprecated: alter state to offset the entire sequence."""
         pass
 
-    @abstractmethod
     def is_on_sequence(self, point):
         """Is point on-sequence, disregarding bounds?"""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def is_valid(self, point):

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -292,7 +292,7 @@ class ISO8601Sequence(SequenceBase):
                  'offset', '_cached_first_point_values',
                  '_cached_next_point_values', '_cached_valid_point_booleans',
                  '_cached_recent_valid_points', 'spec', 'abbrev_util',
-                 'recurrence', 'exclusions', 'step', 'value')
+                 'recurrence', 'exclusions', 'step', 'value', 'is_on_sequence')
 
     @classmethod
     def get_async_expr(cls, start_point=None):
@@ -306,6 +306,10 @@ class ISO8601Sequence(SequenceBase):
         SequenceBase.__init__(
             self, dep_section, context_start_point, context_end_point)
         self.dep_section = dep_section
+
+        # cache is_on_sequence
+        # see B019 - https://github.com/PyCQA/flake8-bugbear#list-of-warnings
+        self.is_on_sequence = lru_cache(maxsize=100)(self._is_on_sequence)
 
         if (
             context_start_point is None
@@ -391,8 +395,8 @@ class ISO8601Sequence(SequenceBase):
         if self.exclusions:
             self.value += '!' + str(self.exclusions)
 
-    @lru_cache(100)
-    def is_on_sequence(self, point):
+    # lru_cache'd see __init__()
+    def _is_on_sequence(self, point):
         """Return True if point is on-sequence."""
         # Iterate starting at recent valid points, for speed.
         if self.exclusions and point in self.exclusions:


### PR DESCRIPTION
Fix valid B019 bug flagged by flake8-bugbear.

This bug will cause a memory leak with `ISO8601Sequence` instances. As it happens Cylc does not release these instances anyway (since they are required by the taskdefs which must live for the life of the Scheduler) so this memory leak is of no consequence at present.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (inconsequential at present).
- [x] No documentation update required.