### PR TITLE
Remove `--directory` option for `cylc install`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,13 @@ ones in. -->
 
 Third Release Candidate for Cylc 8 suitable for acceptance testing.
 
+### Enhancements
+
+[#4823](https://github.com/cylc/cylc-flow/pull/4823) - Remove the `--directory`
+option for `cylc install` (the functionality has been merged into the
+workflow source argument), and rename the `--flow-name` option to
+`--workflow-name`.
+
 ### Fixes
 
 [#4554](https://github.com/cylc/cylc-flow/pull/4554) - Fix incorrect

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/.validate
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/.validate
@@ -18,7 +18,7 @@
 set -eux
 APIKEY="$(head --lines 1 ../api-keys)"
 FLOW_NAME="$(< /dev/urandom tr -dc A-Za-z | head -c6)"
-cylc install --flow-name "$FLOW_NAME" --no-run-name
+cylc install --workflow-name "$FLOW_NAME" --no-run-name
 sed -i "s/DATAPOINT_API_KEY/$APIKEY/" "$HOME/cylc-run/$FLOW_NAME/flow.cylc"
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"
 cylc play --no-detach --abort-if-any-task-fails "$FLOW_NAME"

--- a/cylc/flow/etc/tutorial/runtime-introduction/.validate
+++ b/cylc/flow/etc/tutorial/runtime-introduction/.validate
@@ -17,7 +17,7 @@
 
 set -eux
 FLOW_NAME="$(< /dev/urandom tr -dc A-Za-z | head -c6)"
-cylc install --flow-name "$FLOW_NAME" --no-run-name
+cylc install --workflow-name "$FLOW_NAME" --no-run-name
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"
 cylc play --no-detach --abort-if-any-task-fails "$FLOW_NAME"
 cylc clean "$FLOW_NAME"

--- a/cylc/flow/install_plugins/log_vc_info.py
+++ b/cylc/flow/install_plugins/log_vc_info.py
@@ -190,7 +190,7 @@ def get_vc_info(path: Union[Path, str]) -> Optional[Dict[str, Any]]:
 
 
 def _run_cmd(vcs: str, args: Iterable[str], cwd: Union[Path, str]) -> str:
-    """Run a command, return stdout.
+    """Run a VCS command, return stdout.
 
     Args:
         vcs: The version control system.
@@ -198,7 +198,9 @@ def _run_cmd(vcs: str, args: Iterable[str], cwd: Union[Path, str]) -> str:
         cwd: Directory to run the command in.
 
     Raises:
-        OSError: with stderr if non-zero return code.
+        VCSNotInstalledError: The VCS is not found.
+        VCSMissingBaseError: There is no base commit in the repo.
+        OSError: Non-zero return code for VCS command.
     """
     cmd = [vcs, *args]
     try:
@@ -218,8 +220,7 @@ def _run_cmd(vcs: str, args: Iterable[str], cwd: Union[Path, str]) -> str:
     ret_code = proc.wait()
     out, err = proc.communicate()
     if ret_code:
-        if any(err.lower().startswith(msg)
-               for msg in NO_BASE_ERRS[vcs]):
+        if any(err.lower().startswith(msg) for msg in NO_BASE_ERRS[vcs]):
             # No base commit in repo
             raise VCSMissingBaseError(vcs, cwd)
         raise OSError(ret_code, err)

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -28,9 +28,19 @@ from cylc.flow.exceptions import (
 )
 from cylc.flow.platforms import get_localhost_install_target
 
+
 # Note: do not import this elsewhere, as it might bypass unit test
 # monkeypatching:
 _CYLC_RUN_DIR = os.path.join('$HOME', 'cylc-run')
+
+EXPLICIT_RELATIVE_PATH_REGEX = re.compile(
+    rf'''
+    ^({re.escape(os.curdir)}|{re.escape(os.pardir)})
+    ({re.escape(os.sep)}|$)
+    ''',
+    re.VERBOSE
+)
+"""Matches relative paths that are explicit (starts with ./)"""
 
 
 def expand_path(*args: Union[Path, str]) -> str:

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -91,7 +91,7 @@ Workflow IDs:
     Every Installed Cylc workflow has an ID.
 
     For example if we install a workflow like so:
-      $ cylc install --flow-name=foo
+      $ cylc install --workflow-name=foo
 
     We will end up with a workflow with the ID "foo/run1".
 
@@ -107,7 +107,7 @@ Workflow IDs:
       $ cylc stop foo
 
     Workflows can be installed hierarchically:
-      $ cylc install --flow-name=foo/bar/baz
+      $ cylc install --workflow-name=foo/bar/baz
 
       # play the workflow with the ID "foo/bar/baz"
       $ cylc play foo/bar/baz

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -54,7 +54,7 @@ Examples:
 
   # Install $PWD/flow.cylc as "fido", regardless of what $PWD is, with
   # run directory ~/cylc-run/fido/run1
-  $ cylc install --flow-name=fido
+  $ cylc install --workflow-name=fido
 
   # Install $PWD/bunny/rabbit/flow.cylc as "rabbit", with run directory
   # ~/cylc-run/rabbit/run1
@@ -90,8 +90,8 @@ def get_option_parser():
     )
 
     parser.add_option(
-        "--flow-name",
-        help="Install into ~/cylc-run/<workflow_name>/runN ",
+        "--workflow-name", "-n",
+        help="Install into ~/cylc-run/<WORKFLOW_NAME>/runN ",
         action="store",
         metavar="WORKFLOW_NAME",
         default=None,
@@ -108,10 +108,12 @@ def get_option_parser():
     parser.add_option(
         "--symlink-dirs",
         help=(
-            "Enter a list, in the form 'log=path/to/store, share = $...'"
-            ". Use this option to override local symlinks for directories run,"
-            " log, work, share, share/cycle, as configured in global.cylc. "
-            "Enter an empty list \"\" to skip making localhost symlink dirs."
+            "Enter a comma-delimited list, in the form "
+            "'log=path/to/store, share = $HOME/some/path, ...'. "
+            "Use this option to override the global.cylc configuration for "
+            "local symlinks for the run, log, work, share and "
+            "share/cycle directories. "
+            "Enter an empty list '' to skip making localhost symlink dirs."
         ),
         action="store",
         dest="symlink_dirs"
@@ -119,7 +121,9 @@ def get_option_parser():
 
     parser.add_option(
         "--run-name",
-        help="Name the run.",
+        help=(
+            "Give the run a custom name instead of automatically numbering it."
+        ),
         action="store",
         metavar="RUN_NAME",
         default=None,
@@ -127,7 +131,10 @@ def get_option_parser():
 
     parser.add_option(
         "--no-run-name",
-        help="Install the workflow directly into ~/cylc-run/<workflow_name>",
+        help=(
+            "Install the workflow directly into ~/cylc-run/<workflow_name>, "
+            "without an automatic run number or custom run name."
+        ),
         action="store_true",
         default=False,
         dest="no_run_name")

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -22,18 +22,25 @@ Install a new workflow.
 
 The workflow can then be started, stopped, and targeted by name.
 
-Normal installation creates a directory "~/cylc-run/WORKFLOW_NAME/", with a run
-directory "~/cylc-run/WORKFLOW_NAME/run1". A "_cylc-install/source" symlink to
-the source directory will be created in the WORKFLOW_NAME directory.
+Normal installation creates a directory "~/cylc-run/<workflow>/", with a run
+directory "~/cylc-run/<workflow>/run1". A "_cylc-install/source" symlink to
+the source directory will be created in the workflow directory.
 Any files or directories (excluding .git, .svn) from the source directory are
 copied to the new run directory.
 A ".service" directory will also be created and used for server authentication
 files at run time.
 
-If the argument WORKFLOW_NAME is used, Cylc will search for the workflow in the
-list of directories given by "global.cylc[install]source dirs", and install the
-first match. Otherwise, the workflow in the current working directory, or the
-one specified by the "--directory" option, will be installed.
+The SOURCE argument accepts three types of path:
+* implicit relative path (e.g. "foo/bar") - Cylc will search for the
+  workflow source in the list of directories given by
+  "global.cylc[install]source dirs", and install the first match.
+* explicit relative path (e.g. "./foo/bar") - Cylc will install the workflow
+  from the source that is relative to the current working directory.
+* absolute path (e.g. "~/foo/bar") - Cylc will install the workflow from the
+  source given by the path.
+
+If the SOURCE argument is not supplied, Cylc will install the workflow from
+the source in the current working directory.
 
 Workflow names can be hierarchical, corresponding to the path under ~/cylc-run.
 
@@ -44,24 +51,28 @@ Examples:
   # this will increment)
   $ cylc install dogs/fido
 
-  # Install $PWD/flow.cylc as "rabbit", if $PWD is ~/bunny/rabbit, with
+  # Install $PWD as "rabbit", if $PWD is ~/bunny/rabbit, with
   # run directory ~/cylc-run/rabbit/run1
   $ cylc install
 
-  # Install $PWD/flow.cylc as "rabbit", if $PWD is ~/bunny/rabbit, with
+  # Install $PWD as "rabbit", if $PWD is ~/bunny/rabbit, with
   # run directory ~/cylc-run/rabbit (note: no "run1" sub-directory)
   $ cylc install --no-run-name
 
-  # Install $PWD/flow.cylc as "fido", regardless of what $PWD is, with
+  # Install $PWD as "fido", regardless of what $PWD is called, with
   # run directory ~/cylc-run/fido/run1
   $ cylc install --workflow-name=fido
 
-  # Install $PWD/bunny/rabbit/flow.cylc as "rabbit", with run directory
+  # Install $PWD/bunny/rabbit/ as "rabbit", with run directory
   # ~/cylc-run/rabbit/run1
-  $ cylc install --directory=bunny/rabbit
+  $ cylc install ./bunny/rabbit
 
-  # Install $PWD/flow.cylc as "cats", if $PWD is ~/cats, overriding the
-  # run1, run2, run3 etc. structure with run directory ~/cylc-run/cats/paws
+  # Install /home/somewhere/badger as "badger", with run directory
+  # ~/cylc-run/badger/run1
+  $ cylc install /home/somewhere/badger
+
+  # Install $PWD as "cats", if $PWD is ~/cats, with run directory
+  # ~/cylc-run/cats/paws
   $ cylc install --run-name=paws
 
 The same workflow can be installed with multiple names; this results in
@@ -69,11 +80,15 @@ multiple workflow run directories that link to the same workflow definition.
 
 """
 
+from pathlib import Path
 from typing import Optional, TYPE_CHECKING, Dict, Any
 
 from cylc.flow import iter_entry_points
 from cylc.flow.exceptions import PluginError, UserInputError
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import (
+    CylcOptionParser as COP,
+)
+from cylc.flow.pathutil import EXPLICIT_RELATIVE_PATH_REGEX, expand_path
 from cylc.flow.workflow_files import (
     install_workflow, search_install_source_dirs, parse_cli_sym_dirs
 )
@@ -86,7 +101,7 @@ if TYPE_CHECKING:
 def get_option_parser():
     parser = COP(
         __doc__, comms=True, prep=True,
-        argdoc=[('[WORKFLOW_NAME]', 'Workflow source name')]
+        argdoc=[('[SOURCE]', 'Path to workflow source')]
     )
 
     parser.add_option(
@@ -96,14 +111,6 @@ def get_option_parser():
         metavar="WORKFLOW_NAME",
         default=None,
         dest="workflow_name")
-
-    parser.add_option(
-        "--directory", "-C",
-        help="Install the workflow found in path specfied.",
-        action="store",
-        metavar="PATH/TO/FLOW",
-        default=None,
-        dest="source")
 
     parser.add_option(
         "--symlink-dirs",
@@ -144,6 +151,22 @@ def get_option_parser():
     return parser
 
 
+def get_source_location(path: Optional[str]) -> Path:
+    """Return the workflow source location as an absolute path.
+
+    Note: does not check that the source actually exists.
+    """
+    if path is None:
+        return Path.cwd()
+    path = path.strip()
+    expanded_path = Path(expand_path(path))
+    if expanded_path.is_absolute():
+        return expanded_path
+    if EXPLICIT_RELATIVE_PATH_REGEX.match(path):
+        return Path.cwd() / expanded_path
+    return search_install_source_dirs(expanded_path)
+
+
 @cli_function(get_option_parser)
 def main(parser, opts, reg=None):
     install(parser, opts, reg)
@@ -157,25 +180,12 @@ def install(
             "options --no-run-name and --run-name are mutually exclusive."
         )
 
-    if reg is None:
-        source = opts.source
-    else:
-        if opts.source:
-            raise UserInputError(
-                "WORKFLOW_NAME and --directory are mutually exclusive."
-            )
-        source = search_install_source_dirs(reg)
-    workflow_name = opts.workflow_name or reg
-
+    source = get_source_location(reg)
     for entry_point in iter_entry_points(
         'cylc.pre_configure'
     ):
         try:
-            if source:
-                entry_point.resolve()(srcdir=source, opts=opts)
-            else:
-                from pathlib import Path
-                entry_point.resolve()(srcdir=Path().cwd(), opts=opts)
+            entry_point.resolve()(srcdir=source, opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors
@@ -192,8 +202,8 @@ def install(
         cli_symdirs = parse_cli_sym_dirs(opts.symlink_dirs)
 
     source_dir, rundir, _workflow_name = install_workflow(
-        workflow_name=workflow_name,
         source=source,
+        workflow_name=opts.workflow_name,
         run_name=opts.run_name,
         no_run_name=opts.no_run_name,
         cli_symlink_dirs=cli_symdirs

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -130,9 +130,9 @@ def main(
             ) from None
 
     reinstall_workflow(
+        source=Path(source),
         named_run=workflow_id,
         rundir=run_dir,
-        source=source,
         dry_run=False  # TODO: ready for dry run implementation
     )
 

--- a/tests/flakyfunctional/xtriggers/01-workflow_state.t
+++ b/tests/flakyfunctional/xtriggers/01-workflow_state.t
@@ -26,7 +26,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 # Register and validate the upstream workflow.
 WORKFLOW_NAME_UPSTREAM="${WORKFLOW_NAME}-upstream"
-cylc install --flow-name="${WORKFLOW_NAME_UPSTREAM}" -C "${TEST_DIR}/${WORKFLOW_NAME}/upstream" --no-run-name
+cylc install --workflow-name="${WORKFLOW_NAME_UPSTREAM}" -C "${TEST_DIR}/${WORKFLOW_NAME}/upstream" --no-run-name
 run_ok "${TEST_NAME_BASE}-validate-up" cylc validate --debug "${WORKFLOW_NAME_UPSTREAM}"
 
 # Validate the downstream test workflow.

--- a/tests/flakyfunctional/xtriggers/01-workflow_state.t
+++ b/tests/flakyfunctional/xtriggers/01-workflow_state.t
@@ -26,7 +26,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 # Register and validate the upstream workflow.
 WORKFLOW_NAME_UPSTREAM="${WORKFLOW_NAME}-upstream"
-cylc install --workflow-name="${WORKFLOW_NAME_UPSTREAM}" -C "${TEST_DIR}/${WORKFLOW_NAME}/upstream" --no-run-name
+cylc install "${TEST_DIR}/${WORKFLOW_NAME}/upstream" --workflow-name="${WORKFLOW_NAME_UPSTREAM}" --no-run-name
 run_ok "${TEST_NAME_BASE}-validate-up" cylc validate --debug "${WORKFLOW_NAME_UPSTREAM}"
 
 # Validate the downstream test workflow.

--- a/tests/functional/authentication/00-shared-fs.t
+++ b/tests/functional/authentication/00-shared-fs.t
@@ -28,7 +28,7 @@ WORKFLOW_NAME="${CYLC_TEST_REG_BASE}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}"
 WORKFLOW_RUN_DIR="$RUN_DIR/${WORKFLOW_NAME}"
 mkdir -p "$(dirname "${WORKFLOW_RUN_DIR}")"
 cp -r "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}" "${WORKFLOW_RUN_DIR}"
-cylc install --flow-name="${WORKFLOW_NAME}" --no-run-name 2>'/dev/null'
+cylc install --workflow-name="${WORKFLOW_NAME}" --no-run-name 2>'/dev/null'
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 

--- a/tests/functional/authentication/01-remote-workflow-same-name.t
+++ b/tests/functional/authentication/01-remote-workflow-same-name.t
@@ -35,7 +35,7 @@ scp ${SSH_OPTS} -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-install" \
     ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" \
-    CYLC_VERSION="$(cylc version)" cylc install --flow-name="${WORKFLOW_NAME}" \
+    CYLC_VERSION="$(cylc version)" cylc install --workflow-name="${WORKFLOW_NAME}" \
     --no-run-name --directory="${SRC_DIR}"
 
 workflow_run_ok "${TEST_NAME_BASE}" \

--- a/tests/functional/authentication/01-remote-workflow-same-name.t
+++ b/tests/functional/authentication/01-remote-workflow-same-name.t
@@ -34,9 +34,8 @@ scp ${SSH_OPTS} -pqr "${TEST_SOURCE_DIR}/${TEST_NAME_BASE}/"* \
     "${CYLC_TEST_HOST}:${SRC_DIR}"
 # shellcheck disable=SC2086
 run_ok "${TEST_NAME_BASE}-install" \
-    ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" \
-    CYLC_VERSION="$(cylc version)" cylc install --workflow-name="${WORKFLOW_NAME}" \
-    --no-run-name --directory="${SRC_DIR}"
+    ssh ${SSH_OPTS} "${CYLC_TEST_HOST}" bash -lc \
+    "CYLC_VERSION=$(cylc version) cylc install ${SRC_DIR} --workflow-name=${WORKFLOW_NAME} --no-run-name"
 
 workflow_run_ok "${TEST_NAME_BASE}" \
     cylc play --debug --no-detach --reference-test "${WORKFLOW_NAME}"

--- a/tests/functional/authentication/02-workflow2-stop-workflow1.t
+++ b/tests/functional/authentication/02-workflow2-stop-workflow1.t
@@ -28,7 +28,7 @@ RND_WORKFLOW_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
 RND_WORKFLOW_SOURCE="$PWD/${RND_WORKFLOW_NAME}"
 mkdir -p "${RND_WORKFLOW_SOURCE}"
 cp -p "${TEST_SOURCE_DIR}/basic/flow.cylc" "${RND_WORKFLOW_SOURCE}"
-cylc install --flow-name="${NAME1}" --directory="${RND_WORKFLOW_SOURCE}" --no-run-name
+cylc install --workflow-name="${NAME1}" --directory="${RND_WORKFLOW_SOURCE}" --no-run-name
 
 RND_WORKFLOW_NAME2=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
 RND_WORKFLOW_SOURCE2="$PWD/${RND_WORKFLOW_NAME2}"
@@ -43,7 +43,7 @@ cat >"${RND_WORKFLOW_SOURCE2}/flow.cylc" <<__FLOW_CONFIG__
     [[t1]]
         script=cylc shutdown "${NAME1}"
 __FLOW_CONFIG__
-cylc install --flow-name="${NAME2}" --directory="${RND_WORKFLOW_SOURCE2}" --no-run-name
+cylc install --workflow-name="${NAME2}" --directory="${RND_WORKFLOW_SOURCE2}" --no-run-name
 cylc play --no-detach "${NAME1}" 1>'1.out' 2>&1 &
 WORKFLOW_RUN_DIR="${WORKFLOW1_RUND}" poll_workflow_running
 run_ok "${TEST_NAME_BASE}" cylc play --no-detach --abort-if-any-task-fails "${NAME2}"

--- a/tests/functional/authentication/02-workflow2-stop-workflow1.t
+++ b/tests/functional/authentication/02-workflow2-stop-workflow1.t
@@ -28,7 +28,7 @@ RND_WORKFLOW_NAME=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
 RND_WORKFLOW_SOURCE="$PWD/${RND_WORKFLOW_NAME}"
 mkdir -p "${RND_WORKFLOW_SOURCE}"
 cp -p "${TEST_SOURCE_DIR}/basic/flow.cylc" "${RND_WORKFLOW_SOURCE}"
-cylc install --workflow-name="${NAME1}" --directory="${RND_WORKFLOW_SOURCE}" --no-run-name
+cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${NAME1}" --no-run-name
 
 RND_WORKFLOW_NAME2=x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)
 RND_WORKFLOW_SOURCE2="$PWD/${RND_WORKFLOW_NAME2}"
@@ -43,7 +43,7 @@ cat >"${RND_WORKFLOW_SOURCE2}/flow.cylc" <<__FLOW_CONFIG__
     [[t1]]
         script=cylc shutdown "${NAME1}"
 __FLOW_CONFIG__
-cylc install --workflow-name="${NAME2}" --directory="${RND_WORKFLOW_SOURCE2}" --no-run-name
+cylc install "${RND_WORKFLOW_SOURCE2}" --workflow-name="${NAME2}" --no-run-name
 cylc play --no-detach "${NAME1}" 1>'1.out' 2>&1 &
 WORKFLOW_RUN_DIR="${WORKFLOW1_RUND}" poll_workflow_running
 run_ok "${TEST_NAME_BASE}" cylc play --no-detach --abort-if-any-task-fails "${NAME2}"

--- a/tests/functional/cylc-diff/01-same.t
+++ b/tests/functional/cylc-diff/01-same.t
@@ -33,7 +33,7 @@ init_workflow "${TEST_NAME_BASE}-1" "${PWD}/flow.cylc"
 WORKFLOW_NAME1="${WORKFLOW_NAME}"
 # shellcheck disable=SC2153
 WORKFLOW_NAME2="${WORKFLOW_NAME1%1}2"
-cylc install --workflow-name="${WORKFLOW_NAME2}" --directory="${TEST_DIR}/${WORKFLOW_NAME1}" --no-run-name 2>'/dev/null'
+cylc install "${TEST_DIR}/${WORKFLOW_NAME1}" --workflow-name="${WORKFLOW_NAME2}" --no-run-name 2>'/dev/null'
 
 run_ok "${TEST_NAME_BASE}" cylc diff "${WORKFLOW_NAME1}" "${WORKFLOW_NAME2}"
 cmp_ok "${TEST_NAME_BASE}.stdout" <<__OUT__

--- a/tests/functional/cylc-diff/01-same.t
+++ b/tests/functional/cylc-diff/01-same.t
@@ -33,7 +33,7 @@ init_workflow "${TEST_NAME_BASE}-1" "${PWD}/flow.cylc"
 WORKFLOW_NAME1="${WORKFLOW_NAME}"
 # shellcheck disable=SC2153
 WORKFLOW_NAME2="${WORKFLOW_NAME1%1}2"
-cylc install --flow-name="${WORKFLOW_NAME2}" --directory="${TEST_DIR}/${WORKFLOW_NAME1}" --no-run-name 2>'/dev/null'
+cylc install --workflow-name="${WORKFLOW_NAME2}" --directory="${TEST_DIR}/${WORKFLOW_NAME1}" --no-run-name 2>'/dev/null'
 
 run_ok "${TEST_NAME_BASE}" cylc diff "${WORKFLOW_NAME1}" "${WORKFLOW_NAME2}"
 cmp_ok "${TEST_NAME_BASE}.stdout" <<__OUT__

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -70,7 +70,7 @@ TEST_NAME="${TEST_NAME_BASE}-suite.rc"
 make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -101,7 +101,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-flow-name"
 make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}-olaf"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}-olaf"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}-olaf/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -114,7 +114,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-flow-name-no-run-name"
 make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}-olaf" --no-run-name
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}-olaf" --no-run-name
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}-olaf from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -126,7 +126,7 @@ purge_rnd_workflow
 # Test "cylc install" --directory given (flow in --directory)
 TEST_NAME="${TEST_NAME_BASE}-option--directory"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__

--- a/tests/functional/cylc-install/00-simple.t
+++ b/tests/functional/cylc-install/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow installation
 . "$(dirname "$0")/test_header"
-set_test_number 26
+set_test_number 18
 
 create_test_global_config "" "
 [install]
@@ -45,17 +45,10 @@ make_rnd_workflow
 # Before adding workflow to ~/cylc-src/, check install fails:
 TEST_NAME="${TEST_NAME_BASE}-WORKFLOW_NAME-fail-no-src-dir"
 run_fail "${TEST_NAME}" cylc install "${RND_WORKFLOW_NAME}"
-# Now add workflow to ~/cylc-src/
+# Now add workflow to ~/cylc-src/ and test again
 RND_WORKFLOW_SOURCE="${PWD}/cylc-src/${RND_WORKFLOW_NAME}"
 mv "$RND_WORKFLOW_NAME" "${PWD}/cylc-src/"
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-# Test WORKFLOW_NAME and --directory are mutually exclusive
-TEST_NAME="${TEST_NAME_BASE}-WORKFLOW_NAME-and--directory-forbidden"
-run_fail "${TEST_NAME}" cylc install "${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
-cmp_ok "${TEST_NAME}.stderr" <<__ERR__
-UserInputError: WORKFLOW_NAME and --directory are mutually exclusive.
-__ERR__
-# Finally test normal case
 TEST_NAME="${TEST_NAME_BASE}-WORKFLOW_NAME-install-ok"
 run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
@@ -66,11 +59,12 @@ purge_rnd_workflow
 
 # -----------------------------------------------------------------------------
 # Test cylc install succeeds if suite.rc file in source dir
+# (also tests installing from absolute path)
 TEST_NAME="${TEST_NAME_BASE}-suite.rc"
 make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -78,9 +72,7 @@ __OUT__
 # Test deprecation message is displayed on installing a suite.rc file
 MSG=$(python -c 'from cylc.flow.workflow_files import SUITERC_DEPR_MSG;
 print(SUITERC_DEPR_MSG)')
-
 grep_ok "$MSG" "${TEST_NAME}.stderr"
-
 
 purge_rnd_workflow
 
@@ -123,16 +115,6 @@ rm -rf "${RUN_DIR}/${RND_WORKFLOW_NAME}-olaf"
 purge_rnd_workflow
 
 # -----------------------------------------------------------------------------
-# Test "cylc install" --directory given (flow in --directory)
-TEST_NAME="${TEST_NAME_BASE}-option--directory"
-make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
-contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
-__OUT__
-purge_rnd_workflow
-
-# -----------------------------------------------------------------------------
 # Test running cylc install twice increments run dirs correctly
 TEST_NAME="${TEST_NAME_BASE}-install-twice-1"
 make_rnd_workflow
@@ -148,21 +130,3 @@ INSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 popd || exit 1
 purge_rnd_workflow
-
-# -----------------------------------------------------------------------------
-# Test running cylc install twice increments run dirs correctly
-TEST_NAME="${TEST_NAME_BASE}-install-C-twice-1"
-make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install -C "${RND_WORKFLOW_NAME}"
-contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_NAME}
-__OUT__
-TEST_NAME="${TEST_NAME_BASE}-install-C-twice-2"
-run_ok "${TEST_NAME}" cylc install -C "${RND_WORKFLOW_NAME}"
-contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run2 from ${RND_WORKFLOW_NAME}
-__OUT__
-purge_rnd_workflow
-
-
-exit

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -40,7 +40,7 @@ create_test_global_config "" "
 # Test "cylc install" ensure symlinks are created
 TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -66,10 +66,10 @@ SYMDIR=${TMPDIR}/${USER}/test_cylc_cli_symlink/
 
 TEST_NAME="${TEST_NAME_BASE}-cli-opt-install"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
---directory="${RND_WORKFLOW_SOURCE}" \
---symlink-dirs="run= ${SYMDIR}cylctb_tmp_run_dir, log=${SYMDIR}, share=${SYMDIR}, \
-work = ${SYMDIR}"
+run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_SOURCE}" \
+    --workflow-name="${RND_WORKFLOW_NAME}" \
+    --symlink-dirs="run= ${SYMDIR}cylctb_tmp_run_dir, log=${SYMDIR}, share=${SYMDIR}, \
+    work = ${SYMDIR}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -121,8 +121,8 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-sym-dirs-cli"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
---directory="${RND_WORKFLOW_SOURCE}" --symlink-dirs=""
+run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_SOURCE}" \
+    --workflow-name="${RND_WORKFLOW_NAME}" --symlink-dirs=""
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -170,9 +170,9 @@ SYMDIR=${TMPDIR}/${USER}/test_cylc_cli_symlink/
 TEST_NAME="${TEST_NAME_BASE}-share-share-cycle-same-dirs"
 make_rnd_workflow
 # check install runs without failure
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
---directory="${RND_WORKFLOW_SOURCE}" \
---symlink-dirs="share/cycle=${SYMDIR}, share=${SYMDIR}"
+run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_SOURCE}" \
+    --workflow-name="${RND_WORKFLOW_NAME}" \
+    --symlink-dirs="share/cycle=${SYMDIR}, share=${SYMDIR}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__

--- a/tests/functional/cylc-install/01-symlinks.t
+++ b/tests/functional/cylc-install/01-symlinks.t
@@ -40,7 +40,7 @@ create_test_global_config "" "
 # Test "cylc install" ensure symlinks are created
 TEST_NAME="${TEST_NAME_BASE}-symlinks-created"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --directory="${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -66,7 +66,7 @@ SYMDIR=${TMPDIR}/${USER}/test_cylc_cli_symlink/
 
 TEST_NAME="${TEST_NAME_BASE}-cli-opt-install"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" \
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
 --directory="${RND_WORKFLOW_SOURCE}" \
 --symlink-dirs="run= ${SYMDIR}cylctb_tmp_run_dir, log=${SYMDIR}, share=${SYMDIR}, \
 work = ${SYMDIR}"
@@ -87,7 +87,7 @@ for DIR in 'work' 'share' 'log'; do
 done
 
 INSTALL_LOG="$(find "${WORKFLOW_RUN_DIR}/log/install" -type f -name '*.log')"
- 
+
 for DIR in 'work' 'share' 'log'; do
     grep_ok "${TMPDIR}/${USER}/test_cylc_cli_symlink/cylc-run/${RND_WORKFLOW_NAME}/run1/${DIR}" "${INSTALL_LOG}"
 done
@@ -121,7 +121,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-sym-dirs-cli"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" \
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
 --directory="${RND_WORKFLOW_SOURCE}" --symlink-dirs=""
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
@@ -164,13 +164,13 @@ rm -rf "${TMPDIR}/${USER}/test_cylc_cli_symlink/"
 purge_rnd_workflow
 
 
-# test share and share/cycle same symlinks don't error 
+# test share and share/cycle same symlinks don't error
 SYMDIR=${TMPDIR}/${USER}/test_cylc_cli_symlink/
 
 TEST_NAME="${TEST_NAME_BASE}-share-share-cycle-same-dirs"
 make_rnd_workflow
 # check install runs without failure
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" \
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" \
 --directory="${RND_WORKFLOW_SOURCE}" \
 --symlink-dirs="share/cycle=${SYMDIR}, share=${SYMDIR}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -35,7 +35,7 @@ WORKFLOW_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR##*tests/}/${TEST_
 mkdir -p "${PWD}/${SOURCE_DIR_1}"
 pushd "${SOURCE_DIR_1}" || exit 1
 touch flow.cylc
-run_ok "${TEST_NAME}" cylc install --flow-name "$WORKFLOW_NAME"
+run_ok "${TEST_NAME}" cylc install --workflow-name "$WORKFLOW_NAME"
 popd || exit 1
 
 SOURCE_DIR_2="test-install-${CYLC_TEST_TIME_INIT}2/${TEST_NAME_BASE}"
@@ -43,7 +43,7 @@ WORKFLOW_NAME="cylctb-${CYLC_TEST_TIME_INIT}/${TEST_SOURCE_DIR##*tests/}/${TEST_
 mkdir -p "${PWD}/${SOURCE_DIR_2}"
 pushd "${SOURCE_DIR_2}" || exit 1
 touch flow.cylc
-run_fail "${TEST_NAME}" cylc install --flow-name "$WORKFLOW_NAME"
+run_fail "${TEST_NAME}" cylc install --workflow-name "$WORKFLOW_NAME"
 grep_ok "previous installations were from" "${TEST_NAME}.stderr"
 rm -rf "${PWD:?}/${SOURCE_DIR_1}" "${PWD:?}/${SOURCE_DIR_2}"
 purge
@@ -56,7 +56,7 @@ make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
-run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: No flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -68,7 +68,7 @@ make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-both-suite-and-flow-file"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: Both flow.cylc and suite.rc files are present in ${RND_WORKFLOW_SOURCE}. \
 Please remove one and try again. For more information visit: \
@@ -79,7 +79,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-nodir"
 rm -rf "${RND_WORKFLOW_SOURCE}"
-run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" --no-run-name -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: No flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -92,7 +92,7 @@ purge_rnd_workflow
 make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-abs-path-flow-name"
-run_fail "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_SOURCE}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_SOURCE}" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: workflow name cannot be an absolute path: ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -108,7 +108,7 @@ __ERR__
 # Test cylc install invalid flow-name
 
 TEST_NAME="${TEST_NAME_BASE}-invalid-flow-name"
-run_fail "${TEST_NAME}" cylc install --flow-name=".invalid" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name=".invalid" -C "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: invalid workflow name '.invalid' - cannot start with: \`.\`, \`-\`, numbers
 __ERR__
@@ -202,7 +202,7 @@ TEST_NAME="${TEST_NAME_BASE}-nested-rundir"
 make_rnd_workflow
 mkdir -p "${RND_WORKFLOW_RUNDIR}/.service"
 run_fail "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" \
-    --flow-name="${RND_WORKFLOW_NAME}/nested"
+    --workflow-name="${RND_WORKFLOW_NAME}/nested"
 cmp_ok "${TEST_NAME}-install.stderr" <<__ERR__
 WorkflowFilesError: Nested run directories not allowed - cannot install workflow in '${RND_WORKFLOW_RUNDIR}/nested/run1' as '${RND_WORKFLOW_RUNDIR}' is already a valid run directory.
 __ERR__
@@ -236,7 +236,7 @@ TEST_NAME="${TEST_NAME_BASE}-forbid-cylc-run-dir-install"
 BASE_NAME="test-install-${CYLC_TEST_TIME_INIT}"
 mkdir -p "${RUN_DIR}/${BASE_NAME}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME}" && cd "$_" || exit
 touch flow.cylc
-run_fail "${TEST_NAME}" cylc install --flow-name "$RND_WORKFLOW_NAME"
+run_fail "${TEST_NAME}" cylc install --workflow-name "$RND_WORKFLOW_NAME"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: ${RND_WORKFLOW_NAME} installation failed. Source directory should not be in ${RUN_DIR}.
 __ERR__
@@ -253,7 +253,7 @@ TEST_NAME="${TEST_NAME_BASE}-forbid-cylc-run-dir-install"
 BASE_NAME="test-install-${CYLC_TEST_TIME_INIT}"
 mkdir -p "${RUN_DIR}/${BASE_NAME}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME}" && cd "$_" || exit
 touch flow.cylc
-run_fail "${TEST_NAME}" cylc install --run-name=foo/bar/baz --flow-name "$RND_WORKFLOW_NAME"
+run_fail "${TEST_NAME}" cylc install --run-name=foo/bar/baz --workflow-name "$RND_WORKFLOW_NAME"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: Run name cannot be a path. (You used foo/bar/baz)
 __ERR__

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -56,7 +56,7 @@ make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
-run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: No flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -68,7 +68,7 @@ make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-both-suite-and-flow-file"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: Both flow.cylc and suite.rc files are present in ${RND_WORKFLOW_SOURCE}. \
 Please remove one and try again. For more information visit: \
@@ -79,7 +79,7 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-nodir"
 rm -rf "${RND_WORKFLOW_SOURCE}"
-run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: No flow.cylc or suite.rc in ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -92,7 +92,7 @@ purge_rnd_workflow
 make_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-abs-path-flow-name"
-run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_SOURCE}" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_SOURCE}" "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: workflow name cannot be an absolute path: ${RND_WORKFLOW_SOURCE}
 __ERR__
@@ -100,7 +100,7 @@ __ERR__
 # Test cylc install fails when given forbidden run-name
 
 TEST_NAME="${TEST_NAME_BASE}-run-name-forbidden"
-run_fail "${TEST_NAME}" cylc install --run-name=_cylc-install -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --run-name=_cylc-install "${RND_WORKFLOW_SOURCE}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: Workflow/run name cannot contain a directory named '_cylc-install' (that filename is reserved)
 __ERR__
@@ -108,7 +108,7 @@ __ERR__
 # Test cylc install invalid flow-name
 
 TEST_NAME="${TEST_NAME_BASE}-invalid-flow-name"
-run_fail "${TEST_NAME}" cylc install --workflow-name=".invalid" -C "${RND_WORKFLOW_SOURCE}"
+run_fail "${TEST_NAME}" cylc install --workflow-name=".invalid" "${RND_WORKFLOW_SOURCE}"
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
 WorkflowFilesError: invalid workflow name '.invalid' - cannot start with: \`.\`, \`-\`, numbers
 __ERR__
@@ -201,7 +201,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-nested-rundir"
 make_rnd_workflow
 mkdir -p "${RND_WORKFLOW_RUNDIR}/.service"
-run_fail "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" \
+run_fail "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" \
     --workflow-name="${RND_WORKFLOW_NAME}/nested"
 cmp_ok "${TEST_NAME}-install.stderr" <<__ERR__
 WorkflowFilesError: Nested run directories not allowed - cannot install workflow in '${RND_WORKFLOW_RUNDIR}/nested/run1' as '${RND_WORKFLOW_RUNDIR}' is already a valid run directory.
@@ -211,9 +211,9 @@ __ERR__
 
 TEST_NAME="${TEST_NAME_BASE}-install-moving-src-dir"
 make_rnd_workflow
-run_ok "${TEST_NAME}" cylc install -C "${RND_WORKFLOW_NAME}"
+run_ok "${TEST_NAME}" cylc install "./${RND_WORKFLOW_NAME}"
 contains_ok "${TEST_NAME}.stdout" <<__OUT__
-INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_NAME}
+INSTALLED $RND_WORKFLOW_NAME/run1 from ${PWD}/${RND_WORKFLOW_NAME}
 __OUT__
 rm -rf "${RND_WORKFLOW_SOURCE}"
 ALT_SOURCE="${TMPDIR}/${USER}/cylctb-x$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c6)"
@@ -222,7 +222,7 @@ touch "${ALT_SOURCE}/${RND_WORKFLOW_NAME}/flow.cylc"
 
 
 TEST_NAME="${TEST_NAME_BASE}-install-twice-moving-src-dir-raises-error"
-run_fail "${TEST_NAME}" cylc install -C "${ALT_SOURCE}/${RND_WORKFLOW_NAME}"
+run_fail "${TEST_NAME}" cylc install "${ALT_SOURCE}/${RND_WORKFLOW_NAME}"
 grep_ok "WorkflowFilesError: Symlink broken" "${TEST_NAME}.stderr"
 
 rm -rf "${ALT_SOURCE}"

--- a/tests/functional/cylc-install/04-symlinks-not-resolved.t
+++ b/tests/functional/cylc-install/04-symlinks-not-resolved.t
@@ -39,7 +39,7 @@ mkdir -p "${elsewhere}/foo"
 ln -s "${elsewhere}/foo" "bar"
 
 # Install the workflow:
-run_ok "$TEST_NAME_BASE" cylc install --no-run-name --directory "$PWD" --symlink-dirs=run="${elsewhere}/bar"
+run_ok "$TEST_NAME_BASE" cylc install --no-run-name --symlink-dirs=run="${elsewhere}/bar"
 
 # Check the installed workflow:
 ls -l "$RUN_DIR/$(basename "$PWD")" > list

--- a/tests/functional/cylc-install/05-check-logs-git.t
+++ b/tests/functional/cylc-install/05-check-logs-git.t
@@ -56,7 +56,7 @@ echo "Outside workflow" > test_file_outside_workflow
 run_ok "${TEST_NAME_BASE}-install" \
     cylc install \
         -C "$PWD/${WORKFLOW}" \
-        --flow-name "${WORKFLOW_NAME}"
+        --workflow-name "${WORKFLOW_NAME}"
 named_grep_ok \
     "File inside flow VC'd" \
     "Inside workflow" \

--- a/tests/functional/cylc-install/06-check-logs-svn.t
+++ b/tests/functional/cylc-install/06-check-logs-svn.t
@@ -56,14 +56,10 @@ echo "Outside workflow" > test_file_outside_workflow
 # Carry out actual test:
 
 run_ok "${TEST_NAME_BASE}-install" \
-    cylc install \
-        -C "$PWD/${WORKFLOW}" \
-        --no-run-name \
-        --workflow-name "${WORKFLOW_NAME}"
-named_grep_ok \
-    "File inside flow VC'd" \
-    "Inside workflow" \
-    "${WORKFLOW_RUN_DIR}/log/version/uncommitted.diff"
-grep_fail "Outside workflow" "${WORKFLOW_RUN_DIR}/log/version/uncommitted.diff"
+    cylc install "./${WORKFLOW}" --no-run-name --workflow-name "${WORKFLOW_NAME}"
+
+DIFF_FILE="${WORKFLOW_RUN_DIR}/log/version/uncommitted.diff"
+grep_ok "Inside workflow" "$DIFF_FILE"
+grep_fail "Outside workflow" "$DIFF_FILE"
 
 purge

--- a/tests/functional/cylc-install/06-check-logs-svn.t
+++ b/tests/functional/cylc-install/06-check-logs-svn.t
@@ -59,7 +59,7 @@ run_ok "${TEST_NAME_BASE}-install" \
     cylc install \
         -C "$PWD/${WORKFLOW}" \
         --no-run-name \
-        --flow-name "${WORKFLOW_NAME}"
+        --workflow-name "${WORKFLOW_NAME}"
 named_grep_ok \
     "File inside flow VC'd" \
     "Inside workflow" \

--- a/tests/functional/cylc-install/07-no-recursive-installations.t
+++ b/tests/functional/cylc-install/07-no-recursive-installations.t
@@ -36,27 +36,27 @@ MSG="Nested install directories not allowed"
 
 TEST_FOLDER=cylctb-$(uuidgen)
 TEST_FOLDERS+=("$TEST_FOLDER")
-cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/"
+cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/"
 
 TEST_NAME="${TEST_NAME_BASE}-child"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/child/grandchild"
+run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 TEST_NAME="${TEST_NAME_BASE}-child-no-run-name"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/child/grandchild" --no-run-name
+run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild" --no-run-name
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 
 TEST_FOLDER=cylctb-$(uuidgen)
 TEST_FOLDERS+=("$TEST_FOLDER")
-cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/child/grandchild"
+cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
 
 TEST_NAME="${TEST_NAME_BASE}-parent"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/"
+run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/"
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 TEST_NAME="${TEST_NAME_BASE}-parent-no-run-name"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --flow-name "${TEST_FOLDER}/" --no-run-name
+run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/" --no-run-name
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 # Cleanup all the test folders added to the array.

--- a/tests/functional/cylc-install/07-no-recursive-installations.t
+++ b/tests/functional/cylc-install/07-no-recursive-installations.t
@@ -36,27 +36,27 @@ MSG="Nested install directories not allowed"
 
 TEST_FOLDER=cylctb-$(uuidgen)
 TEST_FOLDERS+=("$TEST_FOLDER")
-cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/"
+cylc install "$PWD" --workflow-name "${TEST_FOLDER}/"
 
 TEST_NAME="${TEST_NAME_BASE}-child"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
+run_fail "$TEST_NAME" cylc install "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 TEST_NAME="${TEST_NAME_BASE}-child-no-run-name"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild" --no-run-name
+run_fail "$TEST_NAME" cylc install "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild" --no-run-name
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 
 TEST_FOLDER=cylctb-$(uuidgen)
 TEST_FOLDERS+=("$TEST_FOLDER")
-cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
+cylc install "$PWD" --workflow-name "${TEST_FOLDER}/child/grandchild"
 
 TEST_NAME="${TEST_NAME_BASE}-parent"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/"
+run_fail "$TEST_NAME" cylc install "$PWD" --workflow-name "${TEST_FOLDER}/"
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 TEST_NAME="${TEST_NAME_BASE}-parent-no-run-name"
-run_fail "$TEST_NAME" cylc install -C "$PWD" --workflow-name "${TEST_FOLDER}/" --no-run-name
+run_fail "$TEST_NAME" cylc install "$PWD" --workflow-name "${TEST_FOLDER}/" --no-run-name
 grep_ok "$MSG" "${TEST_NAME}.stderr"
 
 # Cleanup all the test folders added to the array.

--- a/tests/functional/cylc-play/07-timezones-compat.t
+++ b/tests/functional/cylc-play/07-timezones-compat.t
@@ -36,7 +36,7 @@ __FLOW_CONFIG__
 
 WORKFLOW_NAME="${CYLC_TEST_REG_BASE}/${TEST_SOURCE_DIR_BASE}/${TEST_NAME_BASE}"
 
-cylc install --no-run-name --flow-name="${WORKFLOW_NAME}"
+cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}"
 
 # Pick a deliberately peculier timezone;
 export TZ=Australia/Eucla
@@ -55,7 +55,7 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
         R1 = foo
 __FLOW_CONFIG__
 
-cylc install --no-run-name --flow-name="${WORKFLOW_NAME}-foo"
+cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}-foo"
 
 run_ok "${TEST_NAME_BASE}" cylc play "${WORKFLOW_NAME}-foo" --no-detach
 grep_ok "+08:45 INFO" "${TEST_NAME_BASE}.stderr"

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -39,7 +39,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-named-flow"
 make_rnd_workflow
 pushd "${TMPDIR}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}"
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -56,7 +56,7 @@ TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_ok "${TEST_NAME}" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 cmp_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -67,7 +67,7 @@ purge_rnd_workflow
 # Test cylc reinstall from within rundir, no args given
 TEST_NAME="${TEST_NAME_BASE}-no-args"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install --flow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}-install" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
 cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -39,7 +39,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-named-flow"
 make_rnd_workflow
 pushd "${TMPDIR}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -56,7 +56,7 @@ TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_workflow
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
-run_ok "${TEST_NAME}" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stdout" <<__OUT__
 INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -67,7 +67,7 @@ purge_rnd_workflow
 # Test cylc reinstall from within rundir, no args given
 TEST_NAME="${TEST_NAME_BASE}-no-args"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install --workflow-name="${RND_WORKFLOW_NAME}" -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
@@ -84,7 +84,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-no-args-no-run-name"
 make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install --no-run-name -C "${RND_WORKFLOW_SOURCE}"
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --no-run-name
 cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
 INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
 __OUT__

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -24,7 +24,7 @@ set_test_number 26
 
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-run-dir"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -rf "${RND_WORKFLOW_RUNDIR}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
@@ -36,7 +36,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-dir"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -rf "${RND_WORKFLOW_SOURCE}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
@@ -49,7 +49,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
@@ -61,7 +61,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-both-flow-and-suite-file"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -24,7 +24,7 @@ set_test_number 26
 
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-run-dir"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -rf "${RND_WORKFLOW_RUNDIR}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
@@ -36,7 +36,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-dir"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -rf "${RND_WORKFLOW_SOURCE}"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
@@ -49,7 +49,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 rm -f "${RND_WORKFLOW_SOURCE}/flow.cylc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
@@ -61,7 +61,7 @@ purge_rnd_workflow
 
 TEST_NAME="${TEST_NAME_BASE}-both-flow-and-suite-file"
 make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --flow-name="${RND_WORKFLOW_NAME}" --no-run-name
+run_ok "${TEST_NAME}-install" cylc install -C "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
 touch "${RND_WORKFLOW_SOURCE}/suite.rc"
 run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
 cmp_ok "${TEST_NAME}.stderr" <<__ERR__
@@ -77,7 +77,7 @@ for DIR in 'work' 'share' 'log' '_cylc-install'; do
     TEST_NAME="${TEST_NAME_BASE}-${DIR}-forbidden-in-source"
     make_rnd_workflow
     pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-    cylc install --no-run-name --flow-name="${RND_WORKFLOW_NAME}"
+    cylc install --no-run-name --workflow-name="${RND_WORKFLOW_NAME}"
     mkdir ${DIR}
     run_fail "${TEST_NAME}" cylc reinstall "${RND_WORKFLOW_NAME}"
     cmp_ok "${TEST_NAME}.stderr" <<__ERR__
@@ -91,7 +91,7 @@ done
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error"
 make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_WORKFLOW_NAME}"
+run_ok "${TEST_NAME}-install" cylc install --no-run-name --workflow-name="${RND_WORKFLOW_NAME}"
 pushd "${RND_WORKFLOW_RUNDIR}" || exit 1
 rm -rf "_cylc-install"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall
@@ -106,7 +106,7 @@ purge_rnd_workflow
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error2"
 make_rnd_workflow
 pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install --no-run-name --flow-name="${RND_WORKFLOW_NAME}"
+run_ok "${TEST_NAME}-install" cylc install --no-run-name --workflow-name="${RND_WORKFLOW_NAME}"
 pushd "${RND_WORKFLOW_RUNDIR}" || exit 1
 rm -rf "_cylc-install"
 run_fail "${TEST_NAME}-reinstall" cylc reinstall "$RND_WORKFLOW_NAME"

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -487,9 +487,9 @@ init_workflow() {
     cat "${FLOW_CONFIG}" >"${TEST_DIR}/${WORKFLOW_NAME}/flow.cylc"
     cd "${TEST_DIR}/${WORKFLOW_NAME}"
     if "${RUN_NUMS}"; then
-        cylc install --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install "${TEST_DIR}/${WORKFLOW_NAME}" --workflow-name="${WORKFLOW_NAME}"
     else
-        cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install "${TEST_DIR}/${WORKFLOW_NAME}" --no-run-name --workflow-name="${WORKFLOW_NAME}"
     fi
 }
 
@@ -503,9 +503,9 @@ install_workflow() {
     cp -r "${TEST_SOURCE_DIR}/${TEST_SOURCE_BASE}/"* "${TEST_DIR}/${WORKFLOW_NAME}/"
     cd "${TEST_DIR}/${WORKFLOW_NAME}"
     if "$RUN_NUMS"; then
-        cylc install --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install "${TEST_DIR}/${WORKFLOW_NAME}" --workflow-name="${WORKFLOW_NAME}"
     else
-        cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install "${TEST_DIR}/${WORKFLOW_NAME}" --no-run-name --workflow-name="${WORKFLOW_NAME}"
     fi
 }
 

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -487,9 +487,9 @@ init_workflow() {
     cat "${FLOW_CONFIG}" >"${TEST_DIR}/${WORKFLOW_NAME}/flow.cylc"
     cd "${TEST_DIR}/${WORKFLOW_NAME}"
     if "${RUN_NUMS}"; then
-        cylc install --flow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
     else
-        cylc install --no-run-name --flow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
     fi
 }
 
@@ -503,9 +503,9 @@ install_workflow() {
     cp -r "${TEST_SOURCE_DIR}/${TEST_SOURCE_BASE}/"* "${TEST_DIR}/${WORKFLOW_NAME}/"
     cd "${TEST_DIR}/${WORKFLOW_NAME}"
     if "$RUN_NUMS"; then
-        cylc install --flow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
     else
-        cylc install --no-run-name --flow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
+        cylc install --no-run-name --workflow-name="${WORKFLOW_NAME}" --directory="${TEST_DIR}/${WORKFLOW_NAME}"
     fi
 }
 

--- a/tests/functional/workflow-state/00-polling.t
+++ b/tests/functional/workflow-state/00-polling.t
@@ -28,7 +28,7 @@ install_workflow "${TEST_NAME_BASE}" 'polling'
 cp -r "${TEST_SOURCE_DIR}/upstream" "${TEST_DIR}/"
 # use full range of characters in the workflow-to-be-polled name:
 UPSTREAM="${WORKFLOW_NAME}-up_stre.am"
-cylc install --workflow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream" --no-run-name
+cylc install  "${TEST_DIR}/upstream" --workflow-name="${UPSTREAM}" --no-run-name
 #-------------------------------------------------------------------------------
 # validate both workflows as tests
 TEST_NAME="${TEST_NAME_BASE}-validate-upstream"

--- a/tests/functional/workflow-state/00-polling.t
+++ b/tests/functional/workflow-state/00-polling.t
@@ -28,7 +28,7 @@ install_workflow "${TEST_NAME_BASE}" 'polling'
 cp -r "${TEST_SOURCE_DIR}/upstream" "${TEST_DIR}/"
 # use full range of characters in the workflow-to-be-polled name:
 UPSTREAM="${WORKFLOW_NAME}-up_stre.am"
-cylc install --flow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream" --no-run-name
+cylc install --workflow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream" --no-run-name
 #-------------------------------------------------------------------------------
 # validate both workflows as tests
 TEST_NAME="${TEST_NAME_BASE}-validate-upstream"

--- a/tests/functional/workflow-state/01-polling.t
+++ b/tests/functional/workflow-state/01-polling.t
@@ -28,7 +28,7 @@ install_workflow "${TEST_NAME_BASE}" 'polling'
 cp -r "${TEST_SOURCE_DIR}/upstream" "${TEST_DIR}/"
 # this version uses a simple Rose-style workflow name [\w-]
 UPSTREAM="${WORKFLOW_NAME}-upstream"
-cylc install --workflow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream"  --no-run-name
+cylc install "${TEST_DIR}/upstream" --workflow-name="${UPSTREAM}" --no-run-name
 #-------------------------------------------------------------------------------
 # validate both workflows as tests
 TEST_NAME="${TEST_NAME_BASE}-validate-upstream"

--- a/tests/functional/workflow-state/01-polling.t
+++ b/tests/functional/workflow-state/01-polling.t
@@ -28,7 +28,7 @@ install_workflow "${TEST_NAME_BASE}" 'polling'
 cp -r "${TEST_SOURCE_DIR}/upstream" "${TEST_DIR}/"
 # this version uses a simple Rose-style workflow name [\w-]
 UPSTREAM="${WORKFLOW_NAME}-upstream"
-cylc install --flow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream"  --no-run-name
+cylc install --workflow-name="${UPSTREAM}" -C "${TEST_DIR}/upstream"  --no-run-name
 #-------------------------------------------------------------------------------
 # validate both workflows as tests
 TEST_NAME="${TEST_NAME_BASE}-validate-upstream"

--- a/tests/unit/scripts/test_install.py
+++ b/tests/unit/scripts/test_install.py
@@ -1,0 +1,76 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os.path
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from cylc.flow.scripts.install import get_source_location
+
+
+@pytest.mark.parametrize(
+    'path, expected',
+    [
+        pytest.param(
+            'isla/nublar', '{cylc_src}/isla/nublar',
+            id="implicit relative"
+        ),
+        pytest.param(
+            './isla/nublar', '{cwd}/isla/nublar',
+            id="explicit relative"
+        ),
+        pytest.param(
+            '/welcome/to/jurassic/park', '/welcome/to/jurassic/park',
+            id="absolute"
+        ),
+        pytest.param(
+            None, '{cwd}',
+            id="None"
+        ),
+        pytest.param(
+            '.', '{cwd}',
+            id="dot"
+        ),
+        pytest.param(
+            '$GENNARO/coupon-day', '{env_var}/coupon-day',
+            id="env var expanded"
+        ),
+    ]
+)
+def test_get_source_location(
+    path: Optional[str],
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch
+):
+    # Setup
+    mock_cylc_src = '/ingen/cylc-src'
+    monkeypatch.setattr(
+        'cylc.flow.scripts.install.search_install_source_dirs',
+        lambda x: Path(mock_cylc_src, x)
+    )
+    mock_env_var = '/donald/gennaro'
+    monkeypatch.setenv('GENNARO', mock_env_var)
+    expected = expected.format(
+        cwd=Path.cwd(),
+        cylc_src=mock_cylc_src,
+        env_var=mock_env_var,
+    )
+    # Test
+    assert get_source_location(path) == Path(expected)
+    assert os.path.isabs(expected)

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock, patch, call
 
 from cylc.flow.exceptions import UserInputError, WorkflowFilesError
 from cylc.flow.pathutil import (
+    EXPLICIT_RELATIVE_PATH_REGEX,
     expand_path,
     get_dirs_to_symlink,
     get_next_rundir_number,
@@ -52,6 +53,24 @@ from .conftest import MonkeyMock
 
 
 HOME = Path.home()
+
+
+@pytest.mark.parametrize(
+    'string, match_expected',
+    [
+        ('./foo/bar', True),
+        ('../foo', True),
+        ('./', True),
+        ('../', True),
+        ('.', True),
+        ('..', True),
+        ('foo/bar', False),
+        ('.foo/bar', False),
+        ('foo/..', False),
+    ]
+)
+def test_explicit_relative_path_regex(string: str, match_expected: bool):
+    assert bool(EXPLICIT_RELATIVE_PATH_REGEX.match(string)) is match_expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -46,6 +46,7 @@ from cylc.flow.workflow_files import (
     clean,
     detect_both_flow_and_suite,
     get_rsync_rund_cmd,
+    get_run_dir_info,
     get_source_workflow_name,
     get_symlink_dirs,
     get_workflow_source_dir,
@@ -1885,3 +1886,78 @@ def test_validate_source_dir(tmp_run_dir: Callable, tmp_src_dir: Callable):
     with pytest.raises(WorkflowFilesError) as exc_info:
         validate_source_dir(src_dir, 'dieter')
     assert "Source directory should not be in" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'args, expected_relink, expected_run_num, expected_run_dir',
+    [
+        (
+            ['{cylc_run}/numbered', None, False],
+            True, 1, '{cylc_run}/numbered/run1'
+        ),
+        (
+            ['{cylc_run}/named', 'dukat', False],
+            False, None, '{cylc_run}/named/dukat'
+        ),
+        (
+            ['{cylc_run}/unnamed', None, True],
+            False, None, '{cylc_run}/unnamed'
+        ),
+    ]
+)
+def test_get_run_dir_info(
+    args: list,
+    expected_relink: bool,
+    expected_run_num: Optional[int],
+    expected_run_dir: Union[Path, str],
+    tmp_run_dir: Callable
+):
+    """Test get_run_dir_info().
+
+    Params:
+        args: Input args to function.
+        expected_*: Expected return values.
+    """
+    # Setup
+    cylc_run_dir: Path = tmp_run_dir()
+    sub = lambda x: Path(x.format(cylc_run=cylc_run_dir))  # noqa: E731
+    args[0] = sub(args[0])
+    expected_run_dir = sub(expected_run_dir)
+    # Test
+    assert get_run_dir_info(*args) == (
+        expected_relink, expected_run_num, expected_run_dir
+    )
+    assert expected_run_dir.is_absolute()
+
+
+def test_get_run_dir_info__increment_run_num(tmp_run_dir: Callable):
+    """Test that get_run_dir_info() increments run number and unlinks runN."""
+    # Setup
+    cylc_run_dir: Path = tmp_run_dir()
+    run_dir: Path = tmp_run_dir('gowron/run1')
+    runN = run_dir.parent / WorkflowFiles.RUN_N
+    assert os.path.lexists(runN)
+    # Test
+    assert get_run_dir_info(cylc_run_dir / 'gowron', None, False) == (
+        True, 2, cylc_run_dir / 'gowron' / 'run2'
+    )
+    assert not os.path.lexists(runN)
+
+
+def test_get_run_dir_info__fail(tmp_run_dir: Callable):
+    # Test that you can't install named runs when numbered runs exist
+    cylc_run_dir: Path = tmp_run_dir()
+    run_dir: Path = tmp_run_dir('martok/run1')
+    with pytest.raises(WorkflowFilesError) as excinfo:
+        get_run_dir_info(run_dir.parent, 'targ', False)
+    assert "contains installed numbered runs" in str(excinfo.value)
+
+    # Test that you can install numbered run in an empty dir
+    base_dir = cylc_run_dir / 'odo'
+    base_dir.mkdir()
+    get_run_dir_info(base_dir, None, False)
+    # But not when named runs exist
+    tmp_run_dir('odo/meter')
+    with pytest.raises(WorkflowFilesError) as excinfo:
+        get_run_dir_info(base_dir, None, False)
+    assert "contains an installed workflow"


### PR DESCRIPTION
These changes close #4676 and partially address #4786

Remove `--directory` option for `cylc install` and instead allow any directory in the source arg (`cylc install [SOURCE]`):
- Implicit relative path (e.g. `foo/bar`): look for source relative to each path in `global.cylc[install]source dirs` and install first match
- Explicit relative path (e.g. `./foo/bar`): source is relative to PWD
- Absolute path (e.g. `/home/user/foo/bar`): source is at that path
- No path specified: source is PWD 

Rename `--flow-name` option to `--workflow-name` and add `-n` for short (the consensus in #4786 seemed to be `--workflow-name` is preferable to `--id`).

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.