### PR TITLE
cylc clean: remove top level dir when no run dirs left

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,17 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.0.1 (<span actions:bind='release-date'>Upcoming</span>)__
+
+Maintenance release.
+
+### Fixes
+
+[#5033](https://github.com/cylc/cylc-flow/pull/5033) - Running `cylc clean`
+on a top level dir containing run dir(s) will now remove that top level dir
+in addition to the run(s) (if there is nothing else inside it).
+
+-------------------------------------------------------------------------------
 ## __cylc-8.0.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 
 Cylc 8 production-ready release.

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -47,7 +47,7 @@ Examples:
   $ cylc clean foo/bar --rm log --rm work
 
   # Remove all job log files from the 2020 cycle points
-  cylc clean foo/bar --rm 'log/job/2020*'
+  $ cylc clean foo/bar --rm 'log/job/2020*'
 
   # Remove all .csv files
   $ cylc clean foo/bar --rm '**/*.csv'

--- a/tests/functional/cylc-clean/03-multi.t
+++ b/tests/functional/cylc-clean/03-multi.t
@@ -18,45 +18,115 @@
 # Test cleaning multiple run dirs
 
 . "$(dirname "$0")/test_header"
-set_test_number 14
+if ! command -v 'tree' > /dev/null; then
+    skip_all '"tree" command not available'
+fi
+set_test_number 18
+
+FUNCTIONAL_DIR="${TEST_SOURCE_DIR_BASE%/*}"
+
+# -----------------------------------------------------------------------------
 
 for _ in 1 2; do
     install_workflow "$TEST_NAME_BASE" basic-workflow true
 done
 
-exists_ok "${WORKFLOW_RUN_DIR}/run1"
-exists_ok "${WORKFLOW_RUN_DIR}/run2"
+TEST_NAME="tree-pre-clean-1"
+run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
+# Note: backticks need to be escaped in the heredoc
+cmp_ok "${TEST_NAME}.stdout" << __TREE__
+${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
+\`-- ${FUNCTIONAL_DIR}
+    \`-- cylc-clean
+        \`-- ${TEST_NAME_BASE}
+            |-- _cylc-install
+            |-- run1
+            |-- run2
+            \`-- runN -> run2
+__TREE__
 
 # Test trying to clean multiple run dirs without --yes fails:
 run_fail "${TEST_NAME_BASE}-no" cylc clean "$WORKFLOW_NAME"
 exists_ok "${WORKFLOW_RUN_DIR}/run1"
 exists_ok "${WORKFLOW_RUN_DIR}/run2"
 
-
-# Should work with --yes:
+# Should work with --yes (removes top level dir too):
 run_ok "${TEST_NAME_BASE}-yes" cylc clean -y "$WORKFLOW_NAME"
-exists_fail "${WORKFLOW_RUN_DIR}/run1"
-exists_fail "${WORKFLOW_RUN_DIR}/run2"
+exists_fail "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
 
-# Should continue cleaning a list of worflows even if one fails.
+# -----------------------------------------------------------------------------
+# Should continue cleaning a list of workflows even if one fails.
 
 for _ in 1 2; do
     install_workflow "$TEST_NAME_BASE" basic-workflow true
 done
 
-exists_ok "${WORKFLOW_RUN_DIR}/run1"
-exists_ok "${WORKFLOW_RUN_DIR}/run2"
+TEST_NAME="tree-pre-clean-2"
+run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
+cmp_ok "${TEST_NAME}.stdout" << __TREE__
+${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
+\`-- ${FUNCTIONAL_DIR}
+    \`-- cylc-clean
+        \`-- ${TEST_NAME_BASE}
+            |-- _cylc-install
+            |-- run1
+            |-- run2
+            \`-- runN -> run2
+__TREE__
 
 mkdir "${WORKFLOW_RUN_DIR}/run1/.service"
 touch "${WORKFLOW_RUN_DIR}/run1/.service/db"  # corrupted db!
 
-TEST_NAME="${TEST_NAME_BASE}-yes-no" 
+TEST_NAME="${TEST_NAME_BASE}-yes-no"
 run_fail "${TEST_NAME}" \
     cylc clean -y "$WORKFLOW_NAME/run1" "$WORKFLOW_NAME/run2"
 
 grep_ok "Cannot clean .*/run1" "${TEST_NAME}.stderr" -e
 
-exists_ok "${WORKFLOW_RUN_DIR}/run1"
-exists_fail "${WORKFLOW_RUN_DIR}/run2"
+TEST_NAME="tree-post-clean-2"
+run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
+cmp_ok "${TEST_NAME}.stdout" << __TREE__
+${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
+\`-- ${FUNCTIONAL_DIR}
+    \`-- cylc-clean
+        \`-- ${TEST_NAME_BASE}
+            |-- _cylc-install
+            \`-- run1
+__TREE__
+
+purge
+
+# -----------------------------------------------------------------------------
+# Should not clean top level dir if not empty.
+
+install_workflow "$TEST_NAME_BASE" basic-workflow true
+
+touch "${WORKFLOW_RUN_DIR}/jellyfish.txt"
+
+TEST_NAME="tree-pre-clean-3"
+run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
+cmp_ok "${TEST_NAME}.stdout" << __TREE__
+${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
+\`-- ${FUNCTIONAL_DIR}
+    \`-- cylc-clean
+        \`-- ${TEST_NAME_BASE}
+            |-- _cylc-install
+            |-- jellyfish.txt
+            |-- run1
+            \`-- runN -> run1
+__TREE__
+
+run_ok "${TEST_NAME}" cylc clean -y "$WORKFLOW_NAME"
+
+TEST_NAME="tree-post-clean-3"
+run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"
+cmp_ok "${TEST_NAME}.stdout" << __TREE__
+${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
+\`-- ${FUNCTIONAL_DIR}
+    \`-- cylc-clean
+        \`-- ${TEST_NAME_BASE}
+            |-- _cylc-install
+            \`-- jellyfish.txt
+__TREE__
 
 purge


### PR DESCRIPTION
These changes close #4963

When cleaning all runs or the last remaining run in a workflow dir, `cylc clean` will now also remove the `_cylc-install` and top level directory, if it is empty.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [ ] [if bugfix] PRs raised to both master and the relevant bugfix branch.