### PR TITLE
Close File Installation Log

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -356,7 +356,8 @@ def scheduler_cli(options: 'Values', workflow_id: str) -> None:
     # NOTE: any threads which include sleep statements could cause
     #       sys.exit to hang if not shutdown properly
     LOG.info("DONE")
-    close_log(LOG)
+    for log in (LOG, RSYNC_LOG):
+        close_log(log)
     sys.exit(ret)
 
 


### PR DESCRIPTION
Turns out the file installation log is not closed properly. 

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (strange one to test, attempted to prove closure by reloading and checking that a new file is opened, which is the desired behaviour.).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
