### PR TITLE
Make TUI refuse to show non-installed workflows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ ones in. -->
 
 ### Fixes:
 
+[#4748](https://github.com/cylc/cylc-flow/pull/4748) -
+`cylc tui` gives a more helpful error message when a workflow is not running;
+distinguishing between workflow not running and not in run-directory.
+
 [#4797](https://github.com/cylc/cylc-flow/pull/4797) -
 `cylc reload` now triggers a fresh remote file installation for all relevant
 platforms, any files configured to be installed will be updated on the remote

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -21,6 +21,7 @@ import sys
 import urwid
 from urwid import html_fragment
 from urwid.wimp import SelectableIcon
+from pathlib import Path
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.exceptions import (
@@ -28,6 +29,7 @@ from cylc.flow.exceptions import (
     ClientTimeout,
     WorkflowStopped
 )
+from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.task_state import (
     TASK_STATUSES_ORDERED,
     TASK_STATUS_SUBMITTED,
@@ -56,6 +58,7 @@ from cylc.flow.tui.util import (
     get_workflow_status_str,
     render_node
 )
+from cylc.flow.workflow_files import WorkflowFiles
 
 
 urwid.set_encoding('utf8')  # required for unicode task icons
@@ -310,10 +313,20 @@ class TuiApp:
                 }
             )
         except WorkflowStopped:
+            # Distinguish stopped flow from non-existent flow.
+            full_path = Path(get_workflow_run_dir(self.reg))
+            if(
+                (full_path / WorkflowFiles.SUITE_RC).exists()
+                or (full_path / WorkflowFiles.FLOW_FILE).exists()
+            ):
+                message = "stopped"
+            else:
+                message = "workflow not found"
+
             return dummy_flow({
                 'name': self.reg,
                 'id': self.reg,
-                'status': 'Workflow not found',
+                'status': message,
                 'stateTotals': {}
             })
         except (ClientError, ClientTimeout) as exc:

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -321,7 +321,10 @@ class TuiApp:
             ):
                 message = "stopped"
             else:
-                message = "workflow not found"
+                message = (
+                    f"No {WorkflowFiles.SUITE_RC} or {WorkflowFiles.FLOW_FILE}"
+                    f"found in {self.reg}."
+                )
 
             return dummy_flow({
                 'name': self.reg,

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -310,11 +310,10 @@ class TuiApp:
                 }
             )
         except WorkflowStopped:
-            self.client = None
             return dummy_flow({
                 'name': self.reg,
                 'id': self.reg,
-                'status': 'stopped',
+                'status': 'Workflow not found',
                 'stateTotals': {}
             })
         except (ClientError, ClientTimeout) as exc:


### PR DESCRIPTION
These changes close #4715 

### Summary

When Cylc TUI is started it should check whether the workflow has actually been installed before doing anything to display it.

### Requirements check-list
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [ ] Change log rebased after 8.0rc2 release. 
- [x] No documentation update required.
