### PR TITLE
scan CLI: handle bad contact files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Third Release Candidate for Cylc 8 suitable for acceptance testing.
 
 ### Enhancements
 
+[#4828](https://github.com/cylc/cylc-flow/pull/4828) - scan CLI: corrupt
+workflow contact files should result in a warning, not a crash.
+
 [#4823](https://github.com/cylc/cylc-flow/pull/4823) - Remove the `--directory`
 option for `cylc install` (the functionality has been merged into the
 workflow source argument), and rename the `--flow-name` option to

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -405,9 +405,17 @@ async def _tree(pipe, formatter, opts, write):
     async for flow in pipe:
         ret.append(flow)
 
-    # construct tree
     tree = {}
-    for flow in sorted(ret, key=lambda f: f['name']):
+    _construct_tree(ret, tree, formatter, opts, write)
+
+    # print tree
+    ret = get_tree(tree, '', sort=False, use_unicode=True)
+    write('\n'.join(ret))
+
+
+def _construct_tree(flows, tree, formatter, opts, write):
+    """Construct the tree, for given flows and formatter."""
+    for flow in sorted(flows, key=lambda f: f['name']):
         parts = Path(flow['name']).parts
         pointer = tree
         for part in parts[:-1]:
@@ -422,10 +430,6 @@ async def _tree(pipe, formatter, opts, write):
         if len(parts) > 1:
             item = f' {item}'
         pointer[item] = ''
-
-    # print tree
-    ret = get_tree(tree, '', sort=False, use_unicode=True)
-    write('\n'.join(ret))
 
 
 def get_pipe(opts, formatter, scan_dir=None):

--- a/tests/unit/scripts/test_scan.py
+++ b/tests/unit/scripts/test_scan.py
@@ -14,11 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+from pathlib import Path
+
 from cylc.flow.scripts.scan import (
     ScanOptions,
     get_pipe,
     _format_plain,
-    FLOW_STATES
+    FLOW_STATES,
+    format_and_write,
+    BAD_CONTACT_FILE_MSG
 )
 
 
@@ -32,3 +37,43 @@ def test_ping_connection():
     """Ensure scan always connects to the flow when requested via --ping."""
     pipe = get_pipe(ScanOptions(states=FLOW_STATES, ping=True), _format_plain)
     assert 'graphql_query' in repr(pipe)
+
+
+def test_good_contact_info(capsys, monkeypatch):
+    """Check correct printing of workflow contact information."""
+    port = 8888
+    host = "wizard"
+    name = "blargh/run1"
+    format_and_write(
+        sys.stdout.write,
+        _format_plain,
+        {
+            "name": name,
+            "contact": Path("/path/to/blargh/run1"),
+            "CYLC_WORKFLOW_HOST": host,
+            "CYLC_WORKFLOW_PORT": port,
+        },
+        None
+    )
+    outerr = capsys.readouterr()
+    assert name in outerr.out
+    assert f"{host}:{port}" in outerr.out
+
+
+def test_bad_contact_info(capsys, monkeypatch):
+    """Check correct printing of bad contact info.
+
+    Missing contact keys should result in a warning, not crash scan.
+    """
+    name = "blargh/run1"
+    format_and_write(
+        sys.stdout.write,
+        _format_plain,
+        {
+            "name": name,
+            "contact": Path("/path/to/blargh/run1"),
+        },
+        None
+    )
+    outerr = capsys.readouterr()
+    assert BAD_CONTACT_FILE_MSG.format(workflow_name=name) in outerr.err


### PR DESCRIPTION

This is a small change with no associated Issue.

`cylc scan` currently fails if it encounters a corrupt contact file.

To test this, e.g.:
```console
$ touch ~/cylc-run/blah/.service/contact
$ cylc scan  # ... all hell breaks loose
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
