### PR TITLE
cli: updated cylc term logo

### DIFF
--- a/cylc/flow/scripts/common.py
+++ b/cylc/flow/scripts/common.py
@@ -16,7 +16,6 @@
 
 """Shared utilities for Cylc scripts."""
 
-from re import sub
 from itertools import zip_longest
 from ansimarkup import strip
 
@@ -28,31 +27,31 @@ from cylc.flow.terminal import get_width
 # fmt: off
 LOGO_LETTERS = (
     (
-        "ooo",
-        "oo ",
-        "oooo",
+        '▗███',
+        '██  ',
+        '▝███',
     ),
     (
-        "oo oo",
-        "ooooo",
-        " ooo",
+        '▝█▙ ▟█▘',
+        '  ▜█▛  ',
+        '  ▐█▌  ',
     ),
     (
-        "oo ",
-        "ooo",
-        "ooo",
+        '▐█  ',
+        '▐█  ',
+        '▐██▌',
     ),
     (
-        "oooo",
-        "oo  ",
-        "oooo",
+        '▗███▙ ',
+        '██    ',
+        '▝███▛ ',
     )
 )
 # fmt: on
 
 LOGO = [
     ''.join(
-        sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
+        f'<{tag}>{letter[ind]}</{tag}>'
         for tag, letter in zip(
             ('red', 'yellow', 'green', 'blue'),
             LOGO_LETTERS


### PR DESCRIPTION
Attempt at improving the readability of the in-terminal Cylc logo using unicode "block elements". I think these chars are the only dependably full width/height chars.

### Before
![Screenshot from 2022-06-21 18-00-19](https://user-images.githubusercontent.com/16705946/174857106-5bd3043d-9d0b-4e1f-97f1-0097d4009bb2.png)

### After

![Screenshot from 2022-06-21 18-00-47](https://user-images.githubusercontent.com/16705946/174857135-b1370276-612d-4795-b0b7-b80e26b80fd5.png)

Might try to improve the kerning on the "L".

Thoughts?