### PR TITLE
Added blank line to have linter rules render properly

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -16,7 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Cylc configuration linter.
 
-Checks code style, deprecated syntax and other issues."""
+Checks code style, deprecated syntax and other issues.
+
+"""
 # NOTE: docstring needed for `cylc help all` output
 # (if editing check this still comes out as expected)
 


### PR DESCRIPTION
This is a small change with no associated Issue.

Add spaces so that the next heading after [this one](https://cylc.github.io/cylc-doc/stable/html/user-guide/writing-workflows/configuration.html#module-cylc.flow.scripts.lint) ("7 to 8 upgrades") renders correctly.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (documentation change).
- [x] No change log entry required (Doc change).
- [x] No documentation update required.
