### PR TITLE
Disallow direct validation (etc.) of source FILE

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -47,6 +47,7 @@ from cylc.flow.workflow_files import (
     get_workflow_run_dir,
     infer_latest_run_from_id,
     validate_workflow_name,
+    abort_if_flow_file_in_path
 )
 
 
@@ -509,18 +510,8 @@ def _parse_src_path(id_):
     ID with the same name.
 
     """
+    abort_if_flow_file_in_path(id_)
     src_path = Path(id_)
-
-    # First catch a common error, to avoid confusing warnings that
-    # "dir/flow.cylc" is not a valid workflow ID when the user was obviously
-    # trying (erroneously) to target a source config file.
-    if src_path.name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
-        raise UserInputError(
-            f"Not a valid workflow ID or source directory: {src_path}"
-            f"\n(Note you should not include {src_path.name}"
-            " in the workflow source path)"
-        )
-
     if (
         id_ != os.curdir
         and not EXPLICIT_RELATIVE_PATH_REGEX.match(id_)

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -512,8 +512,7 @@ def _parse_src_path(id_):
     abort_if_flow_file_in_path(Path(id_))
     src_path = Path(id_)
     if (
-        id_ != os.curdir
-        and not EXPLICIT_RELATIVE_PATH_REGEX.match(id_)
+        not EXPLICIT_RELATIVE_PATH_REGEX.match(id_)
         and not src_path.is_absolute()
     ):
         # Not a valid source path, but it could be a workflow ID.

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -515,7 +515,9 @@ def _parse_src_path(id_):
     # trying (erroneously) to target a source config file.
     if src_path.name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
         raise UserInputError(
-            f"Not a valid workflow ID or source directory: {src_path}")
+            f"Not a valid workflow ID or source directory: {src_path}"
+            f"\n(Note you should not include {src_path.name} in the path)"
+        )
 
     if (
         id_ != os.curdir

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -39,7 +39,6 @@ from cylc.flow.network.scan import (
     scan,
 )
 from cylc.flow.workflow_files import (
-    WorkflowFiles,
     NO_FLOW_FILE_MSG,
     check_flow_file,
     detect_both_flow_and_suite,
@@ -510,7 +509,7 @@ def _parse_src_path(id_):
     ID with the same name.
 
     """
-    abort_if_flow_file_in_path(id_)
+    abort_if_flow_file_in_path(Path(id_))
     src_path = Path(id_)
     if (
         id_ != os.curdir

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -32,6 +32,7 @@ from cylc.flow.id import (
     contains_multiple_workflows,
     upgrade_legacy_ids,
 )
+from cylc.flow.pathutil import EXPLICIT_RELATIVE_PATH_REGEX
 from cylc.flow.network.scan import (
     filter_name,
     is_active,
@@ -516,12 +517,13 @@ def _parse_src_path(id_):
     if src_path.name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
         raise UserInputError(
             f"Not a valid workflow ID or source directory: {src_path}"
-            f"\n(Note you should not include {src_path.name} in the path)"
+            f"\n(Note you should not include {src_path.name}"
+            " in the workflow source path)"
         )
 
     if (
         id_ != os.curdir
-        and not id_.startswith(f'{os.curdir}{os.sep}')
+        and not EXPLICIT_RELATIVE_PATH_REGEX.match(id_)
         and not src_path.is_absolute()
     ):
         # Not a valid source path, but it could be a workflow ID.

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -33,13 +33,6 @@ from cylc.flow.platforms import get_localhost_install_target
 # monkeypatching:
 _CYLC_RUN_DIR = os.path.join('$HOME', 'cylc-run')
 
-EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
-    rf'''
-    ^({re.escape(os.curdir)}|{re.escape(os.pardir)})
-    ({re.escape(os.sep)}|$)
-    ''',
-    re.VERBOSE
-)
 """Matches relative paths that are explicit (starts with ./)"""
 
 

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -43,13 +43,13 @@ EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
 """Matches relative paths that are explicit (starts with ./)"""
 
 
-EXPLICIT_RELATIVE_PATH_REGEX = re.compile( 
-    rf''' 
-    ^({re.escape(os.curdir)}|{re.escape(os.pardir)}) 
-    ({re.escape(os.sep)}|$) 
-    ''', 
-    re.VERBOSE 
-) 
+EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
+    rf'''
+    ^({re.escape(os.curdir)}|{re.escape(os.pardir)})
+    ({re.escape(os.sep)}|$)
+    ''',
+    re.VERBOSE
+)
 
 
 def expand_path(*args: Union[Path, str]) -> str:

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -33,9 +33,6 @@ from cylc.flow.platforms import get_localhost_install_target
 # monkeypatching:
 _CYLC_RUN_DIR = os.path.join('$HOME', 'cylc-run')
 
-"""Matches relative paths that are explicit (starts with ./)"""
-
-
 EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
     rf'''
     ^({re.escape(os.curdir)}|{re.escape(os.pardir)})
@@ -43,6 +40,7 @@ EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
     ''',
     re.VERBOSE
 )
+"""Matches relative paths that are explicit (starts with ./)"""
 
 
 def expand_path(*args: Union[Path, str]) -> str:

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -43,6 +43,15 @@ EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
 """Matches relative paths that are explicit (starts with ./)"""
 
 
+EXPLICIT_RELATIVE_PATH_REGEX = re.compile( 
+    rf''' 
+    ^({re.escape(os.curdir)}|{re.escape(os.pardir)}) 
+    ({re.escape(os.sep)}|$) 
+    ''', 
+    re.VERBOSE 
+) 
+
+
 def expand_path(*args: Union[Path, str]) -> str:
     """Expand both vars and user in path and normalise it, joining any
     extra args."""

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1494,6 +1494,22 @@ def reinstall_workflow(
     close_log(reinstall_log)
 
 
+def abort_if_flow_file_in_path(source: str) -> None:
+    """Raise an exception if a flow file is found in a source path.
+
+    This allows us to avoid seemingly silly warnings that "path/flow.cylc"
+    is not a valid workflow ID, when "path" is valid and the user was just
+    (erroneously) trying to (e.g.) validate the config file directly.
+
+    """
+    if Path(source).name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
+        raise UserInputError(
+            f"Not a valid workflow ID or source directory: {source}"
+            f"\n(Note you should not include {Path(source).name}"
+            " in the workflow source path)"
+        )
+
+
 def install_workflow(
     source: Path,
     workflow_name: Optional[str] = None,
@@ -1530,8 +1546,11 @@ def install_workflow(
             Another workflow already has this name (unless --redirect).
             Trying to install a workflow that is nested inside of another.
     """
-    if source.name == WorkflowFiles.FLOW_FILE:
-        source = source.parent
+    if not source:
+        source = Path.cwd()
+    else:
+        abort_if_flow_file_in_path(source)
+    source = Path(expand_path(source))
     if not workflow_name:
         workflow_name = get_source_workflow_name(source)
     validate_workflow_name(workflow_name, check_reserved_names=True)
@@ -1865,6 +1884,7 @@ def link_runN(latest_run: Union[Path, str]):
 def search_install_source_dirs(workflow_name: Union[Path, str]) -> Path:
     """Return the path of a workflow source dir if it is present in the
     'global.cylc[install]source dirs' search path."""
+    abort_if_flow_file_in_path(workflow_name)
     search_path: List[str] = get_source_dirs()
     if not search_path:
         raise WorkflowFilesError(

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1257,11 +1257,13 @@ def infer_latest_run(
     except ValueError:
         raise ValueError(f"{path} is not in the cylc-run directory")
     if not path.exists():
-        raise UserInputError(f'Path does not exist: {path}')
+        raise UserInputError(
+            f'Workflow ID not found: {reg}\n(Directory not found: {path})'
+        )
     if path.name == WorkflowFiles.RUN_N:
         LOG.warning(
             f"Explicit use of {WorkflowFiles.RUN_N} in the Workflow ID is not"
-            f" necessary. It is used automatically to select the latest run"
+            " necessary. It is used automatically to select the latest run"
             " number."
         )
         runN_path = path

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1546,10 +1546,7 @@ def install_workflow(
             Another workflow already has this name (unless --redirect).
             Trying to install a workflow that is nested inside of another.
     """
-    if not source:
-        source = Path.cwd()
-    else:
-        abort_if_flow_file_in_path(source)
+    abort_if_flow_file_in_path(source)
     source = Path(expand_path(source))
     if not workflow_name:
         workflow_name = get_source_workflow_name(source)

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1494,7 +1494,7 @@ def reinstall_workflow(
     close_log(reinstall_log)
 
 
-def abort_if_flow_file_in_path(source: str) -> None:
+def abort_if_flow_file_in_path(source: Path) -> None:
     """Raise an exception if a flow file is found in a source path.
 
     This allows us to avoid seemingly silly warnings that "path/flow.cylc"
@@ -1502,10 +1502,10 @@ def abort_if_flow_file_in_path(source: str) -> None:
     (erroneously) trying to (e.g.) validate the config file directly.
 
     """
-    if Path(source).name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
+    if source.name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
         raise UserInputError(
             f"Not a valid workflow ID or source directory: {source}"
-            f"\n(Note you should not include {Path(source).name}"
+            f"\n(Note you should not include {source.name}"
             " in the workflow source path)"
         )
 
@@ -1884,7 +1884,7 @@ def link_runN(latest_run: Union[Path, str]):
 def search_install_source_dirs(workflow_name: Union[Path, str]) -> Path:
     """Return the path of a workflow source dir if it is present in the
     'global.cylc[install]source dirs' search path."""
-    abort_if_flow_file_in_path(workflow_name)
+    abort_if_flow_file_in_path(Path(workflow_name))
     search_path: List[str] = get_source_dirs()
     if not search_path:
         raise WorkflowFilesError(

--- a/tests/functional/cylc-cat-log/03-bad-workflow.t
+++ b/tests/functional/cylc-cat-log/03-bad-workflow.t
@@ -24,7 +24,8 @@ BAD_NAME="NONEXISTENTWORKFLOWNAME"
 
 run_fail "${TEST_NAME_BASE}-workflow" cylc cat-log -f l "${BAD_NAME}"
 cmp_ok "${TEST_NAME_BASE}-workflow.stderr" <<__ERR__
-UserInputError: Path does not exist: ${CYLC_RUN_DIR}/${BAD_NAME}
+UserInputError: Workflow ID not found: ${BAD_NAME}
+(Directory not found: ${CYLC_RUN_DIR}/${BAD_NAME})
 __ERR__
 
 mkdir "${CYLC_RUN_DIR}/${BAD_NAME}"

--- a/tests/functional/cylc-graph-diff/00-simple.t
+++ b/tests/functional/cylc-graph-diff/00-simple.t
@@ -42,7 +42,8 @@ run_fail "${TEST_NAME}" \
     cylc graph "${DIFF_WORKFLOW_NAME}" --diff "${CONTROL_WORKFLOW_NAME}.bad"
 cmp_ok "${TEST_NAME}.stdout" </'dev/null'
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-UserInputError: Path does not exist: ${RUN_DIR}/${CONTROL_WORKFLOW_NAME}.bad
+UserInputError: Workflow ID not found: ${CONTROL_WORKFLOW_NAME}.bad
+(Directory not found: ${RUN_DIR}/${CONTROL_WORKFLOW_NAME}.bad)
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-deps-fail"

--- a/tests/functional/cylc-install/07-no-recursive-installations.t
+++ b/tests/functional/cylc-install/07-no-recursive-installations.t
@@ -28,7 +28,7 @@ cat > flow.cylc <<__HEREDOC__
         R1 = foo
 __HEREDOC__
 
-run_ok "$TEST_NAME_BASE" cylc validate "$PWD"/flow.cylc
+run_ok "$TEST_NAME_BASE" cylc validate "$PWD"
 
 TEST_FOLDERS=()
 MSG="Nested install directories not allowed"

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -28,7 +28,8 @@ run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-n
 rm -rf "${RND_WORKFLOW_RUNDIR}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-UserInputError: Path does not exist: ${RND_WORKFLOW_RUNDIR}
+UserInputError: Workflow ID not found: ${RND_WORKFLOW_RUNDIR#*/cylc-run/}
+(Directory not found: ${RND_WORKFLOW_RUNDIR})
 __ERR__
 purge_rnd_workflow
 

--- a/tests/functional/graphing/06-family-or.t
+++ b/tests/functional/graphing/06-family-or.t
@@ -40,9 +40,9 @@ cat >'flow.cylc' <<'__FLOW_CONFIG__'
     [[c]]
 __FLOW_CONFIG__
 
-run_ok "${TEST_NAME_BASE}-validate" cylc validate "${PWD}/flow.cylc"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${PWD}"
 
-graph_workflow "${PWD}/flow.cylc" "graph.plain" \
+graph_workflow "${PWD}" "graph.plain" \
    -g A -g B -g X 20000101T0000Z 20000103T0000Z
 cmp_ok 'graph.plain' - <<'__GRAPH__'
 edge "20000101T0000Z/A" "20000102T0000Z/c"

--- a/tests/functional/validate/35-pass-special-tasks-non-word-names.t
+++ b/tests/functional/validate/35-pass-special-tasks-non-word-names.t
@@ -36,5 +36,5 @@ cat >'flow.cylc' <<'__FLOW_CONFIG__'
     [[t-1, t+1, t%1, t@1]]
         script = true
 __FLOW_CONFIG__
-run_ok "${TEST_NAME_BASE}" cylc validate "${PWD}/flow.cylc"
+run_ok "${TEST_NAME_BASE}" cylc validate "${PWD}"
 exit

--- a/tests/functional/validate/37-special-implicit-task.t
+++ b/tests/functional/validate/37-special-implicit-task.t
@@ -29,7 +29,7 @@ cat >'flow.cylc' <<'__FLOW_CONFIG__'
     [[bar]]
         script = true
 __FLOW_CONFIG__
-run_fail "${TEST_NAME_BASE}" cylc validate "${PWD}/flow.cylc"
+run_fail "${TEST_NAME_BASE}" cylc validate "${PWD}"
 cmp_ok "${TEST_NAME_BASE}.stderr" << '__ERR__'
 WorkflowConfigError: implicit tasks detected (no entry under [runtime]):
     * foo

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -309,6 +309,12 @@ def src_dir(tmp_path):
     src_dir.mkdir()
     src_file = src_dir / 'flow.cylc'
     src_file.touch()
+
+    other_dir = (tmp_path / 'blargh')
+    other_dir.mkdir()
+    other_file = other_dir / 'nugget'
+    other_file.touch()
+ 
     os.chdir(tmp_path)
     yield src_dir
     os.chdir(cwd_before)
@@ -357,6 +363,20 @@ def test_parse_src_path(src_dir, monkeypatch):
     # Might be a workflow ID, even though there's a matching relative path
     res = _parse_src_path('a')
     assert res is None
+
+    # Not a src directory (dir)
+    with pytest.raises(WorkflowFilesError) as exc_ctx:
+        _parse_src_path('./blargh')
+    assert 'No flow.cylc or suite.rc in .' in str(exc_ctx.value)
+
+    # Not a src directory (file)
+    with pytest.raises(UserInputError) as exc_ctx:
+        _parse_src_path('./blargh/nugget')
+    assert 'Path is not a source directory' in str(exc_ctx.value)
+
+    res = _parse_src_path('a')
+    assert res is None
+
 
     # move into the src dir
     monkeypatch.chdir(src_dir)

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -374,10 +374,6 @@ def test_parse_src_path(src_dir, monkeypatch):
         _parse_src_path('./blargh/nugget')
     assert 'Path is not a source directory' in str(exc_ctx.value)
 
-    res = _parse_src_path('a')
-    assert res is None
-
-
     # move into the src dir
     monkeypatch.chdir(src_dir)
 

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -330,7 +330,7 @@ def test_parse_src_path(src_dir, monkeypatch):
             str(src_dir.resolve()) + 'xyz'
         )
 
-    # valid relative path
+    # valid ./relative path
     workflow_id, src_path, src_file_path = _parse_src_path('./a')
     assert workflow_id == 'a'
     assert src_path == src_dir
@@ -340,25 +340,37 @@ def test_parse_src_path(src_dir, monkeypatch):
     with pytest.raises(UserInputError):
         _parse_src_path('./xxx')
 
-    # relative '.' (invalid)
+    # relative '.' dir (invalid)
     with pytest.raises(WorkflowFilesError) as exc_ctx:
         workflow_id, src_path, src_file_path = _parse_src_path('.')
     assert 'No flow.cylc or suite.rc in .' in str(exc_ctx.value)
 
+    # relative 'invalid/<flow-file>' (invalid)
+    with pytest.raises(UserInputError) as exc_ctx:
+        _parse_src_path('xxx/flow.cylc')
+    assert 'Not a valid workflow ID or source directory' in str(exc_ctx.value)
+
+    # Might be a workflow ID
+    res = _parse_src_path('the/quick/brown/fox')
+    assert res is None
+
+    # Might be a workflow ID, even though there's a matching relative path
+    res = _parse_src_path('a')
+    assert res is None
+
     # move into the src dir
     monkeypatch.chdir(src_dir)
 
-    # relative '.' (valid)
+    # relative '.' dir (valid)
     workflow_id, src_path, src_file_path = _parse_src_path('.')
     assert workflow_id == 'a'
     assert src_path == src_dir
     assert src_file_path == src_dir / 'flow.cylc'
 
-    # relative './<flow-file>'
-    workflow_id, src_path, src_file_path = _parse_src_path('./flow.cylc')
-    assert workflow_id == 'a'
-    assert src_path == src_dir
-    assert src_file_path == src_dir / 'flow.cylc'
+    # relative './<flow-file>' (invalid)
+    with pytest.raises(UserInputError) as exc_ctx:
+        _parse_src_path('./flow.cylc')
+    assert 'Not a valid workflow ID or source directory' in str(exc_ctx.value)
 
 
 async def test_parse_ids_src_path(src_dir):

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -352,7 +352,10 @@ def test_infer_latest_run__bad(
         )
     elif reason == 'not exist':
         run_dir = run_dir / 'not-exist'
-        err_msg = f"Path does not exist: {run_dir}"
+        err_msg = (
+            f"Workflow ID not found: sulu/not-exist\n"
+            f"(Directory not found: {run_dir})"
+        )
     else:
         raise ValueError(reason)
     # -- Test --

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1968,7 +1968,7 @@ def test_get_run_dir_info__fail(tmp_run_dir: Callable):
 
 
 def test_validate_abort_if_flow_file_in_path():
-    assert abort_if_flow_file_in_path("path/to/wflow") is None
+    assert abort_if_flow_file_in_path(Path("path/to/wflow")) is None
     with pytest.raises(UserInputError) as exc_info:
-        abort_if_flow_file_in_path("path/to/wflow/flow.cylc")
+        abort_if_flow_file_in_path(Path("path/to/wflow/flow.cylc"))
     assert "Not a valid workflow ID or source directory" in str(exc_info.value)

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -60,7 +60,8 @@ from cylc.flow.workflow_files import (
     reinstall_workflow,
     search_install_source_dirs,
     validate_source_dir,
-    validate_workflow_name
+    validate_workflow_name,
+    abort_if_flow_file_in_path
 )
 
 from .conftest import MonkeyMock
@@ -1964,3 +1965,10 @@ def test_get_run_dir_info__fail(tmp_run_dir: Callable):
     with pytest.raises(WorkflowFilesError) as excinfo:
         get_run_dir_info(base_dir, None, False)
     assert "contains an installed workflow"
+
+
+def test_validate_abort_if_flow_file_in_path():
+    assert abort_if_flow_file_in_path("path/to/wflow") is None
+    with pytest.raises(UserInputError) as exc_info:
+        abort_if_flow_file_in_path("path/to/wflow/flow.cylc")
+    assert "Not a valid workflow ID or source directory" in str(exc_info.value)


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #4615 (and supersede #4810)

Disallow the following:
```console
$ cylc val ./flow.cylc
$ cylc val ./test/flow.cylc
$ cylc val /path/to/flow.cylc
```

Additionally, I've tried to make the various error messages less confusing:
- check explicitly for a flow config filename on the command line
  -  this will be a common user error, and there's no need to report it as a bad workflow ID
- distinguish between "source path does not exist" and "workflow ID/path does not exist", when that is possible.

```console
$ cylc val hydr/flow.cylc
UserInputError: Not a valid workflow ID or source directory: hydr/flow.cylc

$ cylc val ./hydr/flow.cylc
UserInputError: Not a valid workflow ID or source directory: hydr/flow.cylc

$ cylc val ./hydr  # valid source
Valid for cylc-8.0rc3.dev

$ cylc val hydr  # valid ID
Valid for cylc-8.0rc3.dev

$ cylc val ./no/exist 
UserInputError: Source directory not found: /home/oliverh/cylc-src/no/exist

$ cylc val no/exist 
UserInputError: Workflow ID not found: no/exist
(Directory not found: /home/oliverh/cylc-run/no/exist)
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit).
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.

