### PR TITLE
Tidy & homogenise usage of `CylcOptionParser`

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -34,6 +34,7 @@ from cylc.flow.loggingutil import (
 )
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
     CylcOptionParser as COP,
     Options,
     icp_option,
@@ -95,8 +96,6 @@ happened to them while the workflow was down.
 """
 
 
-WORKFLOW_NAME_ARG_DOC = ("WORKFLOW", "Workflow name or ID")
-
 RESUME_MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!
@@ -111,13 +110,14 @@ mutation (
 
 
 @lru_cache()
-def get_option_parser(add_std_opts=False):
+def get_option_parser(add_std_opts: bool = False) -> COP:
     """Parse CLI for "cylc play"."""
     parser = COP(
         PLAY_DOC,
         jset=True,
         comms=True,
-        argdoc=[WORKFLOW_NAME_ARG_DOC])
+        argdoc=[WORKFLOW_ID_ARG_DOC]
+    )
 
     parser.add_option(
         "-n", "--no-detach", "--non-daemon",

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -94,7 +94,10 @@ from cylc.flow.cfgspec.workflow import SPEC, upg
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.parsec.validate import cylc_config_validate
 from cylc.flow.print_tree import get_tree
@@ -225,13 +228,13 @@ def report_bad_options(bad_options, is_set=False):
     return bad_opts
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     """CLI for "cylc broadcast"."""
     parser = COP(
         __doc__,
         comms=True,
         multiworkflow=True,
-        argdoc=[('WORKFLOW_ID [WORKFLOW_ID ...]', 'Workflow ID(s)')],
+        argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -68,6 +68,7 @@ import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote_platform
 from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import (
+    ID_MULTI_ARG_DOC,
     CylcOptionParser as COP,
     verbosity_to_opts,
 )
@@ -219,12 +220,12 @@ def view_log(logpath, mode, tailer_tmpl, batchview_cmd=None, remote=False,
         return proc.wait()
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     """Set up the CLI option parser."""
     parser = COP(
         __doc__,
         argdoc=[
-            ("ID [...]", "Workflow/Cycle/Task ID"),
+            ID_MULTI_ARG_DOC,
         ]
     )
 

--- a/cylc/flow/scripts/check_versions.py
+++ b/cylc/flow/scripts/check_versions.py
@@ -37,7 +37,10 @@ import sys
 from typing import TYPE_CHECKING
 
 import cylc.flow.flags
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.cylc_subproc import procopen, PIPE, DEVNULL
 from cylc.flow import __version__ as CYLC_VERSION
 from cylc.flow.config import WorkflowConfig
@@ -54,15 +57,18 @@ if TYPE_CHECKING:
 def get_option_parser():
     parser = COP(
         __doc__,
-        prep=True,
         jset=True,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
+        argdoc=[WORKFLOW_ID_OR_PATH_ARG_DOC],
     )
 
     parser.add_option(
-        "-e", "--error", help="Exit with error status "
-        "if " + CYLC_VERSION + " is not available on all remote platforms.",
-        action="store_true", default=False, dest="error")
+        "-e", "--error",
+        help=(
+            f"Exit with error status if {CYLC_VERSION} is not available "
+            "on all remote platforms."
+        ),
+        action="store_true", default=False, dest="error"
+    )
 
     return parser
 

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -66,7 +66,11 @@ from cylc.flow.exceptions import InputError
 import cylc.flow.flags
 from cylc.flow.id_cli import parse_ids_async
 from cylc.flow.loggingutil import disable_timestamps
-from cylc.flow.option_parsers import CylcOptionParser as COP, Options
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+    Options,
+)
 from cylc.flow.terminal import cli_function, is_terminal
 from cylc.flow.workflow_files import init_clean, get_contained_workflows
 
@@ -78,7 +82,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         multiworkflow=True,
-        argdoc=[('WORKFLOW_ID [WORKFLOW_ID ...]', 'Workflow IDs')],
+        argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
         segregated_log=True,
     )
 

--- a/cylc/flow/scripts/client.py
+++ b/cylc/flow/scripts/client.py
@@ -30,7 +30,10 @@ import sys
 from typing import TYPE_CHECKING
 
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.network.server import PB_METHOD_MAP
 from cylc.flow.terminal import cli_function
@@ -43,9 +46,13 @@ INTERNAL = True
 
 
 def get_option_parser():
-    parser = COP(__doc__, comms=True, argdoc=[
-        ('WORKFLOW_ID', 'Workflow ID'),
-        ('METHOD', 'Network API function name')])
+    parser = COP(
+        __doc__, comms=True,
+        argdoc=[
+            WORKFLOW_ID_ARG_DOC,
+            ('METHOD', 'Network API function name')
+        ]
+    )
 
     parser.add_option(
         '-n', '--no-input',

--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -56,7 +56,11 @@ from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
 from cylc.flow.exceptions import InputError
-from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+    icp_option,
+)
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
@@ -66,10 +70,10 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
-        argdoc=[("[WORKFLOW_ID]", "Workflow ID or path to source")],
+        argdoc=[COP.optional(WORKFLOW_ID_OR_PATH_ARG_DOC)],
         jset=True,
     )
 

--- a/cylc/flow/scripts/cycle_point.py
+++ b/cylc/flow/scripts/cycle_point.py
@@ -66,12 +66,16 @@ import metomi.isodatetime.parsers
 from metomi.isodatetime.exceptions import IsodatetimeError
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         color=False,
         argdoc=[
-            ('[POINT]', 'ISO8601 date-time, default=$CYLC_TASK_CYCLE_POINT')])
+            COP.optional(
+                ('POINT', 'ISO8601 date-time, default=$CYLC_TASK_CYCLE_POINT')
+            )
+        ]
+    )
 
     parser.add_option(
         "--offset-hours", metavar="HOURS",

--- a/cylc/flow/scripts/diff.py
+++ b/cylc/flow/scripts/diff.py
@@ -32,7 +32,11 @@ import sys
 from typing import TYPE_CHECKING
 
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+    icp_option,
+)
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.templatevars import load_template_vars
 from cylc.flow.terminal import cli_function
@@ -114,12 +118,13 @@ def prdict(dct, arrow='<', section='', level=0, diff=False, nested=False):
                 print(' ' + arrow + '  ', key, '=', dct[key])
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
-        __doc__, jset=True, prep=True,
+        __doc__,
+        jset=True,
         argdoc=[
-            ('WORKFLOW_ID_1', 'Workflow ID or path to source'),
-            ('WORKFLOW_ID_2', 'Workflow ID or path to source')
+            (f'WORKFLOW_{n}', WORKFLOW_ID_OR_PATH_ARG_DOC[1])
+            for n in (1, 2)
         ]
     )
 

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -41,7 +41,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.terminal import cli_function
 
@@ -147,7 +150,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         comms=True,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID')],
+        argdoc=[WORKFLOW_ID_ARG_DOC],
     )
     parser.add_option(
         "-g", "--global", help="Global information only.",

--- a/cylc/flow/scripts/ext_trigger.py
+++ b/cylc/flow/scripts/ext_trigger.py
@@ -45,7 +45,10 @@ from cylc.flow import LOG
 from cylc.flow.exceptions import CylcError, ClientError
 from cylc.flow.id_cli import parse_id
 from cylc.flow.network.client_factory import get_client
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -76,12 +79,12 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         argdoc=[
-            ("WORKFLOW_ID", "Workflow ID"),
+            WORKFLOW_ID_ARG_DOC,
             ("MSG", "External trigger message"),
             ("TRIGGER_ID", "Unique trigger ID"),
         ],

--- a/cylc/flow/scripts/get_resources.py
+++ b/cylc/flow/scripts/get_resources.py
@@ -52,13 +52,11 @@ def get_option_parser():
     parser = COP(
         __doc__,
         argdoc=[
-            (
-                '[RESOURCE]',
-                'Resource to extract.'
+            COP.optional(
+                ('RESOURCE', 'Resource to extract.')
             ),
-            (
-                '[DIR]',
-                'Target directory.'
+            COP.optional(
+                ('DIR', 'Target directory.')
             )
         ]
     )

--- a/cylc/flow/scripts/get_workflow_contact.py
+++ b/cylc/flow/scripts/get_workflow_contact.py
@@ -24,7 +24,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import CylcError, ServiceFileError
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.workflow_files import load_contact_file
 from cylc.flow.terminal import cli_function
 
@@ -33,7 +36,7 @@ if TYPE_CHECKING:
 
 
 def get_option_parser():
-    return COP(__doc__, argdoc=[('WORKFLOW_ID', 'Workflow ID')])
+    return COP(__doc__, argdoc=[WORKFLOW_ID_ARG_DOC])
 
 
 @cli_function(get_option_parser)

--- a/cylc/flow/scripts/get_workflow_version.py
+++ b/cylc/flow/scripts/get_workflow_version.py
@@ -28,7 +28,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -52,7 +55,7 @@ def get_option_parser():
         __doc__,
         comms=True,
         multiworkflow=True,
-        argdoc=[('WORKFLOW_ID ...', 'Workflow IDs')],
+        argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
     return parser
 

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -44,7 +44,11 @@ from cylc.flow.config import WorkflowConfig
 from cylc.flow.exceptions import InputError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+    icp_option,
+)
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -183,20 +187,21 @@ def get_config(workflow_id: str, opts: 'Values') -> WorkflowConfig:
     )
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     """CLI."""
     parser = COP(
         __doc__,
         jset=True,
-        prep=True,
         argdoc=[
-            ('WORKFLOW_ID', 'Workflow ID or path to source'),
-            ('[START]', 'Graph start; defaults to initial cycle point'),
-            (
-                '[STOP]',
+            WORKFLOW_ID_OR_PATH_ARG_DOC,
+            COP.optional(
+                ('START', 'Graph start; defaults to initial cycle point')
+            ),
+            COP.optional((
+                'STOP',
                 'Graph stop point or interval; defaults to 3 points from START'
-            )
-        ],
+            ))
+        ]
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -60,7 +60,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 from cylc.flow.network.multi import call_multi
 
@@ -103,7 +106,7 @@ def get_option_parser() -> COP:
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -96,10 +96,15 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
-        __doc__, comms=True, prep=True,
-        argdoc=[('[SOURCE]', 'Path to workflow source')]
+        __doc__,
+        comms=True,
+        argdoc=[
+            COP.optional(
+                ('SOURCE', 'Path to workflow source')
+            )
+        ]
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/jobs_kill.py
+++ b/cylc/flow/scripts/jobs_kill.py
@@ -30,12 +30,14 @@ from cylc.flow.terminal import cli_function
 INTERNAL = True
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         argdoc=[
             ("JOB-LOG-ROOT", "The log/job sub-directory for the workflow"),
-            ("[JOB-LOG-DIR ...]", "A point/name/submit_num sub-directory"),
+            COP.optional(
+                ("JOB-LOG-DIR ...", "A point/name/submit_num sub-directory")
+            )
         ],
     )
 

--- a/cylc/flow/scripts/jobs_poll.py
+++ b/cylc/flow/scripts/jobs_poll.py
@@ -29,12 +29,14 @@ from cylc.flow.terminal import cli_function
 INTERNAL = True
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         argdoc=[
             ("JOB-LOG-ROOT", "The log/job sub-directory for the workflow"),
-            ("[JOB-LOG-DIR ...]", "A point/name/submit_num sub-directory"),
+            COP.optional(
+                ("JOB-LOG-DIR ...", "A point/name/submit_num sub-directory")
+            )
         ],
     )
 

--- a/cylc/flow/scripts/jobs_submit.py
+++ b/cylc/flow/scripts/jobs_submit.py
@@ -29,12 +29,14 @@ from cylc.flow.job_runner_mgr import JobRunnerManager
 INTERNAL = True
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         argdoc=[
             ("JOB-LOG-ROOT", "The log/job sub-directory for the workflow"),
-            ("[JOB-LOG-DIR ...]", "A point/name/submit_num sub-directory"),
+            COP.optional(
+                ("JOB-LOG-DIR ...", "A point/name/submit_num sub-directory")
+            )
         ],
     )
     parser.add_option(

--- a/cylc/flow/scripts/kill.py
+++ b/cylc/flow/scripts/kill.py
@@ -37,7 +37,10 @@ from typing import TYPE_CHECKING
 from cylc.flow.id import Tokens
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -59,13 +62,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     return parser

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -35,7 +35,11 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+    icp_option,
+)
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -47,8 +51,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         jset=True,
-        prep=True,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
+        argdoc=[WORKFLOW_ID_OR_PATH_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -76,7 +76,10 @@ import sys
 from typing import TYPE_CHECKING
 
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP
+)
 from cylc.flow.task_message import record_messages
 from cylc.flow.terminal import cli_function
 from cylc.flow.exceptions import InputError
@@ -86,15 +89,22 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         argdoc=[
             # TODO
-            ('[WORKFLOW_ID]', 'Workflow ID'),
-            ('[TASK-JOB]', 'Task job identifier CYCLE/TASK_NAME/SUBMIT_NUM'),
-            ('[[SEVERITY:]MESSAGE ...]', 'Messages')])
+            COP.optional(WORKFLOW_ID_ARG_DOC),
+            COP.optional(
+                ('TASK-JOB', 'Task job identifier CYCLE/TASK_NAME/SUBMIT_NUM')
+            ),
+            COP.optional(
+                ('[SEVERITY:]MESSAGE ...', 'Messages')
+            )
+        ]
+    )
+
     parser.add_option(
         '-s', '--severity', '-p', '--priority',
         metavar='SEVERITY',

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -35,7 +35,10 @@ Not to be confused with `cylc hold`.
 from functools import partial
 from typing import TYPE_CHECKING
 
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.network.multi import call_multi
 from cylc.flow.terminal import cli_function
@@ -57,13 +60,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('WORKFLOW_ID [WORKFLOW_ID ...]', 'Workflow ID(s)')],
+        argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
     return parser
 

--- a/cylc/flow/scripts/ping.py
+++ b/cylc/flow/scripts/ping.py
@@ -32,7 +32,10 @@ from typing import Any, Dict, TYPE_CHECKING
 import cylc.flow.flags
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.task_state import TASK_STATUS_RUNNING
 from cylc.flow.terminal import cli_function
 
@@ -61,13 +64,13 @@ query ($tProxy: ID!) {
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     return parser

--- a/cylc/flow/scripts/poll.py
+++ b/cylc/flow/scripts/poll.py
@@ -38,7 +38,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -60,13 +63,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
     return parser
 

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -44,7 +44,10 @@ from typing import Optional, TYPE_CHECKING
 from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError, WorkflowFilesError
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.pathutil import get_cylc_run_dir, get_workflow_run_dir
 from cylc.flow.workflow_files import (
     get_workflow_source_dir,
@@ -56,9 +59,9 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
-        __doc__, comms=True, argdoc=[('[WORKFLOW_ID]', 'Workflow ID')]
+        __doc__, comms=True, argdoc=[COP.optional(WORKFLOW_ID_ARG_DOC)]
     )
 
     parser.add_cylc_rose_options()

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -44,7 +44,10 @@ from typing import TYPE_CHECKING
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -84,7 +87,7 @@ def get_option_parser() -> COP:
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -57,7 +57,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -82,7 +85,7 @@ def get_option_parser():
         __doc__,
         comms=True,
         multiworkflow=True,
-        argdoc=[('WORKFLOW_ID [WORKFLOW_ID ...]', 'Workflow ID(s)')],
+        argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
     return parser
 

--- a/cylc/flow/scripts/remote_init.py
+++ b/cylc/flow/scripts/remote_init.py
@@ -43,13 +43,15 @@ from cylc.flow.terminal import cli_function
 INTERNAL = True
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         argdoc=[
             ("INSTALL_TARGET", "Target to be initialised"),
             ("RUND", "The run directory of the workflow"),
-            ('[DIRS_TO_BE_SYMLINKED ...]', "Directories to be symlinked")
+            COP.optional(
+                ('DIRS_TO_BE_SYMLINKED ...', "Directories to be symlinked")
+            )
         ],
         color=False
     )

--- a/cylc/flow/scripts/remote_tidy.py
+++ b/cylc/flow/scripts/remote_tidy.py
@@ -31,10 +31,13 @@ from cylc.flow.terminal import cli_function
 INTERNAL = True
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
-        __doc__, argdoc=[("INSTALL_TARGET", "target platform to be tidied"),
-                         ("RUND", "The run directory of the workflow")]
+        __doc__,
+        argdoc=[
+            ("INSTALL_TARGET", "target platform to be tidied"),
+            ("RUND", "The run directory of the workflow")
+        ]
     )
 
     return parser

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -26,7 +26,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -48,13 +51,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     return parser

--- a/cylc/flow/scripts/report_timings.py
+++ b/cylc/flow/scripts/report_timings.py
@@ -57,7 +57,10 @@ from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.pathutil import get_workflow_run_pub_db_name
 from cylc.flow.rundb import CylcWorkflowDAO
 from cylc.flow.terminal import cli_function
@@ -86,10 +89,10 @@ def smart_open(filename=None):
             fh.close()
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID')]
+        argdoc=[WORKFLOW_ID_ARG_DOC]
     )
     parser.add_option(
         "-r", "--raw",

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -164,12 +164,10 @@ RICH_FIELDS = {
 }
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     """CLI opts for "cylc scan"."""
     parser = COP(
-        __doc__,
-        comms=True,
-        argdoc=[],
+        __doc__, comms=True
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -51,7 +51,10 @@ from optparse import Values
 
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 MUTATION = '''
@@ -73,13 +76,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/set_verbosity.py
+++ b/cylc/flow/scripts/set_verbosity.py
@@ -32,7 +32,10 @@ from cylc.flow import LOG_LEVELS
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 
 MUTATION = '''
@@ -50,17 +53,16 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multiworkflow=True,
         argdoc=[
             ('LEVEL', ', '.join(LOG_LEVELS.keys())),
-            ('WORKFLOW_ID [WORKFLOW_ID ...]', 'Workflow ID(s)'),
+            WORKFLOW_ID_MULTI_ARG_DOC,
         ]
     )
-
     return parser
 
 

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -44,7 +44,10 @@ from cylc.flow.exceptions import InputError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_ids
 from cylc.flow.network.client_factory import get_client
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP
+)
 from cylc.flow.terminal import cli_function
 
 
@@ -151,7 +154,7 @@ def get_option_parser():
         __doc__,
         comms=True,
         multitask=True,
-        argdoc=[('ID [ID ...]', 'Workflow/Cycle/Family/Task ID(s)')],
+        argdoc=[ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -48,8 +48,8 @@ There are several shutdown methods:
   1. (default) stop after current active tasks finish
   2. (--now) stop immediately, orphaning current active tasks
   3. (--kill) stop after killing current active tasks
-  4. (with STOP as a cycle point) stop after cycle point STOP
-  5. (with STOP as a task ID) stop after task ID STOP has succeeded
+  4. (if ID specifies a cycle point) stop after the cycle point
+  5. (if ID specifies a task ID) stop after the task has succeeded
   6. (--wall-clock=T) stop after time T (an ISO 8601 date-time format e.g.
      CCYYMMDDThh:mm, CCYY-MM-DDThh, etc).
 
@@ -76,7 +76,10 @@ from cylc.flow.exceptions import (
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.network.schema import WorkflowStopMode
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    CylcOptionParser as COP,
+    ID_MULTI_ARG_DOC,
+)
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
@@ -138,13 +141,13 @@ class StopPoller(Poller):
             return False
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multiworkflow=True,
         argdoc=[
-            ('ID [ID ...]', 'Workflow/Cycle/Task ID(s)'),
+            ID_MULTI_ARG_DOC,
         ],
     )
 

--- a/cylc/flow/scripts/subscribe.py
+++ b/cylc/flow/scripts/subscribe.py
@@ -30,7 +30,10 @@ import time
 from google.protobuf.json_format import MessageToDict
 
 from cylc.flow.exceptions import ClientError
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.network import get_location
 from cylc.flow.network.subscriber import WorkflowSubscriber, process_delta_msg
 from cylc.flow.terminal import cli_function
@@ -52,13 +55,11 @@ def print_message(topic, data, subscriber=None, once=False):
         subscriber.stop()
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     """Augment options parser to current context."""
     parser = COP(
         __doc__,
-        argdoc=[
-            ('WORKFLOW_ID', 'Workflow ID')
-        ],
+        argdoc=[WORKFLOW_ID_ARG_DOC],
         comms=True
     )
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -49,7 +49,10 @@ from typing import TYPE_CHECKING
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    FULL_ID_MULTI_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 from cylc.flow.flow_mgr import FLOW_NONE, FLOW_NEW, FLOW_ALL
 
@@ -86,13 +89,13 @@ mutation (
 '''
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
         multitask=True,
         multiworkflow=True,
-        argdoc=[('ID [ID ...]', 'Cycle/Family/Task ID(s)')],
+        argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/tui.py
+++ b/cylc/flow/scripts/tui.py
@@ -33,7 +33,10 @@ from typing import TYPE_CHECKING
 from urwid import html_fragment
 
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.terminal import cli_function
 from cylc.flow.tui import TUI
 from cylc.flow.tui.app import (
@@ -49,12 +52,10 @@ if TYPE_CHECKING:
 __doc__ += indent(TUI, '           ')
 
 
-def get_option_parser():
+def get_option_parser() -> COP:
     parser = COP(
         __doc__,
-        argdoc=[
-            ('WORKFLOW_ID', 'Workflow ID')
-        ],
+        argdoc=[WORKFLOW_ID_ARG_DOC],
         # auto_add=False,  NOTE: at present auto_add can not be turned off
         color=False
     )

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -39,6 +39,7 @@ import cylc.flow.flags
 from cylc.flow.id_cli import parse_id
 from cylc.flow.loggingutil import disable_timestamps
 from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
     CylcOptionParser as COP,
     Options,
     icp_option,
@@ -53,8 +54,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         jset=True,
-        prep=True,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
+        argdoc=[WORKFLOW_ID_OR_PATH_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/view.py
+++ b/cylc/flow/scripts/view.py
@@ -42,7 +42,10 @@ from typing import TYPE_CHECKING
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import CylcError
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_OR_PATH_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.parsec.fileparse import read_and_proc
 from cylc.flow.templatevars import load_template_vars
 from cylc.flow.terminal import cli_function
@@ -55,8 +58,7 @@ def get_option_parser():
     parser = COP(
         __doc__,
         jset=True,
-        prep=True,
-        argdoc=[('WORKFLOW_ID', 'Workflow ID or path to source')],
+        argdoc=[WORKFLOW_ID_OR_PATH_ARG_DOC],
     )
 
     parser.add_option(

--- a/cylc/flow/scripts/workflow_state.py
+++ b/cylc/flow/scripts/workflow_state.py
@@ -59,7 +59,10 @@ from typing import TYPE_CHECKING
 from cylc.flow.exceptions import CylcError, InputError
 import cylc.flow.flags
 from cylc.flow.id_cli import parse_id
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    WORKFLOW_ID_ARG_DOC,
+    CylcOptionParser as COP,
+)
 from cylc.flow.dbstatecheck import CylcWorkflowDBChecker
 from cylc.flow.command_polling import Poller
 from cylc.flow.task_state import TASK_STATUSES_ORDERED
@@ -129,7 +132,7 @@ class WorkflowPoller(Poller):
 def get_option_parser() -> COP:
     parser = COP(
         __doc__,
-        argdoc=[('WORKFLOW_ID', "Workflow ID")]
+        argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
     parser.add_option(

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+from typing import List
 
 import sys
 import io
@@ -28,11 +29,15 @@ USAGE_WITH_COMMENT = "usage \n # comment"
 
 @pytest.fixture(scope='module')
 def parser():
-    return COP('usage')
+    return COP(
+        USAGE_WITH_COMMENT,
+        argdoc=[('SOME_ARG', "Description of SOME_ARG")]
+    )
 
 
 @pytest.mark.parametrize(
-    'args,verbosity', [
+    'args,verbosity',
+    [
         ([], 0),
         (['-v'], 1),
         (['-v', '-v', '-v'], 3),
@@ -44,7 +49,11 @@ def parser():
         (['--debug', '-v'], 3),
     ]
 )
-def test_verbosity(args, verbosity, parser, monkeypatch):
+def test_verbosity(
+    args: List[str],
+    verbosity: int,
+    parser: COP, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """-v, -q, --debug should be additive."""
     # patch the cylc.flow.flags value so that it gets reset after the test
     monkeypatch.setattr('cylc.flow.flags.verbosity', None)
@@ -54,11 +63,10 @@ def test_verbosity(args, verbosity, parser, monkeypatch):
     assert cylc.flow.flags.verbosity == verbosity
 
 
-def test_help_color(monkeypatch):
+def test_help_color(monkeypatch: pytest.MonkeyPatch, parser: COP):
     """Test for colorized comments in 'cylc cmd --help --color=always'."""
     # This colorization is done on the fly when help is printed.
     monkeypatch.setattr("sys.argv", ['cmd', 'foo', '--color=always'])
-    parser = COP(USAGE_WITH_COMMENT)
     parser.parse_args(None)
     assert parser.values.color == "always"
     f = io.StringIO()
@@ -67,11 +75,10 @@ def test_help_color(monkeypatch):
     assert not (f.getvalue()).startswith("Usage: " + USAGE_WITH_COMMENT)
 
 
-def test_help_nocolor(monkeypatch):
+def test_help_nocolor(monkeypatch: pytest.MonkeyPatch, parser: COP):
     """Test for no colorization in 'cylc cmd --help --color=never'."""
     # This colorization is done on the fly when help is printed.
     monkeypatch.setattr(sys, "argv", ['cmd', 'foo', '--color=never'])
-    parser = COP(USAGE_WITH_COMMENT)
     parser.parse_args(None)
     assert parser.values.color == "never"
     f = io.StringIO()


### PR DESCRIPTION
- Centralise common ID arg (name, description) tuples
- Add docstring to `CylcOptionParser.__init__()`
- Remove `CylcOptionParser`'s `prep` argument

This is a small change with no associated Issue. But would be a useful thing to get in before #4676

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
