### PR TITLE
Ignore flake8-simplify SIM9xx rules.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ ignore=
     W503,
     ; line break after binary operator
     W504
+    ; "experimental" SIM9xx rules (flake8-simplify)
+    SIM9
 
 exclude=
     build,


### PR DESCRIPTION

This is a small change with no associated Issue.

Discussed in Element chat: ignore "experimental" flake8-simplify rules. 

(These do eventually get moved into the mainstream, if stabilized and approved, so we should remember to check locally sometimes, to avoid surprises).

