### PR TITLE
Improve config reference docs

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -587,7 +587,16 @@ with Conf('global.cylc', desc='''
             Conf('from', VDR.V_STRING, desc='''
                 :Default For: :cylc:conf:`flow.cylc[scheduler][mail]from`.
             ''')
-            Conf('smtp', VDR.V_STRING)
+            Conf('smtp', VDR.V_STRING, desc='''
+                Specify the SMTP server for sending workflow event email
+                notifications.
+
+                This cannot be configured in ``flow.cylc``.
+
+                Example::
+
+                   smtp.yourorg
+            ''')
             Conf('to', VDR.V_STRING, desc='''
                 :Default For: :cylc:conf:`flow.cylc[scheduler][mail]to`.
             ''')
@@ -638,7 +647,7 @@ with Conf('global.cylc', desc='''
                        .. hint::
 
                           This *appends* to the configured list of plugins
-                          rather than *overriding* it.
+                          rather than overriding it.
 
                     .. versionadded:: 8.0.0
             ''')

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -79,21 +79,22 @@ PLATFORM_REPLACES = (
 
 
 PLATFORM_META_DESCR = '''
-    Metadata for this platform or platform group.
+Metadata for this platform or platform group.
 
-    Allows writers of platform configurations to add information
-    about platform usage. There are no-preset items because
-    Cylc does not use any platform (or group) metadata internally.
+Allows writers of platform configurations to add information
+about platform usage. There are no-preset items because
+Cylc does not use any platform (or group) metadata internally.
 
-    Users can then see information about defined platforms using::
+Users can then see information about defined platforms using::
 
-        cylc config -i [platforms]
-        cylc config -i [platform groups]
+   cylc config -i [platforms]
+   cylc config -i [platform groups]
 
-    .. seealso::
+.. seealso::
 
-        :ref:`AdminGuide.PlatformConfigs`
+   :ref:`AdminGuide.PlatformConfigs`
 
+.. versionadded:: 8.0.0
 '''
 
 # ----------------------------------------------------------------------------
@@ -233,14 +234,12 @@ EVENTS_SETTINGS = {  # workflow events
     '''
 }
 
-MAIL_DESCR = f'''
+MAIL_DESCR = '''
 Settings for the scheduler to send event emails.
 
 These settings are used for both workflow and task events.
 
-.. versionchanged:: 8.0.0
-
-   {REPLACES}``[cylc][events]mail <item>``.
+.. versionadded:: 8.0.0
 '''
 
 MAIL_FROM_DESCR = f'''
@@ -372,7 +371,7 @@ submission fails.
    {REPLACES}``[runtime][<namespace>][job]submission retry delays``.
 '''
 
-EXECUTION_POLL_DESCR = '''
+EXECUTION_POLL_DESCR = f'''
 List of intervals at which to poll status of job execution.
 
 Cylc can poll running jobs to catch problems that prevent task messages from
@@ -391,6 +390,10 @@ Note that if the polling
 :cylc:conf:`global.cylc[platforms][<platform name>]communication method` is
 used then Cylc relies on polling to detect all task state changes, so you may
 want to configure more frequent polling.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[runtime][<namespace>][job]execution polling intervals``.
 '''
 
 TASK_EVENTS_DESCR = '''
@@ -1097,20 +1100,20 @@ with Conf('global.cylc', desc='''
         Platforms allow you to define compute resources available at your
         site.
 
-        .. versionadded:: 8.0.0
-
         A platform consists of a group of one or more hosts which share a
         file system and a job runner (batch system).
 
         A platform must allow interaction with the same task job from *any*
         of its hosts.
+
+        .. versionadded:: 8.0.0
     '''):
         with Conf('<platform name>', desc='''
             Configuration defining a platform.
 
-            Many of these settings replace those of the same name from the
-            deprecated :cylc:conf:`flow.cylc[runtime][<namespace>][job]` and
-            :cylc:conf:`flow.cylc[runtime][<namespace>][remote]` sections.
+            Many of these settings have replaced those of the same name from
+            the old Cylc 7 ``suite.rc[runtime][<namespace>][job]/[remote]``
+            and ``global.rc[hosts][<host>]`` sections.
 
             Platform names can be regular expressions: If you have a set of
             compute resources such as ``bigmachine1, bigmachine2`` or
@@ -1154,6 +1157,8 @@ with Conf('global.cylc', desc='''
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.
+
+                    .. versionadded:: 8.0.0
                 ''')
             Conf('hosts', VDR.V_STRING_LIST, desc='''
                 A list of hosts from which the job host can be selected using
@@ -1201,7 +1206,7 @@ with Conf('global.cylc', desc='''
             ''')
             Conf('communication method',
                  VDR.V_STRING, 'zmq',
-                 options=[meth.value for meth in CommsMeth], desc='''
+                 options=[meth.value for meth in CommsMeth], desc=f'''
                 The means by which task progress messages are reported back to
                 the running workflow.
 
@@ -1213,6 +1218,11 @@ with Conf('global.cylc', desc='''
                    The workflow polls for task status (no task messaging)
                 ssh
                    Use non-interactive ssh for task communications
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]task communication
+                   method``.
             ''')
             Conf(
                 'submission polling intervals', VDR.V_INTERVAL_LIST,
@@ -1238,7 +1248,7 @@ with Conf('global.cylc', desc='''
             Conf('execution time limit polling intervals',
                  VDR.V_INTERVAL_LIST,
                  [DurationFloat(60), DurationFloat(120), DurationFloat(420)],
-                 desc='''
+                 desc=f'''
                 List of intervals after execution time limit to poll jobs.
 
                 If a job exceeds its execution time limit, Cylc can poll
@@ -1250,11 +1260,16 @@ with Conf('global.cylc', desc='''
                 Example::
 
                    5*PT2M, PT5M
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]execution time limit polling``.
             ''')
             Conf('ssh command',
                  VDR.V_STRING,
                  'ssh -oBatchMode=yes -oConnectTimeout=10',
-                 desc='''
+                 desc=f'''
                 A communication command used to invoke commands on this
                 platform.
 
@@ -1262,6 +1277,10 @@ with Conf('global.cylc', desc='''
                 under another user account.  The value is assumed to be ``ssh``
                 with some initial options or a command that implements a
                 similar interface to ``ssh``.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]ssh command``.
             ''')
             Conf('rsync command',
                  VDR.V_STRING,
@@ -1269,8 +1288,10 @@ with Conf('global.cylc', desc='''
                  desc='''
                 Command used for remote file installation. This supports POSIX
                 compliant rsync implementation e.g. GNU or BSD.
+
+                .. versionadded:: 8.0.0
             ''')
-            Conf('use login shell', VDR.V_BOOLEAN, True, desc='''
+            Conf('use login shell', VDR.V_BOOLEAN, True, desc=f'''
                 Whether to use a login shell or not for remote command
                 invocation.
 
@@ -1303,6 +1324,10 @@ with Conf('global.cylc', desc='''
                 which will use the default shell on the remote machine,
                 sourcing ``~/.bashrc`` (or ``~/.cshrc``) to set up the
                 environment.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]use login shell``.
             ''')
             Conf('cylc path', VDR.V_STRING, desc='''
                 The path containing the ``cylc`` executable on a remote
@@ -1338,7 +1363,7 @@ with Conf('global.cylc', desc='''
                    Moved from ``suite.rc[runtime][<namespace>][job]
                    cylc executable``.
             ''')
-            Conf('global init-script', VDR.V_STRING, desc='''
+            Conf('global init-script', VDR.V_STRING, desc=f'''
                 A per-platform script which is run before other job scripts.
 
                 This should be used sparingly to perform any shell
@@ -1358,43 +1383,67 @@ with Conf('global.cylc', desc='''
                    * The job environment is not available to this script.
                    * In debug mode this script will not be included in
                      xtrace output.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]global init-script``.
             ''')
             Conf('copyable environment variables', VDR.V_STRING_LIST, '',
-                 desc='''
+                 desc=f'''
                 A list containing the names of the environment variables to
                 be copied from the scheduler to a job.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]copyable
+                   environment variables``.
             ''')
-            Conf('retrieve job logs', VDR.V_BOOLEAN, desc='''
-                Global default for
-                :cylc:conf:`flow.cylc[runtime][<namespace>][remote]
-                retrieve job logs`.
+            Conf('retrieve job logs', VDR.V_BOOLEAN, desc=f'''
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]retrieve job logs``.
+                   {PLATFORM_REPLACES.format("[remote]retrieve job logs")}
             ''')
             Conf('retrieve job logs command', VDR.V_STRING, 'rsync -a',
-                 desc='''
+                 desc=f'''
                 If ``rsync -a`` is unavailable or insufficient to retrieve job
                 logs from a remote platform, you can use this setting to
                 specify a suitable command.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]retrieve job logs
+                   command``.
             ''')
-            Conf('retrieve job logs max size', VDR.V_STRING, desc='''
-                Global default for
-                :cylc:conf:`flow.cylc[runtime][<namespace>][remote]
-                retrieve job logs max size` for this platform.
+            Conf('retrieve job logs max size', VDR.V_STRING, desc=f'''
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]retrieve job logs
+                   max size``.
+                   {PLATFORM_REPLACES.format(
+                       "[remote]retrieve job logs max size")}
             ''')
             Conf('retrieve job logs retry delays', VDR.V_INTERVAL_LIST,
-                 desc='''
-                Global default for
-                :cylc:conf:`flow.cylc[runtime][<namespace>][remote]
-                retrieve job logs retry delays`
-                for this platform.
+                 desc=f'''
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]retrieve job logs
+                   retry delays``.
+                   {PLATFORM_REPLACES.format(
+                       "[remote]retrieve job logs retry delays")}
             ''')
             Conf('tail command template',
-                 VDR.V_STRING, 'tail -n +1 -F %(filename)s', desc='''
+                 VDR.V_STRING, 'tail -n +1 -F %(filename)s', desc=f'''
                 A command template (with ``%(filename)s`` substitution) to
                 tail-follow job logs this platform, by ``cylc cat-log``.
 
                 You are are unlikely to need to override this.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>]tail command template``.
             ''')
-            Conf('err tailer', VDR.V_STRING, desc='''
+            Conf('err tailer', VDR.V_STRING, desc=f'''
                 A command template (with ``%(job_id)s`` substitution) that can
                 be used to tail-follow the stderr stream of a running job if
                 SYSTEM does not use the normal log file location while the job
@@ -1405,8 +1454,13 @@ with Conf('global.cylc', desc='''
 
                    # for PBS
                    qcat -f -e %(job_id)s
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]err tailer``.
             ''')
-            Conf('out tailer', VDR.V_STRING, desc='''
+            Conf('out tailer', VDR.V_STRING, desc=f'''
                 A command template (with ``%(job_id)s`` substitution) that can
                 be used to tail-follow the stdout stream of a running job if
                 SYSTEM does not use the normal log file location while the job
@@ -1417,8 +1471,13 @@ with Conf('global.cylc', desc='''
 
                    # for PBS
                    qcat -f -o %(job_id)s
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]out tailer``.
             ''')
-            Conf('err viewer', VDR.V_STRING, desc='''
+            Conf('err viewer', VDR.V_STRING, desc=f'''
                 A command template (with ``%(job_id)s`` substitution) that can
                 be used to view the stderr stream of a running job if SYSTEM
                 does not use the normal log file location while the job is
@@ -1428,8 +1487,13 @@ with Conf('global.cylc', desc='''
 
                    # for PBS
                    qcat -e %(job_id)s
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]err viewer``.
             ''')
-            Conf('out viewer', VDR.V_STRING, desc='''
+            Conf('out viewer', VDR.V_STRING, desc=f'''
                 A command template (with ``%(job_id)s`` substitution) that can
                 be used to view the stdout stream of a running job if SYSTEM
                 does not use the normal log file location while the job is
@@ -1439,13 +1503,23 @@ with Conf('global.cylc', desc='''
 
                    # for PBS
                    qcat -o %(job_id)s
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]out viewer``.
             ''')
-            Conf('job name length maximum', VDR.V_INTEGER, desc='''
+            Conf('job name length maximum', VDR.V_INTEGER, desc=f'''
                 The maximum length for job name acceptable by a job runner on
                 a given host.  Currently, this setting is only meaningful for
                 PBS jobs. For example, PBS 12 or older will fail a job submit
                 if the job name has more than 15 characters; whereas PBS 13
                 accepts up to 236 characters.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``global.rc[hosts][<host>][batch systems]
+                   [<system>]job name length maximum``.
             ''')
             Conf('install target', VDR.V_STRING, desc='''
                 This defaults to the platform name. This will be used as the
@@ -1457,6 +1531,8 @@ with Conf('global.cylc', desc='''
                    [platforms]
                        [[Platform_A]]
                            install target = localhost
+
+                .. versionadded:: 8.0.0
             ''')
 
             Conf('clean job submission environment', VDR.V_BOOLEAN, False,
@@ -1482,6 +1558,8 @@ with Conf('global.cylc', desc='''
 
                 A standard set of executable paths is passed through to clean
                 environments, and can be added to if necessary.
+
+                .. versionadded:: 8.0.0
             ''')
 
             Conf('job submission environment pass-through', VDR.V_STRING_LIST,
@@ -1492,6 +1570,8 @@ with Conf('global.cylc', desc='''
                 ``$HOME`` is passed automatically.
 
                 You are unlikely to need this.
+
+                .. versionadded:: 8.0.0
             ''')
             Conf('job submission executable paths', VDR.V_STRING_LIST,
                  desc=f'''
@@ -1499,6 +1579,8 @@ with Conf('global.cylc', desc='''
                 submission subprocess beyond the standard locations
                 {", ".join(f"``{i}``" for i in SYSPATH)}.
                 You are unlikely to need this.
+
+                .. versionadded:: 8.0.0
             ''')
             Conf('max batch submit size', VDR.V_INTEGER, default=100, desc='''
                 Limits the maximum number of jobs that can be submitted at
@@ -1509,6 +1591,8 @@ with Conf('global.cylc', desc='''
                 numbers of jobs can cause problems with some submission
                 systems so for safety there is an upper limit on the number
                 of job submissions which can be batched together.
+
+                .. versionadded:: 8.0.0
             ''')
             with Conf('selection', desc='''
                 How to select platform from list of hosts.
@@ -1537,7 +1621,7 @@ with Conf('global.cylc', desc='''
                     DIRECTIVES_DESCR,
                     "[runtime][<namespace>][directives]",
                     section=True
-                )
+                ) + "\n\n" + ".. versionadded:: 8.0.0"
             )):
                 Conf('<directive>', VDR.V_STRING,
                      desc=short_descr(DIRECTIVES_ITEM_DESCR))
@@ -1552,6 +1636,8 @@ with Conf('global.cylc', desc='''
                host: In this case **"localhost" will refer to the host where
                the scheduler is running and not the computer where you
                ran "cylc play"**.
+
+            .. versionadded:: 8.0.0
         '''):
             Conf('hosts', VDR.V_STRING_LIST, ['localhost'])
             with Conf('selection', meta=Selection):
@@ -1584,6 +1670,8 @@ with Conf('global.cylc', desc='''
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.
+
+                    .. versionadded:: 8.0.0
                 ''')
             Conf('platforms', VDR.V_STRING_LIST, desc='''
                 A list of platforms which can be selected if
@@ -1612,7 +1700,7 @@ with Conf('global.cylc', desc='''
     with Conf('task events', desc=(
         default_for(
             TASK_EVENTS_DESCR, "[runtime][<namespace>][events]", section=True
-        )
+        ) + "\n\n" + ".. versionadded:: 8.0.0"
     )):
         Conf('execution timeout', VDR.V_INTERVAL, desc=(
             default_for(

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -18,6 +18,7 @@
 import os
 from pathlib import Path
 from sys import stderr
+from textwrap import dedent
 from typing import List, Optional, Tuple, Any, Union
 
 from contextlib import suppress
@@ -69,6 +70,13 @@ SYSPATH = [
     '/usr/local/sbin'
 ]
 
+
+UTC_MODE_DESCR = (
+    "If ``True``, UTC will be used as the time zone for timestamps in "
+    "the logs. If ``False``, the local/system time zone will be used."
+)
+
+
 TIMEOUT_DESCR = "Previously, 'timeout' was a stall timeout."
 REPLACES = 'This item was previously called '
 
@@ -93,12 +101,9 @@ PLATFORM_META_DESCR = '''
 
 
 # Event config descriptions shared between global and workflow config.
-EVENTS_DESCR = {
+EVENT_SETTINGS = {
     'startup handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]startup handlers`.
-
         Handlers to run at scheduler startup.
 
         .. versionchanged:: 8.0.0
@@ -109,9 +114,6 @@ EVENTS_DESCR = {
     ),
     'shutdown handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]shutdown handlers`.
-
         Handlers to run at scheduler shutdown.
 
         .. versionchanged:: 8.0.0
@@ -122,8 +124,6 @@ EVENTS_DESCR = {
     ),
     'abort handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc[scheduler][events]abort handlers`.
-
         Handlers to run if the scheduler aborts.
 
         .. versionchanged:: 8.0.0
@@ -133,9 +133,6 @@ EVENTS_DESCR = {
     ),
     'workflow timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]workflow timeout`.
-
         Workflow timeout interval. The timer starts counting down at scheduler
         startup. It resets on workflow restart.
 
@@ -146,9 +143,6 @@ EVENTS_DESCR = {
     ),
     'workflow timeout handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]workflow timeout handlers`.
-
         Handlers to run if the workflow timer times out.
 
         .. versionadded:: 8.0.0
@@ -158,9 +152,6 @@ EVENTS_DESCR = {
     ),
     'abort on workflow timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]abort on workflow timeout`.
-
         Whether to abort if the workflow timer times out.
 
         .. versionadded:: 8.0.0
@@ -170,8 +161,6 @@ EVENTS_DESCR = {
     ),
     'stall handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc[scheduler][events]stall handlers`.
-
         Handlers to run if the scheduler stalls.
 
         .. versionchanged:: 8.0.0
@@ -181,8 +170,6 @@ EVENTS_DESCR = {
     ),
     'stall timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc[scheduler][events]stall timeout`.
-
         The length of a timer which starts if the scheduler stalls.
 
         .. versionadded:: 8.0.0
@@ -192,9 +179,6 @@ EVENTS_DESCR = {
     ),
     'stall timeout handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]stall timeout handlers`.
-
         Handlers to run if the stall timer times out.
 
         .. versionadded:: 8.0.0
@@ -204,9 +188,6 @@ EVENTS_DESCR = {
     ),
     'abort on stall timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]abort on stall timeout`.
-
         Whether to abort if the stall timer times out.
 
         .. versionadded:: 8.0.0
@@ -216,9 +197,6 @@ EVENTS_DESCR = {
     ),
     'inactivity timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]inactivity timeout`.
-
         Scheduler inactivity timeout interval. The timer resets when any
         workflow activity occurs.
 
@@ -229,9 +207,6 @@ EVENTS_DESCR = {
     ),
     'inactivity timeout handlers': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]inactivity timeout handlers`.
-
         Handlers to run if the inactivity timer times out.
 
         .. versionchanged:: 8.0.0
@@ -241,9 +216,6 @@ EVENTS_DESCR = {
     ),
     'abort on inactivity timeout': (
         f'''
-        :Default For: :cylc:conf:`flow.cylc \
-        [scheduler][events]abort on inactivity timeout`.
-
         Whether to abort if the inactivity timer times out.
 
         .. versionchanged:: 8.0.0
@@ -333,8 +305,10 @@ with Conf('global.cylc', desc='''
            :cylc:conf:`global.cylc[scheduler]` should not be confused with
            :cylc:conf:`flow.cylc[scheduling]`.
     '''):
-        Conf('UTC mode', VDR.V_BOOLEAN, False, desc='''
+        Conf('UTC mode', VDR.V_BOOLEAN, False, desc=f'''
             :Default For: :cylc:conf:`flow.cylc[scheduler]UTC mode`.
+
+            {UTC_MODE_DESCR}
         ''')
         Conf('process pool size', VDR.V_INTEGER, 4, desc='''
             Maximum number of concurrent processes used to execute external job
@@ -586,7 +560,13 @@ with Conf('global.cylc', desc='''
                 [scheduler][events]mail events`.
             ''')
 
-            for item, desc in EVENTS_DESCR.items():
+            for item, desc in EVENT_SETTINGS.items():
+                desc = (
+                    ":Default For: "
+                    f":cylc:conf:`flow.cylc[scheduler][events]{item}`."
+                    "\n\n"
+                ) + dedent(desc)
+
                 if item.endswith("handlers"):
                     Conf(item, VDR.V_STRING_LIST, desc=desc)
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -72,6 +72,10 @@ SYSPATH = [
 
 
 REPLACES = 'This item was previously called '
+PLATFORM_REPLACES = (
+    "(Replaces the deprecated setting "
+    ":cylc:conf:`flow.cylc[runtime][<namespace>]{}`.)"
+)
 
 
 PLATFORM_META_DESCR = '''
@@ -550,39 +554,35 @@ with Conf('global.cylc', desc='''
             Maximum number of concurrent processes used to execute external job
             submission, event handlers, and job poll and kill commands
 
+            .. seealso::
+
+               :ref:`Managing External Command Execution`.
+
             .. versionchanged:: 8.0.0
 
                Moved into the ``[scheduler]`` section from the top level.
-
-            .. seealso::
-
-                :ref:`Managing External Command Execution`.
-
         ''')
         Conf('process pool timeout', VDR.V_INTERVAL, DurationFloat(600),
              desc='''
             After this interval Cylc will kill long running commands in the
             process pool.
 
-            .. versionchanged:: 8.0.0
-
-               Moved into the ``[scheduler]`` section from the top level.
-
             .. seealso::
 
                :ref:`Managing External Command Execution`.
 
             .. note::
+
                The default is set quite high to avoid killing important
                processes when the system is under load.
+
+            .. versionchanged:: 8.0.0
+
+               Moved into the ``[scheduler]`` section from the top level.
         ''')
         Conf('auto restart delay', VDR.V_INTERVAL, desc=f'''
             Maximum number of seconds the auto-restart mechanism will delay
             before restarting workflows.
-
-            .. versionchanged:: 8.0.0
-
-               {REPLACES}``global.rc[suite servers]auto restart delay``.
 
             When a host is set to automatically
             shutdown/restart it waits a random period of time
@@ -594,28 +594,31 @@ with Conf('global.cylc', desc='''
 
                :ref:`auto-stop-restart`
 
+            .. versionchanged:: 8.0.0
+
+               {REPLACES}``global.rc[suite servers]auto restart delay``.
         ''')
         with Conf('run hosts', desc=f'''
             Configure workflow hosts and ports for starting workflows.
 
-            .. versionchanged:: 8.0.0
-
-               {REPLACES}``[suite servers]``.
-
             Additionally configure host selection settings specifying how to
             determine the most suitable run host at any given time from those
             configured.
+
+            .. versionchanged:: 8.0.0
+
+               {REPLACES}``[suite servers]``.
         '''):
             Conf('available', VDR.V_SPACELESS_STRING_LIST, desc=f'''
                 A list of workflow run hosts.
 
+                Cylc will choose one of these hosts for a workflow to start on.
+                (Unless an explicit host is provided as an option to the
+                ``cylc play --host=<myhost>`` command.)
+
                 .. versionchanged:: 8.0.0
 
                    {REPLACES}``[suite servers]run hosts``.
-
-               Cylc will choose one of these hosts for a workflow to start on.
-               (Unless an explicit host is provided as an option to the
-               ``cylc play --host=<myhost>`` command.)
             ''')
             Conf('ports', VDR.V_RANGE, Range((43001, 43101)),
                  desc=f'''
@@ -633,10 +636,6 @@ with Conf('global.cylc', desc='''
             Conf('condemned', VDR.V_ABSOLUTE_HOST_LIST, desc=f'''
                 These hosts will not be used to run jobs.
 
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}``[suite servers]condemned hosts``.
-
                 If workflows are already running on
                 condemned hosts, Cylc will shut them down and
                 restart them on different hosts.
@@ -644,13 +643,13 @@ with Conf('global.cylc', desc='''
                 .. seealso::
 
                    :ref:`auto-stop-restart`
-            ''')
-            Conf('ranking', VDR.V_STRING, desc=f'''
-                Rank and filter run hosts based on system information.
 
                 .. versionchanged:: 8.0.0
 
-                   {REPLACES}``[suite servers][run host select]rank``.
+                   {REPLACES}``[suite servers]condemned hosts``.
+            ''')
+            Conf('ranking', VDR.V_STRING, desc=f'''
+                Rank and filter run hosts based on system information.
 
                 Ranking can be used to provide load balancing to ensure no
                 single run host is overloaded. It also provides thresholds
@@ -714,18 +713,22 @@ with Conf('global.cylc', desc='''
                    # if two hosts have the same CPU count
                    # then rank them by CPU usage
                    cpu_percent()
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``[suite servers][run host select]rank``.
             ''')
 
         with Conf('host self-identification', desc=f'''
             How Cylc determines and shares the identity of the workflow host.
 
-            .. versionchanged:: 8.0.0
-
-               {REPLACES}``[suite host self-identification]``.
-
             The workflow host's identity must be determined locally by cylc and
             passed to running tasks (via ``$CYLC_WORKFLOW_HOST``) so that task
             messages can target the right workflow on the right host.
+
+            .. versionchanged:: 8.0.0
+
+               {REPLACES}``[suite host self-identification]``.
         '''):
             # TODO
             # Is it conceivable that different remote task hosts at the same
@@ -737,10 +740,6 @@ with Conf('global.cylc', desc='''
                 desc=f'''
                     Determines how cylc finds the identity of the
                     workflow host.
-
-                    .. versionchanged:: 8.0.0
-
-                       {REPLACES}``[suite host self-identification]``.
 
                     Options:
 
@@ -759,6 +758,10 @@ with Conf('global.cylc', desc='''
                        (only to be used as a last resort) Manually specified
                        host name or IP address (requires *host*) of the
                        workflow host.
+
+                    .. versionchanged:: 8.0.0
+
+                       {REPLACES}``[suite host self-identification]``.
             ''')
             Conf('target', VDR.V_STRING, 'google.com', desc=f'''
                 Target for use by the *address* self-identification method.
@@ -848,12 +851,12 @@ with Conf('global.cylc', desc='''
                     Configure the default main loop plugins to use when
                     starting new workflows.
 
-                    Only enabled plugins are loaded, plugins can be enabled
+                    Only enabled plugins are loaded. Plugins can be enabled
                     in two ways:
 
                     Globally:
-                       To enable a plugin for all workflows add it to:
-                       :cylc:conf:`global.cylc[scheduler][main loop]plugins`
+                       To enable a plugin for all workflows add it to this
+                       setting.
                     Per-Run:
                        To enable a plugin for a one-off run of a workflow,
                        specify it on the command line with
@@ -1105,11 +1108,9 @@ with Conf('global.cylc', desc='''
         with Conf('<platform name>', desc='''
             Configuration defining a platform.
 
-            .. versionadded:: 8.0.0
-
-               Many of the items in platform definitions have been moved from
-               ``flow.cylc[runtime][<namespace>][job]`` and
-               ``flow.cylc[runtime][<namespace>][remote]``
+            Many of these settings replace those of the same name from the
+            deprecated :cylc:conf:`flow.cylc[runtime][<namespace>][job]` and
+            :cylc:conf:`flow.cylc[runtime][<namespace>][remote]` sections.
 
             Platform names can be regular expressions: If you have a set of
             compute resources such as ``bigmachine1, bigmachine2`` or
@@ -1148,6 +1149,7 @@ with Conf('global.cylc', desc='''
                - :ref:`AdminGuide.PlatformConfigs`, an administrator's guide to
                  platform configurations.
 
+            .. versionadded:: 8.0.0
         ''') as Platform:
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
@@ -1157,18 +1159,13 @@ with Conf('global.cylc', desc='''
                 A list of hosts from which the job host can be selected using
                 :cylc:conf:`[..][selection]method`.
 
-                .. versionadded:: 8.0.0
-
                 All hosts should share a file system.
+
+                .. versionadded:: 8.0.0
             ''')
             Conf('job runner', VDR.V_STRING, 'background', desc=f'''
                 The batch system/job submit method used to run jobs on the
                 platform.
-
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}
-                   ``suite.rc[runtime][<namespace>][job]batch system``.
 
                 Examples:
 
@@ -1179,24 +1176,28 @@ with Conf('global.cylc', desc='''
                 .. seealso::
 
                    :ref:`List of built-in Job Runners <AvailableMethods>`
+
+                .. versionadded:: 8.0.0
+
+                   {PLATFORM_REPLACES.format("[job]batch system")}
             ''')
             Conf('job runner command template', VDR.V_STRING, desc=f'''
                 Set the command used by the chosen job runner.
 
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}``suite.rc[runtime][<namespace>][job]
-                   batch system command template``.
-
                 The template's ``%(job)s`` will be
                 substituted by the job file path.
+
+                .. versionadded:: 8.0.0
+
+                   {PLATFORM_REPLACES.format(
+                       "[job]batch submit command template"
+                    )}
             ''')
             Conf('shell', VDR.V_STRING, '/bin/bash', desc='''
 
                 .. versionchanged:: 8.0.0
 
                    Moved from ``suite.rc[runtime][<namespace>]job``.
-
             ''')
             Conf('communication method',
                  VDR.V_STRING, 'zmq',
@@ -1307,11 +1308,6 @@ with Conf('global.cylc', desc='''
                 The path containing the ``cylc`` executable on a remote
                 platform.
 
-                .. versionchanged:: 8.0.0
-
-                   Moved from ``suite.rc[runtime][<namespace>][job]
-                   cylc executable``.
-
                 This may be necessary if the ``cylc`` executable is not in the
                 ``$PATH`` for an ``ssh`` call.
                 Test whether this is the case by using
@@ -1336,6 +1332,11 @@ with Conf('global.cylc', desc='''
 
                    See :ref:`managing environments` for more information on
                    the wrapper script.
+
+                .. versionchanged:: 8.0.0
+
+                   Moved from ``suite.rc[runtime][<namespace>][job]
+                   cylc executable``.
             ''')
             Conf('global init-script', VDR.V_STRING, desc='''
                 A per-platform script which is run before other job scripts.
@@ -1519,8 +1520,6 @@ with Conf('global.cylc', desc='''
                      desc='''
                     Method for choosing the job host from the platform.
 
-                    .. versionadded:: 8.0.0
-
                     .. rubric:: Available options
 
                     - ``random``: Choose randomly from the list of hosts.
@@ -1530,6 +1529,8 @@ with Conf('global.cylc', desc='''
                       this is likely to cause load imbalances, but might
                       be appropriate if following the pattern
                       ``hosts = main, backup, failsafe``.
+
+                    .. versionadded:: 8.0.0
                 ''')
             with Conf('directives', desc=(
                 default_for(
@@ -1561,7 +1562,6 @@ with Conf('global.cylc', desc='''
         Platform groups allow you to group together platforms which would
         all be suitable for a given job.
 
-        .. versionadded:: 8.0.0
 
         When Cylc sets up a task job it will pick a platform from a group.
         Cylc will then use the selected platform for all interactions with
@@ -1574,9 +1574,11 @@ with Conf('global.cylc', desc='''
 
         .. seealso::
 
-            - :ref:`MajorChangesPlatforms` in the Cylc 8 migration guide.
-            - :ref:`AdminGuide.PlatformConfigs`, an guide to platform
-              configurations.
+           - :ref:`MajorChangesPlatforms` in the Cylc 8 migration guide.
+           - :ref:`AdminGuide.PlatformConfigs`, an guide to platform
+             configurations.
+
+        .. versionadded:: 8.0.0
     '''):  # noqa: SIM117 (keep same format)
         with Conf('<group>'):
             with Conf('meta', desc=PLATFORM_META_DESCR):
@@ -1597,13 +1599,13 @@ with Conf('global.cylc', desc='''
                     desc='''
                         Method for selecting platform from group.
 
-                        .. versionadded:: 8.0.0
-
                         options:
 
                         - random: Suitable for an identical pool of platforms.
                         - definition order: Pick the first available platform
                           from the list.
+
+                        .. versionadded:: 8.0.0
                     '''
                 )
     # task

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -77,7 +77,6 @@ UTC_MODE_DESCR = (
 )
 
 
-TIMEOUT_DESCR = "Previously, 'timeout' was a stall timeout."
 REPLACES = 'This item was previously called '
 
 
@@ -132,31 +131,25 @@ EVENT_SETTINGS = {
         '''
     ),
     'workflow timeout': (
-        f'''
+        '''
         Workflow timeout interval. The timer starts counting down at scheduler
         startup. It resets on workflow restart.
 
         .. versionadded:: 8.0.0
-
-           {TIMEOUT_DESCR}
         '''
     ),
     'workflow timeout handlers': (
-        f'''
+        '''
         Handlers to run if the workflow timer times out.
 
         .. versionadded:: 8.0.0
-
-           {TIMEOUT_DESCR}
         '''
     ),
     'abort on workflow timeout': (
-        f'''
+        '''
         Whether to abort if the workflow timer times out.
 
         .. versionadded:: 8.0.0
-
-           {TIMEOUT_DESCR}
         '''
     ),
     'stall handlers': (
@@ -172,27 +165,27 @@ EVENT_SETTINGS = {
         f'''
         The length of a timer which starts if the scheduler stalls.
 
-        .. versionadded:: 8.0.0
+        .. versionchanged:: 8.0.0
 
-           {TIMEOUT_DESCR}
+           {REPLACES}``timeout``.
         '''
     ),
     'stall timeout handlers': (
         f'''
         Handlers to run if the stall timer times out.
 
-        .. versionadded:: 8.0.0
+        .. versionchanged:: 8.0.0
 
-           {TIMEOUT_DESCR}
+           {REPLACES}``timeout handler``.
         '''
     ),
     'abort on stall timeout': (
         f'''
         Whether to abort if the stall timer times out.
 
-        .. versionadded:: 8.0.0
+        .. versionchanged:: 8.0.0
 
-           {TIMEOUT_DESCR}
+           {REPLACES}``abort on timeout``.
         '''
     ),
     'inactivity timeout': (

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -71,12 +71,6 @@ SYSPATH = [
 ]
 
 
-UTC_MODE_DESCR = (
-    "If ``True``, UTC will be used as the time zone for timestamps in "
-    "the logs. If ``False``, the local/system time zone will be used."
-)
-
-
 REPLACES = 'This item was previously called '
 
 
@@ -98,125 +92,385 @@ PLATFORM_META_DESCR = '''
 
 '''
 
+# ----------------------------------------------------------------------------
+# Config items shared between global and workflow config:
+SCHEDULER_DESCR = f'''
+Settings for the scheduler.
 
-# Event config descriptions shared between global and workflow config.
-EVENT_SETTINGS = {
-    'startup handlers': (
-        f'''
+.. note::
+
+   Not to be confused with :cylc:conf:`flow.cylc[scheduling]`.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc]``
+'''
+
+UTC_MODE_DESCR = '''
+If ``True``, UTC will be used as the time zone for timestamps in
+the logs. If ``False``, the local/system time zone will be used.
+
+.. seealso::
+
+   To set a time zone for cycle points, see
+   :cylc:conf:`flow.cylc[scheduler]cycle point time zone`.
+'''
+
+EVENTS_SETTINGS = {  # workflow events
+    'handlers': '''
+        Configure :term:`event handlers` that run when certain workflow
+        events occur.
+
+        This section configures *workflow* event handlers; see
+        :cylc:conf:`flow.cylc[runtime][<namespace>][events]` for *task* event
+        handlers.
+
+        Event handlers can be held in the workflow ``bin/`` directory,
+        otherwise it is up to you to ensure their location is in ``$PATH``
+        (in the shell in which the scheduler runs). They should require
+        little resource to run and return quickly.
+
+        Template variables can be used to configure handlers. For a full list
+        of supported variables see :ref:`workflow_event_template_variables`.
+    ''',
+    'handler events': '''
+        Specify the events for which workflow event handlers should be invoked.
+    ''',
+    'mail events': '''
+        Specify the workflow events for which notification emails should
+        be sent.
+    ''',
+    'startup handlers': f'''
         Handlers to run at scheduler startup.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``startup handler``.
-
-        '''
-    ),
-    'shutdown handlers': (
-        f'''
+    ''',
+    'shutdown handlers': f'''
         Handlers to run at scheduler shutdown.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``shutdown handler``.
-
-        '''
-    ),
-    'abort handlers': (
-        f'''
+    ''',
+    'abort handlers': f'''
         Handlers to run if the scheduler aborts.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``aborted handler``.
-        '''
-    ),
-    'workflow timeout': (
-        '''
+    ''',
+    'workflow timeout': '''
         Workflow timeout interval. The timer starts counting down at scheduler
         startup. It resets on workflow restart.
 
         .. versionadded:: 8.0.0
-        '''
-    ),
-    'workflow timeout handlers': (
-        '''
+    ''',
+    'workflow timeout handlers': '''
         Handlers to run if the workflow timer times out.
 
         .. versionadded:: 8.0.0
-        '''
-    ),
-    'abort on workflow timeout': (
-        '''
+    ''',
+    'abort on workflow timeout': '''
         Whether to abort if the workflow timer times out.
 
         .. versionadded:: 8.0.0
-        '''
-    ),
-    'stall handlers': (
-        f'''
+    ''',
+    'stall handlers': f'''
         Handlers to run if the scheduler stalls.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``stalled handler``.
-        '''
-    ),
-    'stall timeout': (
-        f'''
+    ''',
+    'stall timeout': f'''
         The length of a timer which starts if the scheduler stalls.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``timeout``.
-        '''
-    ),
-    'stall timeout handlers': (
-        f'''
+    ''',
+    'stall timeout handlers': f'''
         Handlers to run if the stall timer times out.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``timeout handler``.
-        '''
-    ),
-    'abort on stall timeout': (
-        f'''
+    ''',
+    'abort on stall timeout': f'''
         Whether to abort if the stall timer times out.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``abort on timeout``.
-        '''
-    ),
-    'inactivity timeout': (
-        f'''
+    ''',
+    'inactivity timeout': f'''
         Scheduler inactivity timeout interval. The timer resets when any
         workflow activity occurs.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES} ``inactivity``.
-        '''
-    ),
-    'inactivity timeout handlers': (
-        f'''
+    ''',
+    'inactivity timeout handlers': f'''
         Handlers to run if the inactivity timer times out.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``inactivity handler``.
-        '''
-    ),
-    'abort on inactivity timeout': (
-        f'''
+    ''',
+    'abort on inactivity timeout': f'''
         Whether to abort if the inactivity timer times out.
 
         .. versionchanged:: 8.0.0
 
            {REPLACES}``abort on inactivity``.
-        '''
-    )
+    '''
 }
+
+MAIL_DESCR = f'''
+Settings for the scheduler to send event emails.
+
+These settings are used for both workflow and task events.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc][events]mail <item>``.
+'''
+
+MAIL_FROM_DESCR = f'''
+Specify an alternative ``from`` email address for workflow event notifications.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc][events]mail from``.
+'''
+
+MAIL_TO_DESCR = f'''
+A list of email addresses that event notifications should be sent to.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc][events]mail to``.
+'''
+
+MAIL_FOOTER_DESCR = f'''
+Specify a string or string template for footers of emails sent for both
+workflow and task events.
+
+Template variables may be used in the mail footer. For a list of supported
+variables see :ref:`workflow_event_template_variables`.
+
+Example::
+
+   footer = see http://ahost/%(owner)s/notes/%(workflow)s``
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc][events]mail footer``.
+'''
+
+MAIL_INTERVAL_DESCR = f'''
+Gather all task event notifications in the given interval into a single email.
+
+Useful to prevent being overwhelmed by emails.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[cylc]task event mail interval``.
+'''
+
+MAIN_LOOP_DESCR = '''
+Configuration of main loop plugins for the scheduler.
+
+For a list of built in plugins see :ref:`Main Loop Plugins <BuiltInPlugins>`.
+
+.. versionadded:: 8.0.0
+'''
+
+MAIN_LOOP_PLUGIN_DESCR = '''
+Configure a main loop plugin.
+
+.. note::
+
+   Only the configured list of
+   :cylc:conf:`global.cylc[scheduler][main loop]plugins`
+   is loaded when a scheduler is started.
+
+.. versionadded:: 8.0.0
+'''
+
+MAIN_LOOP_PLUGIN_INTERVAL_DESCR = '''
+Interval at which the plugin is invoked.
+
+.. versionadded:: 8.0.0
+'''
+
+DIRECTIVES_DESCR = '''
+Job runner (batch scheduler) directives.
+
+Supported for use with job runners:
+
+- pbs
+- slurm
+- loadleveler
+- lsf
+- sge
+- slurm_packjob
+- moab
+
+Directives are written to the top of the task job script in the correct format
+for the job runner.
+
+Specifying directives individually like this allows use of default directives
+for task families which can be individually overridden at lower levels of the
+runtime namespace hierarchy.
+'''
+
+DIRECTIVES_ITEM_DESCR = '''
+Example directives for the built-in job runner handlers are shown in
+:ref:`AvailableMethods`.
+'''
+
+SUBMISSION_POLL_DESCR = f'''
+List of intervals at which to poll status of job submission.
+
+Cylc can poll submitted jobs to catch problems that prevent the submitted job
+from executing at all, such as deletion from an external job runner queue.
+
+The last value is used repeatedly until the task starts running.
+
+Multipliers can be used as shorthand as in the example below.
+
+Example::
+
+   5*PT2M, PT5M
+
+Note that if the polling
+:cylc:conf:`global.cylc[platforms][<platform name>]communication method`
+is used then Cylc relies on polling to detect all task state changes,
+so you may want to configure more frequent polling.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[runtime][<namespace>][job]submission polling intervals``.
+'''
+
+SUBMISSION_RETY_DESCR = f'''
+Cylc can automatically resubmit jobs after submission failures.
+
+A list of intervals which define when the scheduler will resubmit jobs if
+submission fails.
+
+.. versionchanged:: 8.0.0
+
+   {REPLACES}``[runtime][<namespace>][job]submission retry delays``.
+'''
+
+EXECUTION_POLL_DESCR = '''
+List of intervals at which to poll status of job execution.
+
+Cylc can poll running jobs to catch problems that prevent task messages from
+being sent back to the workflow, such as hard job kills, network outages, or
+unplanned job host shutdown.
+
+The last interval in the list is used repeatedly until the job completes.
+
+Multipliers can be used as shorthand as in the example below.
+
+Example::
+
+   5*PT2M, PT5M
+
+Note that if the polling
+:cylc:conf:`global.cylc[platforms][<platform name>]communication method` is
+used then Cylc relies on polling to detect all task state changes, so you may
+want to configure more frequent polling.
+'''
+
+TASK_EVENTS_DESCR = '''
+Configure :term:`event handlers` that run when certain task events occur.
+
+This section configures specific *task* event handlers; see
+:cylc:conf:`flow.cylc[scheduler][events]` for *workflow* event handlers.
+
+Event handlers can be held in the workflow ``bin/`` directory, otherwise it is
+up to you to ensure their location is in ``$PATH`` (in the shell in which the
+scheduler runs). They should require little resource to run and return quickly.
+
+Each task event handler can be specified as a list of command lines or command
+line templates. For a full list of supported template variables see
+:ref:`task_event_template_variables`.
+
+For an explanation of the substitution syntax, see
+`String Formatting Operations in the Python documentation
+<https://docs.python.org/3/library/stdtypes.html
+#printf-style-string-formatting>`_.
+
+Additional variables can be passed to event handlers using
+:ref:`Jinja2 <User Guide Jinja2>`.
+'''
+
+TASK_EVENTS_SETTINGS = {
+    'handlers': '''
+        Specify a list of command lines or command line templates as task
+        event handlers.
+    ''',
+    'execution timeout': '''
+        If a task has not finished after the specified interval, the execution
+        timeout event handler(s) will be called.
+    ''',
+    'handler events': '''
+        Specify the events for which the general task event handlers should
+        be invoked.
+
+        Example::
+
+           submission failed, failed
+    ''',
+    'handler retry delays': '''
+        Specify an initial delay before running an event handler command and
+        any retry delays in case the command returns a non-zero code.
+
+        The default behaviour is to run an event handler command once without
+        any delay.
+
+        Example::
+
+           PT10S, PT1M, PT5M
+    ''',
+    'mail events': '''
+        Specify the events for which notification emails should be sent.
+
+        Example::
+
+           submission failed, failed
+    ''',
+    'submission timeout': '''
+        If a task has not started after the specified interval, the submission
+        timeout event handler(s) will be called.
+    '''
+}
+
+# ----------------------------------------------------------------------------
+
+
+def short_descr(text: str) -> str:
+    """Get dedented one-paragraph description from long description."""
+    return dedent(text).split('\n\n', 1)[0]
+
+
+def default_for(
+    text: str, config_path: str, section: bool = False
+) -> str:
+    """Get dedented short description and insert a 'Default(s) For' directive
+    that links to this config item's flow.cylc counterpart."""
+    directive = f":Default{'s' if section else ''} For:"
+    return (
+        f"{directive} :cylc:conf:`flow.cylc{config_path}`.\n\n"
+        f"{short_descr(text)}"
+    )
 
 
 with Conf('global.cylc', desc='''
@@ -286,23 +540,12 @@ with Conf('global.cylc', desc='''
        Prior to Cylc 8, ``global.cylc`` was named ``global.rc``, but that name
        is no longer supported.
 ''') as SPEC:
-    with Conf('scheduler', desc=f'''
-        :Defaults For: :cylc:conf:`flow.cylc[scheduler]`
-
-        .. versionchanged:: 8.0.0
-
-           {REPLACES}``[cylc]``.
-
-        .. note::
-
-           :cylc:conf:`global.cylc[scheduler]` should not be confused with
-           :cylc:conf:`flow.cylc[scheduling]`.
-    '''):
-        Conf('UTC mode', VDR.V_BOOLEAN, False, desc=f'''
-            :Default For: :cylc:conf:`flow.cylc[scheduler]UTC mode`.
-
-            {UTC_MODE_DESCR}
-        ''')
+    with Conf('scheduler', desc=(
+        default_for(SCHEDULER_DESCR, "[scheduler]", section=True)
+    )):
+        Conf('UTC mode', VDR.V_BOOLEAN, False, desc=(
+            default_for(UTC_MODE_DESCR, "[scheduler]UTC mode")
+        ))
         Conf('process pool size', VDR.V_INTEGER, 4, desc='''
             Maximum number of concurrent processes used to execute external job
             submission, event handlers, and job poll and kill commands
@@ -540,53 +783,32 @@ with Conf('global.cylc', desc='''
         with Conf('events', desc='''
             :Defaults For: :cylc:conf:`flow.cylc[scheduler][events]`.
         '''):
-            Conf('handlers', VDR.V_STRING_LIST, desc='''
-                :Default For: :cylc:conf:`flow.cylc \
-                [scheduler][events]handlers`.
-            ''')
-            Conf('handler events', VDR.V_STRING_LIST, desc='''
-                :Default For: :cylc:conf:`flow.cylc \
-                [scheduler][events]handler events`.
-            ''')
-            Conf('mail events', VDR.V_STRING_LIST, desc='''
-                Default for :cylc:conf:`flow.cylc \
-                [scheduler][events]mail events`.
-            ''')
-
-            for item, desc in EVENT_SETTINGS.items():
-                desc = (
-                    ":Default For: "
-                    f":cylc:conf:`flow.cylc[scheduler][events]{item}`."
-                    "\n\n"
-                ) + dedent(desc)
-
-                if item.endswith("handlers"):
-                    Conf(item, VDR.V_STRING_LIST, desc=desc)
-
+            for item, desc in EVENTS_SETTINGS.items():
+                desc = default_for(desc, f"[scheduler][events]{item}")
+                vdr_type = VDR.V_STRING_LIST
+                default: Any = Conf.UNSET
+                if (
+                    item in {'handlers', 'handler events', 'mail events'} or
+                    item.endswith("handlers")
+                ):
+                    pass
                 elif item.startswith("abort on"):
+                    vdr_type = VDR.V_BOOLEAN
                     default = (item == "abort on stall timeout")
-                    Conf(item, VDR.V_BOOLEAN, default, desc=desc)
-
                 elif item.endswith("timeout"):
+                    vdr_type = VDR.V_INTERVAL
                     if item == "stall timeout":
-                        def_intv: Optional['DurationFloat'] = (
-                            DurationFloat(3600))
+                        default = DurationFloat(3600)
                     else:
-                        def_intv = None
-                    Conf(item, VDR.V_INTERVAL, def_intv, desc=desc)
+                        default = None
+                Conf(item, vdr_type, default, desc=desc)
 
-        with Conf('mail', desc=f'''
-            :Defaults For: :cylc:conf:`flow.cylc[scheduler][mail]`.
-
-            Options for email handling.
-
-            .. versionchanged:: 8.0.0
-
-               {REPLACES}``[cylc][events]mail <item>``.
-        '''):
-            Conf('from', VDR.V_STRING, desc='''
-                :Default For: :cylc:conf:`flow.cylc[scheduler][mail]from`.
-            ''')
+        with Conf('mail', desc=(
+            default_for(MAIL_DESCR, "[scheduler][mail]", section=True)
+        )):
+            Conf('from', VDR.V_STRING, desc=(
+                default_for(MAIL_FROM_DESCR, "[scheduler][mail]from")
+            ))
             Conf('smtp', VDR.V_STRING, desc='''
                 Specify the SMTP server for sending workflow event email
                 notifications.
@@ -597,34 +819,27 @@ with Conf('global.cylc', desc='''
 
                    smtp.yourorg
             ''')
-            Conf('to', VDR.V_STRING, desc='''
-                :Default For: :cylc:conf:`flow.cylc[scheduler][mail]to`.
-            ''')
-            Conf('footer', VDR.V_STRING, desc='''
-                :Default For: :cylc:conf:`flow.cylc[scheduler][mail]footer`.
-            ''')
+            Conf('to', VDR.V_STRING, desc=(
+                default_for(MAIL_TO_DESCR, "[scheduler][mail]to")
+            ))
+            Conf('footer', VDR.V_STRING, desc=(
+                default_for(MAIL_FOOTER_DESCR, "[scheduler][mail]footer")
+            ))
             Conf(
                 'task event batch interval',
                 VDR.V_INTERVAL,
                 DurationFloat(300),
-                desc='''
-                    :Default For: :cylc:conf:`flow.cylc \
-                    [scheduler][mail]task event batch interval`
-
-                    .. versionchanged:: 8.0.0
-
-                       This item was previously
-                       ``[cylc]task event mail interval``
-                '''
+                desc=default_for(
+                    MAIL_INTERVAL_DESCR,
+                    "[scheduler][mail]task event batch interval"
+                )
             )
 
-        with Conf('main loop', desc='''
-            :Defaults For: :cylc:conf:`flow.cylc[scheduler][main loop]`.
-
-            Configuration of the Cylc Scheduler's main loop.
-
-            .. versionadded:: 8.0.0
-        '''):
+        with Conf('main loop', desc=(
+            default_for(
+                MAIN_LOOP_DESCR, "[scheduler][main loop]", section=True
+            )
+        )):
             Conf(
                 'plugins',
                 VDR.V_STRING_LIST,
@@ -652,33 +867,27 @@ with Conf('global.cylc', desc='''
                     .. versionadded:: 8.0.0
             ''')
 
-            with Conf('<plugin name>', desc='''
-                Configure a main loop plugin.
-
-                .. note::
-
-                   Only the configured list of :cylc:conf:`[..]plugins`
-                   is loaded when a scheduler is started.
-            ''') as MainLoopPlugin:
-                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
-                    :Default For: :cylc:conf:`flow.cylc \
-                    [scheduler][main loop][<plugin name>]interval`.
-
-                    The interval with which this plugin is run.
-
-                    .. versionadded:: 8.0.0
-                ''')
+            with Conf('<plugin name>', desc=(
+                default_for(
+                    MAIN_LOOP_PLUGIN_DESCR,
+                    "[scheduler][main loop][<plugin name>]",
+                    section=True
+                )
+            )) as MainLoopPlugin:
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc=(
+                    default_for(
+                        MAIN_LOOP_PLUGIN_INTERVAL_DESCR,
+                        "[scheduler][main loop][<plugin name>]interval"
+                    )
+                ))
 
             with Conf('health check', meta=MainLoopPlugin, desc='''
                 Checks the integrity of the workflow run directory.
 
                 .. versionadded:: 8.0.0
             '''):
-                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
-                    The interval with which this plugin is run.
-
-                    .. versionadded:: 8.0.0
-                ''')
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(600),
+                     desc=MAIN_LOOP_PLUGIN_INTERVAL_DESCR)
 
             with Conf('auto restart', meta=MainLoopPlugin, desc='''
                 Automatically migrates workflows between servers.
@@ -690,11 +899,8 @@ with Conf('global.cylc', desc='''
 
                 .. versionadded:: 8.0.0
             '''):
-                Conf('interval', VDR.V_INTERVAL, DurationFloat(600), desc='''
-                    The interval between runs of this plugin.
-
-                    .. versionadded:: 8.0.0
-                ''')
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(600),
+                     desc=MAIN_LOOP_PLUGIN_INTERVAL_DESCR)
 
             with Conf('reset bad hosts', meta=MainLoopPlugin, desc='''
                 Periodically clear the scheduler list of unreachable (bad)
@@ -702,11 +908,8 @@ with Conf('global.cylc', desc='''
 
                 .. versionadded:: 8.0.0
             '''):
-                Conf('interval', VDR.V_INTERVAL, DurationFloat(1800), desc='''
-                    How often (in seconds) to run this plugin.
-
-                    .. versionadded:: 8.0.0
-                ''')
+                Conf('interval', VDR.V_INTERVAL, DurationFloat(1800),
+                     desc=MAIN_LOOP_PLUGIN_INTERVAL_DESCR)
 
         with Conf('logging', desc=f'''
             Settings for the workflow event log.
@@ -1010,33 +1213,27 @@ with Conf('global.cylc', desc='''
                 ssh
                    Use non-interactive ssh for task communications
             ''')
-            Conf('submission polling intervals',
-                 VDR.V_INTERVAL_LIST,
-                 [DurationFloat(900)],
-                 desc='''
-                List of intervals at which to poll status of job submission.
-
-                This config item is the default for
-                :cylc:conf:`flow.cylc[runtime][<namespace>]
-                submission polling intervals`.
-            ''')
-            Conf('submission retry delays', VDR.V_INTERVAL_LIST, None,
-                 desc='''
-                Cylc can automatically resubmit jobs after submission failures.
-
-                This config item is the default for
-                :cylc:conf:`flow.cylc[runtime][<namespace>]
-                submission retry delays`
-            ''')
-            Conf('execution polling intervals',
-                 VDR.V_INTERVAL_LIST,
-                 [DurationFloat(900)],
-                 desc='''
-                List of intervals at which to poll status of job execution.
-
-                Default for :cylc:conf:`flow.cylc[runtime][<namespace>]
-                execution polling intervals`.
-            ''')
+            Conf(
+                'submission polling intervals', VDR.V_INTERVAL_LIST,
+                [DurationFloat(900)], desc=default_for(
+                    SUBMISSION_POLL_DESCR,
+                    "[runtime][<namespace>]submission polling intervals"
+                )
+            )
+            Conf(
+                'submission retry delays', VDR.V_INTERVAL_LIST, None,
+                desc=default_for(
+                    SUBMISSION_RETY_DESCR,
+                    "[runtime][<namespace>]submission retry delays"
+                )
+            )
+            Conf(
+                'execution polling intervals', VDR.V_INTERVAL_LIST,
+                [DurationFloat(900)], desc=default_for(
+                    EXECUTION_POLL_DESCR,
+                    "[runtime][<namespace>]execution polling intervals"
+                )
+            )
             Conf('execution time limit polling intervals',
                  VDR.V_INTERVAL_LIST,
                  [DurationFloat(60), DurationFloat(120), DurationFloat(420)],
@@ -1334,16 +1531,15 @@ with Conf('global.cylc', desc='''
                       be appropriate if following the pattern
                       ``hosts = main, backup, failsafe``.
                 ''')
-            with Conf('directives', desc='''
-                :Defaults for: :cylc:conf:`flow.cylc\
-                [runtime][<namespace>][directives]`
-
-                Job runner (batch scheduler) directives.
-            '''):
-                Conf('<directive>', VDR.V_STRING, desc='''
-                    Example directives for the built-in job runner handlers
-                    are shown in :ref:`AvailableMethods`.
-                ''')
+            with Conf('directives', desc=(
+                default_for(
+                    DIRECTIVES_DESCR,
+                    "[runtime][<namespace>][directives]",
+                    section=True
+                )
+            )):
+                Conf('<directive>', VDR.V_STRING,
+                     desc=short_descr(DIRECTIVES_ITEM_DESCR))
 
         with Conf('localhost', meta=Platform, desc='''
             A default platform defining settings for jobs to be run on the
@@ -1411,16 +1607,47 @@ with Conf('global.cylc', desc='''
                     '''
                 )
     # task
-    with Conf('task events', desc='''
-        Global site/user defaults for
-        :cylc:conf:`flow.cylc[runtime][<namespace>][events]`.
-    '''):
-        Conf('execution timeout', VDR.V_INTERVAL)
-        Conf('handlers', VDR.V_STRING_LIST)
-        Conf('handler events', VDR.V_STRING_LIST)
-        Conf('handler retry delays', VDR.V_INTERVAL_LIST, None)
-        Conf('mail events', VDR.V_STRING_LIST)
-        Conf('submission timeout', VDR.V_INTERVAL)
+    with Conf('task events', desc=(
+        default_for(
+            TASK_EVENTS_DESCR, "[runtime][<namespace>][events]", section=True
+        )
+    )):
+        Conf('execution timeout', VDR.V_INTERVAL, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['execution timeout'],
+                "[runtime][<namespace>][events]execution timeout"
+            )
+        ))
+        Conf('handlers', VDR.V_STRING_LIST, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['handlers'],
+                "[runtime][<namespace>][events]handlers"
+            )
+        ))
+        Conf('handler events', VDR.V_STRING_LIST, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['handler events'],
+                "[runtime][<namespace>][events]handler events"
+            )
+        ))
+        Conf('handler retry delays', VDR.V_INTERVAL_LIST, None, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['handler retry delays'],
+                "[runtime][<namespace>][events]handler retry delays"
+            )
+        ))
+        Conf('mail events', VDR.V_STRING_LIST, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['mail events'],
+                "[runtime][<namespace>][events]mail events"
+            )
+        ))
+        Conf('submission timeout', VDR.V_INTERVAL, desc=(
+            default_for(
+                TASK_EVENTS_SETTINGS['submission timeout'],
+                "[runtime][<namespace>][events]submission timeout"
+            )
+        ))
 
 
 def upg(cfg, descr):

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -24,8 +24,24 @@ from metomi.isodatetime.data import Calendar
 
 from cylc.flow import LOG
 from cylc.flow.cfgspec.globalcfg import (
-    EVENT_SETTINGS,
+    DIRECTIVES_DESCR,
+    DIRECTIVES_ITEM_DESCR,
+    EVENTS_SETTINGS,
+    EXECUTION_POLL_DESCR,
+    MAIL_DESCR,
+    MAIL_FOOTER_DESCR,
+    MAIL_FROM_DESCR,
+    MAIL_INTERVAL_DESCR,
+    MAIL_TO_DESCR,
+    MAIN_LOOP_DESCR,
+    MAIN_LOOP_PLUGIN_DESCR,
+    MAIN_LOOP_PLUGIN_INTERVAL_DESCR,
     REPLACES,
+    SCHEDULER_DESCR,
+    SUBMISSION_POLL_DESCR,
+    SUBMISSION_RETY_DESCR,
+    TASK_EVENTS_DESCR,
+    TASK_EVENTS_SETTINGS,
     UTC_MODE_DESCR,
 )
 import cylc.flow.flags
@@ -43,11 +59,6 @@ from cylc.flow.task_events_mgr import EventData
 # Regex to check whether a string is a command
 REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 
-GLOBAL_DEFAULT = (
-    "The default value is set in the global config: "
-    ":cylc:conf:`global.cylc{}`."
-)
-
 # Cylc8 Deprecation note.
 REPLACED_BY_PLATFORMS = '''
 .. warning::
@@ -58,6 +69,19 @@ REPLACED_BY_PLATFORMS = '''
 
    Use :cylc:conf:`flow.cylc[runtime][<namespace>]platform` instead.
 '''
+
+
+def global_default(text: str, config_path: str) -> str:
+    """Insert a link to this config item's global counterpart after the first
+    paragraph of the description text. Also dedents.
+    """
+    first, sep, rest = dedent(text).partition('\n\n')
+    return (
+        f"{first}\n\n"
+        "The default value is set in the global config: "
+        f":cylc:conf:`global.cylc{config_path}`."
+        f"{sep}{rest}"
+    )
 
 
 def get_script_common_text(this: str, example: Optional[str] = None):
@@ -159,23 +183,12 @@ with Conf(
             "workflow-priority". An event handler could then respond to
             failure events in a way set by "workflow-priority".
         ''')
-    with Conf('scheduler', desc=f'''
-        Settings for the scheduler.
-
-        .. versionchanged:: 8.0.0
-
-           {REPLACES} ``[cylc]``
-    '''):
-        Conf('UTC mode', VDR.V_BOOLEAN, desc=f'''
-            {UTC_MODE_DESCR}
-
-            {GLOBAL_DEFAULT.format("[scheduler]UTC mode")}
-
-            .. seealso::
-
-               To set a time zone for cycle points, see
-               :cylc:conf:`flow.cylc[scheduler]cycle point time zone`.
-        ''')
+    with Conf('scheduler', desc=(
+        global_default(SCHEDULER_DESCR, "[scheduler]")
+    )):
+        Conf('UTC mode', VDR.V_BOOLEAN, desc=(
+            global_default(UTC_MODE_DESCR, "[scheduler]UTC mode")
+        ))
 
         Conf('allow implicit tasks', VDR.V_BOOLEAN, default=False, desc='''
             Allow tasks in the graph that are not defined in
@@ -356,134 +369,77 @@ with Conf(
 
         with Conf(   # noqa: SIM117 (keep same format)
             'main loop',
-            desc='''
-                Allows the specification of main loop plugins for Cylc.
-
-                For a list of built in plugins see
-                :ref:`Main Loop Plugins <BuiltInPlugins>`.
-
-                .. versionadded:: 8.0.0
-            '''
+            desc=global_default(MAIN_LOOP_DESCR, "[scheduler][main loop]")
         ):
-            with Conf('<plugin name>'):
-                Conf('interval', VDR.V_INTERVAL, desc='''
-                    Interval (in seconds) at which the plugin is invoked.
-                ''')
+            with Conf('<plugin name>', desc=(
+                global_default(
+                    MAIN_LOOP_PLUGIN_DESCR,
+                    "[scheduler][main loop][<plugin name>]"
+                )
+            )):
+                Conf('interval', VDR.V_INTERVAL, desc=(
+                    global_default(
+                        MAIN_LOOP_PLUGIN_INTERVAL_DESCR,
+                        "[scheduler][main loop][<plugin name>]interval"
+                    )
+                ))
 
         with Conf('events'):
-            # Note: default of None for V_STRING_LIST is used to differentiate
-            # between: value not set vs value set to empty
-            Conf('handlers', VDR.V_STRING_LIST, None, desc='''
-                Configure :term:`event handlers` that run when certain
-                workflow events occur.
+            for item, desc in EVENTS_SETTINGS.items():
+                desc = global_default(desc, f"[scheduler][events]{item}")
+                vdr_type = VDR.V_STRING_LIST
+                default: Any = Conf.UNSET
+                if item in {'handlers', 'handler events', 'mail events'}:
+                    # Note: default of None for V_STRING_LIST is used to
+                    # differentiate between not set vs set to empty
+                    default = None
+                elif item.endswith("handlers"):
+                    desc = desc + '\n\n' + dedent(rf'''
+                        Examples:
 
-                This section configures workflow event handlers; see
-                :cylc:conf:`flow.cylc[runtime][<namespace>][events]` for
-                task event handlers.
+                        .. code-block:: cylc
 
-                Event handlers can be held in the workflow ``bin/`` directory,
-                otherwise it is up to you to ensure their location is in
-                ``$PATH`` (in the shell in which the scheduler runs).
-                They should require little resource to run and return
-                quickly.
+                           # configure a single event handler
+                           {item} = echo foo
 
-                Template variables can be used to configure handlers.
-                For a full list of supported variables see
-                :ref:`workflow_event_template_variables`.
-            ''')
-            Conf('handler events', VDR.V_STRING_LIST, None, desc='''
-                Specify the events for which workflow event
-                handlers should be invoked.
-            ''')
-            Conf('mail events', VDR.V_STRING_LIST, None, desc='''
-                Specify the workflow events for which notification emails
-                should be sent.
-            ''')
+                           # provide context to the handler
+                           {item} = echo %(workflow)s
 
-            for item, desc in EVENT_SETTINGS.items():
-                desc = GLOBAL_DEFAULT.format(
-                    f"[scheduler][events]{item}"
-                ) + "\n\n" + dedent(desc)
-
-                if item.endswith("handlers"):
-                    Conf(item, VDR.V_STRING_LIST, desc=(
-                        # add examples
-                        desc + '\n' + dedent(rf'''
-                            Examples:
-
-                            .. code-block:: cylc
-
-                               # configure a single event handler
-                               {item} = echo foo
-
-                               # provide context to the handler
-                               {item} = echo %(workflow)s
-
-                               # configure multiple event handlers
-                               {item} = \
-                                    'echo %(workflow)s, %(event)s', \
-                                    'my_exe %(event)s %(message)s' \
-                                    'curl -X PUT -d event=%(event)s host:port'
-                        ''')))
+                           # configure multiple event handlers
+                           {item} = \
+                               'echo %(workflow)s, %(event)s', \
+                               'my_exe %(event)s %(message)s' \
+                               'curl -X PUT -d event=%(event)s host:port'
+                    ''')
                 elif item.startswith("abort on"):
-                    Conf(item, VDR.V_BOOLEAN, desc=desc)
+                    vdr_type = VDR.V_BOOLEAN
                 elif item.endswith("timeout"):
-                    Conf(item, VDR.V_INTERVAL, desc=desc)
+                    vdr_type = VDR.V_INTERVAL
+                Conf(item, vdr_type, default, desc=desc)
 
             Conf('expected task failures', VDR.V_STRING_LIST, desc='''
                 (For Cylc developers writing a functional tests only)
                 List of tasks that are expected to fail in the test.
             ''')
 
-        with Conf('mail', desc='''
-            Settings for the scheduler to send event emails.
-
-            These settings are used for both workflow and task events.
-
-            .. versionadded:: 8.0.0
-        '''):
-            Conf('footer', VDR.V_STRING, desc=f'''
-                Specify a string or string template for footers of
-                emails sent for both workflow and task events.
-
-                Template variables may be used in the mail footer. For a list
-                of supported variables see
-                :ref:`workflow_event_template_variables`.
-
-                Example:
-
-                ``mail footer = see http://ahost/%(owner)s/notes/%(workflow)s``
-
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES} ``[cylc][events]mail footer``.
-            ''')
-            Conf('to', VDR.V_STRING, desc=f'''
-                A list of email addresses that event notifications
-                should be sent to.
-
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}``[cylc][events]mail to``.
-            ''')
-            Conf('from', VDR.V_STRING, desc=f'''
-                Specify an alternative ``from`` email address for workflow
-                event notifications.
-
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}``[cylc][events]mail from``.
-            ''')
-            Conf('task event batch interval', VDR.V_INTERVAL, desc=f'''
-                Gather all task event notifications in the given interval
-                into a single email.
-
-                Useful to prevent being overwhelmed by emails.
-
-                .. versionchanged:: 8.0.0
-
-                   {REPLACES}``[cylc]mail interval``.
-            ''')
+        with Conf('mail', desc=(
+            global_default(MAIL_DESCR, "[scheduler][mail]")
+        )):
+            Conf('footer', VDR.V_STRING, desc=(
+                global_default(MAIL_FOOTER_DESCR, "[scheduler][mail]footer")
+            ))
+            Conf('to', VDR.V_STRING, desc=(
+                global_default(MAIL_TO_DESCR, "[scheduler][mail]to")
+            ))
+            Conf('from', VDR.V_STRING, desc=(
+                global_default(MAIL_FROM_DESCR, "[scheduler][mail]from")
+            ))
+            Conf('task event batch interval', VDR.V_INTERVAL, desc=(
+                global_default(
+                    MAIL_INTERVAL_DESCR,
+                    "[scheduler][mail]task event batch interval"
+                )
+            ))
 
     with Conf('task parameters', desc='''
         Set task parameters and parameter templates.
@@ -975,7 +931,6 @@ with Conf(
 
                See :ref:`task namespace rules. <namespace-names>`
 
-
             Examples of legal values:
 
             - ``[foo]``
@@ -1110,35 +1065,13 @@ with Conf(
 
                    ``$CYLC_TASK_CYCLE_POINT/shared/``
             ''')
-            Conf('execution polling intervals', VDR.V_INTERVAL_LIST,
-                 None, desc='''
-                List of intervals at which to poll status of job execution.
-
-                Cylc can poll running jobs to catch problems that prevent
-                task messages from being sent back to the workflow, such
-                as hard job kills, network outages, or unplanned job
-                host shutdown.
-
-                The last interval in the list is used repeatedly until
-                the job completes.
-
-                Multipliers can be used as shorthand as in the example
-                below.
-
-                Example::
-
-                   5*PT2M, PT5M
-
-                Note that if the polling
-                :cylc:conf:`global.cylc[platforms][<platform name>]
-                communication method` is used then Cylc relies on polling
-                to detect all task state changes, so you may want to
-                configure more frequent polling.
-
-                This config item overrides
-                :cylc:conf:`global.cylc[platforms][<platform name>]
-                execution polling intervals`
-            ''')
+            Conf(
+                'execution polling intervals', VDR.V_INTERVAL_LIST, None,
+                desc=global_default(
+                    EXECUTION_POLL_DESCR,
+                    "[platforms][<platform name>]execution polling intervals"
+                )
+            )
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
                 Cylc can automate resubmission of a failed task job.
 
@@ -1164,49 +1097,20 @@ with Conf(
                 intervals using :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
             ''')
-            Conf('submission polling intervals', VDR.V_INTERVAL_LIST,
-                 None, desc='''
-                List of intervals at which to poll status of job
-                submission.
-
-                Cylc can poll submitted jobs to catch problems that
-                prevent the submitted job from executing at all, such as
-                deletion from an external job runner queue.
-
-                The last value is used repeatedly until the task starts
-                running.
-
-                Multipliers can be used as shorthand as in the example
-                below.
-
-                Example::
-
-                   5*PT2M, PT5M
-
-                Note that if the polling
-                :cylc:conf:`global.cylc[platforms][<platform name>]
-                communication method`
-                is used then Cylc relies on polling to detect all task
-                state changes,
-                so you may want to configure more
-                frequent polling.
-
-                This config item overrides
-                :cylc:conf:`global.cylc[platforms][<platform name>]
-                submission polling intervals`.
-            ''')
-            Conf('submission retry delays', VDR.V_INTERVAL_LIST,
-                 None, desc='''
-                Cylc can automatically resubmit jobs after submission
-                failures.
-
-                A list of intervals which define when the scheduler will
-                resubmit jobs if submission fails.
-
-                This config item overrides
-                :cylc:conf:`global.cylc[platforms][<platform name>]
-                submission retry delays`
-            ''')
+            Conf(
+                'submission polling intervals', VDR.V_INTERVAL_LIST, None,
+                desc=global_default(
+                    SUBMISSION_POLL_DESCR,
+                    "[platforms][<platform name>]submission polling intervals"
+                )
+            )
+            Conf(
+                'submission retry delays', VDR.V_INTERVAL_LIST, None,
+                desc=global_default(
+                    SUBMISSION_RETY_DESCR,
+                    "[platforms][<platform name>]submission retry delays"
+                )
+            )
             with Conf('meta', desc=r'''
                 Metadata for the task or task family.
 
@@ -1404,77 +1308,45 @@ with Conf(
                 Conf('retrieve job logs retry delays',
                      VDR.V_INTERVAL_LIST, None)
 
-            with Conf('events', desc='''
-                Configure :term:`event handlers` that run when certain task
-                events occur.
-
-                This section configures specific task event
-                handlers; see :cylc:conf:`flow.cylc[scheduler][events]` for
-                workflow event handlers.
-
-                Event handlers can be held in the workflow ``bin/`` directory,
-                otherwise it is up to you to ensure their location is in
-                ``$PATH`` (in the shell in which the scheduler runs).
-                They should require little resource to run and return
-                quickly.
-
-                Each task event handler can be specified as a list of command
-                lines or command line templates. For a full list of supported
-                template variables see :ref:`task_event_template_variables`.
-
-                For an explanation of the substitution syntax, see
-                `String Formatting Operations in the Python
-                documentation
-                <https://docs.python.org/3/library/stdtypes.html
-                #printf-style-string-formatting>`_.
-
-                Additional variables can be passed to event handlers using
-                :ref:`Jinja2 <User Guide Jinja2>`.
-                .
-            '''):
-                Conf('execution timeout', VDR.V_INTERVAL, desc='''
-                    If a task has not finished after the specified ISO 8601
-                    duration/interval, the *execution timeout* event
-                    handler(s) will be called.
-                ''')
-                Conf('handlers', VDR.V_STRING_LIST, None, desc='''
-                    Specify a list of command lines or command line templates
-                    as task event handlers.
-                ''')
-                Conf('handler events', VDR.V_STRING_LIST, None, desc='''
-                    Specify the events for which the general task event
-                    handlers should be invoked.
-
-                    Example:
-
-                    ``submission failed, failed``
-                ''')
-                Conf('handler retry delays', VDR.V_INTERVAL_LIST, None,
-                     desc='''
-                    Specify an initial delay before running an event handler
-                    command and any retry delays in case the command returns a
-                    non-zero code.
-
-                    The default behaviour is to run an event
-                    handler command once without any delay.
-
-                    Example:
-
-                    ``PT10S, PT1M, PT5M``
-                ''')
-                Conf('mail events', VDR.V_STRING_LIST, None, desc='''
-                    Specify the events for which notification emails should be
-                    sent.
-
-                    Example:
-
-                    ``submission failed, failed``
-                ''')
-                Conf('submission timeout', VDR.V_INTERVAL, desc='''
-                    If a task has not started after the specified ISO 8601
-                    duration/interval, the *submission timeout* event
-                    handler(s) will be called.
-                ''')
+            with Conf('events', desc=(
+                global_default(TASK_EVENTS_DESCR, "[task events]")
+            )):
+                Conf('execution timeout', VDR.V_INTERVAL, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['execution timeout'],
+                        "[task events]execution timeout"
+                    )
+                ))
+                Conf('handlers', VDR.V_STRING_LIST, None, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['handlers'],
+                        "[task events]handlers"
+                    )
+                ))
+                Conf('handler events', VDR.V_STRING_LIST, None, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['handler events'],
+                        "[task events]handler events"
+                    )
+                ))
+                Conf('handler retry delays', VDR.V_INTERVAL_LIST, None, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['handler retry delays'],
+                        "[task events]handler retry delays"
+                    )
+                ))
+                Conf('mail events', VDR.V_STRING_LIST, None, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['mail events'],
+                        "[task events]mail events"
+                    )
+                ))
+                Conf('submission timeout', VDR.V_INTERVAL, desc=(
+                    global_default(
+                        TASK_EVENTS_SETTINGS['submission timeout'],
+                        "[task events]submission timeout"
+                    )
+                ))
                 Conf('expired handlers', VDR.V_STRING_LIST, None)
                 Conf('late offset', VDR.V_INTERVAL, None)
                 Conf('late handlers', VDR.V_STRING_LIST, None)
@@ -1631,31 +1503,13 @@ with Conf(
                        moved here.
                 ''')
 
-            with Conf('directives', desc='''
-                Job runner (batch scheduler) directives.
-
-                Supported for use with job runners:
-
-                - pbs
-                - slurm
-                - loadleveler
-                - lsf
-                - sge
-                - slurm_packjob
-                - moab
-
-                Directives are written to the top of the task job script
-                in the correct format for the job runner.
-
-                Specifying directives individually like this allows
-                use of default directives for task families which can be
-                individually overridden at lower levels of the runtime
-                namespace hierarchy.
-            '''):
-                Conf('<directive>', VDR.V_STRING, desc='''
-                    Example directives for the built-in job runner handlers
-                    are shown in :ref:`AvailableMethods`.
-                ''')
+            with Conf('directives', desc=(
+                global_default(
+                    DIRECTIVES_DESCR,
+                    "[platforms][<platform name>][directives]"
+                )
+            )):
+                Conf('<directive>', VDR.V_STRING, desc=DIRECTIVES_ITEM_DESCR)
 
             with Conf('outputs', desc='''
                 Register custom task outputs for use in message triggering in

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -155,7 +155,10 @@ with Conf(
         ''')
     with Conf('scheduler', desc=f'''
         Settings for the scheduler.
-        {REPLACES} ``[cylc]``
+
+        .. versionchanged:: 8.0.0
+
+           {REPLACES} ``[cylc]``
     '''):
         Conf('UTC mode', VDR.V_BOOLEAN, desc='''
             If ``True``, UTC will be used as the time zone for timestamps in

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -441,7 +441,7 @@ with Conf(
                 )
             ))
 
-    with Conf('task parameters', desc='''
+    with Conf('task parameters', desc=f'''
         Set task parameters and parameter templates.
 
         Define parameter values here for use in expanding
@@ -449,8 +449,7 @@ with Conf(
 
         .. versionchanged:: 8.0.0
 
-           This section replaces ``[cylc][parameters]`` and
-           ``[cylc][parameter templates]``.
+           {REPLACES}``[cylc][parameters]``.
     '''):
         Conf('<parameter>', VDR.V_PARAMETER_LIST, desc='''
             A custom parameter to use in a workflow.
@@ -461,12 +460,16 @@ with Conf(
             - ``mem = 1..5``  (equivalent to ``1, 2, 3, 4, 5``).
             - ``mem = -11..-7..2``  (equivalent to ``-11, -9, -7``).
         ''')
-        with Conf('templates', desc='''
+        with Conf('templates', desc=f'''
             Cylc will expand each parameterized task name using a string
             template.
 
             You can set templates for any parameter name here to override the
             default template.
+
+            .. versionchanged:: 8.0.0
+
+               {REPLACES}``[cylc][parameter templates]``.
         '''):
             Conf('<parameter>', VDR.V_STRING, desc='''
                 A template for a parameter.
@@ -797,7 +800,7 @@ with Conf(
 
                {REPLACES}``[runtime][dependencies][graph]``.
         '''):
-            Conf('<recurrence>', VDR.V_STRING, desc='''
+            Conf('<recurrence>', VDR.V_STRING, desc=f'''
                 The recurrence defines the sequence of cycle points
                 for which the dependency graph is valid.
 
@@ -892,6 +895,11 @@ with Conf(
 
                      # bar triggers if submission of foo fails
                      foo:submit-fail => bar
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}
+                   ``[runtime][dependencies][graph][<recurrence>]graph``.
             ''')
 
     with Conf('runtime',  # noqa: SIM117 (keep same format)
@@ -1072,7 +1080,7 @@ with Conf(
                     "[platforms][<platform name>]execution polling intervals"
                 )
             )
-            Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
+            Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc=f'''
                 Cylc can automate resubmission of a failed task job.
 
                 Execution retry delays are a list of ISO 8601
@@ -1083,8 +1091,13 @@ with Conf(
                 variable ``$CYLC_TASK_TRY_NUMBER`` in the task execution
                 environment. ``$CYLC_TASK_TRY_NUMBER`` allows you to vary task
                 behavior between submission attempts.
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``[runtime][<namespace>][job]execution
+                   retry delays``.
             ''')
-            Conf('execution time limit', VDR.V_INTERVAL, desc='''
+            Conf('execution time limit', VDR.V_INTERVAL, desc=f'''
                 Set the execution (:term:`wallclock <wallclock time>`) time
                 limit of a task job.
 
@@ -1096,6 +1109,11 @@ with Conf(
                 poll the job multiple times. You can set polling
                 intervals using :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
+
+                .. versionchanged:: 8.0.0
+
+                   {REPLACES}``[runtime][<namespace>][job]execution
+                   time limit``.
             ''')
             Conf(
                 'submission polling intervals', VDR.V_INTERVAL_LIST, None,
@@ -1347,6 +1365,9 @@ with Conf(
                         "[task events]submission timeout"
                     )
                 ))
+                # TODO: add descriptions for the handlers below. Some of them
+                # didn't have any mention in the Cylc 7 suiterc ref docs, but
+                # a look at git blame indicates none of them are new in Cylc 8.
                 Conf('expired handlers', VDR.V_STRING_LIST, None)
                 Conf('late offset', VDR.V_INTERVAL, None)
                 Conf('late handlers', VDR.V_STRING_LIST, None)

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -43,32 +43,14 @@ REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
 DEFAULT_FOR = re.compile(r'.*:[Dd]efault [Ff]or:.*')
 
 # Cylc8 Deprecation note.
-DEPRECATION_WARN = '''
-.. deprecated:: 8.0.0
-
+REPLACED_BY_PLATFORMS = '''
 .. warning::
 
    Deprecated section kept for compatibility with Cylc 7 workflow definitions.
 
-
    This will be removed in a future version of Cylc 8.
 
    Use :cylc:conf:`flow.cylc[runtime][<namespace>]platform` instead.
-'''
-
-DEPRECATED_IN_FAVOUR_OF_PLATFORMS = '''
-.. deprecated:: 8.0.0
-
-.. warning::
-
-   This config item has been moved to a platform setting in the
-   :cylc:conf:`global.cylc[platforms]` section. It will be used by the
-   automated platform upgrade mechanism and remove in a future version
-   of Cylc 8.
-
-   Ideally, as a user this should be set by your site admins
-   and you will only need to pick a suitable
-   :cylc:conf:`flow.cylc[runtime][<namespace>]platform`.
 '''
 
 
@@ -80,17 +62,17 @@ def get_script_common_text(this: str, example: Optional[str] = None):
     Other user-defined script items:
 
     ''')
-    for item in [
+    for item in (
         'init-script', 'env-script', 'pre-script', 'script', 'post-script',
         'err-script', 'exit-script'
-    ]:
+    ):
         if item != this:
             text += f"* :cylc:conf:`[..]{item}`\n"
     text += dedent(f'''
 
- Example::
+    Example::
 
-        {example if example else 'echo "Hello World"'}
+       {example if example else 'echo "Hello World"'}
     ''')
     return text
 
@@ -1119,39 +1101,35 @@ with Conf(
 
                    ``$CYLC_TASK_CYCLE_POINT/shared/``
             ''')
-            Conf(
-                'execution polling intervals',
-                VDR.V_INTERVAL_LIST,
-                None,
-                desc='''
-                    List of intervals at which to poll status of job execution.
+            Conf('execution polling intervals', VDR.V_INTERVAL_LIST,
+                 None, desc='''
+                List of intervals at which to poll status of job execution.
 
-                    Cylc can poll running jobs to catch problems that prevent
-                    task messages from being sent back to the workflow, such
-                    as hard job kills, network outages, or unplanned job
-                    host shutdown.
+                Cylc can poll running jobs to catch problems that prevent
+                task messages from being sent back to the workflow, such
+                as hard job kills, network outages, or unplanned job
+                host shutdown.
 
-                    The last interval in the list is used repeatedly until
-                    the job completes.
+                The last interval in the list is used repeatedly until
+                the job completes.
 
-                    Multipliers can be used as shorthand as in the example
-                    below.
+                Multipliers can be used as shorthand as in the example
+                below.
 
-                    Example::
+                Example::
 
-                       5*PT2M, PT5M
+                   5*PT2M, PT5M
 
-                    Note that if the polling
-                    :cylc:conf:`global.cylc[platforms][<platform name>]
-                    communication method` is used then Cylc relies on polling
-                    to detect all task state changes, so you may want to
-                    configure more frequent polling.
+                Note that if the polling
+                :cylc:conf:`global.cylc[platforms][<platform name>]
+                communication method` is used then Cylc relies on polling
+                to detect all task state changes, so you may want to
+                configure more frequent polling.
 
-                    This config item overrides
-                    :cylc:conf:`global.cylc[platforms][<platform name>]
-                    execution polling intervals`
-                    '''
-            )
+                This config item overrides
+                :cylc:conf:`global.cylc[platforms][<platform name>]
+                execution polling intervals`
+            ''')
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc='''
                 Cylc can automate resubmission of a failed task job.
 
@@ -1177,57 +1155,49 @@ with Conf(
                 intervals using :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
             ''')
-            Conf(
-                'submission polling intervals',
-                VDR.V_INTERVAL_LIST,
-                None,
-                desc='''
-                    List of intervals at which to poll status of job
-                    submission.
+            Conf('submission polling intervals', VDR.V_INTERVAL_LIST,
+                 None, desc='''
+                List of intervals at which to poll status of job
+                submission.
 
-                    Cylc can poll submitted jobs to catch problems that
-                    prevent the submitted job from executing at all, such as
-                    deletion from an external job runner queue.
+                Cylc can poll submitted jobs to catch problems that
+                prevent the submitted job from executing at all, such as
+                deletion from an external job runner queue.
 
-                    The last value is used repeatedly until the task starts
-                    running.
+                The last value is used repeatedly until the task starts
+                running.
 
-                    Multipliers can be used as shorthand as in the example
-                    below.
+                Multipliers can be used as shorthand as in the example
+                below.
 
-                    Example::
+                Example::
 
-                       5*PT2M, PT5M
+                   5*PT2M, PT5M
 
-                    Note that if the polling
-                    :cylc:conf:`global.cylc[platforms][<platform name>]
-                    communication method`
-                    is used then Cylc relies on polling to detect all task
-                    state changes,
-                    so you may want to configure more
-                    frequent polling.
+                Note that if the polling
+                :cylc:conf:`global.cylc[platforms][<platform name>]
+                communication method`
+                is used then Cylc relies on polling to detect all task
+                state changes,
+                so you may want to configure more
+                frequent polling.
 
-                    This config item overrides
-                    :cylc:conf:`global.cylc[platforms][<platform name>]
-                    submission polling intervals`.
-                    '''
-            )
-            Conf(
-                'submission retry delays',
-                VDR.V_INTERVAL_LIST,
-                None,
-                desc='''
-                    Cylc can automatically resubmit jobs after submission
-                    failures.
+                This config item overrides
+                :cylc:conf:`global.cylc[platforms][<platform name>]
+                submission polling intervals`.
+            ''')
+            Conf('submission retry delays', VDR.V_INTERVAL_LIST,
+                 None, desc='''
+                Cylc can automatically resubmit jobs after submission
+                failures.
 
-                    A list of intervals which define when the scheduler will
-                    resubmit jobs if submission fails.
+                A list of intervals which define when the scheduler will
+                resubmit jobs if submission fails.
 
-                    This config item overrides
-                    :cylc:conf:`global.cylc[platforms][<platform name>]
-                    submission retry delays`
-                    '''
-            )
+                This config item overrides
+                :cylc:conf:`global.cylc[platforms][<platform name>]
+                submission retry delays`
+            ''')
             with Conf('meta', desc=r'''
                 Metadata for the task or task family.
 
@@ -1395,14 +1365,19 @@ with Conf(
                 ''')
 
             with Conf('job', desc=dedent('''
+                .. deprecated:: 8.0.0
+
                 This section configures the means by which cylc submits task
                 job scripts to run.
 
-            ''') + DEPRECATION_WARN):
+            ''') + REPLACED_BY_PLATFORMS):
                 Conf('batch system', VDR.V_STRING)
                 Conf('batch submit command template', VDR.V_STRING)
 
-            with Conf('remote', desc=DEPRECATION_WARN):
+            with Conf('remote', desc=dedent('''
+                .. deprecated:: 8.0.0
+
+            ''') + REPLACED_BY_PLATFORMS):
                 Conf('host', VDR.V_STRING)
                 # TODO: Convert URL to a stable or latest release doc after 8.0
                 # https://github.com/cylc/cylc-flow/issues/4663
@@ -1411,9 +1386,9 @@ with Conf(
 
                     .. seealso::
 
-                        `Documentation on changes to remote owner
-                        <https://cylc.github.io/cylc-doc/latest/html/
-                        7-to-8/major-changes/remote-owner.html>`_
+                       `Documentation on changes to remote owner
+                       <https://cylc.github.io/cylc-doc/latest/html/
+                       7-to-8/major-changes/remote-owner.html>`_
                 """)
                 Conf('retrieve job logs', VDR.V_BOOLEAN)
                 Conf('retrieve job logs max size', VDR.V_STRING)


### PR DESCRIPTION
These changes close #4851 

- Ensure config items shared by global and workflow configs have links to each other
- Centralised such items' descriptions and display the full description for the workflow item, whereas only the first paragraph for the global item
- Tidy up these docs a bit and fix the odd mistake

Would recommend a commit-by-commit review.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (just made sure docs build properly).
- [x] No change log entry required (just a docs change).
- [x] No documentation update required.
