### PR TITLE
clean: push error message to stderr

### DIFF
--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -184,7 +184,7 @@ async def run(*ids: str, opts: 'Values') -> None:
     workflows, multi_mode = await scan(workflows, multi_mode)
 
     if not workflows:
-        print(f"No workflows matching {', '.join(ids)}")
+        LOG.warning(f"No workflows matching {', '.join(ids)}")
         return
 
     workflows.sort()


### PR DESCRIPTION
Message was going to stdout which kinda made sense? Redirected it to stderr via the log so it shows up UIS side.