### PR TITLE
add owner@host for SUCCEEDED and FAILED tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@ management and does not bundle Jinja2.
 
 ### Fixes
 
+[#5016](https://github.com/cylc/cylc-flow/pull/5016) - fix bug where
+polling failure on restart would cause Cylc to assume task is running.
+
 [#4838](https://github.com/cylc/cylc-flow/pull/4838) - fix bug where Cylc 7
 would still be able to run a `suite.rc` workflow previously run with Cylc 8.
 

--- a/lib/cylc/task_pool.py
+++ b/lib/cylc/task_pool.py
@@ -358,7 +358,10 @@ class TaskPool(object):
         except Exception:
             LOG.exception('could not load task %s' % name)
         else:
-            if status in (TASK_STATUS_SUBMITTED, TASK_STATUS_RUNNING):
+            if status in (
+                TASK_STATUS_SUBMITTED, TASK_STATUS_RUNNING, TASK_STATUS_FAILED,
+                TASK_STATUS_SUCCEEDED
+            ):
                 itask.state.set_prerequisites_all_satisfied()
                 # update the task proxy with user@host
                 try:
@@ -374,7 +377,7 @@ class TaskPool(object):
                 if timeout is not None:
                     itask.timeout = timeout
 
-            elif status in (TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED):
+            elif status in (TASK_STATUS_SUBMIT_FAILED):
                 itask.state.set_prerequisites_all_satisfied()
 
             elif status in (TASK_STATUS_QUEUED, TASK_STATUS_READY):
@@ -383,9 +386,6 @@ class TaskPool(object):
                 itask.state.set_prerequisites_all_satisfied()
 
             elif status in (TASK_STATUS_SUBMIT_RETRYING, TASK_STATUS_RETRYING):
-                itask.state.set_prerequisites_all_satisfied()
-
-            elif status == TASK_STATUS_SUCCEEDED:
                 itask.state.set_prerequisites_all_satisfied()
 
             itask.state.reset_state(status)


### PR DESCRIPTION
These changes close #4516

Fix bug where failed tasks could be polled back to incorrect states on restart.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Manual test instructions added to the ticket. It's horrid./ 
- [x] Appropriate change log entry included.
- [x] No documentation update required.
