### PR TITLE
CLI source path fix.

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -495,6 +495,8 @@ def _parse_src_path(id_):
         id_ == os.curdir
         or id_.startswith(f'{os.curdir}{os.sep}')
         or Path(id_).is_absolute()
+        or id_.endswith(WorkflowFiles.FLOW_FILE)
+        or id_.endswith(WorkflowFiles.SUITE_RC)
     ):
         src_path = src_path.resolve()
         if not src_path.exists():


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4615 

Make the CLI consistent with respect to source paths.

On master, commands work with absolute paths ending in `flow.cylc`:
```
$ cylc val $PWD/flow.cylc  # or ./flow.cylc
$ cylc val $PWD/foo/flow.cylc  # or ./foo/flow.cylc
```

On this branch, so do these:
```
$ cylc val flow.cylc
$ cylc val foo/flow.cylc
```
(Other filenames such as `flow2.cylc` are still an error.)

On the linked issue, I've argued that we should do this because:
 a. users will expect this to work
 b. consistency with the absolute path cases (that we already accept!)
 c. There's no ambiguity: we don't allow `flow.cylc` in workflow IDs

We might want to document that targetting a `flow.cylc` file directly really targets the workflow definition directory, not just the file.  But, same goes for the existing absolute path cases.

This is a trivial two-line change, so I can easily go the other way and close the issue by making every case above an error instead. But, do we really need to do that?


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
