### PR TITLE
bump deprecation warnings from Cylc 9 to 8.x

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -51,7 +51,8 @@ DEPRECATION_WARN = '''
 
    Deprecated section kept for compatibility with Cylc 7 workflow definitions.
 
-   **It will not be available at Cylc 9**.
+
+   This will be removed in a future version of Cylc 8.
 
    Use :cylc:conf:`flow.cylc[runtime][<namespace>]platform` instead.
 '''
@@ -63,8 +64,8 @@ DEPRECATED_IN_FAVOUR_OF_PLATFORMS = '''
 
    This config item has been moved to a platform setting in the
    :cylc:conf:`global.cylc[platforms]` section. It will be used by the
-   automated platform upgrade mechanism at Cylc 8, and deprecated
-   at Cylc 9.
+   automated platform upgrade mechanism and remove in a future version
+   of Cylc 8.
 
    Ideally, as a user this should be set by your site admins
    and you will only need to pick a suitable
@@ -1628,7 +1629,7 @@ with Conf(
 
                 This was done to allow users to control the order of
                 definition of the variables. This section will be removed
-                in Cylc 9.
+                in a later version of Cylc 8.
 
                 For the time being, the contents of this section will be
                 prepended to the ``[environment]`` section when running
@@ -1846,13 +1847,11 @@ def upg(cfg, descr):
         ):
             if job_setting in cfg['runtime'][task]:
                 LOG.warning(
-                    f"* (8.0.0) '[runtime][{task}]{job_setting}' - this "
-                    "setting is deprecated; use "
-                    "'global.cylc[platforms][<platform name>]"
-                    f"{job_setting}' "
-                    "instead. Currently, this item will override"
-                    " the corresponding item in global.cylc, "
-                    "but support for this will be removed in Cylc 9."
+                    f"* (8.0.0) '[runtime][{task}]{job_setting}' - this"
+                    " setting is deprecated; use"
+                    f" 'global.cylc[platforms][<platform name>]{job_setting}'"
+                    " instead. Currently, this item will override"
+                    " the corresponding item in global.cylc."
                 )
 
 
@@ -1948,8 +1947,8 @@ def warn_about_depr_platform(cfg):
             if depr:
                 msg = "\n".join(depr)
                 LOG.warning(
-                    f'Task {task_name}: deprecated "host" and "batch system" '
-                    f'will be removed at Cylc 9 - upgrade to platform:\n{msg}'
+                    f'Task {task_name}: deprecated "host" and "batch system"'
+                    f' use "platform".\n{msg}'
                 )
 
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1629,7 +1629,7 @@ with Conf(
 
                 This was done to allow users to control the order of
                 definition of the variables. This section will be removed
-                in a later version of Cylc 8.
+                in a future version of Cylc 8.
 
                 For the time being, the contents of this section will be
                 prepended to the ``[environment]`` section when running

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2286,7 +2286,7 @@ class WorkflowConfig:
                 # to:
                 #     Cylc8
                 # remove at:
-                #     Cylc9
+                #     Cylc8.x
                 self.cfg['meta']['URL'] = url % {
                     # cylc 7
                     'suite_name': self.workflow,
@@ -2319,7 +2319,7 @@ class WorkflowConfig:
                 # to:
                 #     Cylc8
                 # remove at:
-                #     Cylc9
+                #     Cylc8.x
                 try:
                     cfg['meta']['URL'] = cfg['meta']['URL'] % {
                         # cylc 7

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -103,14 +103,14 @@ cylc__job__main() {
         export CYLC_WORKFLOW_HOST CYLC_WORKFLOW_OWNER
         # BACK COMPAT: DEPRECATED environment variables
         # remove at:
-        #     Cylc9
+        #     Cylc8.x
         export CYLC_SUITE_HOST="${CYLC_WORKFLOW_HOST}"
         export CYLC_SUITE_OWNER="${CYLC_WORKFLOW_OWNER}"
     fi
 
     # BACK COMPAT: DEPRECATED environment variables
     # remove at:
-    #     Cylc9
+    #     Cylc8.x
     export CYLC_SUITE_SHARE_DIR="${CYLC_WORKFLOW_SHARE_DIR}"
     export CYLC_SUITE_SHARE_PATH="${CYLC_WORKFLOW_SHARE_DIR}"
     export CYLC_SUITE_NAME="${CYLC_WORKFLOW_ID}"

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -165,7 +165,7 @@ def addict(cfig, key, val, parents, index):
             # to:
             #     Cylc8
             # remove at:
-            #     Cylc9
+            #     Cylc8.x
             parents[0:2] == ['scheduling', 'dependencies']
         ):
             # append the new graph string to the existing one

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -82,13 +82,13 @@ def get_platform(
 
 
 # BACK COMPAT: get_platform
-#     At Cylc 9 remove all Cylc7 upgrade logic.
+#     At Cylc 8.x remove all Cylc7 upgrade logic.
 # from:
 #     Cylc8
 # to:
-#     Cylc9
+#     Cylc8.x
 # remove at:
-#     Cylc9
+#     Cylc8.x
 def get_platform(
     task_conf: Union[str, Dict[str, Any], None] = None,
     task_id: str = UNKNOWN_TASK,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1458,7 +1458,7 @@ class TaskEventsManager():
             # from:
             #     Cylc 8
             # remove at:
-            #     Cylc 9
+            #     Cylc 8.x
             EventData.Suite.value:  # deprecated
                 quote(self.workflow),
             EventData.SuiteUUID.value:  # deprecated
@@ -1471,7 +1471,7 @@ class TaskEventsManager():
             # from:
             #     Cylc < 8
             # remove at:
-            #     Cylc9 - pending announcement of deprecation
+            #     Cylc8.x - pending announcement of deprecation
             # next 2 (JobID_old, JobRunnerName_old) are deprecated
             EventData.JobID_old.value:
                 quote(str(itask.summary['submit_method_id'])),

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1110,7 +1110,7 @@ class TaskJobManager:
         # - Platform exists, host doesn't = eval platform_name
         # - host exists - eval host_n
         # remove at:
-        #     Cylc9
+        #     Cylc8.x
         if (
             rtconfig['platform'] is not None and
             rtconfig['remote']['host'] is not None

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -126,7 +126,7 @@ class TaskRemoteMgr:
         """
         # BACK COMPAT: references to "host"
         # remove at:
-        #     Cylc9
+        #     Cylc8.x
         if not command:
             return 'localhost'
 
@@ -159,7 +159,7 @@ class TaskRemoteMgr:
         # Environment variable substitution
         command = os.path.expandvars(command)
         # Remote?
-        # TODO - Remove at Cylc 9 as this only makes sense with host logic
+        # TODO - Remove at Cylc 8.x as this only makes sense with host logic
         if host_check is True:
             if is_remote_host(command):
                 return command

--- a/cylc/flow/workflow_events.py
+++ b/cylc/flow/workflow_events.py
@@ -86,7 +86,7 @@ class EventData(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     Suite = 'suite'
     """The workflow ID
 
@@ -101,7 +101,7 @@ class EventData(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     Suite_UUID = 'suite_uuid'
     """The unique identification string for this workflow run.
 
@@ -116,7 +116,7 @@ class EventData(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     SuiteURL = 'suite_url'
     """The URL defined in :cylc:conf:`flow.cylc[meta]URL`.
 
@@ -158,7 +158,7 @@ def get_template_variables(
         # from:
         #     Cylc 8
         # remove at:
-        #     Cylc 9
+        #     Cylc 8.x
         EventData.Suite.value:
             schd.workflow,
         EventData.Suite_UUID.value:

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -617,7 +617,7 @@ def load_contact_file(reg: str) -> Dict[str, str]:
         # from:
         #     Cylc 8
         # remove at:
-        #     Cylc 9
+        #     Cylc 8.x
         data[key.replace('SUITE', 'WORKFLOW')] = value
     return data
 
@@ -643,7 +643,7 @@ async def load_contact_file_async(reg, run_dir=None):
                 # from:
                 #     Cylc 8
                 # remove at:
-                #     Cylc 9
+                #     Cylc 8.x
                 data[key.replace('SUITE', 'WORKFLOW')] = value
             return data
     except IOError:

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -87,7 +87,7 @@ class TemplateVariables(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     WorkflowName = 'workflow_name'
     """The workflow ID.
 
@@ -102,7 +102,7 @@ class TemplateVariables(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     SuiteName = 'suite_name'
     """The workflow ID.
 
@@ -117,7 +117,7 @@ class TemplateVariables(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     SuiteRunDir = 'suite_run_dir'
     """The path to the workflow run directory.
 
@@ -132,7 +132,7 @@ class TemplateVariables(Enum):
     # from:
     #     Cylc 8
     # remove at:
-    #     Cylc 9
+    #     Cylc 8.x
     SuiteShareDir = 'suite_share_dir'
     """The path to the workflow share directory.
 

--- a/tests/functional/cylc-play/07-timezones-compat.t
+++ b/tests/functional/cylc-play/07-timezones-compat.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #------------------------------------------------------------------------
 # Test for Timezone = Z
-# TODO deprecated suite.rc section at Cylc 9
+# TODO remove deprecated suite.rc section at Cylc 8.x
 
 . "$(dirname "$0")/test_header"
 

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -50,6 +50,6 @@ WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged
 WARNING - deprecated graph items were automatically upgraded in "workflow definition":
      * (8.0.0) [scheduling][dependencies][X]graph -> [scheduling][graph]X - for X in:
            P1D
-WARNING - * (8.0.0) '[runtime][foo, cat, dog]execution polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]execution polling intervals' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.
-WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission polling intervals' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.
-WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission retry delays' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission retry delays' instead. Currently, this item will override the corresponding item in global.cylc, but support for this will be removed in Cylc 9.
+WARNING - * (8.0.0) '[runtime][foo, cat, dog]execution polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]execution polling intervals' instead. Currently, this item will override the corresponding item in global.cylc.
+WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission polling intervals' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission polling intervals' instead. Currently, this item will override the corresponding item in global.cylc.
+WARNING - * (8.0.0) '[runtime][foo, cat, dog]submission retry delays' - this setting is deprecated; use 'global.cylc[platforms][<platform name>]submission retry delays' instead. Currently, this item will override the corresponding item in global.cylc.

--- a/tests/functional/platforms/06-host-to-platform-upgrade-dummy-mode.t
+++ b/tests/functional/platforms/06-host-to-platform-upgrade-dummy-mode.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Check that setting the platform to localhost for dummy mode doesn't
 # cause conflicts with Cylc 7 settings
-# TODO Remove test at Cylc 9.
+# TODO Remove test at Cylc 8.x.
 . "$(dirname "$0")/test_header"
 set_test_number 3
 


### PR DESCRIPTION
[meeting 2022-05-04]

* Logically Cylc 9 should come at the next configuration breaking change, however, that isn't planned for some time.
  (note the Python API should not break flow.cylc compatibility)
* So we will remove back-support in the 8.x series rather than waiting for Cylc 9.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
