### PR TITLE
schema: small docs changes

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1415,7 +1415,7 @@ class Broadcast(Mutation):
 
             A broadcast can set/override any `[runtime]` configuration for all
             cycles or for a specific cycle. If a task is affected by
-            specific-cycle and an all-cycle broadcasts at the same time, the
+            specific-cycle and all-cycle broadcasts at the same time, the
             specific takes precedence.
 
             Broadcasts can also target all tasks, specific tasks or families of

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1275,16 +1275,22 @@ class BroadcastMode(graphene.Enum):
         if self == BroadcastMode.Set:
             return 'Create a new broadcast.'
         if self == BroadcastMode.Clear:
-            return 'Revoke an existing broadcast.'
+            return (
+                'Clear existing broadcasts globally or for specified'
+                ' cycle points and namespaces if provided.'
+            )
         if self == BroadcastMode.Expire:
-            return 'Expire an existing broadcast.'
+            return (
+                'Clear all broadcasts for cycle points earlier than the'
+                ' provided cutoff.'
+            )
         return ''
 
 
 class BroadcastSetting(GenericScalar):
-    """A [runtime] key=value configuration for a namespace.
+    """A `[runtime]` configuration for a namespace.
 
-    Should be a key=value pair where sections are wrapped with square
+    Should be a `key=value` pair where sections are wrapped with square
     brackets.
 
     Examples:
@@ -1398,45 +1404,38 @@ class Flow(String):
 
 # Mutations:
 
-# TODO: re-instate:
-# - get-broadcast (can just use GraphQL query BUT needs CLI access too)
-# - expire-broadcast
-
 class Broadcast(Mutation):
     class Meta:
         description = sstrip('''
-            Override or add new `[runtime]` configurations in a running
-            workflow.
+            Override `[runtime]` configurations in a running workflow.
 
             Uses for broadcast include making temporary changes to task
             behaviour, and task-to-downstream-task communication via
             environment variables.
 
-            A broadcast can target any [runtime] namespace for all cycles or
-            for a specific cycle. If a task is affected by specific-cycle and
-            all-cycle broadcasts at once, the specific takes precedence. If
-            a task is affected by broadcasts to multiple ancestor
-            namespaces, the result is determined by normal [runtime]
-            inheritance. In other words, it follows this order:
+            A broadcast can set/override any `[runtime]` configuration for all
+            cycles or for a specific cycle. If a task is affected by
+            specific-cycle and an all-cycle broadcasts at the same time, the
+            specific takes precedence.
 
-            `all:root -> all:FAM -> all:task -> tag:root -> tag:FAM ->
-            tag:task`
+            Broadcasts can also target all tasks, specific tasks or families of
+            tasks. If a task is affected by broadcasts to multiple ancestor
+            namespaces (tasks it inherits from), the result is determined by
+            normal `[runtime]` inheritance.
 
-            Broadcasts persist, even across restarts, until they expire
-            when their target cycle point is older than the oldest current in
-            the workflow, or until they are explicitly cancelled with this
-            command.  All-cycle broadcasts do not expire.
+            Broadcasts are applied at the time of job submission.
 
-            For each task the final effect of all broadcasts to all namespaces
-            is computed on the fly just prior to job submission.  The
-            `--cancel` and `--clear` options simply cancel (remove) active
-            broadcasts, they do not act directly on the final task-level
-            result. Consequently, for example, you cannot broadcast to "all
-            cycles except Tn" with an all-cycle broadcast followed by a cancel
-            to Tn (there is no direct broadcast to Tn to cancel); and you
-            cannot broadcast to "all members of FAMILY except member_n" with a
-            general broadcast to FAMILY followed by a cancel to member_n (there
-            is no direct broadcast to member_n to cancel).
+            Broadcasts persist, even across restarts. Broadcasts made to
+            specific cycle points will expire when the cycle point is older
+            than the oldest active cycle point in the workflow.
+
+            Active broadcasts can be revoked using the "clear" mode.
+            Any broadcasts matching the specified cycle points and
+            namespaces will be revoked.
+
+            Note: a "clear" broadcast for a specific cycle or namespace does
+            *not* clear all-cycle or all-namespace broadcasts.
+
         ''')
         resolver = partial(mutator, command='broadcast')
 
@@ -1453,24 +1452,28 @@ class Broadcast(Mutation):
         cycle_points = graphene.List(
             CyclePoint,
             description=sstrip('''
-                List of cycle points to target or `*` to cancel all all-cycle
-                broadcasts without canceling all specific-cycle broadcasts.
+                List of cycle points to target (or `*` to cancel all all-cycle
+                broadcasts without canceling all specific-cycle broadcasts).
             '''),
             default_value=['*'])
         namespaces = graphene.List(
             NamespaceName,
-            description='Target namespaces.',
+            description='List of namespaces (tasks or families) to target.',
             default_value=['root']
         )
         settings = graphene.List(
             BroadcastSetting,
             description=sstrip('''
-                The cylc namespace for the setting to modify.
+                The `[runtime]` configuration to override with this broadcast
+                (e.g. `script = true` or `[environment]ANSWER=42`).
             '''),
             # e.g. `{environment: {variable_name: "value",. . .}. . .}`.
         )
         cutoff = CyclePoint(
-            description='Clear broadcasts earlier than cutoff cycle point.'
+            description=(
+                'Clear broadcasts earlier than cutoff cycle point.'
+                ' (for use with "Expire" mode).'
+            )
         )
 
         # TODO: work out how to implement this feature, it needs to be

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -26,7 +26,7 @@ task-to-downstream-task communication via environment variables.
 See also "cylc reload" which reads in the flow.cylc (or suite.rc) file.
 
 A broadcast can set/override any "[runtime]" configuration for all cycles or
-for a specific cycle. If a task is affected by specific-cycle and an all-cycle
+for a specific cycle. If a task is affected by specific-cycle and all-cycle
 broadcasts at the same time, the specific takes precedence.
 
 Broadcasts can also target all tasks, specific tasks or families of tasks. If a

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -18,34 +18,32 @@
 
 """cylc broadcast [OPTIONS] ARGS
 
-Override or add new [runtime] configuration items in a running workflow.
+Override "[runtime]" configurations in a running workflow.
 
-Uses for broadcast include making temporary changes to task behaviour,
-and task-to-downstream-task communication via environment variables.
+Uses for broadcast include making temporary changes to task behaviour, and
+task-to-downstream-task communication via environment variables.
 
-A broadcast can target any [runtime] namespace (task or task family) for all
-cycles or for a specific cycle. If a task is affected by specific-cycle and
-all-cycle broadcasts at the same time, the specific takes precedence. If a task
-is affected by broadcasts to multiple ancestor namespaces, the result is
-determined by normal [runtime] inheritance. In other words, it follows this
-order:
+See also "cylc reload" which reads in the flow.cylc (or suite.rc) file.
 
-all:root -> all:FAM -> all:task -> tag:root -> tag:FAM -> tag:task
+A broadcast can set/override any "[runtime]" configuration for all cycles or
+for a specific cycle. If a task is affected by specific-cycle and an all-cycle
+broadcasts at the same time, the specific takes precedence.
 
-Broadcasts persist, even across workflow restarts, until they expire when
-their target cycle point is older than the oldest current in the workflow,
-or until they are explicitly cancelled with this command.  All-cycle
-broadcasts do not expire.
+Broadcasts can also target all tasks, specific tasks or families of tasks. If a
+task is affected by broadcasts to multiple ancestor namespaces (tasks it
+inherits from), the result is determined by normal "[runtime]" inheritance.
 
-For each task the final effect of all broadcasts to all namespaces is
-computed on the fly just prior to job submission.  The --cancel and
---clear options simply cancel (remove) active broadcasts, they do not
-act directly on the final task-level result. Consequently, for example,
-you cannot broadcast to "all cycles except Tn" with an all-cycle
-broadcast followed by a cancel to Tn (there is no direct broadcast to Tn
-to cancel); and you cannot broadcast to "all members of FAMILY except
-member_n" with a general broadcast to FAMILY followed by a cancel to
-member_n (there is no direct broadcast to member_n to cancel).
+Broadcasts are applied at the time of job submission.
+
+Broadcasts persist, even across restarts. Broadcasts made to specific cycle
+points will expire when the cycle point is older than the oldest active cycle
+point in the workflow.
+
+Active broadcasts can be revoked using the "clear" mode. Any broadcasts
+matching the specified cycle points and namespaces will be revoked.
+
+Note: a "clear" broadcast for a specific cycle or namespace does *not* clear
+all-cycle or all-namespace broadcasts.
 
 Examples:
   # To broadcast a variable to all tasks (quote items with internal spaces):
@@ -57,6 +55,9 @@ Examples:
   >     VERSE = the quick brown fox
   > __FLOW__
   $ cylc broadcast -F 'broadcast.cylc' WORKFLOW_ID
+
+  # view active broadcasts
+  $ cylc broadcast --display WORKFLOW_ID
 
   # To cancel the same broadcast:
   $ cylc broadcast --cancel "[environment]VERSE" WORKFLOW_ID
@@ -76,8 +77,7 @@ when the value contains newline or other metacharacters. If FILE is "-", read
 from standard input.
 
 Broadcast cannot change [runtime] inheritance.
-
-See also 'cylc reload' - reload a modified workflow definition at run time."""
+"""
 
 from ansimarkup import parse as cparse
 from functools import partial


### PR DESCRIPTION
Small changes to the broadcast mutation docs.

Closes the cylc-flow side of #4902, the (larger) cylc-ui portion has been moved to https://github.com/cylc/cylc-ui/issues/647.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
