### PR TITLE
Shorten a couple of error messages.

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1263,15 +1263,14 @@ def infer_latest_run(
         return (path, reg)
     if not runN_path.is_symlink() or not runN_path.is_dir():
         raise WorkflowFilesError(
-            f"runN directory at {runN_path} is a broken or invalid symlink"
+            f"{runN_path} symlink not valid"
         )
     numbered_run = os.readlink(str(runN_path))
     if not re.match(r'run\d+$', numbered_run):
         # Note: the link should be relative. This means it won't work for
         # cylc 8.0b1 workflows where it was absolute (won't fix).
         raise WorkflowFilesError(
-            f"runN symlink at {runN_path} points to invalid location: "
-            f"{numbered_run}"
+            f"{runN_path} symlink target not valid: {numbered_run}"
         )
     path = runN_path.parent / numbered_run
     reg = path.relative_to(cylc_run_dir)

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -314,7 +314,7 @@ def test_infer_latest_run__bad(
     run_dir = cylc_run_dir / 'sulu'
     run_dir.mkdir()
     runN_path = run_dir / 'runN'
-    err_msg = f"runN directory at {runN_path} is a broken or invalid symlink"
+    err_msg = f"{runN_path} symlink not valid"
     if reason == 'not dir':
         (run_dir / 'run1').touch()
         runN_path.symlink_to('run1')
@@ -326,8 +326,7 @@ def test_infer_latest_run__bad(
         (run_dir / 'palpatine').mkdir()
         runN_path.symlink_to('palpatine')
         err_msg = (
-            f"runN symlink at {runN_path} points to invalid "
-            "location: palpatine"
+            f"{runN_path} symlink target not valid: palpatine"
         )
     else:
         raise ValueError(reason)


### PR DESCRIPTION
This is a small change with no associated Issue.

Trivial change to shorten a couple of workflow files error messages.

Pinging @MetRonnie as author of the original lines. One review will do.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
