### PR TITLE
Rename flows job env var.

### DIFF
--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -225,7 +225,7 @@ class JobFileWriter:
         handle.write(
             '\n    export CYLC_TASK_TRY_NUMBER=%s' % job_conf['try_num'])
         handle.write(
-            "\n    export CYLC_TASK_FLOWS="
+            "\n    export CYLC_TASK_FLOW_NUMBERS="
             f"{','.join(str(f) for f in job_conf['flow_nums'])}"
         )
         # Standard parameter environment variables

--- a/tests/functional/restart/50-two-flows/flow.cylc
+++ b/tests/functional/restart/50-two-flows/flow.cylc
@@ -13,14 +13,14 @@
         pre-script = sleep 2
     [[a]]
        script = """
-           if ((CYLC_TASK_FLOWS == 2)); then
+           if ((CYLC_TASK_FLOW_NUMBERS == 2)); then
                cylc__job__poll_grep_workflow_log "\[1/c .* succeeded"
            fi
        """
     [[b, d]]
     [[c]]
        script = """
-           if ((CYLC_TASK_FLOWS == 1)); then
+           if ((CYLC_TASK_FLOW_NUMBERS == 1)); then
                cylc trigger --reflow --meta="cheese wizard" "$CYLC_WORKFLOW_NAME//1/a"
                cylc__job__poll_grep_workflow_log "\[1/a submitted job:02 flows:2\] => running"
                cylc stop $CYLC_WORKFLOW_NAME

--- a/tests/functional/spawn-on-demand/02-merge/flow.cylc
+++ b/tests/functional/spawn-on-demand/02-merge/flow.cylc
@@ -19,12 +19,12 @@
             if [[ $CYLC_TASK_JOB == *01 ]]; then
                 # job(01)
                 if (( CYLC_TASK_CYCLE_POINT == 3 )); then
-                    test $CYLC_TASK_FLOWS == "1,2"
+                    test $CYLC_TASK_FLOW_NUMBERS == "1,2"
                 else
-                    test $CYLC_TASK_FLOWS == "1"
+                    test $CYLC_TASK_FLOW_NUMBERS == "1"
                 fi
             else
                 # job(02)
-                test $CYLC_TASK_FLOWS == "2"
+                test $CYLC_TASK_FLOW_NUMBERS == "2"
             fi
         """

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -391,7 +391,7 @@ def test_write_task_environment():
                 'CYLC_TASK_NAMESPACE_HIERARCHY="baa moo"\n    export '
                 'CYLC_TASK_DEPENDENCIES="moo neigh quack"\n    export '
                 'CYLC_TASK_TRY_NUMBER=1\n    export '
-                'CYLC_TASK_FLOWS=1\n    export '
+                'CYLC_TASK_FLOW_NUMBERS=1\n    export '
                 'CYLC_TASK_PARAM_duck="quack"\n    export '
                 'CYLC_TASK_PARAM_mouse="squeak"\n    '
                 'CYLC_TASK_WORK_DIR_BASE=\'farm_noises/work_d\'\n}')


### PR DESCRIPTION

This is a small change with no associated Issue.

Rename the job environment variable that holds flow numbers.  The current name pre-dates integer flow labels, and is not consistent with other "number" variable names.

```
CYLC_TASK_FLOWS ---> CYLC_TASK_FLOW_NUMBERS
```

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Already covered by existing tests.
- [ ] No change log entry required (why? e.g. invisible to users).
- [ ] (master branch) covered in documentation PR at cylc/cylc-doc/pull/427
