### PR TITLE
Fix optparse Options class for standard options

### DIFF
--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -21,7 +21,7 @@ import sys
 import io
 from contextlib import redirect_stdout
 import cylc.flow.flags
-from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.option_parsers import CylcOptionParser as COP, Options
 
 
 USAGE_WITH_COMMENT = "usage \n # comment"
@@ -85,3 +85,11 @@ def test_help_nocolor(monkeypatch: pytest.MonkeyPatch, parser: COP):
     with redirect_stdout(f):
         parser.print_help()
     assert (f.getvalue()).startswith("Usage: " + USAGE_WITH_COMMENT)
+
+
+def test_Options_std_opts():
+    """Test Python Options API with standard options."""
+    parser = COP(USAGE_WITH_COMMENT, auto_add=True)
+    MyOptions = Options(parser)
+    MyValues = MyOptions(verbosity=1)
+    assert MyValues.verbosity == 1


### PR DESCRIPTION
This is a small change with no associated Issue.

Allow standard options (`CylcOptionParser(auto_add=True)`) in Python API `Options` class

**Before:**
```
>>> from cylc.flow.scripts.clean import CleanOptions
>>> CleanOptions(verbosity=1)
ValueError: verbosity
```
**After:**
`CleanOptions(verbosity=1)` works as expected.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
