### PR TITLE
Change UserInputError to InputError

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -63,7 +63,7 @@ from cylc.flow.exceptions import (
     IntervalParsingError,
     TaskDefError,
     ParamExpandError,
-    UserInputError
+    InputError
 )
 import cylc.flow.flags
 from cylc.flow.graph_parser import GraphParser
@@ -658,7 +658,7 @@ class WorkflowConfig:
         starttask = getattr(self.options, 'starttask', None)
 
         if startcp is not None and starttask is not None:
-            raise UserInputError(
+            raise InputError(
                 "--start-cycle-point and --start-task are mutually exclusive"
             )
         if startcp:
@@ -675,7 +675,7 @@ class WorkflowConfig:
                     for taskid in self.options.starttask
                 ]
             except ValueError as exc:
-                raise UserInputError(str(exc))
+                raise InputError(str(exc))
             self.start_point = min(
                 get_point(cycle).standardise()
                 for cycle in cycle_points if cycle
@@ -2266,7 +2266,7 @@ class WorkflowConfig:
                     'workflow': self.workflow,
                 }
             except (KeyError, ValueError):
-                raise UserInputError(f'Invalid template [meta]URL: {url}')
+                raise InputError(f'Invalid template [meta]URL: {url}')
             else:
                 LOG.warning(
                     'Detected deprecated template variables in [meta]URL.'
@@ -2302,7 +2302,7 @@ class WorkflowConfig:
                         'task': name,
                     }
                 except (KeyError, ValueError):
-                    raise UserInputError(f'Invalid template [meta]URL: {url}')
+                    raise InputError(f'Invalid template [meta]URL: {url}')
                 else:
                     LOG.warning(
                         'Detected deprecated template variables in'

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -56,11 +56,11 @@ class PluginError(CylcError):
         )
 
 
-class UserInputError(CylcError):
+class InputError(CylcError):
     """Exception covering erroneous user input to a Cylc interface.
 
     Ideally this would be handled in the interface (e.g. argument parser).
-    If this isn't possible raise UserInputError.
+    If this isn't possible raise InputError.
 
     """
 

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -23,7 +23,7 @@ import re
 from typing import Optional, Dict, List, Tuple, Any
 
 from cylc.flow.exceptions import (
-    UserInputError,
+    InputError,
     WorkflowFilesError,
 )
 from cylc.flow.hostuserutil import get_user
@@ -106,16 +106,16 @@ def _parse_cli(*ids: str) -> List[Tokens]:
         # errors:
         >>> _parse_cli('////')
         Traceback (most recent call last):
-        UserInputError: Invalid ID: ////
+        InputError: Invalid ID: ////
 
         >>> parse_back('//cycle')
         Traceback (most recent call last):
-        UserInputError: Relative reference must follow an incomplete one.
+        InputError: Relative reference must follow an incomplete one.
         E.G: workflow //cycle/task
 
         >>> parse_back('workflow//cycle', '//cycle')
         Traceback (most recent call last):
-        UserInputError: Relative reference must follow an incomplete one.
+        InputError: Relative reference must follow an incomplete one.
         E.G: workflow //cycle/task
 
     """
@@ -134,7 +134,7 @@ def _parse_cli(*ids: str) -> List[Tokens]:
                 # (e.g. CLI auto completion)
                 tokens = Tokens(id_[:-1])
             else:
-                raise UserInputError(f'Invalid ID: {id_}')
+                raise InputError(f'Invalid ID: {id_}')
         is_partial = tokens.get('workflow') and not tokens.get('cycle')
         is_relative = not tokens.get('workflow')
 
@@ -172,7 +172,7 @@ def _parse_cli(*ids: str) -> List[Tokens]:
                 partials_expended = False
             elif is_relative:
                 # so a relative reference is an error
-                raise UserInputError(
+                raise InputError(
                     'Relative reference must follow an incomplete one.'
                     '\nE.G: workflow //cycle/task'
                 )
@@ -366,24 +366,24 @@ def _validate_constraint(*tokens_list, constraint=None):
     if constraint == 'workflows':
         for tokens in tokens_list:
             if tokens.is_null or tokens.is_task_like:
-                raise UserInputError('IDs must be workflows')
+                raise InputError('IDs must be workflows')
         return
     if constraint == 'tasks':
         for tokens in tokens_list:
             if tokens.is_null or not tokens.is_task_like:
-                raise UserInputError('IDs must be tasks')
+                raise InputError('IDs must be tasks')
         return
     if constraint == 'mixed':
         for tokens in tokens_list:
             if tokens.is_null:
-                raise UserInputError('IDs cannot be null.')
+                raise InputError('IDs cannot be null.')
         return
 
 
 def _validate_workflow_ids(*tokens_list, src_path):
     for ind, tokens in enumerate(tokens_list):
         if tokens['user'] and (tokens['user'] != get_user()):
-            raise UserInputError(
+            raise InputError(
                 "Operating on other users' workflows is not supported"
             )
         if not src_path:
@@ -394,7 +394,7 @@ def _validate_workflow_ids(*tokens_list, src_path):
         else:
             src_path = Path(get_workflow_run_dir(tokens['workflow']))
         if src_path.is_file():
-            raise UserInputError(
+            raise InputError(
                 f'Workflow ID cannot be a file: {tokens["workflow"]}'
             )
         detect_both_flow_and_suite(src_path)
@@ -420,11 +420,11 @@ def _validate_number(*tokens_list, max_workflows=None, max_tasks=None):
         else:
             workflows_count += 1
     if max_workflows and workflows_count > max_workflows:
-        raise UserInputError(
+        raise InputError(
             f'IDs contain too many workflows (max {max_workflows})'
         )
     if max_tasks and tasks_count > max_tasks:
-        raise UserInputError(
+        raise InputError(
             f'IDs contain too many cycles/tasks/jobs (max {max_tasks})'
         )
 
@@ -474,7 +474,7 @@ async def _expand_workflow_tokens_impl(tokens, match_active=True):
     """Use "cylc scan" to expand workflow patterns."""
     workflow_sel = tokens['workflow_sel']
     if workflow_sel and workflow_sel != 'running':
-        raise UserInputError(
+        raise InputError(
             f'The workflow selector :{workflow_sel} is not'
             'currently supported.'
         )
@@ -498,7 +498,7 @@ def _parse_src_path(id_):
     ):
         src_path = src_path.resolve()
         if not src_path.exists():
-            raise UserInputError(f'Path does not exist: {src_path}')
+            raise InputError(f'Path does not exist: {src_path}')
         if src_path.name in {WorkflowFiles.FLOW_FILE, WorkflowFiles.SUITE_RC}:
             src_path = src_path.parent
         try:

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -163,7 +163,7 @@ from textwrap import indent
 from time import time
 
 from cylc.flow import LOG, iter_entry_points
-from cylc.flow.exceptions import CylcError, UserInputError
+from cylc.flow.exceptions import CylcError, InputError
 
 
 class MainLoopPluginException(Exception):
@@ -326,7 +326,7 @@ def load(config, additional_plugins=None):
         try:
             module_name = entry_points[plugin_name.replace(' ', '_')]
         except KeyError:
-            raise UserInputError(
+            raise InputError(
                 f'No main-loop plugin: "{plugin_name}"\n'
                 + '    Available plugins:\n'
                 + indent('\n'.join(sorted(entry_points)), '        ')

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -24,7 +24,7 @@ from typing import Dict, Iterable, Set, Union, Optional, Any
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import (
-    UserInputError, WorkflowFilesError, handle_rmtree_err
+    InputError, WorkflowFilesError, handle_rmtree_err
 )
 from cylc.flow.platforms import get_localhost_install_target
 
@@ -395,12 +395,12 @@ def parse_rm_dirs(rm_dirs: Iterable[str]) -> Set[str]:
             is_dir = part.endswith(os.sep)
             part = os.path.normpath(part)
             if os.path.isabs(part):
-                raise UserInputError("--rm option cannot take absolute paths")
+                raise InputError("--rm option cannot take absolute paths")
             if (
                 part in {os.curdir, os.pardir} or
                 part.startswith(f"{os.pardir}{os.sep}")  # '../'
             ):
-                raise UserInputError(
+                raise InputError(
                     "--rm option cannot take paths that point to the "
                     "run directory or above"
                 )

--- a/cylc/flow/resources.py
+++ b/cylc/flow/resources.py
@@ -25,7 +25,7 @@ from typing import Optional
 import cylc.flow
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.wallclock import get_current_time_string
 
 
@@ -88,7 +88,7 @@ def get_resources(resource: str, tgt_dir: Optional[str]):
 
     src = RESOURCE_DIR / resource_path
     if not src.exists():
-        raise UserInputError(
+        raise InputError(
             f'No such resources {resource}.'
             '\nRun `cylc get-resources --list` for resource names.'
         )

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -56,7 +56,7 @@ from cylc.flow.exceptions import (
     CyclingError,
     CylcConfigError,
     CylcError,
-    UserInputError,
+    InputError,
 )
 import cylc.flow.flags
 from cylc.flow.host_select import select_workflow_host
@@ -1958,18 +1958,18 @@ class Scheduler:
             value = getattr(self.options, opt, None)
             if self.is_restart:
                 if value is not None:
-                    raise UserInputError(
+                    raise InputError(
                         f"option --{opt} is not valid for restart"
                     )
             elif value == 'reload':
-                raise UserInputError(
+                raise InputError(
                     f"option --{opt}=reload is not valid "
                     "(only --fcp and --stopcp can be 'reload')"
                 )
         if not self.is_restart:
             for opt in ('fcp', 'stopcp'):
                 if getattr(self.options, opt, None) == 'reload':
-                    raise UserInputError(
+                    raise InputError(
                         f"option --{opt}=reload is only valid for restart"
                     )
 

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -91,7 +91,7 @@ from cylc.flow.broadcast_report import (
     get_broadcast_change_report,
 )
 from cylc.flow.cfgspec.workflow import SPEC, upg
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import CylcOptionParser as COP
@@ -161,7 +161,7 @@ def get_rdict(left, right=None):
     left can be key, [key], [key1]key2, [key1][key2], [key1][key2]key3, etc.
     """
     if left == "inherit":
-        raise UserInputError(
+        raise InputError(
             "Inheritance cannot be changed by broadcast")
     rdict = {}
     cur_dict = rdict
@@ -346,7 +346,7 @@ async def run(options: 'Values', workflow_id):
                 query_kwargs['variables']['nIds'] = [options.showtask]
             except ValueError:
                 # TODO validate showtask?
-                raise UserInputError(
+                raise InputError(
                     'TASK_ID_GLOB must be in the format: cycle/task'
                 )
         result = await pclient.async_request('graphql', query_kwargs)
@@ -381,7 +381,7 @@ async def run(options: 'Values', workflow_id):
         settings = []
         for option_item in options.cancel:
             if "=" in option_item:
-                raise UserInputError(
+                raise InputError(
                     "--cancel=[SEC]ITEM does not take a value")
             option_item = option_item.strip()
             setting = get_rdict(option_item)
@@ -400,7 +400,7 @@ async def run(options: 'Values', workflow_id):
         settings = []
         for option_item in options.settings:
             if "=" not in option_item:
-                raise UserInputError(
+                raise InputError(
                     "--set=[SEC]ITEM=VALUE requires a value")
             lhs, rhs = [s.strip() for s in option_item.split("=", 1)]
             setting = get_rdict(lhs, rhs)

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -63,7 +63,7 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import is_remote_platform
 from cylc.flow.id_cli import parse_id
@@ -365,7 +365,7 @@ def main(
     if not tokens or not tokens.get('task'):
         # Cat workflow logs, local only.
         if options.filename is not None:
-            raise UserInputError("The '-f' option is for job logs only.")
+            raise InputError("The '-f' option is for job logs only.")
 
         logpath = get_workflow_run_log_name(workflow_id)
         if options.rotation_num:
@@ -374,7 +374,7 @@ def main(
             try:
                 logpath = logs[int(options.rotation_num)]
             except IndexError:
-                raise UserInputError(
+                raise InputError(
                     "max rotation %d" % (len(logs) - 1))
         tail_tmpl = os.path.expandvars(
             get_platform()["tail command template"]
@@ -389,7 +389,7 @@ def main(
     else:
         # Cat task job logs, may be on workflow or job host.
         if options.rotation_num is not None:
-            raise UserInputError(
+            raise InputError(
                 "only workflow (not job) logs get rotated")
         task = tokens['task']
         point = tokens['cycle']

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -62,7 +62,7 @@ import sys
 from typing import TYPE_CHECKING, Iterable, List, Tuple
 
 from cylc.flow import LOG
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 import cylc.flow.flags
 from cylc.flow.id_cli import parse_ids_async
 from cylc.flow.loggingutil import disable_timestamps
@@ -193,7 +193,7 @@ def main(_, opts: 'Values', *ids: str):
         disable_timestamps(LOG)
 
     if opts.local_only and opts.remote_only:
-        raise UserInputError(
+        raise InputError(
             "--local and --remote options are mutually exclusive"
         )
 

--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -55,7 +55,7 @@ from typing import List, Optional, TYPE_CHECKING
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
@@ -152,7 +152,7 @@ def main(
     if options.print_platform_names or options.print_platforms:
         # Get platform information:
         if ids:
-            raise UserInputError(
+            raise InputError(
                 "Workflow IDs are incompatible with --platform options."
             )
         glbl_cfg().platform_dump(

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -41,7 +41,7 @@ from tempfile import NamedTemporaryFile
 from typing import List, Optional, TYPE_CHECKING, Tuple
 
 from cylc.flow.config import WorkflowConfig
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import CylcOptionParser as COP, icp_option
@@ -373,7 +373,7 @@ def main(
 ) -> None:
     """Implement ``cylc graph``."""
     if opts.grouping and opts.namespaces:
-        raise UserInputError('Cannot combine --group and --namespaces.')
+        raise InputError('Cannot combine --group and --namespaces.')
 
     lines: List[str] = []
     if not (opts.reference or opts.diff):

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -58,7 +58,7 @@ See also 'cylc release'.
 from functools import partial
 from typing import TYPE_CHECKING
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
@@ -118,12 +118,12 @@ def _validate(options: 'Values', *task_globs: str) -> None:
     """Check combination of options and task globs is valid."""
     if options.hold_point_string:
         if task_globs:
-            raise UserInputError(
+            raise InputError(
                 "Cannot combine --after with Cylc/Task IDs.\n"
                 "`cylc hold --after` holds all tasks after the given "
                 "cycle point.")
     elif not task_globs:
-        raise UserInputError(
+        raise InputError(
             "Must define Cycles/Tasks. See `cylc hold --help`.")
 
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -84,10 +84,8 @@ from pathlib import Path
 from typing import Optional, TYPE_CHECKING, Dict, Any
 
 from cylc.flow import iter_entry_points
-from cylc.flow.exceptions import PluginError, UserInputError
-from cylc.flow.option_parsers import (
-    CylcOptionParser as COP,
-)
+from cylc.flow.exceptions import PluginError, InputError
+from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.pathutil import EXPLICIT_RELATIVE_PATH_REGEX, expand_path
 from cylc.flow.workflow_files import (
     install_workflow, search_install_source_dirs, parse_cli_sym_dirs
@@ -176,10 +174,9 @@ def install(
     parser: COP, opts: 'Values', reg: Optional[str] = None
 ) -> None:
     if opts.no_run_name and opts.run_name:
-        raise UserInputError(
+        raise InputError(
             "options --no-run-name and --run-name are mutually exclusive."
         )
-
     source = get_source_location(reg)
     for entry_point in iter_entry_points(
         'cylc.pre_configure'

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -79,7 +79,7 @@ from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.task_message import record_messages
 from cylc.flow.terminal import cli_function
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.unicode_rules import TaskMessageValidator
 
 if TYPE_CHECKING:
@@ -152,7 +152,7 @@ def main(parser: COP, options: 'Values', *args: str) -> None:
         elif ':' in message_str:
             valid, err_msg = TaskMessageValidator.validate(message_str)
             if not valid:
-                raise UserInputError(
+                raise InputError(
                     f'Invalid task message "{message_str}" - {err_msg}')
             messages.append(
                 [item.strip() for item in message_str.split(':', 1)])

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -41,7 +41,7 @@ See also 'cylc hold'.
 from functools import partial
 from typing import TYPE_CHECKING
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import CylcOptionParser as COP
@@ -101,10 +101,10 @@ def _validate(options: 'Values', *tokens_list: str) -> None:
     """Check combination of options and task globs is valid."""
     if options.release_all:
         if tokens_list:
-            raise UserInputError("Cannot combine --all with Cycle/Task IDs")
+            raise InputError("Cannot combine --all with Cycle/Task IDs")
     else:
         if not tokens_list:
-            raise UserInputError(
+            raise InputError(
                 "Must define Cycles/Tasks. See `cylc release --help`."
             )
 

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -58,7 +58,7 @@ from ansimarkup import ansiprint as cprint
 
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.scan import (
     contact_info,
     filter_name,
@@ -539,7 +539,7 @@ async def main(
             for state in opts.states
         )
     ):
-        raise UserInputError(
+        raise InputError(
             '--states must be set to a comma separated list of workflow'
             ' states. \nSee `cylc scan --help` for a list of supported'
             ' states.'

--- a/cylc/flow/scripts/set_verbosity.py
+++ b/cylc/flow/scripts/set_verbosity.py
@@ -29,7 +29,7 @@ from functools import partial
 from optparse import Values
 
 from cylc.flow import LOG_LEVELS
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import CylcOptionParser as COP
@@ -83,7 +83,7 @@ def main(parser: COP, options: 'Values', severity_str: str, *ids) -> None:
     try:
         severity = LOG_LEVELS[severity_str]
     except KeyError:
-        raise UserInputError("Illegal logging level, %s" % severity_str)
+        raise InputError("Illegal logging level, %s" % severity_str)
     call_multi(
         partial(run, options, severity),
         *ids,

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -40,7 +40,7 @@ from typing import Dict
 
 from ansimarkup import ansiprint
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_ids
 from cylc.flow.network.client_factory import get_client
@@ -346,7 +346,7 @@ def main(_, options: 'Values', *ids) -> None:
     tokens_list = workflow_args[workflow_id]
 
     if tokens_list and options.task_defs:
-        raise UserInputError(
+        raise InputError(
             'Cannot query both live tasks and task definitions.'
         )
 

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -70,7 +70,7 @@ from cylc.flow.exceptions import (
     ClientError,
     ClientTimeout,
     CylcError,
-    UserInputError,
+    InputError,
     WorkflowStopped,
 )
 from cylc.flow.network.client_factory import get_client
@@ -187,17 +187,17 @@ def _validate(
 ) -> None:
     """Check option choices are valid."""
     if stop_task is not None and options.kill:
-        raise UserInputError("--kill is not compatible with stop-task")
+        raise InputError("--kill is not compatible with stop-task")
     if stop_cycle is not None and options.kill:
-        raise UserInputError("--kill is not compatible with stop-cycle")
+        raise InputError("--kill is not compatible with stop-cycle")
     if stop_task and stop_cycle:
-        raise UserInputError('stop-task is not compatible with stop-cycle')
+        raise InputError('stop-task is not compatible with stop-cycle')
     if options.kill and options.now:
-        raise UserInputError("--kill is not compatible with --now")
+        raise InputError("--kill is not compatible with --now")
     if options.flow_num and int(options.max_polls) > 0:
-        raise UserInputError("--flow is not compatible with --max-polls")
+        raise InputError("--flow is not compatible with --max-polls")
     if options.flow_num and globs:
-        raise UserInputError("--flow is not compatible with task IDs")
+        raise InputError("--flow is not compatible with task IDs")
 
 
 async def run(

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -46,7 +46,7 @@ Examples:
 from functools import partial
 from typing import TYPE_CHECKING
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import CylcOptionParser as COP
@@ -123,18 +123,18 @@ def _validate(options):
         val = val.strip()
         if val in [FLOW_NONE, FLOW_NEW, FLOW_ALL]:
             if len(options.flow) != 1:
-                raise UserInputError(ERR_OPT_FLOW_INT)
+                raise InputError(ERR_OPT_FLOW_INT)
         else:
             try:
                 int(val)
             except ValueError:
-                raise UserInputError(ERR_OPT_FLOW_VAL.format(val))
+                raise InputError(ERR_OPT_FLOW_VAL.format(val))
 
     if options.flow_descr and options.flow != [FLOW_NEW]:
-        raise UserInputError(ERR_OPT_FLOW_META)
+        raise InputError(ERR_OPT_FLOW_META)
 
     if options.flow_wait and options.flow[0] in [FLOW_NEW, FLOW_NONE]:
-        raise UserInputError(ERR_OPT_FLOW_WAIT)
+        raise InputError(ERR_OPT_FLOW_WAIT)
 
 
 async def run(options: 'Values', workflow_id: str, *tokens_list):

--- a/cylc/flow/scripts/workflow_state.py
+++ b/cylc/flow/scripts/workflow_state.py
@@ -56,7 +56,7 @@ import sys
 from time import sleep
 from typing import TYPE_CHECKING
 
-from cylc.flow.exceptions import CylcError, UserInputError
+from cylc.flow.exceptions import CylcError, InputError
 import cylc.flow.flags
 from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import CylcOptionParser as COP
@@ -193,16 +193,16 @@ def main(parser: COP, options: 'Values', workflow_id: str) -> None:
     )
 
     if options.use_task_point and options.cycle:
-        raise UserInputError(
+        raise InputError(
             "cannot specify a cycle point and use environment variable")
 
     if options.use_task_point:
         if "CYLC_TASK_CYCLE_POINT" not in os.environ:
-            raise UserInputError("CYLC_TASK_CYCLE_POINT is not defined")
+            raise InputError("CYLC_TASK_CYCLE_POINT is not defined")
         options.cycle = os.environ["CYLC_TASK_CYCLE_POINT"]
 
     if options.offset and not options.cycle:
-        raise UserInputError(
+        raise InputError(
             "You must target a cycle point to use an offset")
 
     # Attempt to apply specified offset to the targeted cycle
@@ -211,16 +211,16 @@ def main(parser: COP, options: 'Values', workflow_id: str) -> None:
 
     # Exit if both task state and message are to being polled
     if options.status and options.msg:
-        raise UserInputError("cannot poll both status and custom output")
+        raise InputError("cannot poll both status and custom output")
 
     if options.msg and not options.task and not options.cycle:
-        raise UserInputError("need a taskname and cyclepoint")
+        raise InputError("need a taskname and cyclepoint")
 
     # Exit if an invalid status is requested
     if (options.status and
             options.status not in TASK_STATUSES_ORDERED and
             options.status not in CylcWorkflowDBChecker.STATE_ALIASES):
-        raise UserInputError(f"invalid status '{options.status}'")
+        raise InputError(f"invalid status '{options.status}'")
 
     # this only runs locally
     if options.run_dir:

--- a/cylc/flow/templatevars.py
+++ b/cylc/flow/templatevars.py
@@ -19,7 +19,7 @@ from ast import literal_eval
 from optparse import Values
 from typing import Any, Dict
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 
 
 def eval_var(var):
@@ -32,23 +32,23 @@ def eval_var(var):
         'string'
         >>> eval_var('string')
         Traceback (most recent call last):
-        cylc.flow.exceptions.UserInputError: Invalid template variable: string
+        cylc.flow.exceptions.InputError: Invalid template variable: string
         (note string values must be quoted)
         >>> eval_var('[')
         Traceback (most recent call last):
-        cylc.flow.exceptions.UserInputError: Invalid template variable: [
+        cylc.flow.exceptions.InputError: Invalid template variable: [
         (values must be valid Python literals)
 
     """
     try:
         return literal_eval(var)
     except ValueError:
-        raise UserInputError(
+        raise InputError(
             f'Invalid template variable: {var}'
             '\n(note string values must be quoted)'
         ) from None
     except SyntaxError:
-        raise UserInputError(
+        raise InputError(
             f'Invalid template variable: {var}'
             '\n(values must be valid Python literals)'
         ) from None

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -46,7 +46,7 @@ from cylc.flow.exceptions import (
     PlatformError,
     PlatformLookupError,
     ServiceFileError,
-    UserInputError,
+    InputError,
     WorkflowFilesError,
     handle_rmtree_err,
 )
@@ -1249,7 +1249,7 @@ def infer_latest_run(
 
     Raises:
         - WorkflowFilesError if the runN symlink is not valid.
-        - UserInputError if the path does not exist.
+        - InputError if the path does not exist.
     """
     cylc_run_dir = get_cylc_run_dir()
     try:
@@ -1257,7 +1257,7 @@ def infer_latest_run(
     except ValueError:
         raise ValueError(f"{path} is not in the cylc-run directory")
     if not path.exists():
-        raise UserInputError(f'Path does not exist: {path}')
+        raise InputError(f'Path does not exist: {path}')
     if path.name == WorkflowFiles.RUN_N:
         LOG.warning(
             f"Explicit use of {WorkflowFiles.RUN_N} in the Workflow ID is not"
@@ -1823,14 +1823,14 @@ def parse_cli_sym_dirs(symlink_dirs: str) -> Dict[str, Dict[str, Any]]:
             key, val = pair.split("=")
             key = key.strip()
         except ValueError:
-            raise UserInputError(
+            raise InputError(
                 'There is an error in --symlink-dirs option:'
                 f' {pair}. Try entering option in the form '
                 '--symlink-dirs=\'log=$DIR, share=$DIR2, ...\''
             )
         if key not in possible_symlink_dirs:
             dirs = ', '.join(possible_symlink_dirs)
-            raise UserInputError(
+            raise InputError(
                 f"{key} not a valid entry for --symlink-dirs. "
                 f"Configurable symlink dirs are: {dirs}"
             )

--- a/tests/functional/cli/03-set-verbosity.t
+++ b/tests/functional/cli/03-set-verbosity.t
@@ -19,5 +19,5 @@
 . "$(dirname "$0")/test_header"
 set_test_number 2
 run_fail "${TEST_NAME_BASE}" cylc set-verbosity duck quack
-grep_ok 'UserInputError: Illegal logging level, duck' "${TEST_NAME_BASE}.stderr"
+grep_ok 'InputError: Illegal logging level, duck' "${TEST_NAME_BASE}.stderr"
 exit

--- a/tests/functional/cylc-cat-log/00-local.t
+++ b/tests/functional/cylc-cat-log/00-local.t
@@ -33,7 +33,7 @@ contains_ok "${TEST_NAME}.stdout" "${WORKFLOW_RUN_DIR}/log/workflow/log"
 TEST_NAME=${TEST_NAME_BASE}-workflow-log-fail
 run_fail "${TEST_NAME}" cylc cat-log -f e "${WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stderr" - << __END__
-UserInputError: The '-f' option is for job logs only.
+InputError: The '-f' option is for job logs only.
 __END__
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-task-out

--- a/tests/functional/cylc-cat-log/03-bad-workflow.t
+++ b/tests/functional/cylc-cat-log/03-bad-workflow.t
@@ -24,7 +24,7 @@ BAD_NAME="NONEXISTENTWORKFLOWNAME"
 
 run_fail "${TEST_NAME_BASE}-workflow" cylc cat-log -f l "${BAD_NAME}"
 cmp_ok "${TEST_NAME_BASE}-workflow.stderr" <<__ERR__
-UserInputError: Path does not exist: ${CYLC_RUN_DIR}/${BAD_NAME}
+InputError: Path does not exist: ${CYLC_RUN_DIR}/${BAD_NAME}
 __ERR__
 
 mkdir "${CYLC_RUN_DIR}/${BAD_NAME}"

--- a/tests/functional/cylc-graph-diff/00-simple.t
+++ b/tests/functional/cylc-graph-diff/00-simple.t
@@ -42,7 +42,7 @@ run_fail "${TEST_NAME}" \
     cylc graph "${DIFF_WORKFLOW_NAME}" --diff "${CONTROL_WORKFLOW_NAME}.bad"
 cmp_ok "${TEST_NAME}.stdout" </'dev/null'
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-UserInputError: Path does not exist: ${RUN_DIR}/${CONTROL_WORKFLOW_NAME}.bad
+InputError: Path does not exist: ${RUN_DIR}/${CONTROL_WORKFLOW_NAME}.bad
 __ERR__
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-deps-fail"

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -119,7 +119,7 @@ TEST_NAME="${TEST_NAME_BASE}--no-run-name-and--run-name-forbidden"
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
 run_fail "${TEST_NAME}" cylc install --run-name="${RND_WORKFLOW_NAME}" --no-run-name
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-UserInputError: options --no-run-name and --run-name are mutually exclusive.
+InputError: options --no-run-name and --run-name are mutually exclusive.
 __ERR__
 popd || exit 1
 

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -28,7 +28,7 @@ run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-n
 rm -rf "${RND_WORKFLOW_RUNDIR}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-UserInputError: Path does not exist: ${RND_WORKFLOW_RUNDIR}
+InputError: Path does not exist: ${RND_WORKFLOW_RUNDIR}
 __ERR__
 purge_rnd_workflow
 

--- a/tests/unit/scripts/test_config.py
+++ b/tests/unit/scripts/test_config.py
@@ -18,7 +18,7 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Optional, List
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 
 import pytest
 from pytest import param

--- a/tests/unit/scripts/test_hold.py
+++ b/tests/unit/scripts/test_hold.py
@@ -20,7 +20,7 @@ from optparse import Values
 import pytest
 from typing import Iterable, Optional, Tuple, Type
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.option_parsers import Options
 from cylc.flow.scripts.hold import get_option_parser, _validate
 
@@ -36,12 +36,12 @@ Opts = Options(get_option_parser())
         (
             Opts(hold_point_string='2'),
             ['*'],
-            (UserInputError, "Cannot combine --after with Cylc/Task ID")
+            (InputError, "Cannot combine --after with Cylc/Task ID")
         ),
         (
             Opts(),
             [],
-            (UserInputError, "Must define Cycles/Tasks")
+            (InputError, "Must define Cycles/Tasks")
         ),
     ]
 )

--- a/tests/unit/scripts/test_release.py
+++ b/tests/unit/scripts/test_release.py
@@ -20,7 +20,7 @@ from optparse import Values
 import pytest
 from typing import Iterable, Optional, Tuple, Type
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.option_parsers import Options
 from cylc.flow.scripts.release import get_option_parser, _validate
 
@@ -36,12 +36,12 @@ Opts = Options(get_option_parser())
         (
             Opts(release_all=True),
             ['*'],
-            (UserInputError, "Cannot combine --all with Cycle/Task IDs")
+            (InputError, "Cannot combine --all with Cycle/Task IDs")
         ),
         (
             Opts(),
             [],
-            (UserInputError, "Must define Cycles/Tasks")
+            (InputError, "Must define Cycles/Tasks")
         ),
     ]
 )

--- a/tests/unit/scripts/test_stop.py
+++ b/tests/unit/scripts/test_stop.py
@@ -20,7 +20,7 @@ from optparse import Values
 import pytest
 from typing import Iterable, Optional, Tuple, Type
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.option_parsers import Options
 from cylc.flow.scripts.stop import get_option_parser, _validate
 
@@ -43,35 +43,35 @@ Opts = Options(get_option_parser())
             None,
             '10',
             None,
-            (UserInputError, "--kill is not compatible with stop-cycle")
+            (InputError, "--kill is not compatible with stop-cycle")
         ),
         (
             Opts(),
             '10/foo',
             '10',
             None,
-            (UserInputError, "stop-task is not compatible with stop-cycle")
+            (InputError, "stop-task is not compatible with stop-cycle")
         ),
         (
             Opts(kill=True, now=True),
             None,
             None,
             None,
-            (UserInputError, "--kill is not compatible with --now")
+            (InputError, "--kill is not compatible with --now")
         ),
         (
             Opts(flow_num=2, max_polls=2),
             None,
             None,
             None,
-            (UserInputError, "--flow is not compatible with --max-polls")
+            (InputError, "--flow is not compatible with --max-polls")
         ),
         (
             Opts(flow_num=2),
             None,
             None,
             '*',
-            (UserInputError, "--flow is not compatible with task IDs")
+            (InputError, "--flow is not compatible with task IDs")
         ),
     ]
 )

--- a/tests/unit/scripts/test_trigger.py
+++ b/tests/unit/scripts/test_trigger.py
@@ -20,7 +20,7 @@ from optparse import Values
 import pytest
 from typing import Iterable, Optional, Tuple, Type
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.option_parsers import Options
 from cylc.flow.flow_mgr import FLOW_ALL, FLOW_NEW, FLOW_NONE
 from cylc.flow.scripts.trigger import get_option_parser, _validate
@@ -53,7 +53,7 @@ Opts = Options(get_option_parser())
                 flow_wait=False
             ),
             (
-                UserInputError,
+                InputError,
                 "Multiple flow options must all be integer valued"
             )
         ),
@@ -64,7 +64,7 @@ Opts = Options(get_option_parser())
                 flow_descr="the quick brown fox"
             ),
             (
-                UserInputError,
+                InputError,
                 "Metadata is only for new flows"
             )
         ),
@@ -74,7 +74,7 @@ Opts = Options(get_option_parser())
                 flow_wait=False
             ),
             (
-                UserInputError,
+                InputError,
                 "Flow values must be integer, 'all', 'new', or 'none'"
             )
         ),
@@ -84,7 +84,7 @@ Opts = Options(get_option_parser())
                 flow_wait=True
             ),
             (
-                UserInputError,
+                InputError,
                 "--wait is not compatible with --flow=new or --flow=none"
             )
         ),
@@ -94,7 +94,7 @@ Opts = Options(get_option_parser())
                 flow_wait=False
             ),
             (
-                UserInputError,
+                InputError,
                 "Multiple flow options must all be integer valued"
             )
         ),
@@ -104,7 +104,7 @@ Opts = Options(get_option_parser())
                 flow_wait=False
             ),
             (
-                UserInputError,
+                InputError,
                 "Multiple flow options must all be integer valued"
             )
         ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,7 +29,7 @@ from cylc.flow.cycling import loader
 from cylc.flow.cycling.loader import INTEGER_CYCLING_TYPE, ISO8601_CYCLING_TYPE
 from cylc.flow.exceptions import (
     PointParsingError,
-    UserInputError,
+    InputError,
     WorkflowConfigError,
     XtriggerConfigError,
 )
@@ -426,7 +426,7 @@ def test_process_icp(
             ['20090802T0615+0530/foo'],
             None,
             (
-                UserInputError,
+                InputError,
                 "--start-cycle-point and --start-task are mutually exclusive"
             ),
         )
@@ -1208,7 +1208,7 @@ def test_process_urls(caplog, log_filter, workflow_meta, url_type):
     if url_type == 'good':
         WorkflowConfig.process_metadata_urls(config)
     elif url_type in {'bad', 'broken'}:
-        with pytest.raises(UserInputError):
+        with pytest.raises(InputError):
             WorkflowConfig.process_metadata_urls(config)
     elif url_type == 'ugly':
         WorkflowConfig.process_metadata_urls(config)

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -20,7 +20,7 @@ import pytest
 from unittest.mock import patch
 
 from cylc.flow.async_util import pipe
-from cylc.flow.exceptions import UserInputError, WorkflowFilesError
+from cylc.flow.exceptions import InputError, WorkflowFilesError
 from cylc.flow.id import detokenise, tokenise, Tokens
 from cylc.flow.id_cli import (
     _expand_workflow_tokens,
@@ -196,12 +196,12 @@ async def test_parse_ids_max_workflows(ids_in, errors, mock_exists):
     try:
         await parse_ids_async(
             *ids_in, constraint='workflows', max_workflows=2)
-    except UserInputError:
+    except InputError:
         if not errors:
             raise
     else:
         if errors:
-            raise Exception('Should have raised UserInputError')
+            raise Exception('Should have raised InputError')
 
 
 @pytest.mark.parametrize(
@@ -216,12 +216,12 @@ async def test_parse_ids_max_tasks(ids_in, errors, mock_exists):
     """It should validate input against the max_tasks constraint."""
     try:
         await parse_ids_async(*ids_in, constraint='tasks', max_tasks=2)
-    except UserInputError:
+    except InputError:
         if not errors:
             raise
     else:
         if errors:
-            raise Exception('Should have raised UserInputError')
+            raise Exception('Should have raised InputError')
 
 
 async def test_parse_ids_infer_run_name(tmp_run_dir):
@@ -325,7 +325,7 @@ def test_parse_src_path(src_dir, monkeypatch):
     assert src_file_path == src_dir / 'flow.cylc'
 
     # broken absolute path
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         workflow_id, src_path, src_file_path = _parse_src_path(
             str(src_dir.resolve()) + 'xyz'
         )
@@ -337,7 +337,7 @@ def test_parse_src_path(src_dir, monkeypatch):
     assert src_file_path == src_dir / 'flow.cylc'
 
     # broken relative path
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _parse_src_path('./xxx')
 
     # relative '.' (invalid)
@@ -432,11 +432,11 @@ async def test_parse_ids_constraint(mock_exists):
     """It should validate input against the constraint."""
     # constraint: workflows
     await parse_ids_async('a//', constraint='workflows')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         await parse_ids_async('a//b', constraint='workflows')
     # constraint: tasks
     await parse_ids_async('a//b', constraint='tasks')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         await parse_ids_async('a//', constraint='tasks')
     # constraint: mixed
     await parse_ids_async('a//', constraint='mixed')
@@ -472,29 +472,29 @@ def test_validate_constraint():
     """It should validate tokens against the constraint."""
     # constraint=workflows
     _validate_constraint(Tokens(workflow='a'), constraint='workflows')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_constraint(Tokens(cycle='a'), constraint='workflows')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_constraint(Tokens(), constraint='workflows')
     # constraint=tasks
     _validate_constraint(Tokens(cycle='a'), constraint='tasks')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_constraint(Tokens(workflow='a'), constraint='tasks')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_constraint(Tokens(), constraint='tasks')
     # constraint=mixed
     _validate_constraint(Tokens(workflow='a'), constraint='mixed')
     _validate_constraint(Tokens(cycle='a'), constraint='mixed')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_constraint(Tokens(), constraint='mixed')
 
 
 def test_validate_workflow_ids(tmp_run_dir):
     _validate_workflow_ids(Tokens('workflow'), src_path='')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_workflow_ids(Tokens('~alice/workflow'), src_path='')
     run_dir = tmp_run_dir('b')
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_workflow_ids(
             Tokens('workflow'),
             src_path=run_dir / 'flow.cylc',
@@ -503,12 +503,12 @@ def test_validate_workflow_ids(tmp_run_dir):
 
 def test_validate_number():
     _validate_number(Tokens('a'), max_workflows=1)
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_number(Tokens('a'), Tokens('b'), max_workflows=1)
     t1 = Tokens(cycle='1')
     t2 = Tokens(cycle='2')
     _validate_number(t1, max_tasks=1)
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         _validate_number(t1, t2, max_tasks=1)
 
 
@@ -529,5 +529,5 @@ async def test_expand_workflow_tokens_impl_selector(no_scan):
     tokens = tokenise('~user/*')
     await _expand_workflow_tokens([tokens])
     tokens['workflow_sel'] = 'stopped'
-    with pytest.raises(UserInputError):
+    with pytest.raises(InputError):
         await _expand_workflow_tokens([tokens])

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -23,7 +23,7 @@ from pytest import param
 from typing import Callable, Dict, Iterable, List, Set
 from unittest.mock import Mock, patch, call
 
-from cylc.flow.exceptions import UserInputError, WorkflowFilesError
+from cylc.flow.exceptions import InputError, WorkflowFilesError
 from cylc.flow.pathutil import (
     EXPLICIT_RELATIVE_PATH_REGEX,
     expand_path,
@@ -513,7 +513,7 @@ def test_parse_rm_dirs(dirs: List[str], expected: Set[str]):
 )
 def test_parse_rm_dirs__bad(dirs: List[str], err_msg: str):
     """Test parse_dirs() with bad inputs"""
-    with pytest.raises(UserInputError) as exc:
+    with pytest.raises(InputError) as exc:
         parse_rm_dirs(dirs)
     assert err_msg in str(exc.value)
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 from typing import Any, List
 from unittest.mock import create_autospec, Mock, patch
 
-from cylc.flow.exceptions import UserInputError
+from cylc.flow.exceptions import InputError
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.scheduler_cli import RunOptions
 
@@ -144,6 +144,6 @@ def test_check_startup_opts(
     for opt in opts_to_test:
         mocked_scheduler = Mock(is_restart=is_restart)
         mocked_scheduler.options = SimpleNamespace(**{opt: 'reload'})
-        with pytest.raises(UserInputError) as excinfo:
+        with pytest.raises(InputError) as excinfo:
             Scheduler._check_startup_opts(mocked_scheduler)
         assert(err_msg.format(opt) in str(excinfo))

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -30,7 +30,7 @@ from cylc.flow.exceptions import (
     CylcError,
     PlatformError,
     ServiceFileError,
-    UserInputError,
+    InputError,
     WorkflowFilesError,
 )
 from cylc.flow.pathutil import parse_rm_dirs
@@ -323,7 +323,7 @@ def test_infer_latest_run_warns_for_runN(caplog, tmp_run_dir):
         ('not symlink', WorkflowFilesError),
         ('broken symlink', WorkflowFilesError),
         ('invalid target', WorkflowFilesError),
-        ('not exist', UserInputError)
+        ('not exist', InputError)
     ]
 )
 def test_infer_latest_run__bad(
@@ -1193,7 +1193,7 @@ def test_init_clean__targeted_bad(
     tmp_run_dir('chalmers')
     mock_clean = monkeymock('cylc.flow.workflow_files.clean')
     mock_remote_clean = monkeymock('cylc.flow.workflow_files.remote_clean')
-    with pytest.raises(UserInputError) as exc_info:
+    with pytest.raises(InputError) as exc_info:
         init_clean('chalmers', opts=CleanOptions(rm_dirs=rm_dirs))
     assert "cannot take paths that point to the run directory or above" in str(
         exc_info.value
@@ -1738,7 +1738,7 @@ def test_parse_cli_sym_dirs(
     """Test parse_cli_sym_dirs returns dict or correctly raises errors on cli
     symlink dir options"""
     if err_msg is not None:
-        with pytest.raises(UserInputError) as exc:
+        with pytest.raises(InputError) as exc:
             parse_cli_sym_dirs(symlink_dirs)
             assert(err_msg) in str(exc)
 


### PR DESCRIPTION
This is a small change with no associated Issue.

As I noted on Element chat (but got no response) `UserInputError`:
- sounds a bit insulting to the user
- the "User Input" bit is obvious (and therefore unnecessary) when it comes in response to a console command 
  - (Just `Error` would do, but the exception class name always gets printed...)

Just a quick search-and-replace one-liner:
```console
$ find cylc tests -type f | xargs perl -pi -e 's/UserInputError/InputError/g'
```

One 2-minute review will do if no one objects to the change. 

[UPDATE] Went with `InputError` rather than `CommandLineError` as originally suggested.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
