### PR TITLE
Fix restart number bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ Maintenance release.
 [#5007](https://github.com/cylc/cylc-flow/pull/5007) - Fix for `cylc broadcast`
 cycle point validation in the UI.
 
+[#5037](https://github.com/cylc/cylc-flow/pull/5037) - Fix bug where the
+workflow restart number would get wiped on reload.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -332,11 +332,8 @@ class WorkflowDatabaseManager:
             {"key": self.KEY_UUID_STR, "value": schd.uuid_str},
             {"key": self.KEY_CYLC_VERSION, "value": CYLC_VERSION},
             {"key": self.KEY_UTC_MODE, "value": get_utc_mode()},
+            {"key": self.KEY_RESTART_COUNT, "value": self.n_restart},
         ])
-        if schd.is_restart is False:
-            self.put_workflow_params_1(
-                self.KEY_RESTART_COUNT, 0
-            )
         if schd.config.cycle_point_dump_format is not None:
             self.put_workflow_params_1(
                 self.KEY_CYCLE_POINT_FORMAT,
@@ -674,8 +671,8 @@ class WorkflowDatabaseManager:
         try:
             pri_dao.vacuum()
             self.n_restart = pri_dao.select_workflow_params_restart_count() + 1
-            self.put_workflow_params_1(
-                self.KEY_RESTART_COUNT, self.n_restart)
+            self.put_workflow_params_1(self.KEY_RESTART_COUNT, self.n_restart)
+            self.process_queued_ops()
         finally:
             pri_dao.close()
 

--- a/tests/integration/test_workflow_db_mgr.py
+++ b/tests/integration/test_workflow_db_mgr.py
@@ -1,0 +1,49 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cylc.flow.scheduler import Scheduler
+
+
+async def test_restart_number(
+    flow, one_conf, start, scheduler, log_filter, db_select
+):
+    """The restart number should increment correctly."""
+    reg = flow(one_conf)
+
+    async def test(expected_restart_num: int, do_reload: bool = False):
+        """(Re)start the workflow and check the restart number is as expected.
+        """
+        schd: Scheduler = scheduler(reg, paused_start=True)
+        async with start(schd) as log:
+            if do_reload:
+                schd.command_reload_workflow()
+            assert schd.workflow_db_mgr.n_restart == expected_restart_num
+            assert log_filter(
+                log, contains=f"(re)start number={expected_restart_num + 1}"
+                # (In the log, it's 1 higher than backend value)
+            )
+        assert ('n_restart', f'{expected_restart_num}') in db_select(
+            schd, False, 'workflow_params'
+        )
+
+    # First start
+    await test(expected_restart_num=0)
+    # Restart
+    await test(expected_restart_num=1)
+    # Restart + reload - https://github.com/cylc/cylc-flow/issues/4918
+    await test(expected_restart_num=2, do_reload=True)
+    # Final restart
+    await test(expected_restart_num=3)

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -61,7 +61,7 @@ def _make_flow(
 @contextmanager
 def _make_scheduler():
     """Return a scheduler object for a flow registration."""
-    schd: Scheduler = None  # type: ignore
+    schd: Scheduler = None  # type: ignore[assignment]
 
     def __make_scheduler(reg: str, **opts: Any) -> Scheduler:
         # This allows paused_start to be overridden:


### PR DESCRIPTION
Closes #4918

A bug was causing the restart number to be wiped from the `workflow_params` table in the DB on reload.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included 
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [ ] PRs raised to both master and the relevant bugfix branch.