### PR TITLE
Keep prerequisites for the datastore.

### DIFF
--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -452,8 +452,6 @@ class WorkflowDatabaseManager:
         relevant insert statements for the current tasks in the pool.
         """
         self.db_deletes_map[self.TABLE_TASK_POOL].append({})
-        # We can comment this out to keep prereq history for the data-store:
-        self.db_deletes_map[self.TABLE_TASK_PREREQUISITES].append({})
         # No need to do:
         # self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
         # Should already be done by self.put_task_event_timers above.

--- a/tests/functional/restart/53-task-prerequisites.t
+++ b/tests/functional/restart/53-task-prerequisites.t
@@ -34,6 +34,8 @@ TEST_NAME="${TEST_NAME_BASE}-db-task-prereq"
 QUERY='SELECT * FROM task_prerequisites ORDER BY cycle, name, prereq_cycle;'
 run_ok "$TEST_NAME" sqlite3 "$DB_FILE" "$QUERY"
 cmp_ok "${TEST_NAME}.stdout" << '__EOF__'
+1|bar|[1]|foo|0|succeeded|satisfied naturally
+1|bar|[1]|apollo|1|The Eagle has landed|satisfied naturally
 2|bar|[1]|foo|1|succeeded|0
 2|bar|[1]|apollo|2|The Eagle has landed|satisfied naturally
 3|bar|[1]|foo|2|succeeded|satisfied naturally


### PR DESCRIPTION
These changes close #4036 by retaining task prerequisite history in the DB (at the point of triggering), because we can't in general infer prerequisite satisfaction of completed tasks from task state, or use other data in the DB to compute it.

Main use cases for querying task prerequisites:
 1. what prerequisites does a future `n>0` task have?
     - (:+1: works already: we know what they are, and by definition they have not been satisfied)
 1. which prerequisites of a current `n=0` task remain unsatisfied?
     - (:+1: works already - stored in DB in case of restart)
 1. which prerequisites of a past `n>0` task were satisfied, i.e. why exactly did it trigger?
     - :-1:  we can't in general infer this from task state because of:
        - **manual triggering** (task triggered even though prerequisites were unsatisfied)
        - **conditional prerequisites** (task triggered even though some component prerequisites were not satisfied)
     - given the use case (which upstream events caused this task to trigger?) we need to know exactly which prerequisites were satisfied.
  1. (also: what prerequisites does a past task have regardless of state? no need to consider this because we always know what they are; it's just their state that is the problem)
  
Therefore, we need to use the DB to determine exactly which prerequisites were satisfied when past tasks triggered.

The information in the prerequisites table is not redundant with other DB data, because we need to know the prerequisite state *at trigger time*, NOT the eventual final state of all the upstream tasks that contribute to the prerequisites.  

This means the `task_prerequisites` table necessarily grows forever, but it's no worse than the existing history tables.

The only real solution to unconstrained history growth is to provide a housekeeping option. (Main loop plugin?)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
