### PR TITLE
scan: ignore FileNotFoundError

### DIFF
--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -250,7 +250,12 @@ async def scan(
             return_when=asyncio.FIRST_COMPLETED
         )
         for task in done:
-            path, depth, contents = task.result()
+            try:
+                path, depth, contents = task.result()
+            except FileNotFoundError:
+                # directory has been removed since the scan was scheduled
+                running.remove(task)
+                continue
             running.remove(task)
             is_flow = dir_is_flow(contents)
             if is_flow:


### PR DESCRIPTION
* During a scan directories are listed asynchronously and recursively.
* If a directory is queued for listing, but then deleted before the
  listing takes place a FileNotFoundError will occur.
* This is highly unlikely IRL, however, in the integration tests, where run
  dirs are created and destroyed at scale and in parallel this is
  actually quite likely.

Example fail: https://github.com/cylc/cylc-flow/runs/7805964418?check_suite_focus=true

Likely caused by #5028, not sure why, perhaps it didn't raise the error, perhaps it was more eager with its scheduling.

Tested with 110X parallelism (`pytest -n 110 tests/integration`), couldn't reproduce post-fix.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.