### PR TITLE
uid: warn if the run number is provided as a cycle

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -14,13 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import asyncio
 import fnmatch
 from pathlib import Path
 import re
 from typing import Optional, Dict, List, Tuple, Any
 
+from cylc.flow import LOG
 from cylc.flow.exceptions import (
     InputError,
     WorkflowFilesError,
@@ -397,6 +397,16 @@ def _validate_workflow_ids(*tokens_list, src_path):
             raise InputError(
                 f'Workflow ID cannot be a file: {tokens["workflow"]}'
             )
+        if tokens['cycle'] and tokens['cycle'].startswith('run'):
+            # issue a warning if the run number is provided after the //
+            # separator e.g. workflow//run1 rather than workflow/run1//
+            suggested = Tokens(
+                user=tokens['user'],
+                workflow=f'{tokens["workflow"]}/{tokens["cycle"]}',
+                cycle=tokens['task'],
+                task=tokens['job'],
+            )
+            LOG.warning(f'Did you mean: {suggested.id}')
         detect_both_flow_and_suite(src_path)
 
 


### PR DESCRIPTION
* E.G. workflow//run/cycle rather than workflow/run//cycle.
* Closes #4923

![Screenshot from 2022-06-22 13-12-58](https://user-images.githubusercontent.com/16705946/175026152-cfb5c3e7-c3e8-421e-a162-0378ffe8c2ea.png)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (minor change)
- [x] No documentation update required.
