### PR TITLE
CLI banner: cylc logo with block characters.

### DIFF
--- a/cylc/flow/scripts/common.py
+++ b/cylc/flow/scripts/common.py
@@ -25,9 +25,9 @@ from cylc.flow.terminal import get_width
 
 # fmt: off
 CYLC_LOGO = [
-    "  <yellow>▪</yellow> <blue>■ </blue>",
-    "  <green>██</green>  ",
-    " <red>▝▘</red>   ",
+    " <yellow>▪</yellow> <blue>■ </blue>",
+    " <green>██</green>  ",
+    "<red>▝▘</red>   ",
 ]
 # fmt: on
 

--- a/cylc/flow/scripts/common.py
+++ b/cylc/flow/scripts/common.py
@@ -16,7 +16,6 @@
 
 """Shared utilities for Cylc scripts."""
 
-from re import sub
 from itertools import zip_longest
 from ansimarkup import strip
 
@@ -24,42 +23,13 @@ from cylc.flow import __version__
 from cylc.flow.scripts import _copyright_year
 from cylc.flow.terminal import get_width
 
-
 # fmt: off
-LOGO_LETTERS = (
-    (
-        "ooo",
-        "oo ",
-        "oooo",
-    ),
-    (
-        "oo oo",
-        "ooooo",
-        " ooo",
-    ),
-    (
-        "oo ",
-        "ooo",
-        "ooo",
-    ),
-    (
-        "oooo",
-        "oo  ",
-        "oooo",
-    )
-)
-# fmt: on
-
-LOGO = [
-    ''.join(
-        sub('o', f'<white,{tag}> </white,{tag}>', letter[ind])
-        for tag, letter in zip(
-            ('red', 'yellow', 'green', 'blue'),
-            LOGO_LETTERS
-        )
-    )
-    for ind in range(len(LOGO_LETTERS[0]))
+CYLC_LOGO = [
+    "  <yellow>▪</yellow> <blue>■ </blue>",
+    "  <green>██</green>  ",
+    " <red>▝▘</red>   ",
 ]
+# fmt: on
 
 CYLC = (
     "<b>"
@@ -84,16 +54,16 @@ def cylc_header(width=None):
     width = width or get_width()
     lmax = (
         max(len(strip(line)) for line in LICENSE) +
-        len(strip(LOGO[0]))
+        len(strip(CYLC_LOGO[0]))
     )
     if width >= lmax + 1:
         header = '\n'.join(
             ('{0} {1}').format(*x)
             for x in zip_longest(
-                LOGO,
+                CYLC_LOGO,
                 LICENSE
             )
         )
     else:
-        header = '\n'.join(LOGO) + '\n' + '\n'.join(LICENSE)
+        header = '\n'.join(CYLC_LOGO) + '\n' + '\n'.join(LICENSE)
     return f"\n{header}\n"


### PR DESCRIPTION
Supersede #4921

Compact terminal banner, with a decent rendition of the Cylc logo in block characters.

Counting explicit comments and thumbs-up, this version is declared the winner by 4 votes (including my own) to none.

![banner-white](https://user-images.githubusercontent.com/2362137/179633385-cb74723b-dea1-4423-a888-df185a51878b.png)
![banner-black](https://user-images.githubusercontent.com/2362137/179633389-f5405e0c-bdc4-4f60-af9c-31013eafc4cb.png)

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.
