### PR TITLE
De flake tests/f/ihs/03

### DIFF
--- a/tests/functional/intelligent-host-selection/03-polling.t
+++ b/tests/functional/intelligent-host-selection/03-polling.t
@@ -15,8 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Test job polling. Set the auto clearance of badhosts to be << small time
-# so that polling will need to retry.
+# Test intelligent host selection for job polling.
+#
+# Set the peridic clearance of unreachable hosts by
+# `[scheduler][main loop][reset bad hosts]interval = PT1S` so that between
+# Submission of a job and execution polling the list of bad hosts will have
+# cleared. Having cleared bad hosts we can then test that polling goes through
+# the host selection process.
+
 export REQUIRE_PLATFORM='loc:remote fs:indep'
 
 . "$(dirname "$0")/test_header"
@@ -36,7 +42,7 @@ create_test_global_config "" "
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
         communication method = poll
-        execution polling intervals = 10*PT2S
+        execution polling intervals = 10*PT3S
         submission polling intervals = PT0S, PT41M
 
     [[mixedhostplatform]]
@@ -44,7 +50,7 @@ create_test_global_config "" "
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
         communication method = poll
-        execution polling intervals = 10*PT2S
+        execution polling intervals = 10*PT3S
         submission polling intervals = PT0S, PT41M
         [[[selection]]]
             method = 'definition order'

--- a/tests/functional/intelligent-host-selection/03-polling.t
+++ b/tests/functional/intelligent-host-selection/03-polling.t
@@ -43,7 +43,7 @@ create_test_global_config "" "
         retrieve job logs = True
         communication method = poll
         execution polling intervals = 10*PT3S
-        submission polling intervals = PT0S, PT41M
+        submission polling intervals = PT0S, 5*PT2S
 
     [[mixedhostplatform]]
         hosts = unreachable_host, ${CYLC_TEST_HOST}
@@ -51,7 +51,7 @@ create_test_global_config "" "
         retrieve job logs = True
         communication method = poll
         execution polling intervals = 10*PT3S
-        submission polling intervals = PT0S, PT41M
+        submission polling intervals = PT0S, 5*PT2S
         [[[selection]]]
             method = 'definition order'
     "

--- a/tests/functional/intelligent-host-selection/03-polling.t
+++ b/tests/functional/intelligent-host-selection/03-polling.t
@@ -36,7 +36,7 @@ create_test_global_config "" "
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
         communication method = poll
-        execution polling intervals = PT0S, PT14M
+        execution polling intervals = 10*PT2S
         submission polling intervals = PT0S, PT41M
 
     [[mixedhostplatform]]
@@ -44,7 +44,7 @@ create_test_global_config "" "
         install target = ${CYLC_TEST_INSTALL_TARGET}
         retrieve job logs = True
         communication method = poll
-        execution polling intervals = PT0S, PT14M
+        execution polling intervals = 10*PT2S
         submission polling intervals = PT0S, PT41M
         [[[selection]]]
             method = 'definition order'

--- a/tests/functional/intelligent-host-selection/03-polling/flow.cylc
+++ b/tests/functional/intelligent-host-selection/03-polling/flow.cylc
@@ -10,7 +10,7 @@ execution polling.
 
 [scheduler]
     [[events]]
-        expected task failures = 1/t1, 1/t2
+        expected task failures = 1/goodhosttask 1/mixedhosttask
 
 
 [scheduling]
@@ -20,7 +20,7 @@ execution polling.
         R1 = """
             goodhosttask:start => stop_g
             mixedhosttask:start => stop_m
-            stop_m & stop_g => full_stop
+            goodhosttask:fail & mixedhosttask:fail => full_stop
         """
 
 [runtime]
@@ -49,4 +49,3 @@ execution polling.
         """
 
     [[full_stop]]
-        script = cylc stop $CYLC_WORKFLOW_ID

--- a/tests/functional/intelligent-host-selection/03-polling/flow.cylc
+++ b/tests/functional/intelligent-host-selection/03-polling/flow.cylc
@@ -20,7 +20,7 @@ execution polling.
         R1 = """
             goodhosttask:start => stop_g
             mixedhosttask:start => stop_m
-            goodhosttask:fail & mixedhosttask:fail => full_stop
+            goodhosttask:fail & mixedhosttask:fail
         """
 
 [runtime]
@@ -47,5 +47,3 @@ execution polling.
             sleep 5  # Give the badhosts list time to empty
             cylc kill "$CYLC_WORKFLOW_ID//1/mixedhosttask" || true
         """
-
-    [[full_stop]]

--- a/tests/functional/intelligent-host-selection/03-polling/flow.cylc
+++ b/tests/functional/intelligent-host-selection/03-polling/flow.cylc
@@ -8,11 +8,6 @@ Once each has started trigger a task which kills each to test the
 execution polling.
 """
 
-[scheduler]
-    [[events]]
-        expected task failures = 1/goodhosttask 1/mixedhosttask
-
-
 [scheduling]
     cycling mode = integer
     initial cycle point = 1

--- a/tests/functional/intelligent-host-selection/03-polling/flow.cylc
+++ b/tests/functional/intelligent-host-selection/03-polling/flow.cylc
@@ -1,9 +1,11 @@
 [meta]
 title = "Try out scenarios for intelligent host selection."
 description = """
-Tasks
-- goodhost: a control to check that everything works
-- mixedhost contains some hosts that will and won't fail
+Runs two long running tasks on a known good platform and on a
+platform with some unreachable hosts.
+
+Once each has started trigger a task which kills each to test the
+execution polling.
 """
 
 [scheduler]
@@ -15,7 +17,6 @@ Tasks
     cycling mode = integer
     initial cycle point = 1
     [[graph]]
-        # Run good and mixed as controls
         R1 = """
             goodhosttask:start => stop_g
             mixedhosttask:start => stop_m
@@ -23,23 +24,25 @@ Tasks
         """
 
 [runtime]
-    [[root]]
-
     [[goodhosttask]]
+        # Sleep for a long time, expect to be killed by stop_g
         script=sleep 120 & echo $! >file; wait
         platform = goodhostplatform
 
     [[mixedhosttask]]
+        # Sleep for a long time, expect to be killed by stop_m
         script=sleep 120 & echo $! >file; wait
         platform = mixedhostplatform
 
     [[stop_g]]
+        # Kill goodhosttask when polling confirms it's started.
         script="""
             sleep 5  # Give the badhosts list time to empty
             cylc kill "$CYLC_WORKFLOW_ID//1/goodhosttask" || true
         """
 
     [[stop_m]]
+        # Kill mixedhosttask when polling confirms it's started.
         script="""
             sleep 5  # Give the badhosts list time to empty
             cylc kill "$CYLC_WORKFLOW_ID//1/mixedhosttask" || true

--- a/tests/functional/intelligent-host-selection/03-polling/flow.cylc
+++ b/tests/functional/intelligent-host-selection/03-polling/flow.cylc
@@ -19,6 +19,7 @@ Tasks
         R1 = """
             goodhosttask:start => stop_g
             mixedhosttask:start => stop_m
+            stop_m & stop_g => full_stop
         """
 
 [runtime]
@@ -26,12 +27,10 @@ Tasks
 
     [[goodhosttask]]
         script=sleep 120 & echo $! >file; wait
-
         platform = goodhostplatform
 
     [[mixedhosttask]]
         script=sleep 120 & echo $! >file; wait
-
         platform = mixedhostplatform
 
     [[stop_g]]
@@ -44,5 +43,7 @@ Tasks
         script="""
             sleep 5  # Give the badhosts list time to empty
             cylc kill "$CYLC_WORKFLOW_ID//1/mixedhosttask" || true
-            cylc stop $CYLC_WORKFLOW_ID
         """
+
+    [[full_stop]]
+        script = cylc stop $CYLC_WORKFLOW_ID


### PR DESCRIPTION
These changes close #4697

### Background

This test tests that polling uses host from platform selection method, and in the case of `mixedhostplatform` has to try twice to get a usable host. `[scheduler][main loop][reset bad hosts]interval` is set to `PT1S` to ensure that the list of unreachable hosts (`bad_hosts`) is cleared before execution polling.

### Cause of the problem

`stop_m` would stop the workflow without waiting for the polling of `stop_g` the test required to pass.

i.e.

```
mixedhosttask => stop_m    # stop_m shuts down the workflow
goodhosttask => stop_g     # ... whatever the state of these tasks!
```


### Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Is a test modification.
- [x] No change log entry required - test fix
- [x] No documentation update required.
