### PR TITLE
reinstall: don't delete unless asked

### DIFF
--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -20,6 +20,13 @@
 
 Reinstall a previously installed workflow.
 
+WARNING: this uninstalls previously-installed files that have since been
+removed from the source directory, by detecting files outside of the standard
+run sub-directory locations (share, work, log) that are not present in the
+source directory. If your workflow tasks write to the top level run directory,
+use the --no-delete option or (preferably) configure your .cylcignore file
+appropriately, to protect these files from deletion.
+
 Examples:
   # Having previously installed:
   $ cylc install myflow
@@ -61,12 +68,18 @@ def get_option_parser() -> COP:
     )
 
     parser.add_option(
-        "--delete", "-d",
-        help="Delete previously installed files that have been removed from"
-        " the source directory.",
+        "--no-delete", "-n",
+        help=(
+            "Do not delete files outside of the standard run sub-directories"
+            " (work, share, etc.) that are not present in the source"
+            " directory. NOTE: we recommend use of a .cylcignore file in the"
+            " source directory rather than this option, because that does"
+            " not prevent removal of previously-installed files that are"
+            " no longer needed."
+        ),
         action='store_true',
         default=False,
-        dest="delete"
+        dest="no_delete"
     )
 
     parser.add_cylc_rose_options()
@@ -131,7 +144,7 @@ def main(
         source=Path(source),
         named_run=workflow_id,
         rundir=run_dir,
-        delete=opts.delete,
+        delete=not opts.no_delete,
         dry_run=False  # TODO: ready for dry run implementation
     )
 

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -60,6 +60,15 @@ def get_option_parser() -> COP:
         __doc__, comms=True, argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
+    parser.add_option(
+        "--delete", "-d",
+        help="Delete previously installed files that have been removed from"
+        " the source directory.",
+        action='store_true',
+        default=False,
+        dest="delete"
+    )
+
     parser.add_cylc_rose_options()
     try:
         # If cylc-rose plugin is available
@@ -122,6 +131,7 @@ def main(
         source=Path(source),
         named_run=workflow_id,
         rundir=run_dir,
+        delete=opts.delete,
         dry_run=False  # TODO: ready for dry run implementation
     )
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1426,7 +1426,7 @@ def _open_install_log(rund, logger):
     logger.addHandler(handler)
 
 
-def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
+def get_rsync_rund_cmd(src, dst, delete=False, dry_run=False):
     """Create and return the rsync command used for cylc install/re-install.
 
     Args:
@@ -1434,8 +1434,8 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
             file path location of source directory
         dst (str):
             file path location of destination directory
-        reinstall (bool):
-            indicate reinstall (--delete option added)
+        delete (bool):
+            add --delete option added (for reinstall)
         dry-run (bool):
             indicate dry-run, rsync will not take place but report output if a
             real run were to be executed
@@ -1447,7 +1447,7 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
     rsync_cmd = ["rsync"] + DEFAULT_RSYNC_OPTS
     if dry_run:
         rsync_cmd.append("--dry-run")
-    if reinstall:
+    if delete:
         rsync_cmd.append('--delete')
     for exclude in [
         '.git',
@@ -1476,6 +1476,7 @@ def reinstall_workflow(
     source: Path,
     named_run: str,
     rundir: Path,
+    delete: bool = False,
     dry_run: bool = False
 ) -> None:
     """Reinstall workflow.
@@ -1493,7 +1494,7 @@ def reinstall_workflow(
     reinstall_log.info(f"Reinstalling \"{named_run}\", from "
                        f"\"{source}\" to \"{rundir}\"")
     rsync_cmd = get_rsync_rund_cmd(
-        source, rundir, reinstall=True, dry_run=dry_run)
+        source, rundir, delete=delete, dry_run=dry_run)
     proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, text=True)  # nosec
     # * command is constructed via internal interface
     stdout, stderr = proc.communicate()
@@ -1506,8 +1507,9 @@ def reinstall_workflow(
             f"An error occurred when copying files from {source} to {rundir}")
         reinstall_log.warning(f" Error: {stderr}")
     check_flow_file(rundir)
-    reinstall_log.info(f'REINSTALLED {named_run} from {source}')
-    print(f'REINSTALLED {named_run} from {source}')
+    msg = f'REINSTALLED {named_run} from {source}'
+    reinstall_log.info(msg)
+    print(msg)
     close_log(reinstall_log)
 
 


### PR DESCRIPTION
Currently `cylc reinstall` deletes files outside of the standard run sub-di.rectories (share, log, work) that do not exist in the source directory (including files files that get there via `rose-suite.conf` file creation mode, but that's OK because the `cylc-rose` plugin gets re-run at reinstall time, to recreate those).

This was reported to me as a serious bug by a NIWA user migrating to Cylc 8.

Marking as a QUESTION because, going back to the `rose suite-run` migration proposal, this is a design feature, not a bug. 

As it happens, typical practice at NIWA is to use an "install task" early in the run to extract, build, and deploy external code into the run directory (under `bin`, but potentially elsewhere too) so `cylc reinstall` nukes all of that.

This PR makes the rsync `--delete` setting an opt-in option, which I think is the right thing to do if you agree that deploying (or generating) files outside of the share directory at run time is not a fundamentally stupid thing to do. (It seems perfectly reasonable to me ... and I would have thought many MO workflows would do the same thing?)


<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

This is a small change with no associated Issue.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
