### PR TITLE
main loop: improve defaults, docs and error handling

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -652,7 +652,7 @@ with Conf('global.cylc', desc='''
                     starting new workflows.
 
                     Only enabled plugins are loaded, plugins can be enabled
-                    in three ways:
+                    in two ways:
 
                     Globally:
                        To enable a plugin for all workflows add it to:
@@ -676,7 +676,7 @@ with Conf('global.cylc', desc='''
                 .. note::
 
                    Only the configured list of :cylc:conf:`[..]plugins`
-                   are loaded when a scheduler is started.
+                   is loaded when a scheduler is started.
             ''') as MainLoopPlugin:
                 Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
                     :Default For: :cylc:conf:`flow.cylc \
@@ -709,7 +709,7 @@ with Conf('global.cylc', desc='''
                 .. versionadded:: 8.0.0
             '''):
                 Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
-                    The interval with which this plugin is run.
+                    The interval between runs of this plugin.
 
                     .. versionadded:: 8.0.0
                 ''')

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -643,19 +643,42 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
         '''):
-            Conf('plugins', VDR.V_STRING_LIST,
-                 ['health check', 'reset bad hosts'],
-                 desc='''
-                     Configure the default main loop plugins to use when
-                     starting new workflows.
+            Conf(
+                'plugins',
+                VDR.V_STRING_LIST,
+                ['health check', 'reset bad hosts'],
+                desc='''
+                    Configure the default main loop plugins to use when
+                    starting new workflows.
 
-                     .. versionadded:: 8.0.0
+                    Only enabled plugins are loaded, plugins can be enabled
+                    in three ways:
+
+                    Globally:
+                       To enable a plugin for all workflows add it to:
+                       :cylc:conf:`global.cylc[scheduler][main loop]plugins`
+                    Per-Run:
+                       To enable a plugin for a one-off run of a workflow,
+                       specify it on the command line with
+                       ``cylc play --main-loop``.
+
+                       .. hint::
+
+                          This *appends* to the configured list of plugins
+                          rather than *overriding* it.
+
+                    .. versionadded:: 8.0.0
             ''')
 
             with Conf('<plugin name>', desc='''
                 Configure a main loop plugin.
+
+                .. note::
+
+                   Only the configured list of :cylc:conf:`[..]plugins`
+                   are loaded when a scheduler is started.
             ''') as MainLoopPlugin:
-                Conf('interval', VDR.V_INTERVAL, desc='''
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
                     :Default For: :cylc:conf:`flow.cylc \
                     [scheduler][main loop][<plugin name>]interval`.
 
@@ -666,6 +689,22 @@ with Conf('global.cylc', desc='''
 
             with Conf('health check', meta=MainLoopPlugin, desc='''
                 Checks the integrity of the workflow run directory.
+
+                .. versionadded:: 8.0.0
+            '''):
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
+                    The interval with which this plugin is run.
+
+                    .. versionadded:: 8.0.0
+                ''')
+
+            with Conf('auto restart', meta=MainLoopPlugin, desc='''
+                Automatically migrates workflows between servers.
+
+                For more information see:
+
+                * :ref:`Submitting Workflows To a Pool Of Hosts`.
+                * :py:mod:`cylc.flow.main_loop.auto_restart`
 
                 .. versionadded:: 8.0.0
             '''):

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -321,7 +321,7 @@ def load(config, additional_plugins=None):
         'state': {},
         'timings': {}
     }
-    for plugin_name in config['plugins'] + additional_plugins:
+    for plugin_name in set(config['plugins'] + additional_plugins):
         # get plugin
         try:
             entry_point = entry_points[plugin_name.replace(' ', '_')]

--- a/tests/unit/main_loop/test_auto_restart.py
+++ b/tests/unit/main_loop/test_auto_restart.py
@@ -20,13 +20,14 @@ from unittest.mock import Mock
 import pytest
 
 from cylc.flow import CYLC_LOG
-from cylc.flow.exceptions import HostSelectException
-from cylc.flow.hostuserutil import get_fqdn_by_host
+from cylc.flow.exceptions import CylcConfigError, HostSelectException
 from cylc.flow.main_loop.auto_restart import (
-    _should_auto_restart,
     _can_auto_restart,
-    _set_auto_restart
+    _set_auto_restart,
+    _should_auto_restart,
+    auto_restart,
 )
+from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.workflow_status import (
     AutoRestartMode,
     StopMode
@@ -280,3 +281,30 @@ def test_set_auto_restart_without_delay(monkeypatch, caplog):
         [(*_, msg)] = caplog.record_tuples
         assert 'will automatically restart' in msg
     assert called
+
+
+@pytest.mark.parametrize('exc_class', [ParsecError, CylcConfigError])
+async def test_log_config_error(caplog, log_filter, monkeypatch, exc_class):
+    """It should log errors in the global config.
+
+    When errors are present in the global config they should be caught and
+    logged nicely rather than left to spill over as traceback in the log.
+    """
+    # make the global config raise an error
+    def global_config_load_error(*args, **kwargs):
+        nonlocal exc_class
+        raise exc_class('something event more bizarrely inexplicable')
+
+    monkeypatch.setattr(
+        'cylc.flow.main_loop.auto_restart.glbl_cfg',
+        global_config_load_error,
+    )
+
+    # call the auto_restart plugin, the error should be caught
+    caplog.clear()
+    assert await auto_restart(None, None) is False
+
+    # the error should have been logged
+    assert len(caplog.messages) == 1
+    assert 'an error in the global config' in caplog.messages[0]
+    assert 'something event more bizarrely inexplicable' in caplog.messages[0]

--- a/tests/unit/main_loop/test_auto_restart.py
+++ b/tests/unit/main_loop/test_auto_restart.py
@@ -293,7 +293,7 @@ async def test_log_config_error(caplog, log_filter, monkeypatch, exc_class):
     # make the global config raise an error
     def global_config_load_error(*args, **kwargs):
         nonlocal exc_class
-        raise exc_class('something event more bizarrely inexplicable')
+        raise exc_class('something even more bizarrely inexplicable')
 
     monkeypatch.setattr(
         'cylc.flow.main_loop.auto_restart.glbl_cfg',
@@ -307,4 +307,4 @@ async def test_log_config_error(caplog, log_filter, monkeypatch, exc_class):
     # the error should have been logged
     assert len(caplog.messages) == 1
     assert 'an error in the global config' in caplog.messages[0]
-    assert 'something event more bizarrely inexplicable' in caplog.messages[0]
+    assert 'something even more bizarrely inexplicable' in caplog.messages[0]


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/4873
  (in combination with https://github.com/cylc/cylc-doc/pull/475)
* There is now a default main loop plugin interval of `PT10M`.
  This prevents any plugins without a hardcoded default from being run with every main loop cycle.
* Explicitly set a default for the `auto restart` plugin (also `PT10M`).
* Added a note on enabling plugins.
* Suppress traceback from reloading the global config in the `auto restart` plugin.
  This is now logged nicely.
* Prevent plugins from being loaded twice when specified both on the CLI
  (--main-loop) and in the config (global.cylc[scheduler][main loop]plugins).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? docs and minor improvements).
- [x] No documentation update required.