### PR TITLE
Back compat deprecation warnings - an addendum

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -794,23 +794,20 @@ class WorkflowConfig:
             is_disallowed = False
         if is_disallowed:
             raise WorkflowConfigError(msg)
-
         # Otherwise "[scheduler]allow implicit tasks" is not set
 
-        # Allow implicit tasks in back-compat mode (unless rose-suite.conf
-        # present, to maintain compat with Rose 2019)
-        if (
-            cylc.flow.flags.cylc7_back_compat and
-            not Path(self.run_dir, 'rose-suite.conf').is_file()
-        ):
+        if not cylc.flow.flags.cylc7_back_compat:
+            msg += (
+                "\nTo allow implicit tasks, use "
+                f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'"
+            )
+        # Allow implicit tasks in back-compat mode unless rose-suite.conf
+        # present (to maintain compat with Rose 2019)
+        elif not Path(self.run_dir, 'rose-suite.conf').is_file():
             LOG.debug(msg)
             return
 
-        raise WorkflowConfigError(
-            f"{msg}\n"
-            "To allow implicit tasks, use "
-            f"'{WorkflowFiles.FLOW_FILE}[scheduler]allow implicit tasks'"
-        )
+        raise WorkflowConfigError(msg)
 
     def _check_circular(self):
         """Check for circular dependence in graph."""


### PR DESCRIPTION
Do not suggest using allow implicit tasks setting when `rose-suite.conf` present in c7 back-compat mode

This is a small change follow-up to #4943, which I forgot to stage

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests 
- [x] No change log entry required.
- [x] No documentation update required.
