### PR TITLE
Wait for preparing tasks to submit before auto restart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ workflow restart number would get wiped on reload.
 [#5049](https://github.com/cylc/cylc-flow/pull/5049) - Fix several small
 bugs related to auto restart.
 
+[#5062](https://github.com/cylc/cylc-flow/pull/5062) - Fix bug where preparing
+tasks could sometimes get orphaned when an auto restart occurred.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 


### PR DESCRIPTION
Fix bug where any preparing local jobs would get orphaned during the shutdown before an auto restart.

You could reproduce this bug by changing
```diff
diff --git a/tests/functional/restart/42-auto-restart-ping-pong.t b/tests/functional/restart/42-auto-restart-ping-pong.t
index 5f897b33e..ecf58e99f 100644
--- a/tests/functional/restart/42-auto-restart-ping-pong.t
+++ b/tests/functional/restart/42-auto-restart-ping-pong.t
@@ -74,5 +74,5 @@ log_scan2() {
 }
 
-EARS=5  # number of times to bounce the workflow between hosts
+EARS=40  # number of times to bounce the workflow between hosts
 NO_TESTS="$(( EARS * 5 + 1 ))"
 set_test_number "${NO_TESTS}"
```

and running the test, eventually it would orphan a preparing job and cause the test to fail.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
