### PR TITLE
provided a alt list of states for filtering Cylc 8 tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,13 @@ cylc-7.9.x (which requires Python 2.7) bundles Jinja2 2.11.
 cylc-8 (master branch, Python 3 - not yet released) uses proper Python package
 management and does not bundle Jinja2.
 
+## __cylc-7.8.12 ()__
+
+### Fixes
+
+[#4897](https://github.com/cylc/cylc-flow/pull/4897) - In Cylc Review task jobs
+view: Only allow filtering by Cylc 8 task states for Cylc 8 workflows.
+
 ## __cylc-7.8.11 (2022-03-07)__
 
 ### Fixes
@@ -40,11 +47,11 @@ Rose Bunch logs correctly.
 
 ### Fixes
 
-[#4429](https://github.com/cylc/cylc-flow/pull/4429) - cylc review: handle 
+[#4429](https://github.com/cylc/cylc-flow/pull/4429) - cylc review: handle
 log files with names changed at Cylc 8.
 
 [#4437](https://github.com/cylc/cylc-flow/pull/4437) - fix for slow polling
-generating an incorrect submit-failed result. 
+generating an incorrect submit-failed result.
 
 
 -------------------------------------------------------------------------------

--- a/lib/cylc/cylc-review/template/job-entry.html
+++ b/lib/cylc/cylc-review/template/job-entry.html
@@ -13,6 +13,7 @@
      no_fuzzy_time_str) | safe
 ) -%}
 <tr class="entry"><!-- entry row -->
+{% if entry.submit_num > 0 %}
   <td>
     <!-- entry: task status -->
     {% if entry.task_status == "succeeded" -%}
@@ -236,5 +237,8 @@
         </ul>
       {% endif -%}<!-- entry.seq_logs_indexes -->
     </small>
+
   </td>
+  {% endif %}
+
 </tr><!-- entry row -->

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -36,6 +36,7 @@ import os
 import pwd
 import re
 import shlex
+from sqlite3 import ProgrammingError
 import tarfile
 from tempfile import NamedTemporaryFile
 from time import gmtime, strftime
@@ -45,7 +46,7 @@ import urllib
 from cylc.hostuserutil import get_host
 from cylc.review_dao import CylcReviewDAO
 from cylc.task_state import (
-    TASK_STATUSES_ORDERED, TASK_STATUS_GROUPS, TASK_STATUS_WAITING)
+    TASK_STATUSES_ORDERED, TASK_STATUS_GROUPS)
 from cylc.version import CYLC_VERSION
 from cylc.ws import get_util_home
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
@@ -315,7 +316,6 @@ class CylcReviewService(object):
             page = 1
 
         # Set list of task states depending on Cylc version 7 or 8
-        from sqlite3 import ProgrammingError
         task_statuses_ordered = TASK_STATUSES_ORDERED
         try:
             if self.suite_dao.is_cylc8(user, suite):

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -51,6 +51,18 @@ from cylc.ws import get_util_home
 from cylc.suite_srv_files_mgr import SuiteSrvFilesManager
 
 
+CYLC8_TASK_STATUSES_ORDERED = [
+    'expired',
+    'failed',
+    'preparing',
+    'running',
+    'submitted',
+    'submit-failed',
+    'succeeded',
+    'waiting',
+]
+
+
 class CylcReviewService(object):
 
     """'Cylc Review Service."""
@@ -302,18 +314,24 @@ class CylcReviewService(object):
         else:
             page = 1
 
+        # Set list of task states depending on Cylc version 7 or 8
+        if self.suite_dao.is_cylc8(user, suite):
+            task_statuses_ordered = CYLC8_TASK_STATUSES_ORDERED
+        else:
+            task_statuses_ordered = TASK_STATUSES_ORDERED
+
         # get selected task states
         if not task_status:
             # default task statuses - if updating please also change the
             # $("#reset_task_statuses").click function in cylc-review.js
-            task_status = [state for state in TASK_STATUSES_ORDERED
+            task_status = [state for state in task_statuses_ordered
                            if state != TASK_STATUS_WAITING]
         elif not isinstance(task_status, list):
             task_status = [task_status]
 
         # generate list of all task states [(state, "0" or "1"), ...]
         task_statuses = [(status, "1" if status in task_status else "0")
-                         for status in TASK_STATUSES_ORDERED]
+                         for status in task_statuses_ordered]
 
         data = {
             "cycles": cycles,

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -315,17 +315,20 @@ class CylcReviewService(object):
             page = 1
 
         # Set list of task states depending on Cylc version 7 or 8
-        if self.suite_dao.is_cylc8(user, suite):
-            task_statuses_ordered = CYLC8_TASK_STATUSES_ORDERED
-        else:
+        from sqlite3 import ProgrammingError
+        try:
+            if self.suite_dao.is_cylc8(user, suite):
+                task_statuses_ordered = CYLC8_TASK_STATUSES_ORDERED
+            else:
+                task_statuses_ordered = TASK_STATUSES_ORDERED
+        except ProgrammingError:
             task_statuses_ordered = TASK_STATUSES_ORDERED
 
         # get selected task states
         if not task_status:
             # default task statuses - if updating please also change the
             # $("#reset_task_statuses").click function in cylc-review.js
-            task_status = [state for state in task_statuses_ordered
-                           if state != TASK_STATUS_WAITING]
+            task_status = list(task_statuses_ordered)
         elif not isinstance(task_status, list):
             task_status = [task_status]
 

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -316,14 +316,12 @@ class CylcReviewService(object):
 
         # Set list of task states depending on Cylc version 7 or 8
         from sqlite3 import ProgrammingError
+        task_statuses_ordered = TASK_STATUSES_ORDERED
         try:
             if self.suite_dao.is_cylc8(user, suite):
                 task_statuses_ordered = CYLC8_TASK_STATUSES_ORDERED
-            else:
-                task_statuses_ordered = TASK_STATUSES_ORDERED
         except ProgrammingError:
-            task_statuses_ordered = TASK_STATUSES_ORDERED
-
+            pass
         # get selected task states
         if not task_status:
             # default task statuses - if updating please also change the


### PR DESCRIPTION

These changes partially address #4782 

**Features check-list**
In `cylc review`...
- [x] Provide a different set of task state filters for Cylc 8 and Cylc 7.
- [x] Turn on waiting tasks by default if workflow is Cylc 8 (still under debate at #4782 )
- [x] Don't show tasks without jobs


**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests - to be manually tested (see below)
- [x] Appropriate change log entry included.
- [x] No documentation update required.

## How I tested 
```ini
# global.cylc (end of)
[platforms]
    [[submitfail]]
        hosts = notahost
    [[submitted]]
        hosts = exvcylcdev01
        install target = exvcylcdev01
        communication method = poll
        submission polling intervals = P1Y
```

```ini
# flow.cylc
[scheduler]
    allow implicit tasks = true
[scheduling]
    initial cycle point = 1
    [[dependencies]]
        R1 = """
             expired & preparing & submitted  => waiting
             running & submit-failed & succeeded & failed =>waiting
            """

[runtime]
    [[submitted]]
        platform = submitted
    [[submit-failed]]
        platform = submitfail
    [[running]]
        script = while true; do sleep 30; done
    [[failed]]
        script = exit 1
```

and add the following hack to Cylc flow:
```diff
diff --git a/cylc/flow/task_job_mgr.py b/cylc/flow/task_job_mgr.py
index ab4174b55..9f3eeadba 100644
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1082,6 +1082,11 @@ class TaskJobManager:
         Return itask on a good preparation.
 
         """
+        if 'preparing' in itask.identity:
+            LOG.critical('Prevent task called preparing ever being marked as prepped.')
+            return False
+
+
         if itask.local_job_file_path:
             return itask

```

Note: Don't forget to check that the change hasn't done anything bad to Cylc Review's ability to read Cylc flow.

Another Note: Recent versions of the wrapper script may re-direct you to the wrong version of `cylc review`, I found it worthwhile running explicitly from a path - i.e. `${HOME}/cylc-7/bin/cylc review start`
