### PR TITLE
expand schema docstring internally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,9 @@ in `global.cylc[install]source dirs`.
 
 ### Fixes
 
+[#4926](https://github.com/cylc/cylc-flow/pull/4926) - Fix a docstring
+formatting problem presenting in the UI mutation flow argument info.
+
 [#4891](https://github.com/cylc/cylc-flow/pull/4891) - Fix bug that could cause
 past jobs to be omitted in the UI.
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1391,15 +1391,9 @@ class WorkflowStopMode(graphene.Enum):
 
 
 class Flow(String):
-    """An integer or one of {FLOW_ALL}, {FLOW_NEW} or {FLOW_NONE}."""
-
-
-# NOTE: docstrings can't be f-strings so we must manually format it.
-Flow.__doc__ = Flow.__doc__.format(  # type: ignore[union-attr]
-    FLOW_ALL=FLOW_ALL,
-    FLOW_NEW=FLOW_NEW,
-    FLOW_NONE=FLOW_NONE,
-)
+    __doc__ = (
+        f"""An integer or one of {FLOW_ALL}, {FLOW_NEW} or {FLOW_NONE}."""
+    )
 
 
 # Mutations:


### PR DESCRIPTION
These changes close #4898
![image](https://user-images.githubusercontent.com/11400777/175181399-2acdcba2-2d41-45f8-b9a9-2a9f11d78f0e.png)

![image](https://user-images.githubusercontent.com/11400777/175181362-6fecea4c-5d94-4d30-9d0e-5bc2c57b3011.png)

```
(flow) sutherlander@graphic-vbox:cylc-flow$ python -c 'from cylc.flow.network.schema import Flow; print(Flow.__doc__); print(Flow().__doc__)'
An integer or one of all, new or none.
An integer or one of all, new or none.
```

(note:  I don't know why the previous arrangement didn't work at the UI, but this does)

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [x] Covered functionally by existing tests, aesthetically by UI (could write a graphql introspection query, however python functionality really).
<!-- choose one: -->
- [x] Appropriate change log entry included.
<!-- choose one: -->
- [x] No documentation update required.
