### PR TITLE
scan: switch from pyuv to os.listdir in asyncio executor

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - protobuf >=3.19.0,<3.20.0
   - psutil >=5.6.0
   - python
-  - pyuv >=1.4.0,<1.5.0
   - pyzmq >=22,<23
   - setuptools >=49
   - urwid >=2,<3

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,6 @@ install_requires =
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
     protobuf==3.19.*
     psutil>=5.6.0
-    pyuv==1.4.*
     pyzmq==22.*
     setuptools>=49
     urwid==2.*
@@ -121,6 +120,7 @@ tests =
     testfixtures>=6.11.0
     # Type annotation stubs
     # http://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
+    types-aiofiles>=0.7.0
     types-Jinja2>=0.1.3
     types-aiofiles>=0.1.3
     types-pkg_resources>=0.1.2

--- a/tests/integration/test_async_util.py
+++ b/tests/integration/test_async_util.py
@@ -34,7 +34,7 @@ def directory(tmp_path):
 
 async def test_scandir(directory):
     """It should list directory contents (including symlinks)."""
-    assert await scandir(directory) == [
+    assert sorted(await scandir(directory)) == [
         Path(directory, 'a'),
         Path(directory, 'b'),
         Path(directory, 'c')


### PR DESCRIPTION
* Closes #5006
* We were using pyuv to perform directory listing.
* Unfortunately pyuv is no longer actively maintained.
* Switching to the simpler method of running `os.listdir` in an executor
  ala aiofiles.
* Unblocks #4524

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.