### PR TITLE
reinstall: require workflow ID argument

### DIFF
--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -32,10 +32,6 @@ Examples:
   $ cylc install myflow --no-run-name
   # To reinstall this workflow run:
   $ cylc reinstall myflow
-
-  # To reinstall a workflow from within the cylc-run directory of a previously
-  # installed workflow:
-  $ cylc reinstall
 """
 
 from pathlib import Path
@@ -48,7 +44,7 @@ from cylc.flow.option_parsers import (
     WORKFLOW_ID_ARG_DOC,
     CylcOptionParser as COP,
 )
-from cylc.flow.pathutil import get_cylc_run_dir, get_workflow_run_dir
+from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.workflow_files import (
     get_workflow_source_dir,
     reinstall_workflow,
@@ -61,7 +57,7 @@ if TYPE_CHECKING:
 
 def get_option_parser() -> COP:
     parser = COP(
-        __doc__, comms=True, argdoc=[COP.optional(WORKFLOW_ID_ARG_DOC)]
+        __doc__, comms=True, argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
     parser.add_cylc_rose_options()
@@ -90,20 +86,10 @@ def main(
 ) -> None:
     run_dir: Optional[Path]
     workflow_id: str
-    if args is None:
-        try:
-            workflow_id = str(Path.cwd().relative_to(
-                Path(get_cylc_run_dir()).resolve()
-            ))
-        except ValueError:
-            raise WorkflowFilesError(
-                "The current working directory is not a workflow run directory"
-            )
-    else:
-        workflow_id, *_ = parse_id(
-            args,
-            constraint='workflows',
-        )
+    workflow_id, *_ = parse_id(
+        args,
+        constraint='workflows',
+    )
     run_dir = Path(get_workflow_run_dir(workflow_id))
     if not run_dir.is_dir():
         raise WorkflowFilesError(

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation
 . "$(dirname "$0")/test_header"
-set_test_number 21
+set_test_number 11
 
 # Test basic cylc reinstall, named run given
 TEST_NAME="${TEST_NAME_BASE}-basic-named-run"
@@ -62,40 +62,6 @@ INSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
 __OUT__
 
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
-purge_rnd_workflow
-
-# Test cylc reinstall from within rundir, no args given
-TEST_NAME="${TEST_NAME_BASE}-no-args"
-make_rnd_workflow
-run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --workflow-name="${RND_WORKFLOW_NAME}"
-cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}
-__OUT__
-pushd "${RND_WORKFLOW_RUNDIR}/run1" || exit 1
-touch "${RND_WORKFLOW_SOURCE}/new_file"
-run_ok "${TEST_NAME}-reinstall" cylc reinstall
-REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/run1/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
-exists_ok new_file
-popd || exit 1
-purge_rnd_workflow
-
-# Test cylc reinstall from within rundir, no args given
-TEST_NAME="${TEST_NAME_BASE}-no-args-no-run-name"
-make_rnd_workflow
-pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install "${RND_WORKFLOW_SOURCE}" --no-run-name
-cmp_ok "${TEST_NAME}-install.stdout" <<__OUT__
-INSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}
-__OUT__
-pushd "${RND_WORKFLOW_RUNDIR}" || exit 1
-touch "${RND_WORKFLOW_SOURCE}/new_file"
-run_ok "${TEST_NAME}-reinstall" cylc reinstall
-REINSTALL_LOG="$(find "${RND_WORKFLOW_RUNDIR}/log/install" -type f -name '*reinstall.log')"
-grep_ok "REINSTALLED ${RND_WORKFLOW_NAME} from ${RND_WORKFLOW_SOURCE}" "${REINSTALL_LOG}"
-exists_ok new_file
-popd || exit 1
-popd || exit 1
 purge_rnd_workflow
 
 exit

--- a/tests/functional/cylc-reinstall/02-failures.t
+++ b/tests/functional/cylc-reinstall/02-failures.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow reinstallation expected failures
 . "$(dirname "$0")/test_header"
-set_test_number 26
+set_test_number 23
 
 # Test fail no workflow run dir
 
@@ -87,21 +87,6 @@ __ERR__
     purge_rnd_workflow
     popd || exit 1
 done
-
-# Test cylc reinstall (no args given) raises error when no source dir.
-TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error"
-make_rnd_workflow
-pushd "${RND_WORKFLOW_SOURCE}" || exit 1
-run_ok "${TEST_NAME}-install" cylc install --no-run-name --workflow-name="${RND_WORKFLOW_NAME}"
-pushd "${RND_WORKFLOW_RUNDIR}" || exit 1
-rm -rf "_cylc-install"
-run_fail "${TEST_NAME}-reinstall" cylc reinstall
-cmp_ok "${TEST_NAME}-reinstall.stderr" <<__ERR__
-WorkflowFilesError: "${RND_WORKFLOW_NAME}" was not installed with cylc install.
-__ERR__
-popd || exit 1
-popd || exit 1
-purge_rnd_workflow
 
 # Test cylc reinstall (args given) raises error when no source dir.
 TEST_NAME="${TEST_NAME_BASE}-reinstall-no-source-rasies-error2"


### PR DESCRIPTION
> Candidate fix for #4928
>
> @dpmatthews I think the reinstall `$PWD` suggestion might have been yours, does this make sense to you?

* Closes #4928
* With `cylc install` we can omit the source name argument,
  it will look for a workflow in `$PWD`.
* However, `cylc reinstall` works with installed workflow IDs
  *not* source names.
* `cylc reinstall` currently supports omitting the workflow ID,
  something which other commands do not support. This has caused issues
  when symlink dirs are involved (#4928).
* Suggest requiring the workflow ID argument. If we develop the
  capability to omit the workflow ID argument for other commands we
  can add it to `reinstall` when we do so, however, it may require more
  thought to implement.

<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes partially address #xxxx
These changes close #xxxx
This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
