### PR TITLE
Fix chained offset bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,17 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.0.1 (<span actions:bind='release-date'>Upcoming</span>)__
+
+Maintenance release.
+
+### Fixes
+
+[#5031](https://github.com/cylc/cylc-flow/pull/5031) - Fix bug where
+specifying multiple datetime offsets (e.g. `final cycle point = +P1M-P1D`)
+would not obey the given order.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 
 Cylc 8 production-ready release.

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -21,7 +21,7 @@ from abc import ABCMeta, abstractmethod
 from cylc.flow.exceptions import CyclerTypeError
 
 
-def parse_exclusion(expr):
+def parse_exclusion(expr: str):
     count = expr.count('!')
     if count == 0:
         return expr, None

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -58,16 +58,16 @@ WARNING_PARSE_EXPANDED_YEAR_DIGITS = (
 class WorkflowSpecifics:
 
     """Store workflow-setup-specific constants and utilities here."""
-    ASSUMED_TIME_ZONE: Optional[Tuple[int, int]] = None
-    DUMP_FORMAT: Optional[str] = None
+    ASSUMED_TIME_ZONE: Tuple[int, int]
+    DUMP_FORMAT: str
+    abbrev_util: CylcTimeParser
+    interval_parser: 'DurationParser'
+    point_parser: 'TimePointParser'
+    recurrence_parser: 'TimeRecurrenceParser'
+    iso8601_parsers: Tuple[
+        'TimePointParser', 'DurationParser', 'TimeRecurrenceParser'
+    ]
     NUM_EXPANDED_YEAR_DIGITS: int = 0
-    abbrev_util: Optional[CylcTimeParser] = None
-    interval_parser: 'DurationParser' = None
-    point_parser: 'TimePointParser' = None
-    recurrence_parser: 'TimeRecurrenceParser' = None
-    iso8601_parsers: Optional[
-        Tuple['TimePointParser', 'DurationParser', 'TimeRecurrenceParser']
-    ] = None
 
 
 class ISO8601Point(PointBase):
@@ -685,10 +685,8 @@ def ingest_time(value: str, now: Optional[str] = None) -> str:
     if offset is not None:
         # add/subtract offset duration to/from chosen timepoint
         duration_parser = WorkflowSpecifics.interval_parser
-
         offset = offset.replace('+', '')
-        offset = duration_parser.parse(offset)
-        cycle_point += offset
+        cycle_point += duration_parser.parse(offset)
 
     return str(cycle_point)
 

--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -130,12 +130,12 @@ class CylcTimeParser:
         )
 
         if isinstance(context_start_point, str):
-            context_start_point = self._get_point_from_expression(
-                context_start_point, None)[0]
+            context_start_point, _ = self._get_point_from_expression(
+                context_start_point, None)
         self.context_start_point: Optional['TimePoint'] = context_start_point
         if isinstance(context_end_point, str):
-            context_end_point = self._get_point_from_expression(
-                context_end_point, None)[0]
+            context_end_point, _ = self._get_point_from_expression(
+                context_end_point, None)
         self.context_end_point: Optional['TimePoint'] = context_end_point
 
     @staticmethod
@@ -178,23 +178,23 @@ class CylcTimeParser:
     ) -> 'TimePoint':
         """Parse an expression in abbrev. or full ISO date/time format.
 
-        expression should be a string such as 20010205T00Z, or a
-        truncated/abbreviated format string such as T06 or -P2Y.
-        context_point should be a metomi.isodatetime.data.TimePoint object
-        that supplies the missing information for truncated
-        expressions. For example, context_point should be the task
-        cycle point for inter-cycle dependency expressions. If
-        context_point is None, self.context_start_point is used.
+        expr: a string such as 20010205T00Z, or a truncated/abbreviated format
+            string such as T06 or -P2Y.
+        context_point: supplies the missing information for truncated
+            expressions. E.g. for inter-cycle dependency expressions,
+            it should be the task cycle point.
+            If None, self.context_start_point is used.
 
         """
         if context_point is None:
             context_point = self.context_start_point
-        point, offset = self._get_point_from_expression(
-            expr, context_point, allow_truncated=True)
+        point, offsets = self._get_point_from_expression(
+            expr, context_point, allow_truncated=True
+        )
         if point is not None:
             if point.truncated:
-                point += context_point
-            if offset is not None:
+                point += context_point  # type: ignore[operator]
+            for offset in offsets:
                 point += offset
             return point
         raise CylcTimeSyntaxError(
@@ -226,13 +226,13 @@ class CylcTimeParser:
             end: Optional[str] = result.groupdict().get("end")
             start_required = (format_num in {1, 3})
             end_required = (format_num in {1, 4})
-            start_point, start_offset = self._get_point_from_expression(
+            start_point, start_offsets = self._get_point_from_expression(
                 start, context_start_point,
                 is_required=start_required,
                 allow_truncated=True
             )
             try:
-                end_point, end_offset = self._get_point_from_expression(
+                end_point, end_offsets = self._get_point_from_expression(
                     end, context_end_point,
                     is_required=end_required,
                     allow_truncated=True
@@ -248,12 +248,11 @@ class CylcTimeParser:
                 for exclusion in exclusions:
                     try:
                         # Attempt to convert to TimePoint
-                        exclusion_point, excl_off = (
-                            self._get_point_from_expression(
-                                exclusion, None, is_required=False,
-                                allow_truncated=False))
-                        if excl_off:
-                            exclusion_point += excl_off
+                        exclusion_point, excl_offsets = (
+                            self._get_point_from_expression(exclusion, None)
+                        )
+                        for offset in excl_offsets:
+                            exclusion_point += offset  # type: ignore[operator]
                         exclusion_points.append(exclusion_point)
                     except (CylcTimeSyntaxError, IndexError):
                         # Not a point, parse it as recurrence later
@@ -273,14 +272,16 @@ class CylcTimeParser:
                 interval = Duration(0)
             if start_point is not None:
                 if start_point.truncated:
-                    start_point += context_start_point
-                if start_offset is not None:
-                    start_point += start_offset
+                    start_point += (  # type: ignore[operator]
+                        context_start_point
+                    )
+                for offset in start_offsets:
+                    start_point += offset
             if end_point is not None:
                 if end_point.truncated:
-                    end_point += context_end_point
-                if end_offset is not None:
-                    end_point += end_offset
+                    end_point += context_end_point  # type: ignore[operator]
+                for offset in end_offsets:
+                    end_point += offset
 
             if (
                 interval and
@@ -365,12 +366,13 @@ class CylcTimeParser:
         ptslist: List['TimePoint'] = []
         min_entry = ""
         for point in points:
-            cpoint, offset = self._get_point_from_expression(
-                point, context, allow_truncated=True)
+            cpoint, offsets = self._get_point_from_expression(
+                point, context, allow_truncated=True
+            )
             if cpoint is not None:
                 if cpoint.truncated:
-                    cpoint += context
-                if offset is not None:
+                    cpoint += context  # type: ignore[operator]
+                for offset in offsets:
                     cpoint += offset
                 ptslist.append(cpoint)
                 if cpoint == min(ptslist):
@@ -383,7 +385,7 @@ class CylcTimeParser:
         context: Optional['TimePoint'],
         is_required: bool = False,
         allow_truncated: bool = False
-    ) -> Tuple[Optional['TimePoint'], Optional[Duration]]:
+    ) -> Tuple[Optional['TimePoint'], List[Duration]]:
         """Gets a TimePoint from an expression"""
         if expr is None:
             if is_required and allow_truncated:
@@ -391,44 +393,34 @@ class CylcTimeParser:
                     raise CylcMissingContextPointError(
                         "Missing context cycle point."
                     )
-                return context, None
-            return None, None
-        expr_point: Optional['TimePoint'] = None
-        expr_offset: Optional[Duration] = None
+                return context, []
+            return None, []
 
         if expr.startswith("min("):
             expr = self._get_min_from_expression(expr, context)
 
+        expr_offsets: List[Duration] = []
         if self.OFFSET_REGEX.search(expr):
-            chain_expr: List[str] = self.CHAIN_REGEX.findall(expr)
-            expr = ""
-            for item in chain_expr:
-                if "P" not in item:
-                    expr += item
-                    continue
-                split_expr = self.OFFSET_REGEX.split(item)
-                expr += split_expr.pop(0)
-                expr_offset_item = self.duration_parser.parse(item[1:])
-                if item[0] == "-":
-                    expr_offset_item *= -1
-                if not expr_offset:
-                    expr_offset = expr_offset_item
-                else:
-                    expr_offset = expr_offset + expr_offset_item
+            expr, expr_offsets = self.parse_chain_expression(expr)
         if not expr and allow_truncated:
-            return context, expr_offset
+            return context, expr_offsets
+
         for invalid_rec, msg in self.POINT_INVALID_FOR_CYLC_REGEXES:
             if invalid_rec.search(expr):
                 raise CylcTimeSyntaxError(f"'{expr}': {msg}")
+
         expr_to_parse = expr
         if expr.endswith("T"):
-            expr_to_parse = expr + "00"
+            expr_to_parse += "00"
         try:
-            expr_point = self.timepoint_parser.parse(expr_to_parse)
+            expr_point: 'TimePoint' = self.timepoint_parser.parse(
+                expr_to_parse
+            )
         except ValueError:  # not IsodatetimeError as too specific
             pass
         else:
-            return expr_point, expr_offset
+            return expr_point, expr_offsets
+
         if allow_truncated:
             for truncation_string, recs in self.TRUNCATED_REC_MAP.items():
                 for rec in recs:
@@ -438,8 +430,43 @@ class CylcTimeParser:
                                 truncation_string + expr_to_parse)
                         except IsodatetimeError:
                             continue
-                        return expr_point, expr_offset
+                        return expr_point, expr_offsets
+
         raise CylcTimeSyntaxError(
             f"'{expr}': not a valid cylc-shorthand or full "
             "ISO 8601 date representation"
         )
+
+    def parse_chain_expression(self, expr: str) -> Tuple[str, List[Duration]]:
+        """Parse an expression such as '+P1M+P1D'.
+
+        Returns:
+            Expression: The expression with any offsets removed.
+            Offsets: List of offsets from the expression. Note: by keeping
+                offsets separate (rather than combine into 1 Duration),
+                we preserve order of operations.
+
+        Examples:
+            >>> ctp = CylcTimeParser(
+            ...    None, None, (TimePointParser(), DurationParser(), None)
+            ... )
+            >>> expr, offsets = ctp.parse_chain_expression('2022+P1M-P1D')
+            >>> expr
+            '2022'
+            >>> [str(i) for i in offsets]
+            ['P1M', '-P1D']
+        """
+        expr_offsets: List[Duration] = []
+        chain_expr: List[str] = self.CHAIN_REGEX.findall(expr)
+        expr = ""
+        for item in chain_expr:
+            if "P" not in item:
+                expr += item
+                continue
+            split_expr = self.OFFSET_REGEX.split(item)
+            expr += split_expr.pop(0)
+            expr_offset_item = self.duration_parser.parse(item[1:])
+            if item[0] == "-":
+                expr_offset_item *= -1
+            expr_offsets.append(expr_offset_item)
+        return expr, expr_offsets

--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -178,12 +178,13 @@ class CylcTimeParser:
     ) -> 'TimePoint':
         """Parse an expression in abbrev. or full ISO date/time format.
 
-        expr: a string such as 20010205T00Z, or a truncated/abbreviated format
-            string such as T06 or -P2Y.
-        context_point: supplies the missing information for truncated
-            expressions. E.g. for inter-cycle dependency expressions,
-            it should be the task cycle point.
-            If None, self.context_start_point is used.
+        Args:
+            expr: a string such as 20010205T00Z, or a truncated/abbreviated
+                format string such as T06 or -P2Y.
+            context_point: supplies the missing information for truncated
+                expressions. E.g. for inter-cycle dependency expressions,
+                it should be the task cycle point.
+                If None, self.context_start_point is used.
 
         """
         if context_point is None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1404,13 +1404,24 @@ def test_zero_interval(
         ('2019-02-28', '+P1D+P1M', '2019-04-01'),
         ('2008-07-01', '+P1M-P1D', '2008-07-31'),
         ('2004-07-01', '-P1D+P1M', '2004-07-30'),
+        ('1992-02-29', '+P1Y+P1M', '1993-03-28'),
+        ('1988-02-29', '+P1M+P1Y', '1989-03-29'),
+        ('1910-08-14', '+P2D-PT6H', '1910-08-15T18:00'),
+        ('1850-04-10', '+P1M-P1D+PT1H', '1850-05-09T01:00'),
+        pytest.param(
+            '1066-10-14', '+PT1H+PT1M', '1066-10-14T01:01',
+            marks=pytest.mark.xfail
+            # https://github.com/cylc/cylc-flow/issues/5047
+        ),
     ]
 )
 def test_chain_expr(
     icp: str, fcp_expr: str, expected_fcp: str, tmp_flow_config: Callable,
 ):
-    """Test a "chain expression" final cycle point offset works in the
-    given order."""
+    """Test a "chain expression" final cycle point offset.
+
+    Note the order matters when "nominal" units (years, months) are used.
+    """
     reg = 'osgiliath'
     flow_file: Path = tmp_flow_config(reg, f"""
         [scheduler]


### PR DESCRIPTION
These changes close #4908

Fix bug where specifying multiple datetime offsets would not obey the given order.

E.g. `final cycle point = +P1M-P1D` would lead to it calculating `icp - P1D + P1M` (smallest unit to largest unit order) instead of `icp + P1M - P1D` (given order).

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [ ] [if bugfix] PRs raised to both master and the relevant bugfix branch.