### PR TITLE
reinstall: no delete in back compat mode

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1433,10 +1433,13 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
         list: command to use for rsync.
 
     """
+    check_deprecation(src)
     rsync_cmd = ["rsync"] + DEFAULT_RSYNC_OPTS
     if dry_run:
         rsync_cmd.append("--dry-run")
-    if reinstall:
+    if reinstall and not cylc.flow.flags.cylc7_back_compat:
+        # In back-compat mode don't delete external (non source-dir) files
+        # deployed to the run directory (would break many Cylc 7 suites).
         rsync_cmd.append('--delete')
     for exclude in [
         '.git',

--- a/tests/functional/cylc-reinstall/03-backcompat.t
+++ b/tests/functional/cylc-reinstall/03-backcompat.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test "cylc reinstall" handling of external (non source) files in the run dir.
+
+. "$(dirname "$0")/test_header"
+set_test_number 9
+
+make_rnd_workflow
+pushd "${RND_WORKFLOW_SOURCE}" || exit 1
+
+# Should delete external files............................................
+run_ok "install-normal" cylc install
+
+# Install an "external" file.
+EXT_FILE=$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/external
+touch "${EXT_FILE}"
+
+run_ok "reinstall-normal" cylc reinstall "${RND_WORKFLOW_NAME}"
+
+exists_fail "${EXT_FILE}"
+
+# Unless listed in .cylcignore............................................
+basename "${EXT_FILE}" > .cylcignore
+run_ok "install-cylcignore" cylc install
+
+EXT_FILE=$HOME/cylc-run/${RND_WORKFLOW_NAME}/run2/external
+touch "${EXT_FILE}"
+
+run_ok "reinstall-cylcignore" cylc reinstall "${RND_WORKFLOW_NAME}"
+exists_ok "${EXT_FILE}"
+
+# Or back-compat mode ....................................................
+
+rm .cylcignore
+rm flow.cylc
+touch suite.rc
+run_ok "install-suiterc" cylc install
+
+EXT_FILE=$HOME/cylc-run/${RND_WORKFLOW_NAME}/run3/external
+touch "${EXT_FILE}"
+
+run_ok "reinstall-suiterc" cylc reinstall "${RND_WORKFLOW_NAME}"
+exists_ok "${EXT_FILE}"
+
+purge_rnd_workflow

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1771,9 +1771,13 @@ def test_is_installed(tmp_run_dir: Callable, reg, installed, named, expected):
     assert actual == expected
 
 
-def test_get_rsync_rund_cmd(tmp_run_dir: Callable):
+def test_get_rsync_rund_cmd(
+    tmp_src_dir: Callable,
+    tmp_run_dir: Callable
+):
     """Test rsync command for cylc install/reinstall excludes cylc dirs.
     """
+    src_dir = tmp_src_dir('foo')
     cylc_run_dir: Path = tmp_run_dir('rsync_flow', installed=True, named=False)
     for wdir in [
         WorkflowFiles.WORK_DIR,
@@ -1781,12 +1785,12 @@ def test_get_rsync_rund_cmd(tmp_run_dir: Callable):
         WorkflowFiles.LOG_DIR,
     ]:
         cylc_run_dir.joinpath(wdir).mkdir(exist_ok=True)
-    actual_cmd = get_rsync_rund_cmd('blah', cylc_run_dir)
+    actual_cmd = get_rsync_rund_cmd(src_dir, cylc_run_dir)
     assert actual_cmd == [
         'rsync', '-a', '--checksum', '--out-format=%o %n%L', '--no-t',
         '--exclude=log', '--exclude=work', '--exclude=share',
         '--exclude=_cylc-install', '--exclude=.service',
-        'blah/', f'{cylc_run_dir}/']
+        f'{src_dir}/', f'{cylc_run_dir}/']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

Supersede #4942

Based on previous discussion, I agree that `.cylcignore` in its full glory means we should not support a no-delete option for `cylc reinstall`.

However, based on the unassailable logic of https://github.com/cylc/cylc-flow/pull/4942#issuecomment-1171747474 we DO need to turn off deletion in back-compat mode.

Summary:
- Without this we can't safely run many Cylc 7 suites (quite possibly all of them outside of the MO) in back-compat mode, without a potentially non-trivial upgrade process
- This has no negative impact impact on Cylc 7 + `rose suite-run` users, because it's only back-compat mode, and reportedly few if any were using (let alone relying on) the `--new` (deletion) option anyway (so I would argue that this is sensible back-compat support for `rose suite-run` file creation mode too - for default re-installation).
 
![Screenshot from 2022-07-01 16-51-45](https://user-images.githubusercontent.com/2362137/176826140-e7197e68-634c-4d36-b2cf-b7d9c6db8bfe.png)


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [ ] Appropriate change log entry included.
- [ ] (master branch) I have opened a documentation PR at cylc/cylc-doc/pull/XXXX.

