### PR TITLE
Shorten error msg

### DIFF
--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -176,9 +176,8 @@ def make_localhost_symlinks(
         target = expand_path(value)
         if '$' in target:
             raise WorkflowFilesError(
-                f'Unable to create symlink to {target}.'
-                f" '{value}' contains an invalid environment variable."
-                ' Please check configuration.')
+                f"Can't symlink to {target}\n"
+                "Undefined variable in global config?")
         symlink_success = make_symlink_dir(symlink_path, target)
         # Symlink info returned for logging purposes. Symlinks should be
         # created before logs as the log dir may be a symlink.

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -320,8 +320,8 @@ def test_incorrect_environment_variables_raise_error(
     with pytest.raises(WorkflowFilesError) as excinfo:
         make_localhost_symlinks('rund', 'test_workflow')
     assert (
-        "'$doh/cylc-run/test_workflow' contains an invalid "
-        "environment variable"
+        "Can't symlink to $doh/cylc-run/test_workflow\n"
+        "Undefined variable in global config?"
     ) in str(excinfo.value)
 
 

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -321,7 +321,7 @@ def test_incorrect_environment_variables_raise_error(
         make_localhost_symlinks('rund', 'test_workflow')
     assert (
         "Can't symlink to $doh/cylc-run/test_workflow\n"
-        "Undefined variable in global config?"
+        "Undefined variables, check global config: $doh"
     ) in str(excinfo.value)
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

Small tweak, and clarification, of an unnecessarily verbose error message from `cylc install`.

Before (with line breaks added):
```
WorkflowFilesError: Unable to create symlink to /big/disk/$PROJECT/oliverh/cylc-run/bug/run3.
   '$DATA/$PROJECT/$USER/cylc-run/bug/run3' contains an invalid environment variable.
    Please check configuration.
```
After:
```
WorkflowFilesError: Can't symlink to /big/disk/$PROJECT/oliverh/cylc-run/bug/run3
Undefined variables, check global config: $PROJECT
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included [modified existing test].
- [x] `CHANGES.md` entry included if this is a change that can affect users [not needed]
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX. [not needed]
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch. [not a bug]
