### PR TITLE
Set excecution polling delays correctly

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1511,13 +1511,15 @@ class TaskEventsManager():
                 if not time_limit_delays:
                     time_limit_delays = [60, 120, 420]
                 timeout = time_limit + sum(time_limit_delays)
-                # Remove excessive polling before time limit
-                while sum(delays) > time_limit:
-                    del delays[-1]
-                # But fill up the gap before time limit
-                if delays:
-                    size = int((time_limit - sum(delays)) / delays[-1])
-                    delays.extend([delays[-1]] * size)
+                if sum(delays) > time_limit:
+                    # Remove excessive polling before time limit
+                    while sum(delays) > time_limit:
+                        del delays[-1]
+                else:
+                    # Fill up the gap before time limit
+                    if delays:
+                        size = int((time_limit - sum(delays)) / delays[-1])
+                        delays.extend([delays[-1]] * size)
                 time_limit_delays[0] += time_limit - sum(delays)
                 delays += time_limit_delays
         else:  # if itask.state.status == TASK_STATUS_SUBMITTED:


### PR DESCRIPTION
These changes partially address #3706

Tested with this workflow:
```
[scheduling]
    [[graph]]
        R1 = nolimit & limit95M & limit1H  & limit10M & limit70S
[runtime]
    [[root]]
        script = "echo Hello"
        execution polling intervals = 3*PT30S, PT10M, PT1H
    [[nolimit]]
    [[limit95M]]
        execution time limit = PT95M
    [[limit1H]]
        execution time limit = PT1H
    [[limit10M]]
        execution time limit = PT10M
    [[limit70S]]
        execution time limit = PT70S
```

Result using master:
```
$ grep "execution timeout" ~/cylc-run/bug.polling-intervals/runN/log/workflow/log
2022-04-29T15:45:33+01:00 INFO - [1/limit10M running job:01 flows:1] health: execution timeout=PT20M, polling intervals=20*PT30S,PT1M,PT2M,PT7M,...
2022-04-29T15:45:33+01:00 INFO - [1/limit1H running job:01 flows:1] health: execution timeout=PT1H10M, polling intervals=3*PT30S,5*PT10M,PT9M30S,PT2M,PT7M,...
2022-04-29T15:45:33+01:00 INFO - [1/limit70S running job:01 flows:1] health: execution timeout=PT11M10S, polling intervals=2*PT30S,PT1M10S,PT2M,PT7M,...
2022-04-29T15:45:33+01:00 INFO - [1/limit95M running job:01 flows:1] health: execution timeout=PT1H45M, polling intervals=3*PT30S,PT10M,PT1H,PT24M30S,PT2M,PT7M,...
2022-04-29T15:45:33+01:00 INFO - [1/nolimit running job:01 flows:1] health: execution timeout=None, polling intervals=3*PT30S,PT10M,PT1H,...
```
e.g. limit10M has `polling intervals=20*PT30S,PT1M,PT2M,PT7M,...` which not what we want.

Result using this branch:
```
$ grep "execution timeout" ~/cylc-run/bug.polling-intervals/runN/log/workflow/log
2022-04-29T15:43:45+01:00 INFO - [1/limit10M running job:01 flows:1] health: execution timeout=PT20M, polling intervals=3*PT30S,PT9M30S,PT2M,PT7M,...
2022-04-29T15:43:45+01:00 INFO - [1/limit1H running job:01 flows:1] health: execution timeout=PT1H10M, polling intervals=3*PT30S,PT10M,PT49M30S,PT2M,PT7M,...
2022-04-29T15:43:45+01:00 INFO - [1/limit70S running job:01 flows:1] health: execution timeout=PT11M10S, polling intervals=2*PT30S,PT1M10S,PT2M,PT7M,...
2022-04-29T15:43:45+01:00 INFO - [1/limit95M running job:01 flows:1] health: execution timeout=PT1H45M, polling intervals=3*PT30S,PT10M,PT1H,PT24M30S,PT2M,PT7M,...
2022-04-29T15:43:45+01:00 INFO - [1/nolimit running job:01 flows:1] health: execution timeout=None, polling intervals=3*PT30S,PT10M,PT1H,...
```
e.g. limit10M now has `polling intervals=3*PT30S,PT9M30S,PT2M,PT7M,...` which makes sense.

**Requirements check-list**
- [X ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ X] Contains logically grouped changes (else tidy your branch by rebase).
- [ X] Does not contain off-topic changes (use other PRs for other changes).
- [ X] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
- [ X] No documentation update required.
