### PR TITLE
cylc reinstall --dry-run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,10 @@ Fourth Release Candidate for Cylc 8 suitable for acceptance testing.
 
 ### Enhancements
 
+[#4964](https://github.com/cylc/cylc-flow/pull/4964) -
+`cylc reinstall` now displays the changes it would make when run
+interactively and has improved help / documentaiton.
+
 [#4836](https://github.com/cylc/cylc-flow/pull/4836) - The log directory has
 been tidied. Workflow logs are now found in `log/scheduler` rather than
 `log/workflow`, filenames now include `start`/`restart`. Other minor directory

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1286,8 +1286,10 @@ with Conf('global.cylc', desc='''
                  VDR.V_STRING,
                  'rsync',
                  desc='''
-                Command used for remote file installation. This supports POSIX
-                compliant rsync implementation e.g. GNU or BSD.
+                Command used for file installation.
+
+                This supports POSIX compliant rsync implementations e.g. GNU or
+                BSD.
 
                 .. versionadded:: 8.0.0
             ''')

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -36,7 +36,7 @@ from textwrap import dedent
 from typing import Any, Dict, Optional, List, Tuple
 
 from cylc.flow import LOG
-from cylc.flow.terminal import supports_color
+from cylc.flow.terminal import supports_color, DIM
 import cylc.flow.flags
 from cylc.flow.loggingutil import (
     CylcLogFormatter,
@@ -70,9 +70,29 @@ def format_shell_examples(string):
     return cparse(
         re.sub(
             r'^(\s*(?:\$[^#]+)?)(#.*)$',
-            r'\1<dim>\2</dim>',
+            rf'\1<{DIM}>\2</{DIM}>',
             string,
-            flags=re.M
+            flags=re.M,
+        )
+    )
+
+
+def format_help_headings(string):
+    """Put "headings" in bold.
+
+    Where "headings" are lines with no indentation which are followed by a
+    colon e.g:
+
+    Examples:
+      ...
+
+    """
+    return cparse(
+        re.sub(
+            r'^(\w.*:)$',
+            r'<bold>\1</bold>',
+            string,
+            flags=re.M,
         )
     )
 
@@ -183,7 +203,9 @@ class CylcHelpFormatter(IndentedHelpFormatter):
             )
         ):
             # Add color formatting to examples text.
-            text = format_shell_examples(text)
+            text = format_shell_examples(
+                format_help_headings(text)
+            )
         else:
             # Strip any hardwired formatting
             text = cstrip(text)

--- a/cylc/flow/scripts/check_versions.py
+++ b/cylc/flow/scripts/check_versions.py
@@ -31,7 +31,8 @@ version if $CYLC_VERSION is defined.
 
 Use -v/--verbose to see the command invoked to determine the remote version
 (all remote cylc command invocations will be of the same form, which may be
-site dependent -- see cylc global config documentation."""
+site dependent -- see cylc global config documentation.
+"""
 
 import sys
 from typing import TYPE_CHECKING

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -18,7 +18,10 @@
 
 """cylc clean [OPTIONS] ARGS
 
-Remove a stopped workflow from the local scheduler filesystem and remote hosts.
+Delete a stopped workflow.
+
+Remove workflow files from the local scheduler filesystem and any remote hosts
+the workflow was installed on.
 
 NOTE: this command is intended for workflows installed with `cylc install`. If
 this is run for a workflow that was instead written directly in ~/cylc-run and
@@ -54,7 +57,6 @@ Examples:
 
   # Only remove the workflow on remote install targets
   $ cylc clean foo/bar --remote-only
-
 """
 
 import asyncio

--- a/cylc/flow/scripts/cycle_point.py
+++ b/cylc/flow/scripts/cycle_point.py
@@ -51,7 +51,8 @@ Other examples:
   $ export CYLC_TASK_CYCLE_POINT=2010-08
   $ export MYTEMPLATE=foo-CCYY-MM.nc
   $ cylc cycle-point --offset-years=2 --template=MYTEMPLATE
-  foo-2012-08.nc"""
+  foo-2012-08.nc
+"""
 
 import os
 import sys

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -429,6 +429,22 @@ def cli_help():
     # modern terminal)
     from colorama import init as color_init
     color_init(autoreset=True, strip=False)
+    commands = [
+        'clean',
+        'hold',
+        'install',
+        'kill',
+        'pause',
+        'play',
+        'release',
+        'scan',
+        'stop',
+        'trigger',
+        'tui',
+        'validate',
+    ]
+    if 'gui' in COMMANDS:
+        commands.append('gui')
     print(USAGE)
     sys.exit(0)
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -26,7 +26,10 @@ from ansimarkup import parse as cparse
 import pkg_resources
 
 from cylc.flow import __version__, iter_entry_points
-from cylc.flow.option_parsers import format_shell_examples
+from cylc.flow.option_parsers import (
+    format_help_headings,
+    format_shell_examples,
+)
 from cylc.flow.scripts.common import cylc_header
 
 
@@ -173,8 +176,7 @@ Filters
 
 # because this command is not served from behind cli_function like the
 # other cylc commands we have to manually patch in colour support
-USAGE = format_shell_examples(USAGE)
-USAGE = cparse(USAGE)
+USAGE = cparse(format_help_headings(format_shell_examples(USAGE)))
 
 # all sub-commands
 # {name: entry_point}
@@ -429,22 +431,6 @@ def cli_help():
     # modern terminal)
     from colorama import init as color_init
     color_init(autoreset=True, strip=False)
-    commands = [
-        'clean',
-        'hold',
-        'install',
-        'kill',
-        'pause',
-        'play',
-        'release',
-        'scan',
-        'stop',
-        'trigger',
-        'tui',
-        'validate',
-    ]
-    if 'gui' in COMMANDS:
-        commands.append('gui')
     print(USAGE)
     sys.exit(0)
 

--- a/cylc/flow/scripts/diff.py
+++ b/cylc/flow/scripts/diff.py
@@ -26,7 +26,8 @@ the order of configuration items, and it sees any include-file content
 after inlining has occurred.
 
 Files in the workflow bin directory and other sub-directories of the
-run directory are not currently differenced."""
+run directory are not currently differenced.
+"""
 
 import sys
 from typing import TYPE_CHECKING

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -32,7 +32,8 @@ Examples:
   $ cylc dump --tasks --sort WORKFLOW_ID | grep running
 
   # Display the state of all tasks in a particular cycle point:
-  $ cylc dump -t WORKFLOW_ID | grep 2010082406"""
+  $ cylc dump -t WORKFLOW_ID | grep 2010082406
+"""
 
 from graphene.utils.str_converters import to_snake_case
 import json

--- a/cylc/flow/scripts/ext_trigger.py
+++ b/cylc/flow/scripts/ext_trigger.py
@@ -36,7 +36,8 @@ triggering system is responding to.
 
 Use the retry options in case the target workflow is down or out of contact.
 
-Note: to manually trigger a task use 'cylc trigger', not this command."""
+Note: to manually trigger a task use 'cylc trigger', not this command.
+"""
 
 from time import sleep
 from typing import TYPE_CHECKING

--- a/cylc/flow/scripts/get_resources.py
+++ b/cylc/flow/scripts/get_resources.py
@@ -36,7 +36,8 @@ Examples:
     $ cylc get-resources tutorial/runtime-tutorial
 
     # copy all of the tutorials to your "source" directory:
-    $ cylc get-resources tutorial"""
+    $ cylc get-resources tutorial
+"""
 
 import sys
 

--- a/cylc/flow/scripts/get_workflow_contact.py
+++ b/cylc/flow/scripts/get_workflow_contact.py
@@ -18,7 +18,8 @@
 
 """cylc get-workflow-contact [OPTIONS] ARGS
 
-Print contact information of a running workflow."""
+Print contact information of a running workflow.
+"""
 
 from typing import TYPE_CHECKING
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -78,7 +78,6 @@ Examples:
 
 The same workflow can be installed with multiple names; this results in
 multiple workflow run directories that link to the same workflow definition.
-
 """
 
 from pathlib import Path

--- a/cylc/flow/scripts/jobs_kill.py
+++ b/cylc/flow/scripts/jobs_kill.py
@@ -21,8 +21,8 @@
 Read job status files to obtain the names of the job runners and the job IDs
 in the runners. Invoke the relevant job runner commands to ask the job runners
 to terminate the jobs.
-
 """
+
 from cylc.flow.job_runner_mgr import JobRunnerManager
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function

--- a/cylc/flow/scripts/jobs_poll.py
+++ b/cylc/flow/scripts/jobs_poll.py
@@ -20,8 +20,8 @@
 
 Read job status files to obtain the statuses of the jobs. If necessary, Invoke
 the relevant job runner commands to ask the job runners for more statuses.
-
 """
+
 from cylc.flow.job_runner_mgr import JobRunnerManager
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function

--- a/cylc/flow/scripts/jobs_submit.py
+++ b/cylc/flow/scripts/jobs_submit.py
@@ -20,8 +20,8 @@
 
 Submit task jobs to relevant job runners.
 On a remote job host, this command reads the job files from STDIN.
-
 """
+
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.terminal import cli_function
 from cylc.flow.job_runner_mgr import JobRunnerManager

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -27,7 +27,8 @@ The first-parent inheritance graph determines the primary task family
 groupings that are collapsible in cylc visualisation tools.
 
 To visualize the full multiple inheritance hierarchy use:
-  $ cylc graph -n"""
+  $ cylc graph -n
+"""
 
 import os
 import sys

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -30,32 +30,74 @@ Examples:
   # Or, to reinstall a specific run:
   $ cylc reinstall myflow/run2
 
-  # View the changes reinstall would make:
-  $ cylc reinstall myflow --dry-run
+  # If the workflow is running:
+  $ cylc reinstall myflow  # reinstall as usual
+  $ cylc reload myflow     # pick up changes in the workflow config
+
+What reinstall does:
+  Reinstall synchronises files between the workflow source and the specified
+  run directory.
+
+  Any files which have been added, updated or removed in the source directory
+  will be added, updated or removed in the run directory. Cylc uses "rsync"
+  to do this (run in "--debug" mode to see the exact command used).
+
+How changes are displayed:
+  Reinstall will first perform a dry run showing the files it would change.
+  This is displayed in "rsync" format e.g:
+
+    <g>send foo</g>   # this means the file "foo" would be added/updated
+    <r>del. bar</r>   # this means the file "bar" would be deleted
+
+How to prevent reinstall deleting files:
+  Reinstall will delete any files which are not present in the source directory
+  (i.e. if you delete a file from the source directory, a reinstall would
+  remove the file from the run directory too). The "work/" and "share/"
+  directory are excluded from this. These are the recommended locations for any
+  files created at runtime.
+
+  You can extend the list of "excluded" paths by creating a ".cylcignore" file.
+  For example the following file would exclude "data/" and any ".csv" files
+  from being overwritten by a reinstallation:
+
+    $ cat .cylcignore
+    data
+    *.csv
+
+  Note any paths listed in ".cylcignore" will not be installed by
+  "cylc install" even if present in the source directory.
 """
 
 from pathlib import Path
 import sys
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, List, Callable
 
 from ansimarkup import parse as cparse
 
 from cylc.flow import iter_entry_points
-from cylc.flow.exceptions import PluginError, WorkflowFilesError
+from cylc.flow.exceptions import (
+    PluginError,
+    ServiceFileError,
+    WorkflowFilesError,
+)
 from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import (
-    WORKFLOW_ID_ARG_DOC,
     CylcOptionParser as COP,
+    Options,
+    WORKFLOW_ID_ARG_DOC,
 )
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.workflow_files import (
     get_workflow_source_dir,
+    load_contact_file,
     reinstall_workflow,
 )
-from cylc.flow.terminal import cli_function
+from cylc.flow.terminal import cli_function, DIM, is_terminal
 
 if TYPE_CHECKING:
     from optparse import Values
+
+_input = input  # to enable testing
 
 
 def get_option_parser() -> COP:
@@ -78,20 +120,174 @@ def get_option_parser() -> COP:
             dest="clear_rose_install_opts"
         )
 
-    parser.add_option(
-        '--dry', '--dry-run',
-        action='store_true',
-        help='Show the changes reinstallation would make.'
-    )
-
     return parser
 
 
-def format_rsync_out(out):
-    """Format rsync stdout for presenting to users.
+ReInstallOptions = Options(get_option_parser())
+
+
+@cli_function(get_option_parser)
+def main(
+    _parser: COP,
+    opts: 'Values',
+    args: Optional[str] = None
+) -> None:
+    """CLI wrapper."""
+    reinstall_cli(opts, args)
+
+
+def reinstall_cli(
+    opts: 'Values',
+    args: Optional[str] = None,
+) -> bool:
+    """Implement cylc reinstall.
+
+    This is the bit which contains all the CLI logic.
+    """
+    run_dir: Optional[Path]
+    workflow_id: str
+    workflow_id, *_ = parse_id(
+        args,
+        constraint='workflows',
+    )
+    run_dir = Path(get_workflow_run_dir(workflow_id))
+    if not run_dir.is_dir():
+        raise WorkflowFilesError(
+            f'"{workflow_id}" is not an installed workflow.')
+    source, source_symlink = get_workflow_source_dir(run_dir)
+    if not source:
+        raise WorkflowFilesError(
+            f'"{workflow_id}" was not installed with cylc install.')
+    source: Path = Path(source)
+    if not source.is_dir():
+        raise WorkflowFilesError(
+            f'Workflow source dir is not accessible: "{source}".\n'
+            f'Restore the source or modify the "{source_symlink}"'
+            ' symlink to continue.'
+        )
+
+    usr: str = ''
+    try:
+        if is_terminal():  # interactive mode - perform dry-run and prompt
+            # dry-mode reinstall
+            if not reinstall(
+                opts,
+                workflow_id,
+                source,
+                run_dir,
+                dry_run=True,
+            ):
+                # no rsync output == no changes => exit
+                print(cparse(
+                    '<magenta>'
+                    f'{workflow_id} up to date with {source}'
+                    '</magenta>'
+                ))
+                return False
+
+            display_rose_warning(source)
+            display_cylcignore_tip()
+
+            # prompt for permission to continue
+            while usr not in ['y', 'n']:
+                usr = _input(
+                    cparse('<bold>Continue [y/n]: </bold>')
+                ).lower()
+
+        else:  # non interactive-mode - no dry-run, no prompt
+            usr = 'y'
+
+    except KeyboardInterrupt:
+        # ensure the "reinstall canceled" message shows for ctrl+c
+        usr = 'n'  # cancel the reinstall
+        print()    # clear the traceback line
+
+    if usr == 'y':
+        # reinstall for real
+        reinstall(opts, workflow_id, source, run_dir, dry_run=False)
+        print(cparse('<green>Successfully reinstalled.</green>'))
+        display_cylc_reload_tip(workflow_id)
+
+    else:
+        # no reinstall
+        print(
+            cparse('<magenta>Reinstall canceled, no changes made.</magenta>')
+        )
+
+    return True
+
+
+def reinstall(
+    opts: 'Values',
+    workflow_id: str,
+    src_dir: Path,
+    run_dir: Path,
+    dry_run: bool = False,
+    write: Callable = print,
+) -> bool:
+    """Perform reinstallation.
+
+    This is the purely functional bit without the CLI logic.
+
+    Args:
+        opts: CLI options.
+        workflow_id: Workflow ID as a string.
+        src_dir: Workflow source directory path.
+        run_dir: Installed workflow run directory path.
+        dry_run: If True perform a "dry run" which doesn't change anything.
+        write: Used to display dry_run output.
+
+    Returns:
+        reinstall_needed - In dry_run mode returns False if rsync *would*
+        update anything, else returns True.
+
+    """
+    # run pre_configure plugins
+    if not dry_run:
+        # don't run plugins in dry-mode
+        pre_configure(opts, src_dir)
+
+    # reinstall from src_dir (will raise WorkflowFilesError on error)
+    stdout: str = reinstall_workflow(
+        source=src_dir,
+        named_run=workflow_id,
+        rundir=run_dir,
+        dry_run=dry_run,
+    )
+
+    # display changes
+    if dry_run:
+        if not stdout or stdout == 'send ./':
+            # no rsync output == no changes => exit
+            return False
+
+        # display rsync output
+        write('\n'.join(format_rsync_out(stdout)), file=sys.stderr)
+
+    # run post_install plugins
+    if not dry_run:
+        # don't run plugins in dry-mode
+        post_install(opts, src_dir, run_dir)
+
+    return True
+
+
+def format_rsync_out(out: str) -> List[str]:
+    r"""Format rsync stdout for presenting to users.
 
     Note: Output formats of different rsync implementations may differ so keep
           this code simple and robust.
+
+    Example:
+        >>> format_rsync_out(
+        ...     'send foo\ndel. bar\nbaz'
+        ...     '\ncannot delete non-empty directory: opt'
+        ... ) == [
+        ...     cparse('<green>send foo</green>'),
+        ...     cparse('<red>del. bar</red>'),
+        ...     'baz',
+        ... ]
+        True
 
     """
     lines = []
@@ -114,84 +310,89 @@ def format_rsync_out(out):
     return lines
 
 
-@cli_function(get_option_parser)
-def main(
-    parser: COP,
-    opts: 'Values',
-    args: Optional[str] = None
-) -> None:
-    run_dir: Optional[Path]
-    workflow_id: str
-    workflow_id, *_ = parse_id(
-        args,
-        constraint='workflows',
-    )
-    run_dir = Path(get_workflow_run_dir(workflow_id))
-    if not run_dir.is_dir():
-        raise WorkflowFilesError(
-            f'"{workflow_id}" is not an installed workflow.')
-    source, source_symlink = get_workflow_source_dir(run_dir)
-    if not source:
-        raise WorkflowFilesError(
-            f'"{workflow_id}" was not installed with cylc install.')
-    if not Path(source).is_dir():
-        raise WorkflowFilesError(
-            f'Workflow source dir is not accessible: "{source}".\n'
-            f'Restore the source or modify the "{source_symlink}"'
-            ' symlink to continue.'
-        )
+def pre_configure(opts: 'Values', src_dir: Path) -> None:
+    """Run pre_configure plugins."""
+    # don't run plugins in dry-mode
+    for entry_point in iter_entry_points(
+        'cylc.pre_configure'
+    ):
+        try:
+            entry_point.resolve()(srcdir=src_dir, opts=opts)
+        except Exception as exc:
+            # NOTE: except Exception (purposefully vague)
+            # this is to separate plugin from core Cylc errors
+            raise PluginError(
+                'cylc.pre_configure',
+                entry_point.name,
+                exc
+            ) from None
 
-    if not opts.dry:
-        for entry_point in iter_entry_points(
-            'cylc.pre_configure'
-        ):
-            try:
-                entry_point.resolve()(srcdir=source, opts=opts)
-            except Exception as exc:
-                # NOTE: except Exception (purposefully vague)
-                # this is to separate plugin from core Cylc errors
-                raise PluginError(
-                    'cylc.pre_configure',
-                    entry_point.name,
-                    exc
-                ) from None
 
-    stdout = reinstall_workflow(
-        source=Path(source),
-        named_run=workflow_id,
-        rundir=run_dir,
-        dry_run=opts.dry,
-    )
+def post_install(opts: 'Values', src_dir: Path, run_dir: Path) -> None:
+    """Run post_install plugins."""
+    for entry_point in iter_entry_points(
+        'cylc.post_install'
+    ):
+        try:
+            entry_point.resolve()(
+                srcdir=src_dir,
+                opts=opts,
+                rundir=str(run_dir)
+            )
+        except Exception as exc:
+            # NOTE: except Exception (purposefully vague)
+            # this is to separate plugin from core Cylc errors
+            raise PluginError(
+                'cylc.post_install',
+                entry_point.name,
+                exc
+            ) from None
 
-    if Path(source, 'rose-suite.conf').is_file():
+
+def display_rose_warning(src_dir: Path) -> None:
+    """Explain why rose installed files are marked as deleted."""
+    if (src_dir / 'rose-suite.conf').is_file():
+        # TODO: remove this in combination with
+        # https://github.com/cylc/cylc-rose/issues/149
         print(
             cparse(
-                '<blue>'
-                'NOTE: Files created by Rose file installation will show as'
-                ' deleted.'
+                f'\n<{DIM}>'
+                'NOTE: Files created by Rose file installation will show'
+                ' as deleted.'
                 '\n      They will be re-created during the reinstall'
                 ' process.'
-                '</blue>',
+                f'</{DIM}>',
             ),
             file=sys.stderr,
         )
-    print('\n'.join(format_rsync_out(stdout)), file=sys.stderr)
 
-    if not opts.dry:
-        for entry_point in iter_entry_points(
-            'cylc.post_install'
-        ):
-            try:
-                entry_point.resolve()(
-                    srcdir=source,
-                    opts=opts,
-                    rundir=str(run_dir)
-                )
-            except Exception as exc:
-                # NOTE: except Exception (purposefully vague)
-                # this is to separate plugin from core Cylc errors
-                raise PluginError(
-                    'cylc.post_install',
-                    entry_point.name,
-                    exc
-                ) from None
+
+def display_cylcignore_tip():
+    print(
+        cparse(
+            f'\n<{DIM}>TIP: You can "exclude" files/dirs to prevent'
+            ' Cylc from installing or overwriting\n     them by adding'
+            ' them to the .cylcignore file. See cylc reinstall --help.'
+            f'</{DIM}>\n'
+            '\n<bold>Reinstall would make the above changes.</bold>'
+        )
+    )
+
+
+def display_cylc_reload_tip(workflow_id: str) -> None:
+    """Recommend use of "cylc reload" if applicable.
+
+    Uses a quick and simple way to tell if a workflow is running.
+
+    It would be better to "ping" the workflow, however, this is sufficient
+    for our purposes.
+    """
+    try:
+        load_contact_file(workflow_id)
+    except ServiceFileError:
+        return
+    print(cparse(
+        '\n<blue>'
+        f'Run "cylc reload {workflow_id}" to pick up changes.'
+        '</blue>'
+    ))

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -50,7 +50,8 @@ line (cylc play --set 'FOO="bar"' WORKFLOW_ID) the same template settings apply
 to the reload (only changes to the flow.cylc file itself are reloaded).
 
 If the modified workflow definition does not parse, failure to reload will
-be reported but no harm will be done to the running workflow."""
+be reported but no harm will be done to the running workflow.
+"""
 
 from functools import partial
 from typing import TYPE_CHECKING

--- a/cylc/flow/scripts/remote_init.py
+++ b/cylc/flow/scripts/remote_init.py
@@ -33,7 +33,6 @@ Return:
         - Print task_remote_cmd.REMOTE_INIT_DONE
     1:
         On failure.
-
 """
 
 from cylc.flow.option_parsers import CylcOptionParser as COP

--- a/cylc/flow/scripts/remote_tidy.py
+++ b/cylc/flow/scripts/remote_tidy.py
@@ -21,7 +21,6 @@
 Remove ".service/contact" from a task remote (i.e. a [owner@]host).
 Remove ".service" directory on the remote if emptied.
 Remove authentication keys.
-
 """
 
 from cylc.flow.option_parsers import CylcOptionParser as COP

--- a/cylc/flow/scripts/report_timings.py
+++ b/cylc/flow/scripts/report_timings.py
@@ -46,7 +46,6 @@ Timings are shown only for succeeded tasks.
 
 For long-running or large workflows (i.e. workflows with many task events),
 the database query to obtain the timing information may take some time.
-
 """
 
 import collections

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -72,15 +72,12 @@ from cylc.flow.option_parsers import (
     Options
 )
 from cylc.flow.print_tree import get_tree
-from cylc.flow.terminal import cli_function
+from cylc.flow.terminal import cli_function, DIM
 from cylc.flow.util import natural_sort_key
 from cylc.flow.workflow_files import ContactFileFields as Cont
 
 if TYPE_CHECKING:
     from optparse import Values
-
-# default grey colour (do not use "dim", it is not sufficiently portable)
-DIM = 'fg 248'
 
 # all supported workflow states
 FLOW_STATES = {

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -18,7 +18,9 @@
 
 """cylc set-outputs [OPTIONS] ARGS
 
-Artificially mark task outputs as completed and spawn downstream tasks that
+Artificially satisfy task outputs.
+
+Mark task outputs as completed and spawn downstream tasks that
 depend on those outputs. By default it marks tasks as succeeded.
 
 This allows you to manually intervene with Cylc's scheduling algorithm by
@@ -43,7 +45,6 @@ Examples:
   $ cylc set-outputs --flow=3 --output=x my_flow//1/foo
 
 Use --output multiple times to spawn off of several outputs at once.
-
 """
 
 from functools import partial

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -59,7 +59,8 @@ job poll and kill commands, however, will be executed prior to shutdown, unless
 --now is used.
 
 This command exits immediately unless --max-polls is greater than zero, in
-which case it polls to wait for workflow shutdown."""
+which case it polls to wait for workflow shutdown.
+"""
 
 from functools import partial
 import sys

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -19,7 +19,8 @@
 
 Force tasks to run despite unsatisfied prerequisites.
 
-* Triggering an unqueued waiting task queues it, regardless of prerequisites.* Triggering a queued task submits it, regardless of queue limiting.
+* Triggering an unqueued waiting task queues it, regardless of prerequisites.
+* Triggering a queued task submits it, regardless of queue limiting.
 * Triggering an active task has no effect (it already triggered).
 
 Incomplete and active-waiting tasks in the n=0 window already belong to a flow.

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -19,11 +19,8 @@
 
 Force tasks to run despite unsatisfied prerequisites.
 
-Triggering an unqueued waiting task queues it, regardless of prerequisites.
-
-Triggering a queued task submits it, regardless of queue limiting.
-
-Triggering an active task has no effect (it already triggered).
+* Triggering an unqueued waiting task queues it, regardless of prerequisites.* Triggering a queued task submits it, regardless of queue limiting.
+* Triggering an active task has no effect (it already triggered).
 
 Incomplete and active-waiting tasks in the n=0 window already belong to a flow.
 Triggering them queues them to run (or rerun) in the same flow.

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -22,7 +22,8 @@ Validate a workflow configuration.
 
 If the workflow definition uses include-files reported line numbers
 will correspond to the inlined version seen by the parser; use
-'cylc view -i,--inline WORKFLOW' for comparison."""
+'cylc view -i,--inline WORKFLOW' for comparison.
+"""
 
 from ansimarkup import parse as cparse
 from optparse import Values

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -40,6 +40,9 @@ from cylc.flow.parsec.exceptions import ParsecError
 # CLI exception message format
 EXC_EXIT = cparse('<red><bold>{name}: </bold>{exc}</red>')
 
+# default grey colour (do not use "dim", it is not sufficiently portable)
+DIM = 'fg 248'
+
 
 def is_terminal():
     """Determine if running in (and printing to) a terminal."""
@@ -174,7 +177,6 @@ def parse_dirty_json(stdout):
                 stdout = stdout.split('\n', 1)[1]
             except IndexError:
                 break
-    # raise ValueError(f'Invalid JSON: {orig}')
     raise ValueError(orig)
 
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1389,12 +1389,24 @@ def get_cylc_run_abs_path(path: Union[Path, str]) -> Union[Path, str]:
     return get_workflow_run_dir(path)
 
 
-def _get_logger(rund, log_name):
-    """Get log and create and open if necessary."""
+def _get_logger(rund, log_name, open_file=True):
+    """Get log and create and open if necessary.
+
+    Args:
+        rund:
+            The workflow run directory of the associated workflow.
+        log_name:
+            The name of the log to open.
+        open_file:
+            Open the appropriate log file and add it as a file handler to
+            the logger. I.E. Start writing the log to a file if not already
+            doing so.
+
+    """
     logger = logging.getLogger(log_name)
     if logger.getEffectiveLevel != logging.INFO:
         logger.setLevel(logging.INFO)
-    if not logger.hasHandlers():
+    if open_file and not logger.hasHandlers():
         _open_install_log(rund, logger)
     return logger
 
@@ -1471,7 +1483,7 @@ def reinstall_workflow(
     named_run: str,
     rundir: Path,
     dry_run: bool = False
-) -> None:
+) -> str:
     """Reinstall workflow.
 
     Args:
@@ -1480,29 +1492,45 @@ def reinstall_workflow(
         rundir: run directory
         dry_run: if True, will not execute the file transfer but report what
             would be changed.
+
+    Returns:
+        Stdout from the rsync command.
+
     """
     validate_source_dir(source, named_run)
     check_nested_dirs(rundir)
-    reinstall_log = _get_logger(rundir, 'cylc-reinstall')
-    reinstall_log.info(f"Reinstalling \"{named_run}\", from "
-                       f"\"{source}\" to \"{rundir}\"")
+    reinstall_log = _get_logger(
+        rundir,
+        'cylc-reinstall',
+        open_file=not dry_run,  # don't open the log file for --dry-run
+    )
+    reinstall_log.info(
+        f'Reinstalling "{named_run}", from "{source}" to "{rundir}"'
+    )
     rsync_cmd = get_rsync_rund_cmd(
-        source, rundir, reinstall=True, dry_run=dry_run)
+        source,
+        rundir,
+        reinstall=True,
+        dry_run=dry_run,
+    )
+    reinstall_log.info(cli_format(rsync_cmd))
+    # print(cli_format(rsync_cmd))
     proc = Popen(rsync_cmd, stdout=PIPE, stderr=PIPE, text=True)  # nosec
     # * command is constructed via internal interface
     stdout, stderr = proc.communicate()
-    reinstall_log.info(
-        f"Copying files from {source} to {rundir}"
-        f'\n{stdout}'
-    )
+
     if proc.returncode != 0:
         reinstall_log.warning(
-            f"An error occurred when copying files from {source} to {rundir}")
+            f"An error occurred when copying files from {source} to {rundir}"
+        )
         reinstall_log.warning(f" Error: {stderr}")
     check_flow_file(rundir)
     reinstall_log.info(f'REINSTALLED {named_run} from {source}')
-    print(f'REINSTALLED {named_run} from {source}')
+    print(
+        f'REINSTALL{"ED" if not dry_run else ""} {named_run} from {source}'
+    )
     close_log(reinstall_log)
+    return stdout
 
 
 def abort_if_flow_file_in_path(source: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,22 +116,37 @@ def port_range():
 @pytest.fixture
 def capcall(monkeypatch):
     """Capture function calls without running the function.
-    Returns a list of captured calls.
-    For each function call a tuple (args: Tuple, kwargs: Dict) is added
-    to the list.
+
+    Returns a list which is populated with function calls.
+
+    Args:
+        function_string:
+            The function to replace as it would be specified to
+            monkeypatch.setattr.
+        substitute_function:
+            An optional function to replace it with, otherwise the captured
+            function will return None.
+
+    Returns:
+        [(args: Tuple, kwargs: Dict), ...]
+
     Example:
         def test_something(capcall):
             capsys = capcall('sys.exit')
             sys.exit(1)
             assert capsys == [(1,), {}]
+
     """
 
-    def _capcall(function_string):
+    def _capcall(function_string, substitute_function=None):
         calls = []
 
         def _call(*args, **kwargs):
             nonlocal calls
+            nonlocal substitute_function
             calls.append((args, kwargs))
+            if substitute_function:
+                return substitute_function(*args, **kwargs)
 
         monkeypatch.setattr(function_string, _call)
         return calls

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation
 . "$(dirname "$0")/test_header"
-set_test_number 11
+set_test_number 17
 
 # Test basic cylc reinstall, named run given
 TEST_NAME="${TEST_NAME_BASE}-basic-named-run"
@@ -35,6 +35,7 @@ grep_ok "REINSTALLED ${RND_WORKFLOW_NAME}/run1 from ${RND_WORKFLOW_SOURCE}" "${R
 popd || exit 1
 purge_rnd_workflow
 
+#------------------------------------------------------------------------------
 # Test install/reinstall executed from elsewhere in filesystem
 TEST_NAME="${TEST_NAME_BASE}-named-flow"
 make_rnd_workflow
@@ -51,6 +52,7 @@ popd || exit 1
 purge_rnd_workflow
 rm -rf "${RUN_DIR:?}/${RND_WORKFLOW_NAME}/"
 
+#------------------------------------------------------------------------------
 # Test cylc reinstall succeeds if suite.rc file in source dir
 TEST_NAME="${TEST_NAME_BASE}-no-flow-file"
 make_rnd_workflow
@@ -63,5 +65,50 @@ __OUT__
 
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 purge_rnd_workflow
+
+#------------------------------------------------------------------------------
+# Test --dry-run
+TEST_NAME="${TEST_NAME_BASE}-dry-run"
+make_rnd_workflow
+touch "${RND_WORKFLOW_SOURCE}/a"
+touch "${RND_WORKFLOW_SOURCE}/b"
+touch "${RND_WORKFLOW_SOURCE}/rose-suite.conf"
+run_ok "${TEST_NAME}" \
+    cylc install "${RND_WORKFLOW_SOURCE}" \
+    --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
+rm "${RND_WORKFLOW_SOURCE}/a"
+touch "${RND_WORKFLOW_SOURCE}/c"
+# make sure the install log was created
+RUN_DIR="${HOME}/cylc-run/${RND_WORKFLOW_NAME}"
+if [[ "$(ls -1 "${RUN_DIR}/log/install"/* | wc -w)" == 1 ]]
+then
+    ok "${TEST_NAME}-log"
+else
+    fail "${TEST_NAME}-log"
+fi
+run_ok "${TEST_NAME}" \
+    cylc reinstall "${RND_WORKFLOW_NAME}" \
+    --dry-run --color=never
+# the dry run output should go to stderr
+cmp_ok "${TEST_NAME}.stderr" <<__OUT__
+NOTE: Files created by Rose file installation will show as deleted.
+      They will be re-created during the reinstall process.
+del. a
+send c
+__OUT__
+# make sure that rsync was indeed run in dry mode!
+if [[ -f "${RUN_DIR}/c" ]]; then
+    fail "${TEST_NAME}-transfer"
+else
+    ok "${TEST_NAME}-transfer"
+fi
+# make sure no reinstall log file was created
+if [[ "$(ls -1 "${RUN_DIR}/log/install"/* | wc -w)" == 1 ]]
+then
+    ok "${TEST_NAME}-log"
+else
+    fail "${TEST_NAME}-log"
+fi
+
 
 exit

--- a/tests/functional/cylc-reinstall/00-simple.t
+++ b/tests/functional/cylc-reinstall/00-simple.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow re-installation
 . "$(dirname "$0")/test_header"
-set_test_number 17
+set_test_number 11
 
 # Test basic cylc reinstall, named run given
 TEST_NAME="${TEST_NAME_BASE}-basic-named-run"
@@ -47,6 +47,7 @@ __OUT__
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 cmp_ok "${TEST_NAME}-reinstall.stdout" <<__OUT__
 REINSTALLED $RND_WORKFLOW_NAME/run1 from ${RND_WORKFLOW_SOURCE}
+Successfully reinstalled.
 __OUT__
 popd || exit 1
 purge_rnd_workflow
@@ -65,50 +66,5 @@ __OUT__
 
 run_ok "${TEST_NAME}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/run1"
 purge_rnd_workflow
-
-#------------------------------------------------------------------------------
-# Test --dry-run
-TEST_NAME="${TEST_NAME_BASE}-dry-run"
-make_rnd_workflow
-touch "${RND_WORKFLOW_SOURCE}/a"
-touch "${RND_WORKFLOW_SOURCE}/b"
-touch "${RND_WORKFLOW_SOURCE}/rose-suite.conf"
-run_ok "${TEST_NAME}" \
-    cylc install "${RND_WORKFLOW_SOURCE}" \
-    --workflow-name="${RND_WORKFLOW_NAME}" --no-run-name
-rm "${RND_WORKFLOW_SOURCE}/a"
-touch "${RND_WORKFLOW_SOURCE}/c"
-# make sure the install log was created
-RUN_DIR="${HOME}/cylc-run/${RND_WORKFLOW_NAME}"
-if [[ "$(ls -1 "${RUN_DIR}/log/install"/* | wc -w)" == 1 ]]
-then
-    ok "${TEST_NAME}-log"
-else
-    fail "${TEST_NAME}-log"
-fi
-run_ok "${TEST_NAME}" \
-    cylc reinstall "${RND_WORKFLOW_NAME}" \
-    --dry-run --color=never
-# the dry run output should go to stderr
-cmp_ok "${TEST_NAME}.stderr" <<__OUT__
-NOTE: Files created by Rose file installation will show as deleted.
-      They will be re-created during the reinstall process.
-del. a
-send c
-__OUT__
-# make sure that rsync was indeed run in dry mode!
-if [[ -f "${RUN_DIR}/c" ]]; then
-    fail "${TEST_NAME}-transfer"
-else
-    ok "${TEST_NAME}-transfer"
-fi
-# make sure no reinstall log file was created
-if [[ "$(ls -1 "${RUN_DIR}/log/install"/* | wc -w)" == 1 ]]
-then
-    ok "${TEST_NAME}-log"
-else
-    fail "${TEST_NAME}-log"
-fi
-
 
 exit

--- a/tests/integration/test_reinstall.py
+++ b/tests/integration/test_reinstall.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid1
+
+import pytest
+
+from cylc.flow.workflow_files import (
+    WorkflowFiles,
+    reinstall_workflow,
+)
+from cylc.flow.exceptions import (
+    WorkflowFilesError,
+)
+from cylc.flow.scripts.reinstall import (
+    ReInstallOptions,
+    reinstall_cli,
+)
+
+
+# cli opts
+
+# interactive: yes no
+# rose: yes no
+# workflow_running: yes no
+
+
+@pytest.fixture
+def interactive(monkeypatch):
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall.is_terminal',
+        lambda: True,
+    )
+
+
+@pytest.fixture
+def non_interactive(monkeypatch):
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall.is_terminal',
+        lambda: False,
+    )
+
+
+@pytest.fixture
+def one_src(tmp_path):
+    src_dir = tmp_path
+    (src_dir / 'flow.cylc').touch()
+    # (src_dir / 'rose-suite.conf').touch()
+    return SimpleNamespace(path=src_dir)
+
+
+@pytest.fixture
+def one_run(one_src, test_dir, run_dir):
+    w_run_dir = test_dir / str(uuid1())
+    w_run_dir.mkdir()
+    (w_run_dir / 'flow.cylc').touch()
+    (w_run_dir / 'rose-suite.conf').touch()
+    install_dir = (w_run_dir / WorkflowFiles.Install.DIRNAME)
+    install_dir.mkdir(parents=True)
+    (install_dir / WorkflowFiles.Install.SOURCE).symlink_to(
+        one_src.path,
+        target_is_directory=True,
+    )
+    return SimpleNamespace(
+        path=w_run_dir,
+        id=w_run_dir.relative_to(run_dir),
+    )
+
+
+def test_rejects_random_workflows(one):
+    """It should only work with workflows installed by cylc install."""
+    with pytest.raises(WorkflowFilesError) as exc_ctx:
+        reinstall_cli(opts=ReInstallOptions(), args=one.workflow)
+    assert 'was not installed with cylc install' in str(exc_ctx.value)
+
+
+def test_invalid_source_dir(one_src, one_run):
+    """It should detect & fail for an invalid source symlink"""
+    source_link = Path(
+        one_run.path,
+        WorkflowFiles.Install.DIRNAME,
+        WorkflowFiles.Install.SOURCE,
+    )
+    source_link.unlink()
+    source_link.symlink_to(one_src.path / 'flow.cylc')
+
+    with pytest.raises(WorkflowFilesError) as exc_ctx:
+        reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert 'Workflow source dir is not accessible' in str(exc_ctx.value)
+
+
+def test_no_changes_needed(one_src, one_run, capsys, interactive):
+    """It should not reinstall if no changes are needed.
+
+    This is not a hard requirement, in practice rsync output may differ
+    from expectation so this is a nice-to-have, not expected to work 100%
+    of the time.
+    """
+    assert not reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert 'up to date with' in capsys.readouterr().out
+
+
+def test_non_interactive(one_src, one_run, capsys, capcall, non_interactive):
+    """It should not perform a dry-run or prompt in non-interactive mode."""
+    # capture reinstall calls
+    reinstall_calls = capcall(
+        'cylc.flow.scripts.reinstall.reinstall_workflow',
+        reinstall_workflow,
+    )
+    # give it something to reinstall
+    (one_src.path / 'a').touch()
+    # reinstall
+    assert reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    # only one rsync call should have been made (i.e. no --dry-run)
+    assert len(reinstall_calls) == 1
+    assert 'Successfully reinstalled' in capsys.readouterr().out
+
+
+def test_interactive(
+    one_src,
+    one_run,
+    capsys,
+    capcall,
+    interactive,
+    monkeypatch
+):
+    """It should perform a dry-run and prompt in interactive mode."""
+    # capture reinstall calls
+    reinstall_calls = capcall(
+        'cylc.flow.scripts.reinstall.reinstall_workflow',
+        reinstall_workflow,
+    )
+    # give it something to reinstall
+    (one_src.path / 'a').touch()
+
+    # reinstall answering "no" to any prompt
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall._input',
+        lambda x: 'n'
+    )
+    assert reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+
+    # only one rsync call should have been made (i.e. the --dry-run)
+    assert [call[1].get('dry_run') for call in reinstall_calls] == [True]
+    assert 'Reinstall canceled, no changes made.' in capsys.readouterr().out
+    reinstall_calls.clear()
+
+    # reinstall answering "yes" to any prompt
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall._input',
+        lambda x: 'y'
+    )
+    assert reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+
+    # two rsync calls should have been made (i.e. the --dry-run and the real)
+    assert [call[1].get('dry_run') for call in reinstall_calls] == [
+        True, False
+    ]
+    assert 'Successfully reinstalled' in capsys.readouterr().out
+
+
+def test_workflow_running(
+    one_src,
+    one_run,
+    monkeypatch,
+    capsys,
+    non_interactive,
+):
+    """It should advise running "cylc reload" where applicable."""
+    # the message we are expecting
+    reload_message = f'Run "cylc reload {one_run.id}"'
+
+    # reinstall with a stopped workflow (reload message shouldn't show)
+    assert reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert reload_message not in capsys.readouterr().out
+
+    # reinstall with a running workflow (reload message should show)
+    monkeypatch.setattr(
+        # make it look like the workflow is running
+        'cylc.flow.scripts.reinstall.load_contact_file',
+        lambda x: None,
+    )
+    assert reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert reload_message in capsys.readouterr().out
+
+
+def test_rsync_stuff(one_src, one_run, capsys, non_interactive):
+    """Make sure rsync is working correctly."""
+    # src contains files: a, b
+    (one_src.path / 'a').touch()
+    with open(one_src.path / 'b', 'w+') as b_file:
+        b_file.write('x')
+    (one_src.path / 'b').touch()
+
+    # run contains files: b, c (where b is different to the source copy)
+    (one_run.path / 'b').touch()
+    (one_run.path / 'c').touch()
+
+    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+
+    # a should have been left
+    assert (one_run.path / 'a').exists()
+    # b should have been updated
+    assert (one_run.path / 'b').exists()
+    with open(one_run.path / 'b', 'r') as b_file:
+        assert b_file.read() == 'x'
+    # c should have been removed
+    assert not (one_run.path / 'c').exists()
+
+
+def test_rose_warning(one_src, one_run, capsys, interactive, monkeypatch):
+    """It should warn that Rose installed files will be deleted.
+
+    See https://github.com/cylc/cylc-rose/issues/149
+    """
+    # fragment of the message we expect
+    rose_message = (
+        'Files created by Rose file installation will show as deleted'
+    )
+
+    # reinstall answering "no" to any prompt
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall._input',
+        lambda x: 'n'
+    )
+    (one_src.path / 'a').touch()  # give it something to install
+
+    # reinstall (no rose-suite.conf file)
+    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert rose_message not in capsys.readouterr().err
+
+    # reinstall (with rose-suite.conf file)
+    (one_src.path / 'rose-suite.conf').touch()
+    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert rose_message in capsys.readouterr().err
+
+
+def test_keyboard_interrupt(
+    one_src,
+    one_run,
+    interactive,
+    monkeypatch,
+    capsys,
+):
+    """It should handle a KeyboardInterrupt during dry-run elegantly.
+
+    E.G. A user may ctrl+c rather than answering "n" (for no). To make it
+    clear a canceled message should show.
+    """
+    def raise_keyboard_interrupt():
+        raise KeyboardInterrupt()
+
+    # currently the first call in the dry-run branch
+    monkeypatch.setattr(
+        'cylc.flow.scripts.reinstall.is_terminal',
+        raise_keyboard_interrupt,
+    )
+
+    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+
+    assert 'Reinstall canceled, no changes made' in capsys.readouterr().out
+
+
+def test_rsync_fail(one_src, one_run, mock_glbl_cfg, non_interactive):
+    """It should raise an error on rsync failure."""
+    mock_glbl_cfg(
+        'cylc.flow.workflow_files.glbl_cfg',
+        '''
+            [platforms]
+                [[localhost]]
+                    rsync command = false
+        ''',
+    )
+
+    (one_src.path / 'a').touch()  # give it something to install
+    with pytest.raises(WorkflowFilesError) as exc_ctx:
+        reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert 'An error occurred reinstalling' in str(exc_ctx.value)


### PR DESCRIPTION
Closes #4960

Not 8.0.0 blocking but an easy win.

Add a `--dry-run` option for `cylc reinstall`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] Docs (I don't think changes are needed ATM, should improve the reinstall migration page soon)
