### PR TITLE
Back-compat mode tweak.

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -288,7 +288,14 @@ class TaskPool:
                         TASK_STATUS_SUCCEEDED,
                         TASK_STATUS_EXPIRED
                     )
-                    or itask.state.outputs.is_incomplete()
+                    or (
+                        # For Cylc 7 back-compat, ignore incomplete tasks.
+                        # (All :succeed is required in back-compat mode, so
+                        # failed tasks end up incomplete; and Cylc 7 ignores
+                        # failed tasks in computing the runhead limit).
+                        itask.state.outputs.is_incomplete()
+                        and not cylc.flow.flags.cylc7_back_compat
+                    )
                     for itask in itasks
                 )
             ):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -290,9 +290,9 @@ class TaskPool:
                     )
                     or (
                         # For Cylc 7 back-compat, ignore incomplete tasks.
-                        # (All :succeed is required in back-compat mode, so
-                        # failed tasks end up incomplete; and Cylc 7 ignores
-                        # failed tasks in computing the runhead limit).
+                        # (Success is required in back-compat mode, so failed
+                        # tasks end up as incomplete; and Cylc 7 ignores
+                        # failed tasks when computing the runahead limit).
                         itask.state.outputs.is_incomplete()
                         and not cylc.flow.flags.cylc7_back_compat
                     )

--- a/tests/functional/optional-outputs/07-finish-fail-c7-backcompat.t
+++ b/tests/functional/optional-outputs/07-finish-fail-c7-backcompat.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#-------------------------------------------------------------------------
+# Test handling of failed tasks in finish triggers in back-compat mode.
+# See comments in finish-fail-c7/suite.rc
+
+. "$(dirname "$0")/test_header"
+set_test_number 7
+
+install_workflow "${TEST_NAME_BASE}" finish-fail-c7
+
+# Validate with a deprecation message
+TEST_NAME="${TEST_NAME_BASE}-validate_as_c7"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+
+DEPR_MSG_1=$(python -c \
+  'from cylc.flow.workflow_files import SUITERC_DEPR_MSG; print(SUITERC_DEPR_MSG)')
+grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
+
+# Stall expected at FCP (but not at runahead limit).
+workflow_run_fail "${TEST_NAME_BASE}-run" cylc play -n --debug "${WORKFLOW_NAME}"
+
+grep_workflow_log_ok grep-0 "Workflow stalled"
+grep_workflow_log_ok grep-1 "WARNING - Incomplete tasks:"
+grep_workflow_log_ok grep-2 "1/foo did not complete required outputs"
+grep_workflow_log_ok grep-3 "2/foo did not complete required outputs"
+
+purge

--- a/tests/functional/optional-outputs/08-finish-fail-c7-c8.t
+++ b/tests/functional/optional-outputs/08-finish-fail-c7-c8.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#-------------------------------------------------------------------------
+# Test handling of failed tasks in finish triggers (non back-compat mode).
+# See comments in finish-fail-c7/suite.rc
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+# (Note install will issue a back-compat mode message here).
+install_workflow "${TEST_NAME_BASE}" finish-fail-c7
+
+# Turn of back-compat mode:
+mv "${WORKFLOW_RUN_DIR}/suite.rc" "${WORKFLOW_RUN_DIR}/flow.cylc"
+
+# Validate with a deprecation message
+TEST_NAME="${TEST_NAME_BASE}-validate_as_c8"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+
+DEPR_MSG="deprecated graph items were automatically upgraded"  # (not back-compat)
+grep_ok "${DEPR_MSG}" "${TEST_NAME}.stderr"
+
+# No stall expected.
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play -n --debug "${WORKFLOW_NAME}"
+
+purge

--- a/tests/functional/optional-outputs/finish-fail-c7/suite.rc
+++ b/tests/functional/optional-outputs/finish-fail-c7/suite.rc
@@ -1,0 +1,25 @@
+# When a task with a finish trigger fails:
+# Cylc 7:
+#   No runahead stall (failed tasks ignored) but stall due to failed tasks at FCP
+# Cylc 8 back-compat mode:
+#   Replicate Cylc 7 behaviour by making success outputs required and ignoring
+#   incomplete tasks in runahead computation.
+# Cylc 8 non-back-compat mode:
+#   No runahead stall and no stall at FCP, because :finish implies success optional. 
+
+[scheduler]
+    [[events]]
+        stall timeout = PT0S
+        abort on stall timeout = True
+[scheduling]
+    cycling mode = integer
+    initial cycle point = 1
+    final cycle point = 2
+    runahead limit = P0
+    [[dependencies]]
+        [[[P1]]]
+            graph = "foo:finish"
+[runtime]
+    [[foo]]
+        script = false
+

--- a/tests/functional/optional-outputs/finish-fail-c7/suite.rc
+++ b/tests/functional/optional-outputs/finish-fail-c7/suite.rc
@@ -1,11 +1,14 @@
 # When a task with a finish trigger fails:
 # Cylc 7:
-#   No runahead stall (failed tasks ignored) but stall due to failed tasks at FCP
+#   No runahead stall (failed tasks are ignored in computing runahead) but
+#   stall when nothing else to do (e.g. final cycle point) due to failed tasks
+#   in the pool.
 # Cylc 8 back-compat mode:
 #   Replicate Cylc 7 behaviour by making success outputs required and ignoring
 #   incomplete tasks in runahead computation.
 # Cylc 8 non-back-compat mode:
-#   No runahead stall and no stall at FCP, because :finish implies success optional. 
+#   No runahead stall and no stall at final cycle point, because finish
+#   triggers imply success is optional (i.e. no incomplete tasks created). 
 
 [scheduler]
     [[events]]


### PR DESCRIPTION
Ignore incomplete tasks in computing the runahead limit, in back compat mode.
(Because: Cylc 7 ignores failed tasks in computing the limit).

These changes close #4965

From comments in the new func test workflow:
```
# When a task with a finish trigger fails:
# Cylc 7:
#   No runahead stall (failed tasks are ignored in computing runahead) but
#   stall when nothing else to do (e.g. final cycle point) due to failed tasks
#   in the pool.
# Cylc 8 back-compat mode:
#   Replicate Cylc 7 behaviour by making success outputs required and ignoring
#   incomplete tasks in runahead computation.
# Cylc 8 non-back-compat mode:
#   No runahead stall and no stall at final cycle point, because finish
#   triggers imply success is optional (i.e. no incomplete tasks created). 
```

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
