### PR TITLE
Fix auto restart bugs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@ cycle point validation in the UI.
 [#5037](https://github.com/cylc/cylc-flow/pull/5037) - Fix bug where the
 workflow restart number would get wiped on reload.
 
+[#5049](https://github.com/cylc/cylc-flow/pull/5049) - Fix several small
+bugs related to auto restart.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -126,21 +126,19 @@ class RotatingLogFileHandler(logging.FileHandler):
     for names.
 
     Argument:
-        log_file_path: path to the log file
+        log_file_path: path to the log file (symlink to latest log file)
         no_detach: non-detach mode?
         restart_num: restart number for the run
         timestamp: Add timestamp to log formatting?
     """
 
     FILE_HEADER_FLAG = 'cylc_log_file_header'
-    FILE_NUM = 'cylc_log_num'
+    ROLLOVER_NUM = 'cylc_log_num'
     MIN_BYTES = 1024
 
-    extra = {FILE_HEADER_FLAG: True}
-    extra_num = {
-        FILE_HEADER_FLAG: True,
-        FILE_NUM: 1
-    }
+    header_extra = {FILE_HEADER_FLAG: True}
+    """Use to indicate the log msg is a header that should be logged on
+    every rollover"""
 
     def __init__(
         self,
@@ -152,6 +150,8 @@ class RotatingLogFileHandler(logging.FileHandler):
         logging.FileHandler.__init__(self, log_file_path)
         self.no_detach = no_detach
         self.formatter = CylcLogFormatter(timestamp=timestamp)
+        # Header records get appended to when calling
+        # LOG.info(extra=RotatingLogFileHandler.[rollover_]header_extra)
         self.header_records: List[logging.LogRecord] = []
         self.restart_num = restart_num
         self.log_num: Optional[int] = None
@@ -169,16 +169,14 @@ class RotatingLogFileHandler(logging.FileHandler):
         except Exception:
             self.handleError(record)
 
-    def load_type_change(self):
+    def load_type_change(self) -> bool:
         """Has there been a load-type change, e.g. restart?"""
-        current_load_type = self.get_load_type()
         existing_load_type = self.existing_log_load_type()
-        # Rollover if the load type has changed.
-        if existing_load_type and current_load_type != existing_load_type:
+        if existing_load_type and self.load_type != existing_load_type:
             return True
         return False
 
-    def existing_log_load_type(self):
+    def existing_log_load_type(self) -> Optional[str]:
         """Return a log load type, if one currently exists"""
         try:
             existing_log_name = os.readlink(self.baseFilename)
@@ -188,8 +186,9 @@ class RotatingLogFileHandler(logging.FileHandler):
         for load_type in [RESTART_LOAD_TYPE, START_LOAD_TYPE]:
             if existing_log_name.find(load_type) > 0:
                 return load_type
+        return None
 
-    def should_rollover(self, record):
+    def should_rollover(self, record: logging.LogRecord) -> bool:
         """Should rollover?"""
         if (self.stream is None or
                 self.load_type_change() or
@@ -208,23 +207,23 @@ class RotatingLogFileHandler(logging.FileHandler):
             raise SystemExit(exc)
         return self.stream.tell() + len(msg.encode('utf8')) >= max_bytes
 
-    def get_load_type(self):
+    @property
+    def load_type(self) -> str:
         """Establish current load type, as perceived by scheduler."""
         if self.restart_num > 0:
             return RESTART_LOAD_TYPE
         return START_LOAD_TYPE
 
-    def do_rollover(self):
+    def do_rollover(self) -> None:
         """Create and rollover log file if necessary."""
         # Generate new file name
         filename = self.get_new_log_filename()
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        os.makedirs(filename.parent, exist_ok=True)
         # Touch file
         with open(filename, 'w+'):
             os.utime(filename, None)
         # Update symlink
-        if (os.path.exists(self.baseFilename) or
-                os.path.lexists(self.baseFilename)):
+        if os.path.lexists(self.baseFilename):
             os.unlink(self.baseFilename)
         os.symlink(os.path.basename(filename), self.baseFilename)
         # Housekeep log files
@@ -235,7 +234,6 @@ class RotatingLogFileHandler(logging.FileHandler):
         # Reopen stream, redirect STDOUT and STDERR to log
         if self.stream:
             self.stream.close()
-            self.stream = None
         self.stream = self._open()
         # Dup STDOUT and STDERR in detach mode
         if not self.no_detach:
@@ -243,15 +241,15 @@ class RotatingLogFileHandler(logging.FileHandler):
             os.dup2(self.stream.fileno(), sys.stderr.fileno())
         # Emit header records (should only do this for subsequent log files)
         for header_record in self.header_records:
-            if self.FILE_NUM in header_record.__dict__:
-                # Increment log file number
-                header_record.__dict__[self.FILE_NUM] += 1
-                # strip the hard coded log number (1) from the log message
-                # replace with the log number for that start.
-                # Note this is different from the log number in the file name
-                # which is cumulative over the workflow.
-                header_record.args = header_record.args[0:-1] + (
-                    header_record.__dict__[self.FILE_NUM],)
+            if self.ROLLOVER_NUM in header_record.__dict__:
+                # A hack to increment the rollover number that gets logged in
+                # the log file. (Rollover number only applies to a particular
+                # workflow run; note this is different from the log count
+                # number in the log filename.)
+                header_record.__dict__[self.ROLLOVER_NUM] += 1
+                header_record.args = (
+                    header_record.__dict__[self.ROLLOVER_NUM],
+                )
             logging.FileHandler.emit(self, header_record)
 
     def update_log_archive(self, arch_len):
@@ -265,17 +263,15 @@ class RotatingLogFileHandler(logging.FileHandler):
         while len(log_files) > arch_len:
             os.unlink(log_files.pop(0))
 
-    def get_new_log_filename(self):
+    def get_new_log_filename(self) -> Path:
         """Build filename for log"""
-        base_dir = Path(self.baseFilename).parent
-        load_type = self.get_load_type()
-        if load_type == START_LOAD_TYPE:
-            run_num = 1
-        elif load_type == RESTART_LOAD_TYPE:
-            run_num = self.restart_num + 1
+        log_dir = Path(self.baseFilename).parent
+        # User-facing restart num is 1 higher than backend value
+        restart_num = self.restart_num + 1
         self.set_log_num()
-        filename = base_dir.joinpath(
-            f'{self.log_num:02d}-{load_type}-{run_num:02d}{LOG_FILE_EXTENSION}'
+        filename = log_dir.joinpath(
+            f'{self.log_num:02d}-{self.load_type}-{restart_num:02d}'
+            f'{LOG_FILE_EXTENSION}'
         )
         return filename
 
@@ -378,29 +374,28 @@ def close_log(logger: logging.Logger) -> None:
             handler.close()
 
 
-def get_next_log_number(log: str) -> str:
-    """Returns the next log number for the log specified.
+def get_next_log_number(log_filepath: Union[str, Path]) -> int:
+    """Returns the next log number for the given log file path/name.
 
     Log name formats are of the form :
         <log number>-<load type>-<start number>
-    When given the latest log it returns the next log number, with padded 0s.
+    When given the latest log it returns the next log number.
 
     Examples:
-        >>> get_next_log_number('01-restart-02.log')
-            '02'
-        >>> get_next_log_number('/some/path/to/19-start-20.cylc')
-            '20'
+        >>> get_next_log_number('03-restart-02.log')
+        4
+        >>> get_next_log_number('/some/path/to/19-start-01.cylc')
+        20
         >>> get_next_log_number('199-start-08.log')
-            '200'
+        200
         >>> get_next_log_number('blah')
-            '01'
+        1
     """
     try:
-        stripped_log = os.path.basename(log)
-        next_log_num = int(stripped_log.partition("-")[0]) + 1
+        stripped_log = os.path.basename(log_filepath)
+        return int(stripped_log.partition("-")[0]) + 1
     except ValueError:
-        next_log_num = 1
-    return f'{next_log_num:02d}'
+        return 1
 
 
 def get_sorted_logs_by_time(

--- a/cylc/flow/main_loop/auto_restart.py
+++ b/cylc/flow/main_loop/auto_restart.py
@@ -96,6 +96,7 @@ from cylc.flow.host_select import select_workflow_host
 from cylc.flow.hostuserutil import get_fqdn_by_host
 from cylc.flow.main_loop import periodic
 from cylc.flow.parsec.exceptions import ParsecError
+from cylc.flow.scheduler import SchedulerError
 from cylc.flow.workflow_status import AutoRestartMode
 from cylc.flow.wallclock import (
     get_time_string_from_unix_time as time2str
@@ -224,7 +225,7 @@ def _set_auto_restart(
     # This should raise an "abort" event and return a non-zero code to the
     # caller still attached to the workflow process.
     if scheduler.options.no_detach:
-        raise RuntimeError('Workflow host condemned in no detach mode')
+        raise SchedulerError('Workflow host condemned in no detach mode')
 
     # Check workflow is able to be safely restarted.
     if not _can_auto_restart():

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -74,7 +74,7 @@ from cylc.flow.network import API
 from cylc.flow.network.authentication import key_housekeeping
 from cylc.flow.network.schema import WorkflowStopMode
 from cylc.flow.network.server import WorkflowRuntimeServer
-from cylc.flow.option_parsers import verbosity_to_env
+from cylc.flow.option_parsers import verbosity_to_env, verbosity_to_opts
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.parsec.OrderedDict import DictTree
 from cylc.flow.parsec.validate import DurationFloat
@@ -1411,7 +1411,10 @@ class Scheduler:
 
     def workflow_auto_restart(self, max_retries: int = 3) -> bool:
         """Attempt to restart the workflow assuming it has already stopped."""
-        cmd = ['cylc', 'play', quote(self.workflow)]
+        cmd = [
+            'cylc', 'play', quote(self.workflow),
+            *verbosity_to_opts(cylc.flow.flags.verbosity)
+        ]
         if self.options.abort_if_any_task_fails:
             cmd.append('--abort-if-any-task-fails')
         for attempt_no in range(max_retries):

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -568,10 +568,7 @@ class TaskRemoteMgr:
         install_log_dir
     ):
         log_files = get_sorted_logs_by_time(install_log_dir, '*.log')
-        if log_files:
-            log_num = get_next_log_number(log_files[-1])
-        else:
-            log_num = '01'
+        log_num = get_next_log_number(log_files[-1]) if log_files else 1
         load_type = "start"
         if self.is_reload:
             load_type = "reload"
@@ -579,7 +576,7 @@ class TaskRemoteMgr:
         elif self.is_restart:
             load_type = "restart"
             self.is_restart = False  # reset marker
-        file_name = f"{log_num}-{load_type}-{install_target}.log"
+        file_name = f"{log_num:02d}-{load_type}-{install_target}.log"
         return file_name
 
     def _remote_init_items(self, comms_meth: CommsMeth):

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1426,11 +1426,8 @@ def _open_install_log(rund, logger):
         WorkflowFiles.LOG_DIR,
         'install')
     log_files = get_sorted_logs_by_time(log_dir, '*.log')
-    if log_files:
-        log_num = get_next_log_number(log_files[-1])
-    else:
-        log_num = '01'
-    log_path = Path(log_dir, f"{log_num}-{log_type}.log")
+    log_num = get_next_log_number(log_files[-1]) if log_files else 1
+    log_path = Path(log_dir, f"{log_num:02d}-{log_type}.log")
     log_parent_dir = log_path.parent
     log_parent_dir.mkdir(exist_ok=True, parents=True)
     handler = logging.FileHandler(log_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ import pytest
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.parsec.config import ParsecConfig
+from cylc.flow.parsec.validate import cylc_config_validate
 
 
 @pytest.fixture
@@ -62,7 +63,7 @@ def mock_glbl_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         nonlocal tmp_path, monkeypatch
         global_config_path = tmp_path / 'global.cylc'
         global_config_path.write_text(global_config)
-        glbl_cfg = ParsecConfig(SPEC)
+        glbl_cfg = ParsecConfig(SPEC, validator=cylc_config_validate)
         glbl_cfg.loadcfg(global_config_path)
 
         def _inner(cached=False):

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -65,7 +65,7 @@
 #     grep_ok PATTERN FILE [$OPTS]
 #         Run "grep [$OPTS] -q -e PATTERN FILE".
 #     grep_workflow_log_ok TEST_NAME PATTERN [$OPTS]
-#         Run "grep [$OPTS] -q -e PATTERN <workflow-log>".
+#         Run "grep [$OPTS] -s -e PATTERN <workflow-log>".
 #     named_grep_ok NAME PATTERN FILE [$OPTS]
 #         Run grep_ok with a custom test name.
 #         OPTS: put grep options like '-E' (extended regex) at end of line.
@@ -429,12 +429,26 @@ grep_ok() {
 
 grep_workflow_log_ok() {
     local TEST_NAME="$1"
-    shift
-    if grep -s "$@" "${WORKFLOW_RUN_DIR}/log/scheduler/log"; then
-      ok "${TEST_NAME}"
-    else
-      fail "${TEST_NAME}"
+    local PATTERN="$2"
+    shift 2
+    local LOG_FILE="${WORKFLOW_RUN_DIR}/log/scheduler/log"
+    if grep "$@" -s -e "$PATTERN" "$LOG_FILE"; then
+        ok "${TEST_NAME}"
+        return
     fi
+    mkdir -p "${TEST_LOG_DIR}"
+    {
+        cat <<__ERR__
+Can't find:
+===========
+${PATTERN}
+===========
+in:
+===========
+__ERR__
+        cat "$LOG_FILE"
+    } >"${TEST_LOG_DIR}/${TEST_NAME}.stderr"
+    fail "${TEST_NAME}"
 }
 
 named_grep_ok() {

--- a/tests/functional/restart/34-auto-restart-basic.t
+++ b/tests/functional/restart/34-auto-restart-basic.t
@@ -84,7 +84,7 @@ run_ok "${TEST_NAME}-restart-success" cylc workflow-state "${WORKFLOW_NAME}" \
 
 # check the command the workflow has been restarted with
 run_ok "${TEST_NAME}-contact" cylc get-contact "${WORKFLOW_NAME}"
-grep_ok "cylc play ${WORKFLOW_NAME} --host=${CYLC_TEST_HOST} --host=localhost" \
+grep_ok "cylc play ${WORKFLOW_NAME} -v --host=${CYLC_TEST_HOST} --host=localhost" \
     "${TEST_NAME}-contact.stdout"
 
 # stop workflow

--- a/tests/functional/restart/34-auto-restart-basic.t
+++ b/tests/functional/restart/34-auto-restart-basic.t
@@ -18,7 +18,7 @@
 export REQUIRE_PLATFORM='loc:remote fs:shared runner:background'
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 9
+set_test_number 10
 if ${CYLC_TEST_DEBUG:-false}; then ERR=2; else ERR=1; fi
 #-------------------------------------------------------------------------------
 # run through the shutdown - restart procedure
@@ -65,7 +65,7 @@ ${BASE_GLOBAL_CONFIG}
 "
 # test shutdown procedure - scan the first log file
 FILE=$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)
-log_scan "${TEST_NAME}-shutdown" "${FILE}" 20 1 \
+log_scan "${TEST_NAME}-shutdown-log-scan" "${FILE}" 20 1 \
     'The Cylc workflow host will soon become un-available' \
     'Workflow shutting down - REQUEST(NOW-NOW)' \
     "Attempting to restart on \"${CYLC_TEST_HOST}\"" \
@@ -76,7 +76,7 @@ LATEST_TASK=$(cylc workflow-state "${WORKFLOW_NAME}" -S succeeded \
 # test restart procedure  - scan the second log file created on restart
 poll_workflow_restart
 FILE=$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)
-log_scan "${TEST_NAME}-restart" "${FILE}" 20 1 \
+log_scan "${TEST_NAME}-restart-log-scan" "${FILE}" 20 1 \
     "Scheduler: url=tcp://$(get_fqdn "${CYLC_TEST_HOST}")"
 run_ok "${TEST_NAME}-restart-success" cylc workflow-state "${WORKFLOW_NAME}" \
     --task="$(printf 'task_foo%02d' $(( LATEST_TASK + 3 )))" \
@@ -89,6 +89,13 @@ grep_ok "cylc play ${WORKFLOW_NAME} --host=${CYLC_TEST_HOST} --host=localhost" \
 
 # stop workflow
 cylc stop "${WORKFLOW_NAME}" --kill --max-polls=10 --interval=2 2>'/dev/null'
-purge
 
-exit
+# Check correct number of logs
+ls "${WORKFLOW_RUN_DIR}/log/scheduler/" > ls_logs.out
+cmp_ok ls_logs.out << __EOF__
+01-start-01.log
+02-restart-02.log
+log
+__EOF__
+
+purge

--- a/tests/functional/restart/41-auto-restart-local-jobs.t
+++ b/tests/functional/restart/41-auto-restart-local-jobs.t
@@ -74,7 +74,7 @@ ${BASE_GLOBAL_CONFIG}
 "
 
 LOG_FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
-log_scan "${TEST_NAME}-stop" "${LOG_FILE}" 40 1 \
+log_scan "${TEST_NAME}-stop-log-scan" "${LOG_FILE}" 40 1 \
     'The Cylc workflow host will soon become un-available' \
     'Waiting for jobs running on localhost to complete' \
     'Waiting for jobs running on localhost to complete' \
@@ -85,7 +85,8 @@ log_scan "${TEST_NAME}-stop" "${LOG_FILE}" 40 1 \
 grep_fail 'orphaned task' "$LOG_FILE"
 
 poll_workflow_restart
-named_grep_ok "restart-log-grep" "Workflow now running on \"${CYLC_TEST_HOST2}\"" "$LOG_FILE"
+log_scan "${TEST_NAME}-restart-log-scan" "$LOG_FILE" 20 1 \
+    "Workflow now running on \"${CYLC_TEST_HOST2}\""
 #-------------------------------------------------------------------------------
 # auto stop-restart - force mode:
 #     ensure the workflow DOESN'T WAIT for local jobs to complete before stopping
@@ -104,7 +105,7 @@ ${BASE_GLOBAL_CONFIG}
 "
 
 LOG_FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
-log_scan "${TEST_NAME}-stop" "${LOG_FILE}" 40 1 \
+log_scan "${TEST_NAME}-stop-log-scan" "${LOG_FILE}" 40 1 \
     'The Cylc workflow host will soon become un-available' \
     'This workflow will be shutdown as the workflow host is unable to continue' \
     'Workflow shutting down - REQUEST(NOW)' \

--- a/tests/functional/restart/41-auto-restart-local-jobs.t
+++ b/tests/functional/restart/41-auto-restart-local-jobs.t
@@ -73,8 +73,8 @@ ${BASE_GLOBAL_CONFIG}
         condemned = ${CYLC_TEST_HOST1}
 "
 
-FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
-log_scan "${TEST_NAME}-stop" "${FILE}" 40 1 \
+LOG_FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
+log_scan "${TEST_NAME}-stop" "${LOG_FILE}" 40 1 \
     'The Cylc workflow host will soon become un-available' \
     'Waiting for jobs running on localhost to complete' \
     'Waiting for jobs running on localhost to complete' \
@@ -82,10 +82,10 @@ log_scan "${TEST_NAME}-stop" "${FILE}" 40 1 \
     "Attempting to restart on \"${CYLC_TEST_HOST2}\""
 # we shouldn't have any orphaned tasks because we should
 # have waited for them to complete
-grep_fail 'orphaned task' "${FILE}"
+grep_fail 'orphaned task' "$LOG_FILE"
 
 poll_workflow_restart
-grep_workflow_log_ok "restart-log-grep" "Workflow now running on \"${CYLC_TEST_HOST2}\""
+named_grep_ok "restart-log-grep" "Workflow now running on \"${CYLC_TEST_HOST2}\"" "$LOG_FILE"
 #-------------------------------------------------------------------------------
 # auto stop-restart - force mode:
 #     ensure the workflow DOESN'T WAIT for local jobs to complete before stopping
@@ -103,8 +103,8 @@ ${BASE_GLOBAL_CONFIG}
         condemned = ${CYLC_TEST_HOST2}!
 "
 
-FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
-log_scan "${TEST_NAME}-stop" "${FILE}" 40 1 \
+LOG_FILE="$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)"
+log_scan "${TEST_NAME}-stop" "${LOG_FILE}" 40 1 \
     'The Cylc workflow host will soon become un-available' \
     'This workflow will be shutdown as the workflow host is unable to continue' \
     'Workflow shutting down - REQUEST(NOW)' \

--- a/tests/integration/main_loop/test_auto_restart.py
+++ b/tests/integration/main_loop/test_auto_restart.py
@@ -1,0 +1,50 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from cylc.flow.main_loop import MainLoopPluginException
+from cylc.flow.scheduler import Scheduler
+from cylc.flow.workflow_status import AutoRestartMode
+
+
+async def test_no_detach(
+    one_conf, flow, scheduler, run, mock_glbl_cfg, log_filter,
+    monkeypatch: pytest.MonkeyPatch
+):
+    """Test that the Scheduler aborts when auto restart tries to happen
+    while in no-detach mode."""
+    mock_glbl_cfg(
+        'cylc.flow.scheduler.glbl_cfg', '''
+        [scheduler]
+            [[main loop]]
+                plugins = auto restart
+                [[[auto restart]]]
+                    interval = PT1S
+    ''')
+    monkeypatch.setattr(
+        'cylc.flow.main_loop.auto_restart._should_auto_restart',
+        Mock(return_value=AutoRestartMode.RESTART_NORMAL)
+    )
+    reg: str = flow(one_conf)
+    schd: Scheduler = scheduler(reg, paused_start=True, no_detach=True)
+    with pytest.raises(MainLoopPluginException) as exc:
+        async with run(schd) as log:
+            await asyncio.sleep(2)
+    assert log_filter(log, contains=f"Workflow shutting down - {exc.value}")


### PR DESCRIPTION
- Fix bug where sometimes the scheduler log would rollover unnecessarily on auto restart, with clashing log count number in the filename (closes #4945)
- Ensure the workflow restarts with the same verbosity.
- Fix bug where the workflow was failing to abort if auto restart was attempted in no-detach mode
- Prevent unexpected exceptions raised during auto restart from being swallowed

Reviewers should run `tests/functional/restart` tests

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
