### PR TITLE
Don't prompt to clean no workflows.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Fourth Release Candidate for Cylc 8 suitable for acceptance testing.
 
 ### Fixes
 
+[#4889](https://github.com/cylc/cylc-flow/pull/4889) - `cylc clean`: don't
+prompt if no matching workflows.
+
 [#4881](https://github.com/cylc/cylc-flow/pull/4881) - Fix bug where commands
 targeting a specific cycle point would not work if using an abbreviated
 cycle point format.

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -183,6 +183,10 @@ async def run(*ids: str, opts: 'Values') -> None:
     # expand partial workflow ids (including run names)
     workflows, multi_mode = await scan(workflows, multi_mode)
 
+    if not workflows:
+        print(f"No workflows matching {', '.join(ids)}")
+        return
+
     workflows.sort()
     if multi_mode and not opts.skip_interactive:
         prompt(workflows)  # prompt for approval or exit


### PR DESCRIPTION
This is a small change with no associated Issue.

Master:
```console
$ cylc clean 'sagittarius-a*'
Would clean the following workflows:
Remove these workflows (y/n): 
```
This branch:
```console
$ cylc clean 'sagittarius-a*'
No workflows matching sagittarius-a*
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
