### PR TITLE
fix install w/ .cylcignore

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1477,8 +1477,9 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
         if (Path(src).joinpath(exclude).exists() or
                 Path(dst).joinpath(exclude).exists()):
             rsync_cmd.append(f"--exclude={exclude}")
-    if Path(src).joinpath('.cylcignore').exists():
-        rsync_cmd.append("--exclude-from=.cylcignore")
+    cylcignore_file = Path(src).joinpath('.cylcignore')
+    if cylcignore_file.exists():
+        rsync_cmd.append(f"--exclude-from={cylcignore_file}")
     rsync_cmd.append(f"{src}/")
     rsync_cmd.append(f"{dst}/")
 


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

A `.cylcignore` file works as expected if you do `cylc install .` from within the source dir. But otherwise, this happens:
 
```console
WorkflowFilesError: No flow.cylc or suite.rc in /home/oliverh/cylc-run/bug/run8
```
and the install log says:
```console
WARNING - An error occurred when copying files from /home/oliverh/cylc-src/bug to /home/oliverh/cylc-run/bug/run8
WARNING -  Warning: rsync: failed to open exclude file .cylcignore: No such file or directory (2)
    rsync error: error in file IO (code 11) at exclude.c(1207) [client=3.1.2]
```
**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
