### PR TITLE
Escape quotes in remote command args.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,10 @@ provided [wrapper script](https://cylc.github.io/cylc-doc/latest/html/installati
 
 ### Fixes
 
+[#4769](https://github.com/cylc/cylc-flow/pull/4769) - Fix handling of quoted
+command args for invocation on remote run hosts.
+
+
 [#4703](https://github.com/cylc/cylc-flow/pull/4703) - Fix `ImportError` when
 validating/running a Jinja2 workflow (for users who have installed Cylc
 using `pip`.)

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -18,6 +18,7 @@
 from ansimarkup import parse as cparse
 import asyncio
 from functools import lru_cache
+from shlex import quote
 import sys
 from typing import TYPE_CHECKING
 
@@ -365,8 +366,9 @@ def _distribute(host):
     if not host:
         host = select_workflow_host()[0]
     if is_remote_host(host):
+        # quote here for (e.g.) --set='TEST="test"'
+        cmd = [quote(c) for c in sys.argv[1:]]
         # Prevent recursive host selection
-        cmd = sys.argv[1:]
         cmd.append("--host=localhost")
         _remote_cylc_cmd(cmd, host=host)
         sys.exit(0)

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -1,0 +1,24 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for Cylc scheduler CLI."""
+
+from cylc.flow.scheduler_cli import _protect_remote_cmd_args
+
+
+def test__protect_remote_cmd_args():
+    cmd = ['cylc', 'play', '-n', '--set=FOO="foo"', 'wf']
+    exp = ['cylc', 'play', '-n', '\'--set=FOO="foo"\'', 'wf']
+    assert _protect_remote_cmd_args(cmd) == exp


### PR DESCRIPTION
These changes close #4760 

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
