### PR TITLE
waiting turned on by default for Cylc 8 flows.

### DIFF
--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -306,8 +306,12 @@ class CylcReviewService(object):
         if not task_status:
             # default task statuses - if updating please also change the
             # $("#reset_task_statuses").click function in cylc-review.js
-            task_status = [state for state in TASK_STATUSES_ORDERED
-                           if state != TASK_STATUS_WAITING]
+            # If Cylc 8 defaults should include waiting.
+            if self.suite_dao.is_cylc8(user, suite):
+                task_status = TASK_STATUSES_ORDERED
+            else:
+                task_status = [state for state in TASK_STATUSES_ORDERED
+                            if state != TASK_STATUS_WAITING]
         elif not isinstance(task_status, list):
             task_status = [task_status]
 


### PR DESCRIPTION
This is a small change with no associated Issue.

#### Issue summary

User report that when in the "task jobs list" view, and selecting failed from the "Select by job status menu" they don't see failed jobs for the task which is waiting for a retry because the "waiting" checkbox in the "Select by task statuses" is not selected by default.

At Cylc 7 this was done in https://github.com/cylc/cylc-flow/pull/2938. It probably isn't necessary at Cylc 8. It's also necessary to enable "waiting" by default at Cylc 8 because tasks which would previously have been described as "retrying" &c are now classified as "waiting".

#### Requirements check-list
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Manually tested
- [ ] Appropriate change log entry included.
- [x] No documentation update required.
