### PR TITLE
Include exception message when a failure to load main loop plugin occurs

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -42,17 +42,24 @@ class CylcError(Exception):
 
 
 class PluginError(CylcError):
-    """Represents an error arising from a Cylc plugin."""
+    """Represents an error arising from a Cylc plugin.
 
-    def __init__(self, entry_point, plugin_name, exc):
+    Args:
+        entry_point: The plugin entry point as defined in setup.cfg
+            (e.g. 'cylc.main_loop')
+        plugin_name: Name of the plugin
+        exc: Original exception caught when trying to run the plugin
+    """
+
+    def __init__(self, entry_point: str, plugin_name: str, exc: Exception):
         self.entry_point = entry_point
         self.plugin_name = plugin_name
         self.exc = exc
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
-            f'Error in plugin {self.entry_point}.{self.plugin_name}'
-            f'\n{self.exc}'
+            f"Error in plugin {self.entry_point}.{self.plugin_name}\n"
+            f"{type(self.exc).__name__}: {self.exc}"
         )
 
 


### PR DESCRIPTION
These changes close #4799

Also include original exception name in `PluginError` message for a little bit of extra context.

You can manually test out by applying this change:
```diff
diff --git a/cylc/flow/main_loop/health_check.py b/cylc/flow/main_loop/health_check.py
index 3d4d9453e..d91708289 100644
--- a/cylc/flow/main_loop/health_check.py
+++ b/cylc/flow/main_loop/health_check.py
@@ -24,3 +24,3 @@ Shuts down the workflow in the event of inconsistency or error.
 import os
-
+import flurblegarble
 from cylc.flow import workflow_files
```
and running a workflow.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Does not need tests (why?).
<!-- -->
- [x] No change log entry required (tiny change).
- [x] No documentation update required.
