### PR TITLE
config: detect un-satisfiable dependencies

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -890,7 +890,7 @@ class Scheduler:
     def info_get_graph_raw(self, cto, ctn, grouping=None):
         """Return raw graph."""
         return (
-            self.config.get_graph_raw(cto, ctn, grouping),
+            self.config.get_graph_raw(cto, ctn, grouping, warn=False),
             self.config.workflow_polling_tasks,
             self.config.leaves,
             self.config.feet

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -40,7 +40,7 @@ from shutil import which
 from subprocess import Popen, PIPE
 import sys
 from tempfile import NamedTemporaryFile
-from typing import Dict, List, Optional, TYPE_CHECKING, Tuple
+from typing import Dict, List, Optional, TYPE_CHECKING, Tuple, Callable
 
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.exceptions import InputError, CylcError
@@ -141,6 +141,9 @@ def _get_graph_nodes_edges(
         return [], []
 
     # set sort keys based on cycling mode
+    # (note sorting is very important for the reference format)
+    node_sort: Optional[Callable]
+    edge_sort: Optional[Callable]
     if config.cfg['scheduling']['cycling mode'] == 'integer':
         # integer sorting
         node_sort = sort_integer_node

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -30,18 +30,20 @@ Examples:
 
     # display the difference between the flows one and two
     $ cylc graph one --diff two
+
+    # render the graph to a svg file
+    $ cylc graph one -o 'one.svg'
 """
 
 from difflib import unified_diff
-import re
 from shutil import which
 from subprocess import Popen, PIPE
 import sys
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, TYPE_CHECKING, Tuple
+from typing import Dict, List, Optional, TYPE_CHECKING, Tuple
 
 from cylc.flow.config import WorkflowConfig
-from cylc.flow.exceptions import InputError
+from cylc.flow.exceptions import InputError, CylcError
 from cylc.flow.id import Tokens
 from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import (
@@ -96,22 +98,47 @@ def sort_datetime_edge(item):
     return (item[0], item[1] or '')
 
 
-def graph_workflow(
+# node/edge types
+Node = str  # node ID
+Edge = Tuple[str, str, bool]   # left, right, left_node_exists
+
+
+def get_nodes_and_edges(
+    opts,
+    workflow_id,
+    start,
+    stop,
+) -> Tuple[List[Node], List[Edge]]:
+    """Return graph sorted nodes and edges."""
+    config = get_config(workflow_id, opts)
+    if opts.namespaces:
+        nodes, edges = _get_inheritance_nodes_and_edges(config)
+    else:
+        nodes, edges = _get_graph_nodes_edges(
+            config,
+            start,
+            stop,
+            grouping=opts.grouping,
+            show_suicide=opts.show_suicide,
+        )
+    return nodes, edges
+
+
+def _get_graph_nodes_edges(
     config,
     start_point_str=None,
     stop_point_str=None,
     grouping=None,
     show_suicide=False,
-    write=print
-):
-    """Implement ``cylc-graph --reference``."""
+) -> Tuple[List[Node], List[Edge]]:
+    """Return nodes and edges for a workflow graph."""
     graph = config.get_graph_raw(
         start_point_str,
         stop_point_str,
         grouping
     )
     if not graph:
-        return
+        return [], []
 
     # set sort keys based on cycling mode
     if config.cfg['scheduling']['cycling mode'] == 'integer':
@@ -123,55 +150,43 @@ def graph_workflow(
         node_sort = None  # lexicographically sortable
         edge_sort = sort_datetime_edge
 
-    edges = (
-        (left, right)
-        for left, right, _, suicide, _ in graph
-        if right
-        if show_suicide or not suicide
-    )
-    for left, right in sorted(set(edges), key=edge_sort):
-        write('edge "%s" "%s"' % (left, right))
-
-    write('graph')
-
-    # print nodes
-    nodes = (
+    # get nodes
+    nodes = list({
         node
         for left, right, _, suicide, _ in graph
         for node in (left, right)
         if node
         if show_suicide or not suicide
-    )
-    for node in sorted(set(nodes), key=node_sort):
-        tokens = Tokens(node, relative=True)
-        write(
-            f'node "{node}" "{tokens["task"]}\\n{tokens["cycle"]}"'
-        )
+    })
+    nodes.sort(key=node_sort)
 
-    write('stop')
+    # get edges
+    edges = list({
+        (left, right, node_exists)
+        for left, right, node_exists, suicide, _ in graph
+        if right
+        if show_suicide or not suicide
+    })
+    edges.sort(key=edge_sort)
+
+    return nodes, edges
 
 
-def graph_inheritance(config, write=print):
-    """Implement ``cylc-graph --reference --namespaces``."""
-    edges = set()
+def _get_inheritance_nodes_and_edges(
+    config
+) -> Tuple[List[Node], List[Edge]]:
+    """Return nodes and edges for an inheritance graph."""
     nodes = set()
-    for namespace, tasks in config.get_parent_lists().items():
-        for task in tasks:
-            edges.add((task, namespace))
-            nodes.add(task)
-
     for namespace in config.get_parent_lists():
         nodes.add(namespace)
 
-    for edge in sorted(edges):
-        write('edge "%s" "%s"' % edge)
+    edges = set()
+    for namespace, tasks in config.get_parent_lists().items():
+        for task in tasks:
+            edges.add((task, namespace, True))
+            nodes.add(task)
 
-    write('graph')
-
-    for node in sorted(nodes):
-        write('node "%s" "%s"' % (node, node))
-
-    write('stop')
+    return sorted(nodes), sorted(edges)
 
 
 def get_config(workflow_id: str, opts: 'Values') -> WorkflowConfig:
@@ -185,6 +200,237 @@ def get_config(workflow_id: str, opts: 'Values') -> WorkflowConfig:
     return WorkflowConfig(
         workflow_id, flow_file, opts, template_vars=template_vars
     )
+
+
+def format_graphviz(
+    opts,
+    nodes: List[Node],
+    edges: List[Edge],
+) -> List[str]:
+    """Write graph in graphviz format."""
+    # write graph header
+    dot_lines = [
+        'digraph {',
+        '  graph [fontname="sans" fontsize="25"]',
+        '  node [fontname="sans"]',
+    ]
+    if opts.transpose:
+        dot_lines.append('  rankdir="LR"')
+    if opts.namespaces:
+        dot_lines.append('  node [shape="rect"]')
+    dot_lines.append('')
+
+    # write nodes
+    if opts.namespaces:
+        dot_lines.extend([
+            rf'  "{node}"'
+            for node in nodes
+        ])
+        dot_lines.append('')
+    else:
+        # group by cycle
+        cycles: Dict[str, List[str]] = {}
+        for node in nodes:
+            tokens = Tokens(node, relative=True)
+            cycle: str = tokens['cycle']
+            task: str = tokens['task']
+            cycles.setdefault(cycle, []).append(task)
+        # write nodes by cycle
+        if opts.cycles:
+            indent = '    '
+        else:
+            indent = '  '
+        for cycle, tasks in cycles.items():
+            if opts.cycles:
+                dot_lines.extend(
+                    [
+                        f'  subgraph "cluster_{cycle}" {{ ',
+                        f'    label="{cycle}"',
+                        '    style="dashed"',
+                    ]
+                )
+            dot_lines.extend(
+                rf'{indent}"{cycle}/{task}" [label="{task}\n{cycle}"]'
+                for task in tasks
+            )
+            if opts.cycles:
+                dot_lines.append('  }')
+            dot_lines.append('')
+
+    # write edges
+    for left, right, node_exists in edges:
+        if not node_exists:
+            # this is an un-satisfiable dependency:
+            # * get_graph_raw will already have raised a warning
+            # * style the node and edge to make it obvious
+            tokens = Tokens(left, relative=True)
+            cycle = tokens['cycle']
+            task = tokens['task']
+            dot_lines.extend([
+                f'  "{cycle}/{task}" [',
+                f'    label="{task}\n{cycle}"',
+                '    color="#888888"',
+                '    fontcolor="#888888"',
+                '  ]'
+            ])
+            dot_lines.append(f'  "{left}" -> "{right}" [color="#888888"]')
+        else:
+            dot_lines.append(f'  "{left}" -> "{right}"')
+
+    # close graph
+    dot_lines.append('}')
+
+    return dot_lines
+
+
+def format_cylc_reference(
+    opts,
+    nodes: List[Node],
+    edges: List[Edge],
+) -> List[str]:
+    """Write graph in cylc reference format."""
+    lines = []
+    # write edges
+    for left, right, _ in edges:
+        lines.append(f'edge "{left}" "{right}"')
+
+    # write separator
+    lines.append('graph')
+
+    # write nodes
+    if opts.namespaces:
+        for node in nodes:
+            lines.append(f'node "{node}" "{node}"')
+    else:
+        for node in nodes:
+            tokens = Tokens(node, relative=True)
+            lines.append(
+                f'node "{node}" "{tokens["task"]}\\n{tokens["cycle"]}"'
+            )
+
+    # write terminator
+    lines.append('stop')
+
+    return lines
+
+
+def render_dot(dot_lines, filename, fmt):
+    """Render graph using `dot`."""
+    # check graphviz-dot is installed
+    if not which('dot'):
+        sys.exit('Graphviz must be installed to render graphs.')
+
+    # render graph with graphviz
+    proc = Popen(  # nosec
+        ['dot', f'-T{fmt}', '-o', filename],
+        stdin=PIPE,
+        text=True
+    )
+    proc.communicate('\n'.join(dot_lines))
+    proc.wait()
+    if proc.returncode:
+        raise CylcError('Graphing Failed')
+
+
+def open_image(filename):
+    """Open an image file."""
+    print(f'Graph rendered to {filename}')
+    try:
+        from PIL import Image
+    except ModuleNotFoundError:
+        # dependencies required to display images not present
+        pass
+    else:
+        img = Image.open(filename)
+        img.show()
+
+
+def graph_render(opts, workflow_id, start, stop) -> int:
+    """Render the workflow graph to the specified format.
+
+    Graph is rendered to the specified format. The Graphviz "dot" format
+    does not require Graphviz to be installed.
+
+    All other formats require Graphviz. Supported formats depend on your
+    Graphviz installation.
+    """
+    # get nodes and edges
+    nodes, edges = get_nodes_and_edges(
+        opts,
+        workflow_id,
+        start,
+        stop,
+    )
+
+    # format the graph in graphviz-dot format
+    dot_lines = format_graphviz(opts, nodes, edges)
+
+    # set filename and output format
+    if opts.output:
+        filename = opts.output
+        try:
+            fmt = filename.rsplit('.', 1)[1]
+        except IndexError:
+            sys.exit('Output filename requires a format.')
+    else:
+        filename = NamedTemporaryFile().name
+        fmt = 'png'
+
+    if fmt == 'dot':
+        # output in dot format (graphviz not needed for this)
+        with open(filename, 'w+') as dot_file:
+            dot_file.write('\n'.join(dot_lines) + '\n')
+        return 0
+
+    # render with graphviz
+    render_dot(dot_lines, filename, fmt)
+
+    # notify the user / open the graph
+    if opts.output:
+        print(f'Graph rendered to {opts.output}')
+    else:
+        open_image(filename)
+    return 0
+
+
+def graph_reference(opts, workflow_id, start, stop, write=print) -> int:
+    """Format the workflow graph using the cylc reference format."""
+    # get nodes and edges
+    nodes, edges = get_nodes_and_edges(
+        opts,
+        workflow_id,
+        start,
+        stop,
+    )
+    for line in format_cylc_reference(opts, nodes, edges):
+        write(line)
+
+    return 0
+
+
+def graph_diff(opts, workflow_a, workflow_b, start, stop) -> int:
+    """Difference the workflow graphs using the cylc reference format."""
+    # load graphs
+    graph_a: List[str] = []
+    graph_b: List[str] = []
+    graph_reference(opts, workflow_a, start, stop, write=graph_a.append),
+    graph_reference(opts, workflow_b, start, stop, write=graph_b.append),
+
+    # compare graphs
+    diff_lines = list(
+        unified_diff(
+            [f'{line}\n' for line in graph_a],
+            [f'{line}\n' for line in graph_b],
+            fromfile=workflow_a,
+            tofile=workflow_b,
+        )
+    )
+
+    # return results
+    if diff_lines:
+        sys.stdout.writelines(diff_lines)
+        return 1
+    return 0
 
 
 def get_option_parser() -> COP:
@@ -228,7 +474,7 @@ def get_option_parser() -> COP:
         '-o',
         help=(
             'Output the graph to a file. The file extension determines the'
-            ' format.'
+            ' format. E.G. "graph.png", "graph.svg", "graph.dot".'
         ),
         action='store',
         dest='output'
@@ -264,110 +510,6 @@ def get_option_parser() -> COP:
     return parser
 
 
-def dot(opts, lines):
-    """Render a graph using graphviz 'dot'.
-
-    This crudely re-parses the output of the reference output for simplicity.
-
-    This functionality will be replaced by the GUI.
-
-    """
-    if not which('dot'):
-        sys.exit('Graphviz must be installed to render graphs.')
-
-    # set filename and output format
-    if opts.output:
-        filename = opts.output
-        try:
-            fmt = filename.rsplit('.', 1)[1]
-        except IndexError:
-            sys.exit('Output filename requires a format.')
-    else:
-        filename = NamedTemporaryFile().name
-        fmt = 'png'
-
-    # scrape nodes and edges from the reference output
-    node = re.compile(r'node "(.*)" "(.*)"')
-    edge = re.compile(r'edge "(.*)" "(.*)"')
-    nodes = {}
-    edges = []
-    for line in lines:
-        match = node.match(line)
-        if match:
-            if opts.namespaces:
-                task = match.group(1)
-                cycle = ''
-            else:
-                cycle, task = match.group(1).split('/')
-                nodes.setdefault(cycle, []).append(task)
-            continue
-        match = edge.match(line)
-        if match:
-            edges.append(match.groups())
-
-    # write graph header
-    dot = [
-        'digraph {',
-        '  graph [fontname="sans" fontsize="25"]',
-        '  node [fontname="sans"]',
-    ]
-    if opts.transpose:
-        dot.append('  rankdir="LR"')
-    if opts.namespaces:
-        dot.append('  node [shape="rect"]')
-
-    # write nodes
-    for cycle, tasks in nodes.items():
-        if opts.cycles:
-            dot.extend(
-                [
-                    f'  subgraph "cluster_{cycle}" {{ ',
-                    f'    label="{cycle}"',
-                    '    style="dashed"',
-                ]
-            )
-        dot.extend(
-            rf'    "{cycle}/{task}" [label="{task}\n{cycle}"]'
-            for task in tasks
-        )
-        dot.append('  }' if opts.cycles else '')
-
-    # write edges
-    for left, right in edges:
-        dot.append(f'  "{left}" -> "{right}"')
-
-    # close graph
-    dot.append('}')
-
-    # render graph
-    proc = Popen(  # nosec
-        ['dot', f'-T{fmt}', '-o', filename],
-        stdin=PIPE,
-        text=True
-    )
-    # * filename is generated in code above
-    # * fmt is user specified and quoted (by subprocess)
-    proc.communicate('\n'.join(dot))
-    proc.wait()
-    if proc.returncode:
-        sys.exit('Graphing Failed')
-
-    return filename
-
-
-def gui(filename):
-    """Open the rendered image file."""
-    print(f'Graph rendered to {filename}')
-    try:
-        from PIL import Image
-    except ModuleNotFoundError:
-        # dependencies required to display images not present
-        pass
-    else:
-        img = Image.open(filename)
-        img.show()
-
-
 @cli_function(get_option_parser)
 def main(
     parser: COP,
@@ -379,50 +521,17 @@ def main(
     """Implement ``cylc graph``."""
     if opts.grouping and opts.namespaces:
         raise InputError('Cannot combine --group and --namespaces.')
-
-    lines: List[str] = []
-    if not (opts.reference or opts.diff):
-        write = lines.append
-    else:
-        write = print
-
-    flows: List[Tuple[str, List[str]]] = [(workflow_id, [])]
-    if opts.diff:
-        flows.append((opts.diff, []))
-
-    for flow, graph in flows:
-        if opts.diff:
-            write = graph.append
-        config = get_config(flow, opts)
-        if opts.namespaces:
-            graph_inheritance(config, write=write)
-        else:
-            graph_workflow(
-                config,
-                start,
-                stop,
-                grouping=opts.grouping,
-                show_suicide=opts.show_suicide,
-                write=write
-            )
+    if opts.cycles and opts.namespaces:
+        raise InputError('Cannot combine --cycles and --namespaces.')
 
     if opts.diff:
-        diff_lines = list(
-            unified_diff(
-                [f'{line}\n' for line in flows[0][1]],
-                [f'{line}\n' for line in flows[1][1]],
-                fromfile=flows[0][0],
-                tofile=flows[1][0]
-            )
+        sys.exit(
+            graph_diff(opts, workflow_id, opts.diff, start, stop)
         )
-
-        if diff_lines:
-            sys.stdout.writelines(diff_lines)
-            sys.exit(1)
-
-    if not (opts.reference or opts.diff):
-        filename = dot(opts, lines)
-        if opts.output:
-            print(f'Graph rendered to {opts.output}')
-        else:
-            gui(filename)
+    if opts.reference:
+        sys.exit(
+            graph_reference(opts, workflow_id, start, stop)
+        )
+    sys.exit(
+        graph_render(opts, workflow_id, start, stop)
+    )

--- a/tests/functional/graphing/12-unsatisfiable.t
+++ b/tests/functional/graphing/12-unsatisfiable.t
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test un-satisfiable dependencies are correctly identified in graphs
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 9
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1
+    [[graph]]
+        # two un-satisfiable dependencies
+        # (the inter-cycle deps are missaligned with the recurrences)
+        1/P2 = a[-P2] => b
+        2/P2 = b[-P2] => a
+__FLOW_CONFIG__
+
+#-------------------------------------------------------------------------------
+# cylc validate should log warnings for the un-satisfiable dependencies
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+grep_ok "Detected un-satisfiable dependencies" "${TEST_NAME}.stderr"
+grep_ok "1/a => 3/b" "${TEST_NAME}.stderr"
+grep_ok "2/b => 4/a" "${TEST_NAME}.stderr"
+
+#-------------------------------------------------------------------------------
+# cylc graph should log warnings for the un-satisfiable dependencies
+TEST_NAME="${TEST_NAME_BASE}-graph"
+run_ok "${TEST_NAME}" cylc graph "${WORKFLOW_NAME}" 1 5 -o "${TEST_NAME}.dot"
+grep_ok "Detected un-satisfiable dependencies" "${TEST_NAME}.stderr"
+grep_ok "1/a => 3/b" "${TEST_NAME}.stderr"
+grep_ok "2/b => 4/a" "${TEST_NAME}.stderr"
+# cylc graph should render the un-satisfiable dependencies in a special way
+# to set them apart
+cmp_ok "${TEST_NAME}.dot" <<'__DOT__'
+digraph {
+  graph [fontname="sans" fontsize="25"]
+  node [fontname="sans"]
+
+  "1/a" [label="a\n1"]
+  "1/b" [label="b\n1"]
+
+  "2/a" [label="a\n2"]
+  "2/b" [label="b\n2"]
+
+  "3/a" [label="a\n3"]
+  "3/b" [label="b\n3"]
+
+  "4/a" [label="a\n4"]
+
+  "5/b" [label="b\n5"]
+
+  "1/a" [
+    label="a
+1"
+    color="#888888"
+    fontcolor="#888888"
+  ]
+  "1/a" -> "3/b" [color="#888888"]
+  "3/a" [
+    label="a
+3"
+    color="#888888"
+    fontcolor="#888888"
+  ]
+  "3/a" -> "5/b" [color="#888888"]
+  "2/b" [
+    label="b
+2"
+    color="#888888"
+    fontcolor="#888888"
+  ]
+  "2/b" -> "4/a" [color="#888888"]
+}
+__DOT__
+purge
+exit

--- a/tests/unit/scripts/test_graph.py
+++ b/tests/unit/scripts/test_graph.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+#
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from types import SimpleNamespace
+import typing as t
+
+import pytest
+
+from cylc.flow.scripts.graph import (
+    Node,
+    Edge,
+    format_graphviz,
+    format_cylc_reference,
+)
+
+
+@pytest.fixture
+def example_graph():
+    """Example workflow graph with inter-cycle dependencies."""
+    nodes: t.List[Node] = [
+        '1/a',
+        '1/b',
+        '1/c',
+        '2/a',
+        '2/b',
+        '2/c',
+    ]
+    edges: t.List[Edge] = [
+        ('1/a', '1/b', True),
+        ('1/b', '1/c', True),
+        ('2/a', '2/b', True),
+        ('2/b', '2/c', True),
+        ('1/b', '2/b', True),
+    ]
+    return nodes, edges
+
+
+@pytest.fixture
+def example_namespace_graph():
+    """Example namespace graph with inheritance."""
+    nodes: t.List[Node] = [
+        'A',
+        'a1',
+        'a2',
+        'B',
+        'B1',
+        'b11',
+        'B2',
+        'b22',
+    ]
+    edges: t.List[Edge] = [
+        ('A', 'a1', True),
+        ('A', 'a2', True),
+        ('B', 'B1', True),
+        ('B', 'B2', True),
+        ('B1', 'b11', True),
+        ('B2', 'b22', True),
+    ]
+    return nodes, edges
+
+
+def test_format_graphviz_normal(example_graph):
+    """Test graphviz output for default options.
+
+    Tests both orientations (--transpose).
+    """
+    nodes, edges = example_graph
+
+    # format the graph in regular orientation
+    opts = SimpleNamespace(transpose=False, namespaces=False, cycles=False)
+    lines = format_graphviz(opts, nodes, edges)
+    assert lines == [
+        'digraph {',
+        '  graph [fontname="sans" fontsize="25"]',
+        '  node [fontname="sans"]',
+        '',
+        '  "1/a" [label="a\\n1"]',
+        '  "1/b" [label="b\\n1"]',
+        '  "1/c" [label="c\\n1"]',
+        '',
+        '  "2/a" [label="a\\n2"]',
+        '  "2/b" [label="b\\n2"]',
+        '  "2/c" [label="c\\n2"]',
+        '',
+        '  "1/a" -> "1/b"',
+        '  "1/b" -> "1/c"',
+        '  "2/a" -> "2/b"',
+        '  "2/b" -> "2/c"',
+        '  "1/b" -> "2/b"',
+        '}',
+    ]
+
+    # format the graph in transposed orientation
+    opts = SimpleNamespace(transpose=True, namespaces=False, cycles=False)
+    transposed_lines = format_graphviz(opts, nodes, edges)
+
+    # the transposed graph should be the same except for one line...
+    assert [
+        line
+        for line in transposed_lines
+        if line not in lines
+    ] == [
+        # ...the one which sets the orientation
+        '  rankdir="LR"',
+    ]
+
+
+def test_format_graphviz_namespace(example_namespace_graph):
+    """Test graphviz output for a namespace graph.
+
+    Tests both orientations (--transpose).
+    """
+    nodes, edges = example_namespace_graph
+
+    # format the graph in regular orientation
+    opts = SimpleNamespace(transpose=False, namespaces=True, cycles=False)
+    lines = format_graphviz(opts, nodes, edges)
+    assert lines == [
+        'digraph {',
+        '  graph [fontname="sans" fontsize="25"]',
+        '  node [fontname="sans"]',
+        '  node [shape="rect"]',
+        '',
+        '  "A"',
+        '  "a1"',
+        '  "a2"',
+        '  "B"',
+        '  "B1"',
+        '  "b11"',
+        '  "B2"',
+        '  "b22"',
+        '',
+        '  "A" -> "a1"',
+        '  "A" -> "a2"',
+        '  "B" -> "B1"',
+        '  "B" -> "B2"',
+        '  "B1" -> "b11"',
+        '  "B2" -> "b22"',
+        '}',
+    ]
+
+    # format the graph in transposed orientation
+    opts = SimpleNamespace(transpose=True, namespaces=True, cycles=False)
+    transposed_lines = format_graphviz(opts, nodes, edges)
+
+    # the transposed graph should be the same except for one line...
+    assert [
+        line
+        for line in transposed_lines
+        if line not in lines
+    ] == [
+        # ...the one which sets the orientation
+        '  rankdir="LR"',
+    ]
+
+
+def test_format_graphviz_cycles(example_graph):
+    """Test graphviz format for the --cycles option (group by cycle).
+
+    Note: There is no difference between iso8601 and integer cycle points here,
+    the graph logic is cycle point format agnostic. Sorting is not performed
+    in this funtion.
+    """
+    nodes, edges = example_graph
+
+    opts = SimpleNamespace(transpose=False, namespaces=False, cycles=True)
+    lines = format_graphviz(opts, nodes, edges)
+    assert lines == [
+        'digraph {',
+        '  graph [fontname="sans" fontsize="25"]',
+        '  node [fontname="sans"]',
+        '',
+        '  subgraph "cluster_1" { ',
+        '    label="1"',
+        '    style="dashed"',
+        '    "1/a" [label="a\\n1"]',
+        '    "1/b" [label="b\\n1"]',
+        '    "1/c" [label="c\\n1"]',
+        '  }',
+        '',
+        '  subgraph "cluster_2" { ',
+        '    label="2"',
+        '    style="dashed"',
+        '    "2/a" [label="a\\n2"]',
+        '    "2/b" [label="b\\n2"]',
+        '    "2/c" [label="c\\n2"]',
+        '  }',
+        '',
+        '  "1/a" -> "1/b"',
+        '  "1/b" -> "1/c"',
+        '  "2/a" -> "2/b"',
+        '  "2/b" -> "2/c"',
+        '  "1/b" -> "2/b"',
+        '}',
+    ]
+
+
+def test_format_cylc_reference_normal(example_graph):
+    """Test Cylc "reference" format (used by the test battery).
+
+    Note: There is no difference between iso8601 and integer cycle points here,
+    the graph logic is cycle point format agnostic. Sorting is not performed
+    in this funtion.
+
+    Note: There is no transpose mode for reference graphs.
+    """
+    nodes, edges = example_graph
+
+    opts = SimpleNamespace(namespaces=False)
+    lines = format_cylc_reference(opts, nodes, edges)
+    assert lines == [
+        'edge "1/a" "1/b"',
+        'edge "1/b" "1/c"',
+        'edge "2/a" "2/b"',
+        'edge "2/b" "2/c"',
+        'edge "1/b" "2/b"',
+        'graph',
+        'node "1/a" "a\\n1"',
+        'node "1/b" "b\\n1"',
+        'node "1/c" "c\\n1"',
+        'node "2/a" "a\\n2"',
+        'node "2/b" "b\\n2"',
+        'node "2/c" "c\\n2"',
+        'stop',
+    ]
+
+
+def test_format_cylc_reference_namespace(example_namespace_graph):
+    """Test Cylc "reference" format for namespace graphs.
+
+    Note: There is no transpose mode for reference graphs.
+    """
+    nodes, edges = example_namespace_graph
+
+    opts = SimpleNamespace(namespaces=True)
+    lines = format_cylc_reference(opts, nodes, edges)
+    assert lines == [
+        'edge "A" "a1"',
+        'edge "A" "a2"',
+        'edge "B" "B1"',
+        'edge "B" "B2"',
+        'edge "B1" "b11"',
+        'edge "B2" "b22"',
+        'graph',
+        'node "A" "A"',
+        'node "a1" "a1"',
+        'node "a2" "a2"',
+        'node "B" "B"',
+        'node "B1" "B1"',
+        'node "b11" "b11"',
+        'node "B2" "B2"',
+        'node "b22" "b22"',
+        'stop',
+    ]


### PR DESCRIPTION
get-graph-raw: check for unsatisfiable dependencies:

* Closes #4514 (@hjoliver to confirm)
* Re-purpose an unused field i `get_graph_raw` output to mark dependencies which cannot be satisfied due to the prerequisite task not existing in the graph at the required point.    
* This can happen due to typos or when an inter-cycle dependence is misaligned with the task's recurrence.    
* This will now warn by default (validate, play, etc), note, however, that this check will be skipped for workflows with >100 tasks (`CHECK_CIRCULAR_LIMIT`) see #4910.    
      
graph: render un-satisfiable dependencies as ghosts:

* Closes #4638    
* Fixes a regression where `cylc graph` was no longer rendering un-satisfiable dependencies differently (see #2346 for original implementation).               
* Restores the missing functionality to `cylc graph` and also adds warnings so un-satisfiable dependencies can be detected more easily.    
* Refactors `cylc graph` a little, main change is that graphviz output is no longer achieved by re-processing the reference output using regexes. It's now generated from the graph directly.   

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [x] (master branch) Documentation issue - https://github.com/cylc/cylc-doc/issues/477
