### PR TITLE
Don't log fake task state changes (datastore)

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1067,11 +1067,11 @@ class DataStoreMgr:
                     flow_nums != itask.flow_nums and
                     not is_parent
             ):
-                itask.state_reset(TASK_STATUS_WAITING)
+                itask.state_reset(TASK_STATUS_WAITING, silent=True)
                 continue
             else:
                 itask.flow_nums = flow_nums
-                itask.state_reset(status)
+                itask.state_reset(status, silent=True)
             if (
                     outputs_str is not None
                     and itask.state(

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -455,11 +455,13 @@ class TaskProxy:
         self.flow_nums.update(flow_nums)
 
     def state_reset(
-        self, status=None, is_held=None, is_queued=None, is_runahead=None
+        self, status=None, is_held=None, is_queued=None, is_runahead=None,
+        silent=False
     ) -> bool:
         """Set new state and log the change. Return whether it changed."""
         before = str(self)
         if self.state.reset(status, is_held, is_queued, is_runahead):
-            LOG.info(f"[{before}] => {self.state}")
+            if not silent:
+                LOG.info(f"[{before}] => {self.state}")
             return True
         return False


### PR DESCRIPTION

These changes close #4868

Probably don't need tests for lack of a spurious log message.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
