### PR TITLE
schema: fix formatting in docstring

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1408,7 +1408,14 @@ class WorkflowStopMode(graphene.Enum):
 
 class Flow(String):
     """An integer or one of {FLOW_ALL}, {FLOW_NEW} or {FLOW_NONE}."""
-    # (Note docstrings can't be f-strings).
+
+
+# NOTE: docstrings can't be f-strings so we must manually format it.
+Flow.__doc__ = Flow.__doc__.format(  # type: ignore[union-attr]
+    FLOW_ALL=FLOW_ALL,
+    FLOW_NEW=FLOW_NEW,
+    FLOW_NONE=FLOW_NONE,
+)
 
 
 # Mutations:


### PR DESCRIPTION
The docstring matters here because it gets fed through to the UI via API-On-The-Fly.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
