### PR TITLE
Scan: make nested sub-wfs visible.

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -356,3 +356,23 @@ cylc__job__dummy_result() {
         return 1
     fi
 }
+
+cylc__job__install_subworkflow() {
+    # Install a new instance of a sub-workflow from source in the main run dir,
+    # symlink flow.cylc to the source, and echo the sub-workflow ID to stdout.
+    local NAME="$1"
+    local PREFIX="$2"
+    if [[ "$NAME" != "sub-"* ]]; then
+        echo "ERROR: sub-workflow names must begin with 'sub-'" >&2
+        exit 1
+    fi
+    local SRC_DIR="${CYLC_WORKFLOW_RUN_DIR}/${NAME}"
+    local RUN_DIR="${SRC_DIR}/${PREFIX}${CYLC_TASK_CYCLE_POINT}"
+    local ID="${RUN_DIR#*/cylc-run/}"
+    # Create sub-workflow run dir.
+    mkdir "$RUN_DIR"
+    # Symlink to the source flow.cylc.
+    ln -s "${SRC_DIR}/flow.cylc" "${RUN_DIR}/flow.cylc"
+    # Echo the new workflow ID to stdout.
+    echo "$ID"
+}

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -80,16 +80,16 @@ from cylc.flow.workflow_files import (
 SERVICE = Path(WorkflowFiles.Service.DIRNAME)
 CONTACT = Path(WorkflowFiles.Service.CONTACT)
 
-FLOW_FILES = {
-    # marker files/dirs which we use to determine if something is a flow
+WORKFLOW_DIR_INDICATORS = {
+    # Marker files/dirs used to identify a workflow dir. (Don't use
+    # flow.cylc or we'll stop at top level of nested sub-workflows).
     WorkflowFiles.Service.DIRNAME,
-    WorkflowFiles.FLOW_FILE,  # cylc8 flow definition file name
     WorkflowFiles.LOG_DIR
 }
 
 EXCLUDE_FILES = {
     WorkflowFiles.RUN_N,
-    WorkflowFiles.Install.SOURCE
+    WorkflowFiles.Install.DIRNAME
 }
 
 
@@ -129,7 +129,7 @@ def dir_is_flow(listing: Iterable[Path]) -> Optional[bool]:
         # so could be either a Cylc 7 or a Cylc 8 workflow
         return True
 
-    if FLOW_FILES & names:
+    if WORKFLOW_DIR_INDICATORS & names:
         # a pure Cylc 8 workflow
         return True
 
@@ -240,6 +240,14 @@ async def scan(
                     'name': str(path.relative_to(run_dir)),
                     'path': path,
                 }
+                # descend into any sub-workflows
+                _scan_subdirs(
+                    [
+                        c for c in contents if
+                        c.name.startswith(WorkflowFiles.SUB_WF_PREFIX)
+                    ],
+                    depth=0
+                )
             elif is_flow is False and depth < max_depth:
                 # we may have a nested flow, lets see...
                 _scan_subdirs(contents, depth)

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -201,6 +201,9 @@ class WorkflowFiles:
     RUN_DIR = 'run'
     """Workflow run directory."""
 
+    SUB_WF_PREFIX = 'sub-'
+    """Directory name prefix for nested sub-workflows."""
+
     class Service:
         """The directory containing Cylc system files."""
 


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4453 and supersede #4477, with minimal support for nested sub-workflows.

On current master, nested sub-workflows are invisible to the UIs. This allows scan to see nested sub-worfklows structured as per https://github.com/cylc/cylc-flow/pull/4477#issuecomment-952996740

Plus:
 - nested sub-workflow directory names must start with `sub-`, to limit what `cylc scan` has to descend into.
 - adds a job function to install new instances of a sub-workflow from the "source" in the main-workflow run directory.

NOTE:  we can't stop users using sub-workflows (it's just `cylc play --no-detach other` inside a task) and there are good use cases for it. This PR just:
- makes it easier, and easier to avoid getting into a mess, if you need to use sub-workflows
- and allows nesting of sub-workflows inside the main workflow, which is convenient and it makes CLI operations easier

**Marked against the rc4 milestone, but if possible I'd like to get it into rc3** (needed urgently at NIWA!).

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list** 
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
