### PR TITLE
Scan: make nested workflows visible.

### DIFF
--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -80,8 +80,7 @@ from cylc.flow.workflow_files import (
 SERVICE = Path(WorkflowFiles.Service.DIRNAME)
 CONTACT = Path(WorkflowFiles.Service.CONTACT)
 
-FLOW_FILES = {
-    # marker files/dirs which we use to determine if something is a flow
+WORKFLOW_DIR_INDICATORS = {
     WorkflowFiles.Service.DIRNAME,
     WorkflowFiles.FLOW_FILE,  # cylc8 flow definition file name
     WorkflowFiles.LOG_DIR
@@ -89,7 +88,7 @@ FLOW_FILES = {
 
 EXCLUDE_FILES = {
     WorkflowFiles.RUN_N,
-    WorkflowFiles.Install.SOURCE
+    WorkflowFiles.Install.DIRNAME
 }
 
 
@@ -129,7 +128,7 @@ def dir_is_flow(listing: Iterable[Path]) -> Optional[bool]:
         # so could be either a Cylc 7 or a Cylc 8 workflow
         return True
 
-    if FLOW_FILES & names:
+    if WORKFLOW_DIR_INDICATORS & names:
         # a pure Cylc 8 workflow
         return True
 
@@ -240,6 +239,14 @@ async def scan(
                     'name': str(path.relative_to(run_dir)),
                     'path': path,
                 }
+                # descend into nested workflows
+                _scan_subdirs(
+                    [
+                        c for c in contents if
+                        c.name.startswith(WorkflowFiles.SUB_WF_PREFIX)
+                    ],
+                    depth=0
+                )
             elif is_flow is False and depth < max_depth:
                 # we may have a nested flow, lets see...
                 _scan_subdirs(contents, depth)

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -201,6 +201,9 @@ class WorkflowFiles:
     RUN_DIR = 'run'
     """Workflow run directory."""
 
+    SUB_WF_PREFIX = 'sub-'
+    """Directory name prefix for nested sub-workflows."""
+
     class Service:
         """The directory containing Cylc system files."""
 


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue. Supersedes #4477 

Allow `cylc scan` to descend into nested workflow directories with names that start with `sub-`.

**Question:** ~~is the `sub-` prefix the best way to prevent a `scan` apocalypse (i.e. to avoid scanning the entire cylc-run tree)?  Another option is a `subworkflows/` sub-directory for all nested workflows,  but that adds an extra level in the hierarchy that the UIs have to deal with.~~

[UPDATE] I'm removing the question label unilaterally so I can finish this off by adding tests. IMO the `sub-` prefix satisfies the following requirements:
- is reasonably descriptive, without being long, which would adversely affect the gscan UI
- and does not add an extra useless level in the hierarchy that the UI has to deal with

(Easily tweaked if others have a better idea, but in lieu of that I'm forging ahead).


NOTE *This PR makes nested subworkflows possible, but it doesn't do anything to specifically encourage or support them*.

```console
~/cylc-src $ tree hydro/   
hydro/
├── flow.cylc
└── sub-wf
    └── flow.cylc
```


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
