### PR TITLE
Change order of `--icp` option in CLI help

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -44,6 +44,18 @@ from cylc.flow.loggingutil import (
 )
 
 
+icp_option = Option(
+    "--initial-cycle-point", "--icp",
+    metavar="CYCLE_POINT",
+    help=(
+        "Set the initial cycle point. "
+        "Required if not defined in flow.cylc."
+    ),
+    action="store",
+    dest="icp",
+)
+
+
 def format_shell_examples(string):
     """Put comments in the terminal "diminished" colour."""
     return cparse(
@@ -217,7 +229,6 @@ class CylcOptionParser(OptionParser):
         multiworkflow: bool = False,
         prep: bool = False,
         auto_add: bool = True,
-        icp: bool = False,
         color: bool = True,
         segregated_log: bool = False
     ) -> None:
@@ -245,7 +256,6 @@ class CylcOptionParser(OptionParser):
         self.comms = comms
         self.jset = jset
         self.prep = prep
-        self.icp = icp
         self.color = color
         # Whether to log messages that are below warning level to stdout
         # instead of stderr:
@@ -362,18 +372,6 @@ class CylcOptionParser(OptionParser):
                     "command line if they need to be overridden."
                 ),
                 action="store", default=None, dest="templatevars_file")
-
-        if self.icp:
-            self.add_option(
-                "--initial-cycle-point", "--icp",
-                metavar="CYCLE_POINT",
-                help=(
-                    "Set the initial cycle point. "
-                    "Required if not defined in flow.cylc."
-                ),
-                action="store",
-                dest="icp",
-            )
 
     def add_cylc_rose_options(self) -> None:
         """Add extra options for cylc-rose plugin if it is installed."""

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -34,7 +34,8 @@ from cylc.flow.loggingutil import (
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
-    Options
+    Options,
+    icp_option,
 )
 from cylc.flow.pathutil import (
     get_workflow_run_log_name,
@@ -113,7 +114,6 @@ def get_option_parser(add_std_opts=False):
     """Parse CLI for "cylc play"."""
     parser = COP(
         PLAY_DOC,
-        icp=True,
         jset=True,
         comms=True,
         argdoc=[WORKFLOW_NAME_ARG_DOC])
@@ -126,6 +126,8 @@ def get_option_parser(add_std_opts=False):
     parser.add_option(
         "--profile", help="Output profiling (performance) information",
         action="store_true", dest="profile_mode")
+
+    parser.add_option(icp_option)
 
     parser.add_option(
         "--start-cycle-point", "--startcp",

--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -56,7 +56,7 @@ from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
 from cylc.flow.exceptions import UserInputError
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
@@ -70,7 +70,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         argdoc=[("[WORKFLOW_ID]", "Workflow ID or path to source")],
-        jset=True, icp=True
+        jset=True,
     )
 
     parser.add_option(
@@ -102,6 +102,8 @@ def get_option_parser():
             "looked for. An existing configuration file lower down the list "
             "overrides any settings it shares with those higher up."),
         action="store_true", default=False, dest="print_hierarchy")
+
+    parser.add_option(icp_option)
 
     platform_listing_options_group = parser.add_option_group(
         'Platform printing options')

--- a/cylc/flow/scripts/diff.py
+++ b/cylc/flow/scripts/diff.py
@@ -32,7 +32,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.templatevars import load_template_vars
 from cylc.flow.terminal import cli_function
@@ -116,7 +116,7 @@ def prdict(dct, arrow='<', section='', level=0, diff=False, nested=False):
 
 def get_option_parser():
     parser = COP(
-        __doc__, jset=True, prep=True, icp=True,
+        __doc__, jset=True, prep=True,
         argdoc=[
             ('WORKFLOW_ID_1', 'Workflow ID or path to source'),
             ('WORKFLOW_ID_2', 'Workflow ID or path to source')
@@ -126,7 +126,10 @@ def get_option_parser():
     parser.add_option(
         "-n", "--nested",
         help="print flow.cylc section headings in nested form.",
-        action="store_true", default=False, dest="nested")
+        action="store_true", default=False, dest="nested"
+    )
+
+    parser.add_option(icp_option)
 
     return parser
 

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -44,7 +44,7 @@ from cylc.flow.config import WorkflowConfig
 from cylc.flow.exceptions import UserInputError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -246,9 +246,7 @@ def get_option_parser():
         help='Show suicide triggers. Not shown by default.',
         action='store_true', default=False, dest='show_suicide')
 
-    parser.add_option(
-        '--icp', action='store', default=None, metavar='CYCLE_POINT', help=(
-            'Set initial cycle point. Required if not defined in flow.cylc.'))
+    parser.add_option(icp_option)
 
     parser.add_option(
         '--diff',

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -48,7 +48,6 @@ def get_option_parser():
         __doc__,
         jset=True,
         prep=True,
-        icp=True,
         argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
     )
 
@@ -90,6 +89,8 @@ def get_option_parser():
         "are optional and STOP can be an interval from START (or from the "
         "initial cycle point, by default). Use '-p , ' for the default range.",
         metavar="[START],[STOP]", action="store", default=None, dest="prange")
+
+    parser.add_option(icp_option)
 
     parser.add_cylc_rose_options()
     return parser

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -40,7 +40,8 @@ from cylc.flow.id_cli import parse_id
 from cylc.flow.loggingutil import disable_timestamps
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
-    Options
+    Options,
+    icp_option,
 )
 from cylc.flow.profiler import Profiler
 from cylc.flow.task_proxy import TaskProxy
@@ -53,7 +54,6 @@ def get_option_parser():
         __doc__,
         jset=True,
         prep=True,
-        icp=True,
         argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
     )
 
@@ -78,6 +78,8 @@ def get_option_parser():
         "-u", "--run-mode", help="Validate for run mode.", action="store",
         default="live", dest="run_mode",
         choices=['live', 'dummy', 'simulation'])
+
+    parser.add_option(icp_option)
 
     parser.add_cylc_rose_options()
 


### PR DESCRIPTION
This is a small change with no associated Issue.

The `--icp` option is awkwardly at the bottom of the list in `cylc play --help`, nowhere near the other cycle point options. This changes that.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry required (very minor).
- [x] No documentation update required.
