### PR TITLE
tui: fix traceback/exit for stopped workflows

### DIFF
--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -314,6 +314,7 @@ class TuiApp:
             )
         except WorkflowStopped:
             # Distinguish stopped flow from non-existent flow.
+            self.client = None
             full_path = Path(get_workflow_run_dir(self.reg))
             if(
                 (full_path / WorkflowFiles.SUITE_RC).is_file()


### PR DESCRIPTION
* Closes #4818
* Reverts regression in #4748

To test try viewing a workflow in Tui, then stop/play it multiple times.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Appropriate tests are included (no test framework for Tui at present)
- [x] Unreleased bug so no changelog.
- [x] No documentation update required.