### PR TITLE
Tidy main command help.

### DIFF
--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -80,7 +80,6 @@ Cylc IDs:
 Cylc commands can be abbreviated:
   $ cylc trigger WORKFLOW//CYCLE/TASK    # trigger TASK in WORKFLOW
   $ cylc trig WORKFLOW//CYCLE/TASK       # ditto
-  $ cylc tr WORKFLOW//CYCLE/TASK         # ditto
   $ cylc t                               # ERROR: trigger or tui?
 """
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -47,7 +47,7 @@ def get_version(long=False):
 
 USAGE = f"""{cylc_header()}
 Cylc ("silk") efficiently manages distributed cycling workflows.
-This is Open Source software (GPL-3.0): see "cylc help license".
+Cylc is Open Source software (GPL-3.0): see "cylc help license".
 
 Version:
   $ cylc version --long

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -63,7 +63,7 @@ To view sub-command help:
   $ cylc <sub-command> --help
 
 Cylc IDs:
-  Workflows and tasks are uniquely identified by IDs of the form:
+  Workflows and tasks are identified by IDs of the form:
     workflow//cycle/task
 
   You can split an ID at the // so following two IDs are equivalent:

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -53,14 +53,16 @@ Version:
   $ cylc version --long
   {get_version(True)}
 
-Usage:
-  $ cylc <sub-command> <OPTS> <ARGS>
+Quick Start:
+  $ cylc install <path>       # install a workflow
+  $ cylc play <workflow_id>   # run or resume a workflow
+  $ cylc stop <workflow_id>   # stop a workflow
+  $ cylc clean <workflow_id>  # delete an installed workflow
+  $ cylc gui                  # start the in-browser web UI
+  $ cylc tui <workflow_id>    # start the in-terminal UI
 
-Selected sub-commands are listed below. To view ALL sub-commands:
-  $ cylc help all
-
-To view sub-command help:
-  $ cylc <sub-command> --help
+  $ cylc help all             # see all cylc commands
+  $ cylc <command> --help     # specific command help
 
 Cylc IDs:
   Workflows and tasks are identified by IDs of the form:
@@ -78,9 +80,9 @@ Cylc IDs:
   $ cylc help id        # More information on IDs
 
 Cylc commands can be abbreviated:
-  $ cylc trigger WORKFLOW//CYCLE/TASK    # trigger TASK in WORKFLOW
-  $ cylc trig WORKFLOW//CYCLE/TASK       # ditto
-  $ cylc t                               # ERROR: trigger or tui?
+  $ cylc trigger workflow//cycle/task    # trigger task in workflow
+  $ cylc trig workflow//cycle/task       # trigger task in workflow
+  $ cylc t                               # error: trigger or tui?
 """
 
 ID_HELP = '''
@@ -428,27 +430,6 @@ def cli_help():
     from colorama import init as color_init
     color_init(autoreset=True, strip=False)
     print(USAGE)
-    print(
-        'Selected sub-commands '
-        '(type "cylc help all" to see ALL sub-commands):'
-    )
-    print_command_list(
-        # print a short list of the main cylc commands
-        commands=[
-            'hold',
-            'install',
-            'kill',
-            'pause',
-            'play',
-            'release',
-            'scan',
-            'stop',
-            'trigger',
-            'tui',
-            'validate'
-        ],
-        indent=2
-    )
     sys.exit(0)
 
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -46,32 +46,24 @@ def get_version(long=False):
 
 
 USAGE = f"""{cylc_header()}
-Cylc ("silk") orchestrates complex cycling (and non-cycling) workflows.
+Cylc ("silk") efficiently manages distributed cycling workflows.
+This is Open Source software (GPL-3.0): see "cylc help license".
 
 Version:
-  $ cylc version --long           # print cylc-flow version and install path
+  $ cylc version --long
   {get_version(True)}
 
 Usage:
-  $ cylc help license             # view the Cylc license (GPL-3.0)
-  $ cylc help all                 # list all commands
-  $ cylc validate <workflow>      # validate a workflow configuration
-  $ cylc install <workflow>       # install a workflow
-  $ cylc play <workflow>          # run/resume a workflow
-  $ cylc scan                     # list all running workflows (by default)
-  $ cylc tui <workflow>           # view/control workflows in the terminal
-  $ cylc stop <workflow>          # stop a running workflow
+  $ cylc <sub-command> <OPTS> <ARGS>
 
-Command Abbreviation:
-  # Commands can be abbreviated as long as there is no ambiguity in
-  # the abbreviated command:
-  $ cylc trigger WORKFLOW//CYCLE/TASK    # trigger TASK in WORKFLOW
-  $ cylc trig WORKFLOW//CYCLE/TASK       # ditto
-  $ cylc tr WORKFLOW//CYCLE/TASK         # ditto
-  $ cylc t                               # Error: ambiguous command
+Selected sub-commands are listed below. To view ALL sub-commands:
+  $ cylc help all
+
+To view sub-command help:
+  $ cylc <sub-command> --help
 
 Cylc IDs:
-  Cylc IDs take the form:
+  Workflows and tasks are uniquely identified by IDs of the form:
     workflow//cycle/task
 
   You can split an ID at the // so following two IDs are equivalent:
@@ -80,10 +72,16 @@ Cylc IDs:
 
   IDs can be written as globs:
     *//                 # All workflows
-    workflow//*         # All cycles in "workflow"
-    workflow//cycle/*   # All tasks in "workflow" in "cycle"
+    workflow//*         # All cycle points in "workflow"
+    workflow//cycle/*   # All tasks in cycle point "cycle" of "workflow"
 
-  For more information type "cylc help id".
+  $ cylc help id        # More information on IDs
+
+Cylc commands can be abbreviated:
+  $ cylc trigger WORKFLOW//CYCLE/TASK    # trigger TASK in WORKFLOW
+  $ cylc trig WORKFLOW//CYCLE/TASK       # ditto
+  $ cylc tr WORKFLOW//CYCLE/TASK         # ditto
+  $ cylc t                               # ERROR: trigger or tui?
 """
 
 ID_HELP = '''
@@ -431,7 +429,10 @@ def cli_help():
     from colorama import init as color_init
     color_init(autoreset=True, strip=False)
     print(USAGE)
-    print('Selected Sub-Commands:')
+    print(
+        'Selected sub-commands '
+        '(type "cylc help all" to see ALL sub-commands):'
+    )
     print_command_list(
         # print a short list of the main cylc commands
         commands=[
@@ -449,7 +450,6 @@ def cli_help():
         ],
         indent=2
     )
-    print('\nTo see all commands run: cylc help all')
     sys.exit(0)
 
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,16 +17,16 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-Trigger tasks - i.e. tell them to run even if they are not ready.
+Force tasks to run despite unsatisfied prerequisites.
 
 Triggering an unqueued waiting task queues it, regardless of prerequisites.
 
-Triggering a queued waiting task submits it, regardless of queue limiting.
+Triggering a queued task submits it, regardless of queue limiting.
 
-Triggering a submitted or running task has no effect (already triggered).
+Triggering an active task has no effect (it already triggered).
 
 Incomplete and active-waiting tasks in the n=0 window already belong to a flow.
-Triggering them queues them to run (or rerun) in the same flow;
+Triggering them queues them to run (or rerun) in the same flow.
 
 Beyond n=0, triggered tasks get all current active flow numbers by default, or
 specified flow numbers via the --flow option. Those flows - if/when they catch


### PR DESCRIPTION
These changes close #4972 

`cylc help`:
- remove some duplication of example sub-commands
- make it clearer that listed sub-commands are not exhaustive
- reorder content by importance (abbreviations are less important than ID)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
