### PR TITLE
Fix spawning of absolute-triggered tasks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,9 @@ default job runner directives for platforms.
 
 ### Fixes
 
+[#5008](https://github.com/cylc/cylc-flow/pull/5008) -
+Autospawn absolute-triggered tasks exactly the same way as parentless tasks.
+
 [#4984](https://github.com/cylc/cylc-flow/pull/4984) -
 Fixes an issue with `cylc reload` which could cause preparing tasks to become
 stuck.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -175,7 +175,7 @@ class TaskPool:
         for name in self.config.get_task_name_list():
             tdef = self.config.get_taskdef(name)
             point = tdef.first_point(self.config.start_point)
-            self.spawn_to_rh_limit(tdef, point, {flow_num}, abs_ok=False)
+            self.spawn_to_rh_limit(tdef, point, {flow_num})
 
     def add_to_pool(self, itask, is_new: bool = True) -> None:
         """Add a task to the hidden (if not satisfied) or main task pool.
@@ -190,6 +190,7 @@ class TaskPool:
             self.hidden_pool.setdefault(itask.point, {})
             self.hidden_pool[itask.point][itask.identity] = itask
             self.hidden_pool_changed = True
+            LOG.debug(f"[{itask}] added to hidden task pool")
         else:
             # Add to main pool.
             # First remove from hidden pool if necessary.
@@ -204,6 +205,7 @@ class TaskPool:
             self.main_pool.setdefault(itask.point, {})
             self.main_pool[itask.point][itask.identity] = itask
             self.main_pool_changed = True
+            LOG.debug(f"[{itask}] added to main task pool")
 
             self.create_data_store_elements(itask)
 
@@ -225,8 +227,6 @@ class TaskPool:
         if itask.tdef.max_future_prereq_offset is not None:
             # (Must do this once added to the pool).
             self.set_max_future_offset()
-
-        LOG.debug(f"[{itask}] added to task pool")
 
     def create_data_store_elements(self, itask):
         """Create the node window elements about given task proxy."""
@@ -625,7 +625,7 @@ class TaskPool:
             self.merge_flows(ntask, flow_nums)
         return ntask  # may be None
 
-    def spawn_to_rh_limit(self, tdef, point, flow_nums, abs_ok=True) -> None:
+    def spawn_to_rh_limit(self, tdef, point, flow_nums) -> None:
         """Spawn parentless task instances from point to runahead limit."""
         if not flow_nums:
             # force-triggered no-flow task.
@@ -633,7 +633,7 @@ class TaskPool:
         if self.runahead_limit_point is None:
             self.compute_runahead()
         while point is not None and (point <= self.runahead_limit_point):
-            if tdef.is_parentless(point, abs_ok):
+            if tdef.is_parentless(point):
                 ntask = self._get_spawned_or_merged_task(
                     point, tdef.name, flow_nums
                 )
@@ -643,7 +643,7 @@ class TaskPool:
             point = tdef.next_point(point)
 
         # Once more (for the rh-limited task: don't rh release it!)
-        if point is not None and tdef.is_parentless(point, abs_ok):
+        if point is not None and tdef.is_parentless(point):
             ntask = self._get_spawned_or_merged_task(
                 point, tdef.name, flow_nums
             )
@@ -656,11 +656,6 @@ class TaskPool:
         if reason:
             msg += f" ({reason})"
 
-        if reason == self.__class__.SUICIDE_MSG:
-            log = LOG.critical
-        else:
-            log = LOG.debug
-
         try:
             del self.hidden_pool[itask.point][itask.identity]
         except KeyError:
@@ -670,7 +665,7 @@ class TaskPool:
             self.hidden_pool_changed = True
             if not self.hidden_pool[itask.point]:
                 del self.hidden_pool[itask.point]
-            log(f"[{itask}] {msg}")
+            LOG.debug(f"[{itask}] {msg}")
             return
 
         try:
@@ -691,7 +686,7 @@ class TaskPool:
             # Event-driven final update of task_states table.
             # TODO: same for datastore (still updated by scheduler loop)
             self.workflow_db_mgr.put_update_task_state(itask)
-            log(f"[{itask}] {msg}")
+            LOG.debug(f"[{itask}] {msg}")
             del itask
 
     def get_all_tasks(self) -> List[TaskProxy]:
@@ -797,6 +792,8 @@ class TaskPool:
                 # Cylc 7 Back Compat: spawn downstream to cause Cylc 7 style
                 # stalls - with unsatisfied waiting tasks - even with single
                 # prerequisites (which result in incomplete tasks in Cylc 8).
+                # We do it here (rather than at runhead release) to avoid
+                # pre-spawning out to the runahead limit.
                 self.spawn_on_all_outputs(itask)
 
         # Note: released and pre_prep_tasks can overlap
@@ -1243,9 +1240,10 @@ class TaskPool:
                     self.data_store_mgr.delta_task_prerequisite(t)
                     # Add it to the hidden pool or move it to the main pool.
                     self.add_to_pool(t)
+
                     if t.point <= self.runahead_limit_point:
                         self.rh_release_and_queue(t)
-                        self.spawn_to_rh_limit(t.tdef, t.point, t.flow_nums)
+
                     # Event-driven suicide.
                     if (
                         t.state.suicide_prerequisites and
@@ -1345,6 +1343,7 @@ class TaskPool:
                 if c_task is not None:
                     # already spawned
                     continue
+
                 c_task = self.spawn_task(c_name, c_point, itask.flow_nums)
                 if c_task is None:
                     # not spawnable
@@ -1461,9 +1460,11 @@ class TaskPool:
                     f"the stop point ({self.stop_point})"
                 )
 
-        # Attempt to satisfy any absolute triggers.
-        # TODO: consider doing this only for tasks with absolute prerequisites.
-        if itask.state.prerequisites_are_not_all_satisfied():
+        # Satisfy any absolute triggers.
+        if (
+            itask.tdef.has_abs_triggers and
+            itask.state.prerequisites_are_not_all_satisfied()
+        ):
             itask.state.satisfy_me(self.abs_outputs_done)
 
         if flow_wait_done:
@@ -1601,6 +1602,7 @@ class TaskPool:
                 # (could also be unhandled failed)
                 self.data_store_mgr.delta_task_state(itask)
             # (No need to set prerequisites satisfied here).
+            self.add_to_pool(itask)  # move from hidden if necessary.
             if itask.state.is_runahead:
                 # Release from runahead, and queue it.
                 self.rh_release_and_queue(itask)

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -336,21 +336,18 @@ class TaskDef:
             p_next = min(adjusted)
         return p_next
 
-    def is_parentless(self, point, abs_ok=True):
-        """Return True if no parents at point.
+    def is_parentless(self, point):
+        """Return True if task has no parents at point.
 
-        A task can have parents at some points and not at others.
+        Tasks are considered parentless if they have:
+          - no parents at all
+          - all parents < initial cycle point
+          - only absolute triggers
 
-        Tasks are parentless if they have no parents, or if the parents:
-          - are before the workflow initial cycle point (we ignore them)
-          - the parents are only absolute triggers (we can consider these
-          satisfied once the first child is spawned).
-
-        How absolute-triggered tasks are handled: at start-up, do not spawn
-        out to RH limit if has only abs parents. Wait for the first instance to
-        be spawned by the parent. THEN when they are RH released, spawn their
-        successors to RH even if abs-only-parented (because at that point the
-        abs trigger is satisified).
+        Absolute-triggered tasks are auto-spawned like true parentless tasks,
+        (once the trigger is satisfied they are effectively parentless) but
+        with a prerequisite that gets satisfied when the absolute output is
+        completed at runtime.
         """
         if not self.graph_parents:
             # No parents at any point
@@ -362,5 +359,5 @@ class TaskDef:
         return (
             not parent_points
             or all(x < self.start_point for x in parent_points)
-            or (abs_ok and self.has_only_abs_triggers(point))
+            or self.has_only_abs_triggers(point)
         )

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -34,8 +34,10 @@ from cylc.flow.task_state import (
 )
 
 
-# NOTE: foo & bar have no parents so at start-up (even with the workflow
-# paused) they are spawned out to the runahead limit.
+# NOTE: foo and bar have no parents so at start-up (even with the workflow
+# paused) they get spawned out to the runahead limit. 2/pub gets spawned
+# immediately too, because we spawn autospawn absolute-triggered tasks as
+# well as parentless tasks.
 EXAMPLE_FLOW_CFG = {
     'scheduler': {
         'allow implicit tasks': True
@@ -47,7 +49,7 @@ EXAMPLE_FLOW_CFG = {
         'runahead limit': 'P3',
         'graph': {
             'P1': 'foo & bar',
-            'R1/2': 'foo[1] => pub'  # 2/pub doesn't spawn at start
+            'R1/2': 'foo[1] => pub'
         }
     },
     'runtime': {
@@ -146,8 +148,8 @@ async def example_flow(
         ),
         param(
             ['*:waiting'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '3/foo', '3/bar', '4/foo',
-             '4/bar', '5/foo', '5/bar'], [], [],
+            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
+             '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
             id="Task state"
         ),
         param(
@@ -167,8 +169,8 @@ async def example_flow(
         ),
         param(
             ['*'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '3/foo', '3/bar', '4/foo',
-             '4/bar', '5/foo', '5/bar'], [], [],
+            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
+             '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
             id="No items given - get all tasks"
         )
     ]
@@ -207,8 +209,8 @@ async def test_filter_task_proxies(
     [
         param(
             ['*:waiting'],
-            ['1/waz', '1/foo', '1/bar', '2/foo', '2/bar', '3/foo', '3/bar', '4/foo',
-             '4/bar', '5/foo', '5/bar'], [], [],
+            ['1/waz', '1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo',
+             '3/bar', '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
             id="Task state"
         ),
     ]
@@ -334,9 +336,9 @@ async def test_match_taskdefs(
         ),
         param(
             ['1/*', '2/*', '6/*'],
-            ['1/foo', '1/bar', '2/foo', '2/bar'],
+            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub'],
             ["No active tasks matching: 6/*"],
-            id="Name globs hold active tasks only"
+            id="Name globs hold active tasks only"  # (active means n=0 here)
         ),
         param(
             ['1/FAM', '2/FAM', '6/FAM'], ['1/bar', '2/bar'],
@@ -434,9 +436,9 @@ async def test_release_held_tasks(
 @pytest.mark.parametrize(
     'hold_after_point, expected_held_task_ids',
     [
-        (0, ['1/foo', '1/bar', '2/foo', '2/bar', '3/foo', '3/bar', '4/foo',
-             '4/bar', '5/foo', '5/bar']),
-        (1, ['2/foo', '2/bar', '3/foo', '3/bar', '4/foo',
+        (0, ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
+             '4/foo', '4/bar', '5/foo', '5/bar']),
+        (1, ['2/foo', '2/bar', '2/pub', '3/foo', '3/bar', '4/foo',
              '4/bar', '5/foo', '5/bar'])
     ]
 )


### PR DESCRIPTION
<!-- Complete this Pull Request template. -->

<!-- Significant PRs should address an existing Issue. Choose one: -->

These changes close #5002

I've run the example out to 50 cycle points several times, with nothing strange happening 

I haven't thought of a reliable way to reproduce the problem (which was more of an inefficiency + confusing warning than a balls-to-the-wall bug) in a short test. But codecov says the change is covered in a strictly technical sense at least.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Already covered by existing tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
