### PR TITLE
reload: preserve retry xtriggers on reload

### DIFF
--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -284,6 +284,13 @@ class TaskProxy:
         reload_successor.state.is_runahead = self.state.is_runahead
         reload_successor.state.is_updated = self.state.is_updated
         reload_successor.state.prerequisites = self.state.prerequisites
+        reload_successor.state.xtriggers.update({
+            # copy across any special "_cylc" xtriggers which were added
+            # dynamically at runtime (i.e. execution retry xtriggers)
+            key: value
+            for key, value in self.state.xtriggers.items()
+            if key.startswith('_cylc')
+        })
         reload_successor.jobs = self.jobs
 
     @staticmethod

--- a/tests/functional/reload/25-xtriggers.t
+++ b/tests/functional/reload/25-xtriggers.t
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# Ensure that xtriggers are preserved after reloads
+# See https://github.com/cylc/cylc-flow/issues/4866
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 6
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduling]
+    [[graph]]
+        R1 = """
+            broken
+            reload
+        """
+
+[runtime]
+    [[broken]]
+        script = false
+        # should be long enough for the reload to complete
+        # (annoyingly we can't make this event driven)
+        execution retry delays = PT1M
+        # NOTE: "execution retry delays" is implemented as an xtrigger
+
+    [[reload]]
+        script = """
+            # wait for "broken" to fail
+            cylc__job__poll_grep_workflow_log \
+                '1/broken .* (received)failed/ERR'
+            # fix "broken" to allow it to pass
+            sed -i 's/false/true/' "${CYLC_WORKFLOW_RUN_DIR}/flow.cylc"
+            # reload the workflow
+            cylc reload "${CYLC_WORKFLOW_ID}"
+        """
+__FLOW_CONFIG__
+
+run_ok "${TEST_NAME_BASE}-val" cylc validate "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach
+
+# ensure the following order of events
+# 1. "1/broken" fails
+# 2. workflow is reloaded (by "1/reload")
+# 3. the retry xtrigger for "1/broken" becomes satisfied (after the reload)
+#    (thus proving that the xtrigger survived the reload)
+# 4. "1/broken" succeeds
+log_scan "${TEST_NAME_BASE}-scan" \
+    "$(cylc cat-log -m p "${WORKFLOW_NAME}")" \
+    1 1 \
+    '1/broken .* (received)failed/ERR' \
+    'Command succeeded: reload_workflow()' \
+    'xtrigger satisfied: _cylc_retry_1/broken' \
+    '1/broken .* (received)succeeded'
+
+purge
+exit


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/4866
* Reload causes new instances of each task to be created.
* The attributes of the old instances are copied onto the new ones.
* Retry xtriggers were not copied so were lost.
* This means that all retry pending tasks would run immediately on reload.

**Requirements check-list**
- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.