### PR TITLE
Better scan workflow detection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@ workflow source argument), and rename the `--flow-name` option to
 
 ### Fixes
 
+[#4830](https://github.com/cylc/cylc-flow/pull/4830) -
+Workflow scan now detects Cylc 7 suites installed, but not yet run, by Cylc 8.
+
 [#4554](https://github.com/cylc/cylc-flow/pull/4554) - Fix incorrect
 implementation of the ISO 8601 recurrence format no. 1
 (`R<number>/<start-point>/<second-point>`)

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -50,6 +50,7 @@ def init_flows(tmp_path, running=None, registered=None, un_registered=None):
     def make_registered(name, running=False):
         run_d = Path(tmp_path, name)
         run_d.mkdir(parents=True, exist_ok=True)
+        (run_d / "flow.cylc").touch()
         if "run" in name:
             root = Path(tmp_path, name).parent
             with suppress(FileExistsError):

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -434,6 +434,13 @@ def cylc7_run_dir(tmp_path):
     Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow').mkdir(parents=True)
     Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow', 'log').touch()
 
+    # a Cylc 7 workflow installed by Cylc 8 but not run yet.
+    # (should appear in scan results)
+    cylc8a = tmp_path / 'cylc8a'
+    cylc8a.mkdir()
+    (cylc8a / WorkflowFiles.SUITE_RC).touch()
+    Path(cylc8a, WorkflowFiles.LOG_DIR, 'install').mkdir(parents=True)
+
     # crazy niche case of a Cylc 7 workflow that has had its DB removed
     # and re-run under Cylc 8
     # (should appear in scan results)
@@ -456,5 +463,5 @@ async def test_scan_cylc7(cylc7_run_dir):
     assert await listify(
         scan(cylc7_run_dir)
     ) == [
-        'cylc78', 'cylc8', 'either'
+        'cylc78', 'cylc8', 'cylc8a', 'either'
     ]


### PR DESCRIPTION
Attempted do-over of scan workflow detection, after noticing that an old workflow definition (i.e. `suite.rc`) installed by Cylc 8 is invisible (to `cylc scan`) until you run it.

New logic based on new explanatory comments in the code, which I've verified by manual testing.


This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
