### PR TITLE
clean: only attempt to clean platforms which have been installed to

### DIFF
--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -187,6 +187,12 @@ class WorkflowDatabaseManager:
         """Delete workflow stop task from workflow_params table."""
         self.delete_workflow_params(self.KEY_STOP_TASK)
 
+    def delete_remote_init_item(self, install_target):
+        self.db_deletes_map.setdefault(CylcWorkflowDAO.TABLE_REMOTE_INIT, [])
+        self.db_deletes_map[CylcWorkflowDAO.TABLE_REMOTE_INIT].append(
+            {'install_target': install_target}
+        )
+
     def get_pri_dao(self):
         """Return the primary DAO."""
         return CylcWorkflowDAO(self.pri_path)
@@ -626,6 +632,14 @@ class WorkflowDatabaseManager:
         self.db_updates_map.setdefault(self.TABLE_TASK_OUTPUTS, [])
         self.db_updates_map[self.TABLE_TASK_OUTPUTS].append(
             (set_args, where_args))
+
+    def put_remote_init_item(self, install_target: str, status: str) -> None:
+        """Insert or update a remote init / fileinstall status."""
+        self.db_inserts_map.setdefault(CylcWorkflowDAO.TABLE_REMOTE_INIT, [])
+        self.db_inserts_map[CylcWorkflowDAO.TABLE_REMOTE_INIT].append({
+            'install_target': install_target,
+            'status': status,
+        })
 
     def _put_update_task_x(self, table_name, itask, set_args):
         """Put UPDATE statement for a task_* table."""


### PR DESCRIPTION
Addresses the "broken platform" side of #4935.

* Store the remote init map in the workflow database.
* This table is not in itself housekept because the database as a whole is housekept by `cylc clean`.
* Add a new remote-init status for platforms which have no hosts available (therefor do not need cleaning as we haven't managed to install anything onto them in the first place).

TODO:
* [ ] Don't update the status of an install_target if the new status would not require clean and the old would (e.g. can happen on restart if no hosts are available but the remote-init completed for the previous start)
* [ ] Requires (extremely simple) DB upgrader (i.e. add blank table on restart).
* [ ] Add test.

**Requirements check-list**
- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
<!-- choose one: -->
- [ ] Appropriate tests are included (unit and/or functional).
- [ ] Already covered by existing tests.
- [ ] Does not need tests (why?).
<!-- choose one: -->
- [ ] Appropriate change log entry included.
- [ ] No change log entry required (why? e.g. invisible to users).
<!-- choose one: -->
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.
- [ ] (7.8.x branch) I have updated the documentation in this PR branch.
- [ ] No documentation update required.
