### PR TITLE
Fix failure to clean on remote host with leftover contact file

### DIFF
--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -282,4 +282,4 @@ jobs:
         with:
           name: '${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}'
           flags: functional-tests
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,9 @@ now fails if
 [owner setting](https://cylc.github.io/cylc-doc/latest/html/reference/config/workflow.html#flow.cylc[runtime][%3Cnamespace%3E][remote]owner)
 is used, as that setting no longer has any effect.
 
+[#4978](https://github.com/cylc/cylc-flow/pull/4978) - `cylc clean`: fix
+occasional failure to clean on remote hosts due to leftover contact file.
+
 [#4889](https://github.com/cylc/cylc-flow/pull/4889) - `cylc clean`: don't
 prompt if no matching workflows.
 

--- a/cylc/flow/main_loop/health_check.py
+++ b/cylc/flow/main_loop/health_check.py
@@ -55,5 +55,5 @@ def _check_contact_file(scheduler):
     except (AssertionError, IOError, ValueError, ServiceFileError):
         raise CylcError(
             '%s: contact file corrupted/modified and may be left'
-            % workflow_files.get_contact_file(scheduler.workflow)
+            % workflow_files.get_contact_file_path(scheduler.workflow)
         )

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -138,7 +138,7 @@ def dir_is_flow(listing: Iterable[Path]) -> Optional[bool]:
             if path.name == WorkflowFiles.LOG_DIR:
                 if (
                         (path / 'suite' / 'log').exists()
-                        and not (path / 'workflow').exists()
+                        and not (path / 'scheduler').exists()
                 ):
                     # ... already run by Cylc 7 (and not re-run by Cylc 8 after
                     # removing the DB)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1782,7 +1782,7 @@ class Scheduler:
         # from running event handlers), because the existence of the file is
         # used to determine if the workflow is running
         if self.contact_data:
-            fname = workflow_files.get_contact_file(self.workflow)
+            fname = workflow_files.get_contact_file_path(self.workflow)
             try:
                 os.unlink(fname)
             except OSError as exc:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -62,7 +62,7 @@ from cylc.flow.workflow_files import (
     KeyOwner,
     KeyType,
     WorkflowFiles,
-    get_contact_file,
+    get_contact_file_path,
     get_workflow_srv_dir,
 )
 
@@ -596,7 +596,7 @@ class TaskRemoteMgr:
         if comms_meth in [CommsMeth.SSH, CommsMeth.ZMQ]:
             # Contact file
             items.append((
-                get_contact_file(self.workflow),
+                get_contact_file_path(self.workflow),
                 os.path.join(
                     WorkflowFiles.Service.DIRNAME,
                     WorkflowFiles.Service.CONTACT)))

--- a/tests/functional/cylc-clean/05-old-remote-contact.t
+++ b/tests/functional/cylc-clean/05-old-remote-contact.t
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# -----------------------------------------------------------------------------
+# Test that cylc clean succesfully removes the workflow on remote host even
+# when there is a leftover contact file with an unreachable host recorded in it
+
+export REQUIRE_PLATFORM='loc:remote fs:indep comms:tcp'
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+SSH_CMD="$(cylc config -d -i "[platforms][${CYLC_TEST_PLATFORM}]ssh command") ${CYLC_TEST_HOST}"
+
+init_workflow "${TEST_NAME_BASE}" << __FLOW__
+[scheduling]
+    [[graph]]
+        R1 = dilophosaurus
+[runtime]
+    [[dilophosaurus]]
+        platform = ${CYLC_TEST_PLATFORM}
+__FLOW__
+
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "$WORKFLOW_NAME"
+
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "$WORKFLOW_NAME" --no-detach
+
+# Create a fake old contact file on the remote host
+echo | $SSH_CMD "cat > \$HOME/cylc-run/${WORKFLOW_NAME}/.service/contact" << EOF
+CYLC_API=5
+CYLC_VERSION=8.0.0
+CYLC_WORKFLOW_COMMAND=echo Hello John
+CYLC_WORKFLOW_HOST=unreachable.isla_nublar.ingen
+CYLC_WORKFLOW_ID=${WORKFLOW_NAME}
+CYLC_WORKFLOW_PID=99999
+CYLC_WORKFLOW_PORT=00000
+EOF
+
+TEST_NAME="cylc-clean"
+run_ok "$TEST_NAME" cylc clean --remote "$WORKFLOW_NAME"
+dump_std "$TEST_NAME"
+
+purge

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -431,8 +431,8 @@ def cylc7_run_dir(tmp_path):
     cylc8 = tmp_path / 'cylc8'
     cylc8.mkdir()
     (cylc8 / WorkflowFiles.SUITE_RC).touch()
-    Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow').mkdir(parents=True)
-    Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow', 'log').touch()
+    Path(cylc8, WorkflowFiles.LOG_DIR, 'scheduler').mkdir(parents=True)
+    Path(cylc8, WorkflowFiles.LOG_DIR, 'scheduler', 'log').touch()
 
     # a Cylc 7 workflow installed by Cylc 8 but not run yet.
     # (should appear in scan results)
@@ -449,8 +449,8 @@ def cylc7_run_dir(tmp_path):
     (cylc8 / WorkflowFiles.SUITE_RC).touch()
     Path(cylc8, WorkflowFiles.LOG_DIR, 'suite').mkdir(parents=True)
     Path(cylc8, WorkflowFiles.LOG_DIR, 'suite', 'log').touch()
-    Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow').mkdir(parents=True)
-    Path(cylc8, WorkflowFiles.LOG_DIR, 'workflow', 'log').touch()
+    Path(cylc8, WorkflowFiles.LOG_DIR, 'scheduler').mkdir(parents=True)
+    Path(cylc8, WorkflowFiles.LOG_DIR, 'scheduler', 'log').touch()
 
     return tmp_path
 

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -385,7 +385,8 @@ def test_clean_check__fail(
     stopped: bool,
     err: Type[Exception],
     err_msg: str,
-    monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Test that _clean_check() fails appropriately.
 
@@ -395,8 +396,6 @@ def test_clean_check__fail(
         err: Expected error class.
         err_msg: Message that is expected to be in the exception.
     """
-    run_dir = mock.Mock()
-
     def mocked_detect_old_contact_file(*a, **k):
         if not stopped:
             raise ServiceFileError('Mocked error')
@@ -407,7 +406,7 @@ def test_clean_check__fail(
     )
 
     with pytest.raises(err) as exc:
-        workflow_files._clean_check(CleanOptions(), reg, run_dir)
+        workflow_files._clean_check(CleanOptions(), reg, tmp_path)
     assert err_msg in str(exc.value)
 
 


### PR DESCRIPTION
This is a small change with no associated Issue.

From Teams:

>Cylc clean bug report... it looks like it is trying to perform the whole "is this workflow running" check on the remote side as well as the invocation side which isn't right:
>```
>$ cylc clean u-co906/run1
>INFO - Cleaning u-co906/run1 on install target: ab
>ERROR - Could not clean u-co906/run1 on install target: ab
>    platform: abc - clean up did not complete
>    COMMAND:
>        ssh CYLC_VERSION=8.0rc4.dev CYLC_ENV_NAME=cylc-8.0rc4.dev-3 \
>            bash --login -c 'exec "$0" "$@"' timeout 120 cylc clean \
>            --local-only u-co906/run1
>    RETURN CODE:
>        1
>    STDOUT:
>    STDERR:
>        CylcError: Cannot determine whether workflow is running on <scheduler-host>.
>        ~fcm/cylc-8.0rc4.dev-3/bin/python3.9 ~fcm/cylc-8.0rc4.dev-3/bin/cylc play u-co906 --host=localhost
>
>CylcError: Remote clean failed for u-co906/run1
>```
>Note: We cannot necessarily SSH back from remote platforms to the scheduler host.

**Solution**

~If there us a leftover contact file when doing `cylc clean`, if the host field gives a host that is not the local host, it means we are doing re-invoked `cylc clean --local-only` on the remote host and we should not check if the scheduler process is still running (it can't be).~

The workflow DB only exists on the scheduler host. So if we are doing `cylc clean --local-only` and there is a leftover contact file but no DB, it probably means this is `cylc clean` being re-invoked on a remote host and we can ignore the contact.

Even if the fix gets hit when someone genuinely someone runs `cylc clean --local-only` on the scheduler host, it shouldn't matter.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
