### PR TITLE
queues: set default limit

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -691,7 +691,7 @@ with Conf(
             with Conf('default', meta=Queue, desc='''
                 The default queue for all tasks not assigned to other queues.
             '''):
-                Conf('limit', VDR.V_INTEGER, 0, desc='''
+                Conf('limit', VDR.V_INTEGER, 100, desc='''
                     Controls the total number of active tasks in the default
                     queue.
 

--- a/tests/functional/cylc-config/00-simple/section1.stdout
+++ b/tests/functional/cylc-config/00-simple/section1.stdout
@@ -8,7 +8,7 @@ cycling mode = integer
 runahead limit = P4
 [[queues]]
     [[[default]]]
-        limit = 0
+        limit = 100
         members = 
 [[special tasks]]
     clock-trigger = 


### PR DESCRIPTION
* Closes #5010
* Set `[scheduling][queues][default]limit=100`.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Does not need tests (why?).
- [ ] Appropriate change log entry included.
- [x] No documentation update required.