### PR TITLE
Fix bug in remote tidy error handling

### DIFF
--- a/lib/cylc/task_remote_mgr.py
+++ b/lib/cylc/task_remote_mgr.py
@@ -275,7 +275,7 @@ class TaskRemoteMgr(object):
                     LOG.warning(TaskRemoteMgmtError(
                         TaskRemoteMgmtError.MSG_TIDY,
                         (host, owner), ' '.join(quote(item) for item in cmd),
-                        proc.ret_code, out, err))
+                        proc.returncode, out, err))
         # Terminate any remaining commands
         for (host, owner), (cmd, proc) in procs.items():
             try:


### PR DESCRIPTION
This is a small change with no associated Issue. Fix an `AttributeError` that could occur if a remote tidy subprocess returned with a non-zero exit code.

I have checked and this bug is not present in Cylc 8 (fixed in https://github.com/cylc/cylc-flow/commit/a917a6f1629ec53c34988a0410b28fab1dc65d10 if anyone was interested)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] No tests needed (Meh).
- [x] No change log entry required (Tiny).
- [x] No documentation update required.
