### PR TITLE
Expand comma separated platform names correctly

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1493,9 +1493,11 @@ class GlobalConfig(ParsecConfig):
                     LOG.error(f'bad {conf_type} {fname}')
                     raise
 
+        # Expand platforms needs to be performed fist because it
+        # manipulates the sparse config.
+        self._expand_platforms()
         self._set_default_editors()
         self._no_platform_group_name_overlap()
-        self._expand_platforms()
 
     def _set_default_editors(self):
         # default to $[G]EDITOR unless an editor is defined in the config

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1493,7 +1493,7 @@ class GlobalConfig(ParsecConfig):
                     LOG.error(f'bad {conf_type} {fname}')
                     raise
 
-        # Expand platforms needs to be performed fist because it
+        # Expand platforms needs to be performed first because it
         # manipulates the sparse config.
         self._expand_platforms()
         self._set_default_editors()

--- a/tests/functional/cylc-config/10-platform-expansion.t
+++ b/tests/functional/cylc-config/10-platform-expansion.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test cylc config expansion of platform section.
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 2
+#-------------------------------------------------------------------------------
+cat > "global.cylc" <<__HEREDOC__
+[platforms]
+    [[ \
+        foo, bar..., \
+        baz\d\d, qux\S\S \
+    ]]
+        hosts = of_melkor, of_valar
+__HEREDOC__
+
+export CYLC_CONF_PATH="${PWD}"
+
+TEST_NAME="${TEST_NAME_BASE}-names"
+run_ok "${TEST_NAME}" cylc config --platform-names
+cmp_ok "${TEST_NAME}.stdout" <<__HEREDOC__
+localhost
+foo
+bar...
+baz\d\d
+qux\S\S
+
+__HEREDOC__
+
+exit


### PR DESCRIPTION
This is a small change with no associated Issue.

## Issue summary:

#4854 did not expand comma separated platform config items in the dense config.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (direct follow on to #4860 ).
- [x] No documentation update required.
