### PR TITLE
Improve task pool integration tests

### DIFF
--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -361,3 +361,6 @@ class TaskDef:
             or all(x < self.start_point for x in parent_points)
             or self.has_only_abs_triggers(point)
         )
+
+    def __repr__(self) -> str:
+        return f"<TaskDef {self.name}>"

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -17,6 +17,7 @@
 """Task definition."""
 
 from collections import deque
+from typing import TYPE_CHECKING
 
 import cylc.flow.flags
 from cylc.flow.exceptions import TaskDefError
@@ -27,8 +28,10 @@ from cylc.flow.task_state import (
     TASK_OUTPUT_SUCCEEDED,
     TASK_OUTPUT_FAILED
 )
-from cylc.flow import LOG
 from cylc.flow.task_outputs import SORT_ORDERS
+
+if TYPE_CHECKING:
+    from cylc.flow.cycling import PointBase
 
 
 def generate_graph_children(tdef, point):
@@ -119,7 +122,6 @@ class TaskDef:
 
     # Store the elapsed times for a maximum of 10 cycles
     MAX_LEN_ELAPSED_TIMES = 10
-    ERR_PREFIX_TASK_NOT_ON_SEQUENCE = "Invalid cycle point for task: "
 
     def __init__(self, name, rtcfg, run_mode, start_point, initial_point):
         if not TaskID.is_valid_name(name):
@@ -299,16 +301,11 @@ class TaskDef:
                         return False
         return has_abs
 
-    def is_valid_point(self, point):
+    def is_valid_point(self, point: 'PointBase') -> bool:
         """Return True if point is on-sequence and within bounds."""
-        is_valid_point = any(
-            sequence.is_valid(point)
-            for sequence in self.sequences
+        return any(
+            sequence.is_valid(point) for sequence in self.sequences
         )
-        if not is_valid_point:
-            LOG.warning("%s%s, %s" % (
-                self.ERR_PREFIX_TASK_NOT_ON_SEQUENCE, self.name, point))
-        return is_valid_point
 
     def first_point(self, icp):
         """Return the first point for this task."""

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -267,6 +267,10 @@ async def test_filter_task_proxies_hidden(
             id="Name glob"
         ),
         param(
+            ['3'], ['3/foo', '3/bar', '3/asd'], [],
+            id="No name"
+        ),
+        param(
             ['2/FAM'], ['2/bar'], [],
             id="Family name"
         ),

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 import logging
 import pytest
 from pytest import param
-from typing import Callable, Iterable, List, Tuple, Union
+from typing import AsyncGenerator, Callable, Iterable, List, Tuple, Union
 
 from cylc.flow.cycling import PointBase
 from cylc.flow.cycling.integer import IntegerPoint
@@ -35,9 +35,9 @@ from cylc.flow.task_state import (
 
 
 # NOTE: foo and bar have no parents so at start-up (even with the workflow
-# paused) they get spawned out to the runahead limit. 2/pub gets spawned
+# paused) they get spawned out to the runahead limit. 2/pub spawns
 # immediately too, because we spawn autospawn absolute-triggered tasks as
-# well as parentless tasks.
+# well as parentless tasks. 3/asd does not spawn at start, however.
 EXAMPLE_FLOW_CFG = {
     'scheduler': {
         'allow implicit tasks': True
@@ -49,7 +49,8 @@ EXAMPLE_FLOW_CFG = {
         'runahead limit': 'P3',
         'graph': {
             'P1': 'foo & bar',
-            'R1/2': 'foo[1] => pub'
+            'R1/2': 'foo[1] => pub',
+            'R1/3': 'foo[-P1] => asd'
         }
     },
     'runtime': {
@@ -62,7 +63,7 @@ EXAMPLE_FLOW_CFG = {
 def get_task_ids(
     name_point_list: Iterable[Tuple[str, Union[PointBase, str, int]]]
 ) -> List[str]:
-    """Helper function to return sorted task identities ("{name}.{point}")
+    """Helper function to return sorted task identities
     from a list of  (name, point) tuples."""
     return sorted(f'{point}/{name}' for name, point in name_point_list)
 
@@ -111,7 +112,7 @@ async def example_flow(
     scheduler: Callable,
     start,
     caplog: pytest.LogCaptureFixture,
-) -> Scheduler:
+) -> AsyncGenerator[Scheduler, None]:
     """Return a scheduler for interrogating its task pool.
 
     This is function-scoped so slower than mod_example_flow; only use this
@@ -131,7 +132,7 @@ async def example_flow(
     [
         param(
             ['*/foo'], ['1/foo', '2/foo', '3/foo', '4/foo', '5/foo'], [], [],
-            id="Basic"
+            id="Point glob"
         ),
         param(
             ['1/*'],
@@ -143,17 +144,14 @@ async def example_flow(
             id="Family name"
         ),
         param(
-            ['*/foo'], ['1/foo', '2/foo', '3/foo', '4/foo', '5/foo'], [], [],
-            id="Point glob"
-        ),
-        param(
             ['*:waiting'],
             ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
              '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
             id="Task state"
         ),
         param(
-            ['8/foo'], [], ['8/foo'], ["No active tasks matching: 8/foo"],
+            ['8/foo', '3/asd'], [], ['8/foo', '3/asd'],
+            [f"No active tasks matching: {x}" for x in ['8/foo', '3/asd']],
             id="Task not yet spawned"
         ),
         param(
@@ -163,15 +161,14 @@ async def example_flow(
         ),
         param(
             ['1/grogu', '*/grogu'], [], ['1/grogu', '*/grogu'],
-            ["No active tasks matching: 1/grogu",
-             "No active tasks matching: */grogu"],
+            [f"No active tasks matching: {x}" for x in ['1/grogu', '*/grogu']],
             id="No such task"
         ),
         param(
             ['*'],
             ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
              '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
-            id="No items given - get all tasks"
+            id="Glob everything"
         )
     ]
 )
@@ -191,7 +188,7 @@ async def test_filter_task_proxies(
     Params:
         items: Arg passed to filter_task_proxies().
         expected_task_ids: IDs of the TaskProxys that are expected to be
-            returned, of the form "{point}/{name}"/
+            returned.
         expected_bad_items: Expected to be returned.
         expected_warnings: Expected to be logged.
     """
@@ -266,7 +263,7 @@ async def test_filter_task_proxies_hidden(
             id="Basic"
         ),
         param(
-            ['2/*'], ['2/foo', '2/bar', '2/pub'], [],
+            ['3/*', '1/f*'], ['3/foo', '3/bar', '3/asd', '1/foo'], [],
             id="Name glob"
         ),
         param(
@@ -278,7 +275,8 @@ async def test_filter_task_proxies_hidden(
             id="Point glob not allowed"
         ),
         param(
-            ['1/grogu'], [], ["No matching tasks found: 1/grogu"],
+            ['1/grogu', '1/gro*'], [],
+            [f"No matching tasks found: {x}" for x in ['1/grogu', '1/gro*']],
             id="No such task"
         ),
         param(
@@ -331,12 +329,12 @@ async def test_match_taskdefs(
     'items, expected_tasks_to_hold_ids, expected_warnings',
     [
         param(
-            ['1/foo', '2/foo'], ['1/foo', '2/foo'], [],
+            ['1/foo', '3/asd'], ['1/foo', '3/asd'], [],
             id="Active & future tasks"
         ),
         param(
-            ['1/*', '2/*', '6/*'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub'],
+            ['1/*', '2/*', '3/*', '6/*'],
+            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar'],
             ["No active tasks matching: 6/*"],
             id="Name globs hold active tasks only"  # (active means n=0 here)
         ),
@@ -403,7 +401,7 @@ async def test_release_held_tasks(
     """Test TaskPool.release_held_tasks().
 
     For a workflow with held active tasks 1/foo & 1/bar, and held future task
-    2/pub.
+    3/asd.
 
     We skip testing the matching logic here because it would be slow using the
     function-scoped example_flow fixture, and it would repeat what is covered
@@ -411,7 +409,7 @@ async def test_release_held_tasks(
     """
     # Setup
     task_pool = example_flow.pool
-    expected_tasks_to_hold_ids = sorted(['1/foo', '1/bar', '2/pub'])
+    expected_tasks_to_hold_ids = sorted(['1/foo', '1/bar', '3/asd'])
     task_pool.hold_tasks(expected_tasks_to_hold_ids)
     for itask in task_pool.get_all_tasks():
         hold_expected = itask.identity in expected_tasks_to_hold_ids
@@ -421,10 +419,9 @@ async def test_release_held_tasks(
     assert get_task_ids(db_tasks_to_hold) == expected_tasks_to_hold_ids
 
     # Test
-    task_pool.release_held_tasks(['1/foo', '2/pub'])
+    task_pool.release_held_tasks(['1/foo', '3/asd'])
     for itask in task_pool.get_all_tasks():
-        hold_expected = itask.identity == '1/bar'
-        assert itask.state.is_held is hold_expected
+        assert itask.state.is_held is (itask.identity == '1/bar')
 
     expected_tasks_to_hold_ids = sorted(['1/bar'])
     assert get_task_ids(task_pool.tasks_to_hold) == expected_tasks_to_hold_ids

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -123,7 +123,7 @@ def mod_tmp_run_dir(tmp_path_factory: pytest.TempPathFactory):
     """Module-scoped version of tmp_run_dir()"""
     tmp_path = tmp_path_factory.getbasetemp()
     with pytest.MonkeyPatch.context() as mp:
-        return _tmp_run_dir(tmp_path, mp)
+        yield _tmp_run_dir(tmp_path, mp)
 
 
 def _tmp_src_dir(tmp_path: Path):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from optparse import Values
-from typing import Any, Callable, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 from pathlib import Path
 import pytest
 import logging
@@ -46,8 +46,7 @@ from cylc.flow.task_outputs import (
 Fixture = Any
 
 
-@pytest.fixture
-def tmp_flow_config(tmp_run_dir: Callable):
+def _tmp_flow_config(tmp_run_dir: Callable):
     """Create a temporary flow config file for use in init'ing WorkflowConfig.
 
     Args:
@@ -56,12 +55,22 @@ def tmp_flow_config(tmp_run_dir: Callable):
 
     Returns the path to the flow file.
     """
-    def _tmp_flow_config(reg: str, config: str) -> Path:
+    def __tmp_flow_config(reg: str, config: str) -> Path:
         run_dir: Path = tmp_run_dir(reg)
         flow_file = run_dir / WorkflowFiles.FLOW_FILE
         flow_file.write_text(config)
         return flow_file
-    return _tmp_flow_config
+    return __tmp_flow_config
+
+
+@pytest.fixture
+def tmp_flow_config(tmp_run_dir: Callable):
+    return _tmp_flow_config(tmp_run_dir)
+
+
+@pytest.fixture(scope='module')
+def mod_tmp_flow_config(mod_tmp_run_dir: Callable):
+    return _tmp_flow_config(mod_tmp_run_dir)
 
 
 class TestWorkflowConfig:
@@ -1439,3 +1448,56 @@ def test_check_for_owner(runtime_cfg):
     else:
         # Assert function doesn't raise if no owner set:
         assert WorkflowConfig.check_for_owner(runtime_cfg) is None
+
+
+@pytest.fixture(scope='module')
+def awe_config(mod_tmp_flow_config: Callable) -> WorkflowConfig:
+    """Return a workflow config object."""
+    reg = 'awe'
+    flow_file = mod_tmp_flow_config(reg, '''
+        [scheduling]
+            cycling mode = integer
+            [[graph]]
+                P1 = ordinary & sterling
+                R1/2 = fra_mauro
+        [runtime]
+            [[USA, MOON]]
+            [[ordinary, sterling]]
+                inherit = USA
+            [[fra_mauro]]
+                inherit = MOON
+    ''')
+    return WorkflowConfig(
+        workflow=reg, fpath=flow_file, options=ValidateOptions()
+    )
+
+
+@pytest.mark.parametrize(
+    'name, expected',
+    [
+        pytest.param(
+            'ordinary', ['ordinary'], id="task name"
+        ),
+        pytest.param(
+            'USA', ['ordinary', 'sterling'], id="family name"
+        ),
+        pytest.param(
+            'fra*', ['fra_mauro'], id="glob task name"
+        ),
+        pytest.param(
+            'U*', ['ordinary', 'sterling'], id="glob family name"
+        ),
+        pytest.param(
+            '*', ['ordinary', 'sterling', 'fra_mauro'], id="glob everything"
+        ),
+        pytest.param(
+            'butte', [], id="no match"
+        ),
+    ]
+)
+def test_find_taskdefs(
+    name: str, expected: List[str], awe_config: WorkflowConfig
+):
+    assert sorted(
+        t.name for t in awe_config.find_taskdefs(name)
+    ) == sorted(expected)


### PR DESCRIPTION
These changes close #5012

- Add task - that does not get spawned at start - to task pool integration tests
- Fix duplicate results in `WorkflowConfig.find_taskdefs()` method
- Fix spurious warnings when using `TaskPool.match_taskdefs()` with a glob pattern for task names

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included 
- [x] No change log entry required (minor).
- [x] No documentation update required.
