### PR TITLE
Fix task filtering.

### DIFF
--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -145,6 +145,8 @@ def filter_ids(
             if tokens.get(lowest_token.value):
                 break
 
+        # This needs to be a set to avoid getting two copies of matched tasks
+        # in cycle points that appear in both pools:
         cycles = set()
         tasks = []
 

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -166,8 +166,6 @@ def filter_ids(
                             cycles.add(icycle)
                             break
 
-            cycles = list(cycles)
-
         # filter by task
         elif lowest_token == IDTokens.Task:   # noqa SIM106
             cycle = tokens[IDTokens.Cycle.value]
@@ -215,7 +213,7 @@ def filter_ids(
             if warn:
                 LOG.warning(f"No active tasks matching: {id_}")
         else:
-            _cycles.extend(cycles)
+            _cycles.extend(list(cycles))
             _tasks.extend(tasks)
 
     ret: List[Any] = []

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -145,7 +145,7 @@ def filter_ids(
             if tokens.get(lowest_token.value):
                 break
 
-        cycles = []
+        cycles = set()
         tasks = []
 
         # filter by cycle
@@ -159,12 +159,14 @@ def filter_ids(
                     if not point_match(icycle, cycle, pattern_match):
                         continue
                     if cycle_sel == '*':
-                        cycles.append(icycle)
+                        cycles.add(icycle)
                         continue
                     for itask in itasks.values():
                         if match(itask.state.status, cycle_sel):
-                            cycles.append(icycle)
+                            cycles.add(icycle)
                             break
+
+            cycles = list(cycles)
 
         # filter by task
         elif lowest_token == IDTokens.Task:   # noqa SIM106

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -215,7 +215,7 @@ def filter_ids(
             if warn:
                 LOG.warning(f"No active tasks matching: {id_}")
         else:
-            _cycles.extend(list(cycles))
+            _cycles.extend(cycles)
             _tasks.extend(tasks)
 
     ret: List[Any] = []


### PR DESCRIPTION
@oliver-sanders - I think this might be a bug in your task filtering function, found too late in the day to fully investigate - can you take a quick look, and if you agree it's a bug I'll finish off the PR?

If both the hidden pool (partially satisfied prereqs) and main pool are passed to the function - which they are, from `TaskPool.filter_task_proxies()` - it seems to return two copies of matched tasks in cycle points that appear in both pools.



<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #xxxx
These changes close #xxxx
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
<!-- choose one: -->
- [x] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [x] No documentation update required.
