### PR TITLE
Don't log flow merge for same flow.

### DIFF
--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -448,6 +448,10 @@ class TaskProxy:
 
     def merge_flows(self, flow_nums: Set) -> None:
         """Merge another set of flow_nums with mine."""
+        if flow_nums == self.flow_nums:
+            # Not a merge if in the same flow. E.g. for "A & B => C" if A
+            # spawns C first, B will find C is already in the task pool.
+            return
         LOG.info(
             f"[{self}] merged in flow(s) "
             f"{','.join(str(f) for f in flow_nums)}"

--- a/tests/functional/spawn-on-demand/14-trigger-flow-blocker/flow.cylc
+++ b/tests/functional/spawn-on-demand/14-trigger-flow-blocker/flow.cylc
@@ -1,6 +1,6 @@
 # This workflow should behave the same as if 3/foo is not force-triggered.
 
-# Force-triggering 3/foo puts a running no-flow task in the way of the main flow.
+# Force-triggering 3/foo to put a running no-flow task in the way of the main flow.
 # When 2/foo tries to spawn its successor 3/foo, we merge its flow number into
 # the running 3/foo. Once 3/foo belongs to the flow its successor 4/foo and
 # child 3/bar must be spawned retroactively.
@@ -20,7 +20,7 @@
                 expected="foo, 2, waiting, not-held, not-queued, runahead"
                 diff <(cylc dump -t "${CYLC_WORKFLOW_NAME}" | grep 'foo, 2') \
                      <(echo "$expected")
-                cylc trigger $CYLC_WORKFLOW_NAME//3/foo
+                cylc trigger --flow=none $CYLC_WORKFLOW_NAME//3/foo
             elif ((CYLC_TASK_CYCLE_POINT == 3)); then
                 # Run until I get merged.
                 cylc__job__poll_grep_workflow_log -E "3/foo .* merged in flow\(s\) 1"


### PR DESCRIPTION
This is a small change with no associated Issue. 

Noticed when investigating #4868 

```
R1 = foo & bar => baz
```
Run this, and in the log:
```
2022-05-13T15:18:44+12:00 INFO - [1/baz waiting(runahead) job:00 flows:1] merged in flow(s) 1
```

If `foo` finishes first and spawns `baz`, when `bar` finishes and tries to spawn `baz` it will find `baz` already in the task pool. This is not a flow merge, unless `bar` belongs to a different flow.

We probably don't need tests for lack of a spurious log message.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
