### PR TITLE
contact: process check should handle dirty JSON

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -447,7 +447,7 @@ def _is_process_running(
             process = parse_dirty_json(out)[0]
         except ValueError:
             # the JSON cannot be parsed, log it
-            LOG.warn(f'Could not parse JSON:\n{out}')
+            LOG.warning(f'Could not parse JSON:\n{out}')
             error = True
 
     if error:


### PR DESCRIPTION
* Closes #4855
* Protects the scheduler process check call against stdout pollution.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.