### PR TITLE
Test reinstall deletion

### DIFF
--- a/tests/functional/cylc-reinstall/03-external-files.t
+++ b/tests/functional/cylc-reinstall/03-external-files.t
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------------
+# Test "cylc reinstall" handling of external (non source) files in the run dir.
+
+. "$(dirname "$0")/test_header"
+set_test_number 6
+
+make_rnd_workflow
+pushd "${RND_WORKFLOW_SOURCE}" || exit 1
+
+# 1. Should delete an external file.
+
+# Install source files.
+run_ok "install-normal" cylc install
+
+# Install an "external" file.
+EXT_FILE=$HOME/cylc-run/${RND_WORKFLOW_NAME}/run1/external
+touch "${EXT_FILE}"
+
+run_ok "reinstall-normal" cylc reinstall "${RND_WORKFLOW_NAME}"
+
+exists_fail "${EXT_FILE}"
+
+# 2. Unless it is listed in .cylcignore.
+basename "${EXT_FILE}" > .cylcignore
+run_ok "install-cylcignore" cylc install
+
+EXT_FILE=$HOME/cylc-run/${RND_WORKFLOW_NAME}/run2/external
+touch "${EXT_FILE}"
+
+run_ok "reinstall-cylcignore" cylc reinstall "${RND_WORKFLOW_NAME}"
+exists_ok "${EXT_FILE}"
+
+purge_rnd_workflow

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1771,9 +1771,13 @@ def test_is_installed(tmp_run_dir: Callable, reg, installed, named, expected):
     assert actual == expected
 
 
-def test_get_rsync_rund_cmd(tmp_run_dir: Callable):
+def test_get_rsync_rund_cmd(
+    tmp_src_dir: Callable,
+    tmp_run_dir: Callable
+):
     """Test rsync command for cylc install/reinstall excludes cylc dirs.
     """
+    src_dir = tmp_src_dir('foo')
     cylc_run_dir: Path = tmp_run_dir('rsync_flow', installed=True, named=False)
     for wdir in [
         WorkflowFiles.WORK_DIR,
@@ -1781,12 +1785,12 @@ def test_get_rsync_rund_cmd(tmp_run_dir: Callable):
         WorkflowFiles.LOG_DIR,
     ]:
         cylc_run_dir.joinpath(wdir).mkdir(exist_ok=True)
-    actual_cmd = get_rsync_rund_cmd('blah', cylc_run_dir)
+    actual_cmd = get_rsync_rund_cmd(src_dir, cylc_run_dir)
     assert actual_cmd == [
         'rsync', '-a', '--checksum', '--out-format=%o %n%L', '--no-t',
         '--exclude=log', '--exclude=work', '--exclude=share',
         '--exclude=_cylc-install', '--exclude=.service',
-        'blah/', f'{cylc_run_dir}/']
+        f'{src_dir}/', f'{cylc_run_dir}/']
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Tests salvaged from #4953 - to test that `cylc reinstall` uses rsync delete mode as expected. Probably still useful to have?

Note the small change to the unit test on this branch is not strictly required, but still makes the code a bit clearer.


