### PR TITLE
Improve `cylc install` usage text & error message

### DIFF
--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -22,25 +22,28 @@ Install a workflow into ~/cylc-run.
 
 The workflow can then be started, stopped, and targeted by name.
 
-Normal installation creates a directory "~/cylc-run/<workflow>/", with a run
-directory "~/cylc-run/<workflow>/run1". A "_cylc-install/source" symlink to
-the source directory will be created in the workflow directory.
-Any files or directories (excluding .git, .svn) from the source directory are
-copied to the new run directory.
-A ".service" directory will also be created and used for server authentication
-files at run time.
+Normal installation creates a numbered run directory
+"~/cylc-run/<workflow-name>/run<number>".
 
-If SOURCE_NAME is supplied, Cylc will search for the workflow source in the
+If a SOURCE_NAME is supplied, Cylc will search for the workflow source in the
 list of directories given by "global.cylc[install]source dirs", and install
-the first match.
+the first match. The installed workflow name will be the same as SOURCE_NAME,
+unless --workflow-name is used.
 
-If PATH is supplied, Cylc will install the workflow from the source given
-by the path. Relative paths must start with "./" to avoid ambiguity with
+If a PATH is supplied, Cylc will install the workflow from the source directory
+given by the path. Relative paths must start with "./" to avoid ambiguity with
 SOURCE_NAME (i.e. "foo/bar" will be interpreted as a source name, whereas
-"./foo/bar" will be interpreted as a path).
+"./foo/bar" will be interpreted as a path). The installed workflow name will
+be the basename of the path, unless --workflow-name is used.
 
 If no argument is supplied, Cylc will install the workflow from the source
 in the current working directory.
+
+A "_cylc-install/source" symlink to the source directory will be created in
+"~/cylc-run/<workflow-name>". Any files or directories (excluding .git, .svn)
+from the source directory are copied to the new run directory. A ".service"
+directory will also be created in the run directory; this is used for server
+authentication files at runtime.
 
 Examples:
   # Install workflow "dogs/fido" from the first match in
@@ -100,7 +103,8 @@ def get_option_parser() -> COP:
         comms=True,
         argdoc=[
             COP.optional(
-                ('SOURCE_NAME | PATH', 'Workflow source name or path')
+                ('SOURCE_NAME | PATH',
+                 'Workflow source name or path to source directory')
             )
         ]
     )

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1543,7 +1543,7 @@ def install_workflow(
         WorkflowFilesError:
             No flow.cylc file found in source location.
             Illegal name (can look like a relative path, but not absolute).
-            Another workflow already has this name (unless --redirect).
+            Another workflow already has this name.
             Trying to install a workflow that is nested inside of another.
     """
     abort_if_flow_file_in_path(source)
@@ -1572,9 +1572,8 @@ def install_workflow(
     check_nested_dirs(rundir, run_path_base)
     if rundir.exists():
         raise WorkflowFilesError(
-            f'"{rundir}" exists.\n'
-            " To install a new run use `cylc install --run-name`,"
-            " or to reinstall use `cylc reinstall`."
+            f"'{rundir}' already exists\n"
+            "To reinstall, use `cylc reinstall`"
         )
     symlinks_created = {}
     named_run = workflow_name

--- a/tests/functional/cylc-install/02-failures.t
+++ b/tests/functional/cylc-install/02-failures.t
@@ -190,7 +190,7 @@ __OUT__
 TEST_NAME="${TEST_NAME_BASE}-install-twice-same-run-name-2nd-install"
 run_fail "${TEST_NAME}" cylc install --run-name=olaf
 contains_ok "${TEST_NAME}.stderr" <<__ERR__
-WorkflowFilesError: "${RND_WORKFLOW_RUNDIR}/olaf" exists.
+WorkflowFilesError: '${RND_WORKFLOW_RUNDIR}/olaf' already exists
 __ERR__
 popd || exit 1
 purge_rnd_workflow


### PR DESCRIPTION
This is a small change with no associated Issue. Improve this error message:

```console
$ tree temp4 -L 1
temp4
|-- _cylc-install
|-- run1
|-- run2
`-- runN -> run2

$ cylc install temp4 --no-run-name
WorkflowFilesError: "~/cylc-run/temp4" exists.
 To install a new run use `cylc install --run-name`, or to reinstall use `cylc reinstall`.
```
You would not be able to use `cylc install --run-name` because numbered runs are being used.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests
- [x] No change log entry required (not a functional change).
- [x] No documentation update required.
