### PR TITLE
play: upgrade --start-task's specified in legacy format

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, List
 from cylc.flow import LOG, RSYNC_LOG
 from cylc.flow.exceptions import ServiceFileError
 import cylc.flow.flags
+from cylc.flow.id import upgrade_legacy_ids
 from cylc.flow.host_select import select_workflow_host
 from cylc.flow.hostuserutil import is_remote_host
 from cylc.flow.id_cli import parse_ids
@@ -411,4 +412,9 @@ async def _run(scheduler: Scheduler) -> int:
 @cli_function(get_option_parser)
 def play(parser: COP, options: 'Values', id_: str):
     """Implement cylc play."""
+    if options.starttask:
+        options.starttask = upgrade_legacy_ids(
+            *options.starttask,
+            relative=True,
+        )
     return scheduler_cli(options, id_)

--- a/tests/functional/cylc-play/10-start-task-upgrade.t
+++ b/tests/functional/cylc-play/10-start-task-upgrade.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# ensure that legacy task ids are upgraded automatically when specified
+# with --start-task
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+run_fail "${TEST_NAME_BASE}" \
+    cylc play Agrajag --start-task foo.123 --start-task bar.234
+
+grep_ok \
+    'Cylc7 format is deprecated, using: 123/foo 234/bar' \
+    "${TEST_NAME_BASE}.stderr"
+


### PR DESCRIPTION
* Extend CLI upgrading to the Cylc 8 --start-task option.
* Closes #4920

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? minor edge case of little concern)
- [x] No documentation update required.