### PR TITLE
glblcfg: increase default rolling archive length

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -737,7 +737,7 @@ with Conf('global.cylc', desc='''
 
                {REPLACES}``[suite logging]``.
         '''):
-            Conf('rolling archive length', VDR.V_INTEGER, 5, desc='''
+            Conf('rolling archive length', VDR.V_INTEGER, 15, desc='''
                 How many rolled logs to retain in the archive.
             ''')
             Conf('maximum size in bytes', VDR.V_INTEGER, 1000000, desc='''


### PR DESCRIPTION
Related to #4836

* Log rollover happens for each restart, if workflows are repeatedly restarted (which often happens when problems occur) the sequence of events can be lost.
* Increase the archive length from 5 to 15.
* Note we have recently reduced the rollover size from 10Mb to 1Mb.

**Question:** Does 15 seem like a sensible number?

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
