### PR TITLE
Emacs syntax highlighting: fix filename pattern matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,9 @@ workflow source argument), and rename the `--flow-name` option to
 
 ### Fixes
 
+[#4875](https://github.com/cylc/cylc-flow/pull/4864) - Fix the file name
+pattern matching used for emacs syntax highlighting.
+
 [#4864](https://github.com/cylc/cylc-flow/pull/4864) - Allow strings
 and more complex data type template variables to be stored correctly
 in the workflow database.

--- a/cylc/flow/etc/syntax/cylc-mode.el
+++ b/cylc/flow/etc/syntax/cylc-mode.el
@@ -6,12 +6,8 @@
 ;; ____________________________________________________________________________
 ;;
 ;; = Instructions =
-;;    Place this file in a directory on your emacs load path (or symlink it)
-;;    e.g.
-;;         mkdir -p $HOME/.emacs.d/lisp
-;;         ln -s $CYLC_HOME/etc/syntax/cylc-mode.el ~/.emacs.d/lisp/
-;;
-;;    and in your $HOME/.emacs file add the following lines:
+;;    Place this file in $HOME/.emacs.d/lisp/ (create this directory if it
+;;    doesn't exist) and add the following lines in your $HOME/.emacs file:
 ;;
 ;;         (add-to-list 'load-path "~/.emacs.d/lisp/")
 ;;         (require 'cylc-mode)

--- a/cylc/flow/etc/syntax/cylc-mode.el
+++ b/cylc/flow/etc/syntax/cylc-mode.el
@@ -114,11 +114,7 @@
   (run-hooks 'cylc-mode-hook))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("suite*.rc" . cylc-mode))
-(setq auto-mode-alist
-  (append
-    '(("suite*.rc" . cylc-mode)
-      ("*.cylc" . cylc-mode))
-   auto-mode-alist))
+(add-to-list 'auto-mode-alist '("suite.*\\.rc\\'" . cylc-mode))
+(add-to-list 'auto-mode-alist '("\\.cylc\\'" . cylc-mode))
 
 (provide 'cylc-mode)

--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -5,7 +5,7 @@
 
  = Instructions =
 
- To use it, place or symlink this file in
+ To use it, place this file in
  ~/.local/share/gtksourceview-2.0/language-specs/ - or, if possible,
  /usr/share/gtksourceview-2.0/language-specs/
 

--- a/cylc/flow/etc/syntax/cylc.xml
+++ b/cylc/flow/etc/syntax/cylc.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE language SYSTEM "language.dtd">
 <language name="Cylc flow.cylc" section="Configuration" extensions="suite*.rc;*.cylc" mimetype="" version="1.0" kateversion="2.0" author="" license="GPL">
 
-<!-- For use with Kate. To use it, place or symlink this file in ~/.kde/share/apps/katepart/syntax/,
+<!-- For use with Kate. To use it, place this file in ~/.kde/share/apps/katepart/syntax/,
  or if possible, /usr/share/kde4/apps/katepart/syntax/ -->
 
   <highlighting>


### PR DESCRIPTION
Looks like the pattern was never correct even at Cylc 7!

This is a small change with no associated Issue.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (no existing tests and not obvious how?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
