### PR TITLE
scheduler: log command failures at error level

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -869,9 +869,8 @@ class Scheduler:
                     cylc.flow.flags.verbosity > 1 or
                     not isinstance(exc, CommandFailedError)
                 ):
-                    LOG.warning(traceback.format_exc())
-                LOG.warning(str(exc))
-                LOG.warning(f"Command failed: {cmdstr}")
+                    LOG.error(traceback.format_exc())
+                LOG.error(f"Command failed: {cmdstr}\n{exc}")
             else:
                 if n_warnings:
                     LOG.info(


### PR DESCRIPTION
Spotted whilst reviewing: https://github.com/cylc/cylc-flow/pull/4720

Command errors are logged at the warning level rather than error. These errors aren't `CRITICAL` (they don't tear down the scheduler), but they are a bit more important than the `WARNING` level which makes it harder to pick them out in the logs.

Also combine two log entries into one for clarity.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
