### PR TITLE
play: check Cylc version on restart

### DIFF
--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -18,11 +18,14 @@
 from ansimarkup import parse as cparse
 import asyncio
 from functools import lru_cache
+from pathlib import Path
 from shlex import quote
 import sys
 from typing import TYPE_CHECKING
 
-from cylc.flow import LOG
+from pkg_resources import parse_version
+
+from cylc.flow import LOG, __version__
 from cylc.flow.exceptions import ServiceFileError
 import cylc.flow.flags
 from cylc.flow.id import upgrade_legacy_ids
@@ -44,11 +47,16 @@ from cylc.flow.pathutil import get_workflow_run_scheduler_log_path
 from cylc.flow.remote import cylc_server_cmd
 from cylc.flow.scheduler import Scheduler, SchedulerError
 from cylc.flow.scripts.common import cylc_header
+from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
 from cylc.flow.workflow_files import (
+    SUITERC_DEPR_MSG,
     detect_old_contact_file,
-    SUITERC_DEPR_MSG
+    get_workflow_srv_dir,
 )
-from cylc.flow.terminal import cli_function
+from cylc.flow.terminal import (
+    cli_function,
+    prompt,
+)
 
 if TYPE_CHECKING:
     from optparse import Values
@@ -231,6 +239,18 @@ def get_option_parser(add_std_opts: bool = False) -> COP:
         action="store_true", default=False, dest="abort_if_any_task_fails"
     )
 
+    parser.add_option(
+        '--force',
+        help=(
+            'By default Cylc prevents you from restarting a workflow with an'
+            ' older version of Cylc than it was previously run with.'
+            ' Use this flag to disable this check, note, this is not'
+            ' recommended!'
+        ),
+        action='store_true',
+        default=False
+    )
+
     if add_std_opts:
         # This is for the API wrapper for integration tests. Otherwise (CLI
         # use) "standard options" are added later in options.parse_args().
@@ -290,39 +310,20 @@ def scheduler_cli(options: 'Values', workflow_id_raw: str) -> None:
         max_workflows=1,
         # warn_depr=False,  # TODO
     )
-    try:
-        detect_old_contact_file(workflow_id)
-    except ServiceFileError as exc:
-        print(f"Resuming already-running workflow\n\n{exc}")
-        pclient = WorkflowRuntimeClient(
-            workflow_id,
-            timeout=options.comms_timeout,
-        )
-        mutation_kwargs = {
-            'request_string': RESUME_MUTATION,
-            'variables': {
-                'wFlows': [workflow_id]
-            }
-        }
-        pclient('graphql', mutation_kwargs)
-        sys.exit(0)
+
+    # resume the workflow if it is already running
+    _resume(workflow_id, options)
+
+    # check the workflow can be safely restarted with this version of Cylc
+    db_file = Path(get_workflow_srv_dir(workflow_id), 'db')
+    if not _version_check(db_file, options.force):
+        sys.exit(1)
 
     # re-execute on another host if required
     _distribute(options.host, workflow_id_raw, workflow_id)
 
     # print the start message
-    if (
-        cylc.flow.flags.verbosity > -1
-        and (options.no_detach or options.format == 'plain')
-    ):
-        print(
-            cparse(
-                cylc_header()
-            )
-        )
-
-    if cylc.flow.flags.cylc7_back_compat:
-        LOG.warning(SUITERC_DEPR_MSG)
+    _print_startup_message(options)
 
     # setup the scheduler
     # NOTE: asyncio.run opens an event loop, runs your coro,
@@ -358,6 +359,104 @@ def scheduler_cli(options: 'Values', workflow_id_raw: str) -> None:
     LOG.info("DONE")
     close_log(LOG)
     sys.exit(ret)
+
+
+def _resume(workflow_id, options):
+    """Resume the workflow if it is already running."""
+    try:
+        detect_old_contact_file(workflow_id)
+    except ServiceFileError as exc:
+        print(f"Resuming already-running workflow\n\n{exc}")
+        pclient = WorkflowRuntimeClient(
+            workflow_id,
+            timeout=options.comms_timeout,
+        )
+        mutation_kwargs = {
+            'request_string': RESUME_MUTATION,
+            'variables': {
+                'wFlows': [workflow_id]
+            }
+        }
+        pclient('graphql', mutation_kwargs)
+        sys.exit(0)
+
+
+def _version_check(db_file: Path, force: bool) -> bool:
+    """Check the workflow can be safely restarted with this version of Cylc."""
+    if not db_file.is_file():
+        # not a restart
+        return True
+    wdbm = WorkflowDatabaseManager(db_file.parent)
+    this_version = parse_version(__version__)
+    last_run_version = wdbm.check_workflow_db_compatibility()
+
+    for itt, (this, that) in enumerate(zip(
+        this_version.release,
+        last_run_version.release,
+    )):
+        if this is None:
+            this = -1
+        if that is None:
+            that = -1
+        if this < that:
+            # restart would REDUCE the Cylc version
+            if force:
+                LOG.warning(
+                    'Restarting with an older version of Cylc'
+                    f' ({last_run_version} -> {__version__})'
+                )
+                return True
+            print(cparse(
+                '<red>'
+                'It is not advisible to restart a workflow with an older'
+                ' version of Cylc than it was previously run with.'
+                '</red>'
+
+                '\n* This workflow was previously run with'
+                f' <green>{last_run_version}</green>.'
+                f'\n* This version of Cylc is <red>{__version__}</red>.'
+
+                '\nUse --force to disable this check (not recommended!) or'
+                ' use a more recent version e.g:'
+                '<blue>'
+                f'\n$ CYLC_VERSION={last_run_version} {" ".join(sys.argv[1:])}'
+                '</blue>'
+            ))
+            return False
+        elif itt < 2 and this > that:
+            # restart would INCREASE the Cylc version in a big way
+            print(cparse(
+                'This workflow was previously run with'
+                f' <yellow>{last_run_version}</yellow>.'
+                f'\nThis version of Cylc is <green>{__version__}</green>.'
+            ))
+            return prompt(
+                'Are you sure you want to upgrade from'
+                f' <yellow>{last_run_version}</yellow>'
+                ' to <green>{__version__}</green>?',
+                {'y': True, 'n': False},
+                process=str.lower,
+            )
+        elif itt > 2 and this < that:
+            # restart would INCREASE the Cylc version in a little way
+            return True
+    return True
+
+
+def _print_startup_message(options):
+    """Print the Cylc header including the CLI logo."""
+    if (
+        cylc.flow.flags.verbosity > -1
+        and (options.no_detach or options.format == 'plain')
+    ):
+        print(
+            cparse(
+                cylc_header()
+            )
+        )
+
+    if cylc.flow.flags.cylc7_back_compat:
+        LOG.warning(SUITERC_DEPR_MSG)
 
 
 def _distribute(host, workflow_id_raw, workflow_id):

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -43,6 +43,9 @@ EXC_EXIT = cparse('<red><bold>{name}: </bold>{exc}</red>')
 # default grey colour (do not use "dim", it is not sufficiently portable)
 DIM = 'fg 248'
 
+# turn input into a global() for testing purposes
+input = input  # noqa
+
 
 def is_terminal():
     """Determine if running in (and printing to) a terminal."""
@@ -285,3 +288,43 @@ def cli_function(
                 raise exc from None
         return wrapper
     return inner
+
+
+def prompt(message, options, default=None, process=None):
+    """Dead simple CLI textural prompting.
+
+    Args:
+        message:
+            The message to put before the user, don't end this with
+            punctuation.
+        options:
+            The choices the user can pick:
+            * If this is a list the option selected will be returned.
+            * If this is a dict the keys are options, the corresponding value
+              will be returned.
+        default:
+            A value to be chosen if the user presses <return> without first
+            typing anything.
+        process:
+            A function to run the user's input through before comparision.
+            E.G. string.lower.
+
+    Returns:
+        The selected option (if options is a list) else the corresponding
+        value (if options is a dict).
+
+    """
+    default_ = ''
+    if default:
+        default_ = f'[{default}] '
+    message += f': {default_}{",".join(options)}'
+    usr = None
+    while usr not in options:
+        usr = input(f'{message}')
+        if default is not None and usr == '':
+            usr = default
+        if process:
+            usr = process(usr)
+    if isinstance(options, dict):
+        return options[usr]
+    return usr

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -291,7 +291,7 @@ def cli_function(
 
 
 def prompt(message, options, default=None, process=None):
-    """Dead simple CLI textural prompting.
+    """Dead simple CLI textual prompting.
 
     Args:
         message:
@@ -317,7 +317,7 @@ def prompt(message, options, default=None, process=None):
     default_ = ''
     if default:
         default_ = f'[{default}] '
-    message += f': {default_}{",".join(options)}'
+    message += f': {default_}{",".join(options)}?'
     usr = None
     while usr not in options:
         usr = input(f'{message}')

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -722,6 +722,10 @@ class WorkflowDatabaseManager:
         )
         conn.commit()
 
+    def upgrade(self, last_run_ver, pri_dao):
+        if last_run_ver < parse_version("8.0.3.dev"):
+            self.upgrade_pre_803(pri_dao)
+
     def check_workflow_db_compatibility(self):
         """Raises ServiceFileError if the existing workflow database is
         incompatible with the current version of Cylc."""
@@ -751,6 +755,6 @@ class WorkflowDatabaseManager:
                     f"Cylc {last_run_ver})."
                     f"\n{manual_rm_msg}"
                 )
-            if last_run_ver < parse_version("8.0.3.dev"):
-                self.upgrade_pre_803(pri_dao)
+            self.upgrade(last_run_ver, pri_dao)
+
         return last_run_ver

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -680,16 +680,10 @@ class WorkflowDatabaseManager:
         """Check & vacuum the runtime DB for a restart.
 
         Increments the restart number in the DB. Sets self.n_restart.
-
-        Raises ServiceFileError if DB is incompatible.
         """
         if self.n_restart != 0:
             # This will not raise unless the method is mistakenly called twice
             raise RuntimeError("restart check must only happen once")
-        try:
-            self.check_workflow_db_compatibility()
-        except ServiceFileError as exc:
-            raise ServiceFileError(f"Cannot restart - {exc}")
         with self.get_pri_dao() as pri_dao:
             pri_dao.vacuum()
             self.n_restart = pri_dao.select_workflow_params_restart_count() + 1
@@ -759,3 +753,4 @@ class WorkflowDatabaseManager:
                 )
             if last_run_ver < parse_version("8.0.3.dev"):
                 self.upgrade_pre_803(pri_dao)
+        return last_run_ver

--- a/tests/functional/job-submission/01-job-nn-localhost.t
+++ b/tests/functional/job-submission/01-job-nn-localhost.t
@@ -26,7 +26,7 @@ mkdir -p "${WORKFLOW_RUN_DIR}/.service/"
 sqlite3 "${WORKFLOW_RUN_DIR}/.service/db" <'db.sqlite3'
 
 workflow_run_ok "${TEST_NAME_BASE}-restart" \
-    cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}"
+    cylc play --reference-test --upgrade --debug --no-detach "${WORKFLOW_NAME}"
 
 purge
 exit

--- a/tests/functional/job-submission/02-job-nn-remote-host.t
+++ b/tests/functional/job-submission/02-job-nn-remote-host.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 mkdir -p "${WORKFLOW_RUN_DIR}/.service/"
 sqlite3 "${WORKFLOW_RUN_DIR}/.service/db" <'db.sqlite3'
 workflow_run_ok "${TEST_NAME_BASE}-restart" \
-    cylc play --reference-test --debug --no-detach  \
+    cylc play --upgrade --reference-test --debug --no-detach  \
     -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${WORKFLOW_NAME}"
 
 purge

--- a/tests/functional/restart/57-ghost-job.t
+++ b/tests/functional/restart/57-ghost-job.t
@@ -54,7 +54,7 @@ _args_
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
-workflow_run_ok "${TEST_NAME_BASE}-restart" cylc play -vv "${WORKFLOW_NAME}" --pause
+workflow_run_ok "${TEST_NAME_BASE}-restart" cylc play --upgrade -vv "${WORKFLOW_NAME}" --pause
 
 # There will be 1 ghost job in DB:
 TEST_NAME="${TEST_NAME_BASE}-db-query-1"
@@ -79,7 +79,7 @@ cmp_json "${TEST_NAME}-cmp" "${TEST_NAME}.stdout" << EOF
 }
 EOF
 
-workflow_run_ok "${TEST_NAME_BASE}-resume" cylc play "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-resume" cylc play --upgrade "${WORKFLOW_NAME}"
 poll_workflow_stopped
 
 # Job should have been replaced in DB with same submit num:

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -1,0 +1,172 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+import sqlite3
+
+import pytest
+
+from cylc.flow.exceptions import ServiceFileError
+from cylc.flow.scheduler_cli import (
+    _version_check,
+)
+
+
+@pytest.fixture
+def stopped_workflow_db(tmp_path):
+    """Returns a workflow DB with the `cylc_version` set to the provided string.
+
+    def test_x(stopped_workflow_db):
+        db_file = stopped_workflow_db(version)
+
+    """
+    def _stopped_workflow_db(version):
+        nonlocal tmp_path
+        db_file = tmp_path / 'db'
+        conn = sqlite3.connect(db_file)
+        conn.execute('''
+            CREATE TABLE
+                workflow_params(key TEXT, value TEXT, PRIMARY KEY(key))
+        ''')
+        conn.execute(
+            '''
+                INSERT INTO
+                    workflow_params
+                VALUES (?, ?)
+            ''',
+            ('cylc_version', version)
+        )
+        conn.commit()
+        conn.close()
+        return db_file
+    return _stopped_workflow_db
+
+
+@pytest.fixture
+def set_cylc_version(monkeypatch):
+    """Set the cylc.flow.__version__ attribute.
+
+    def test_x(set_cylc_version):
+        set_cylc_version('1.2.3')
+
+    """
+    def _set_cylc_version(version):
+        nonlocal monkeypatch
+        monkeypatch.setattr(
+            'cylc.flow.scheduler_cli.__version__',
+            version,
+        )
+    return _set_cylc_version
+
+
+@pytest.fixture
+def answer(monkeypatch):
+    """Answer a `cylc play` CLI prompt.
+
+    def test_x(answer):
+        answer(users_response)
+
+    It also adds an assert on the number of times the prompt interface was
+    called. 0 if response is None, else 1.
+
+    """
+    @contextmanager
+    def _answer(response):
+        nonlocal monkeypatch
+        calls = 0
+
+        def prompt(*args, **kwargs):
+            nonlocal response, calls
+            calls += 1
+            return response
+
+        monkeypatch.setattr(
+            'cylc.flow.scheduler_cli.prompt',
+            prompt,
+        )
+
+        yield
+
+        expected_calls = 1
+        if response is None:
+            expected_calls = 0
+        assert calls == expected_calls
+
+    return _answer
+
+
+@pytest.mark.parametrize(
+    'before, after, force, response, outcome', [
+        # no change
+        ('8.0.0', '8.0.0', False, None, True),
+        # upgrading
+        ('8.0rc4.dev', '8.0.0', False, None, True),
+        ('8.0.0', '8.0.1', False, None, True),
+        ('8.0.0', '8.1.0', False, False, False),
+        ('8.0.0', '8.1.0', False, True, True),
+        ('8.0.0', '9.0.0', False, False, False),
+        ('8.0.0', '9.0.0', False, True, True),
+        # downgrading
+        ('8.1.1', '8.1.0', False, None, False),
+        ('8.1.1', '8.1.0', True, None, True),
+        ('8.1.0', '8.0.0', False, None, False),
+        ('8.1.0', '8.0.0', True, None, True),
+        ('8.1.0', '8.0rc4.dev', True, None, True),
+        ('9.1.0', '8.0.0', False, None, False),
+        ('9.1.0', '8.0.0', True, None, True),
+    ],
+)
+def test_version_check(
+    stopped_workflow_db,
+    set_cylc_version,
+    answer,
+    before,
+    after,
+    response,
+    force,
+    outcome,
+):
+    """It should check compatibility with the Cylc version of the prior run.
+
+    When workflows are restarted we need to perform some checks to make sure
+    it is safe and sensible to restart with this version of Cylc.
+
+    Pytest Params:
+        before:
+            The Cylc version the workflow ran with previously.
+        after:
+            The version of Cylc being used to restart the workflow.
+        force:
+            The --force option of `cylc play`.
+        response:
+            The user's response the any CLI prompts.
+            If `None` it will assert that no prompts were raised.
+        outcome:
+            The response of _version_check, True means safe to restart.
+
+    """
+    db_file = stopped_workflow_db(before)
+    set_cylc_version(after)
+    with answer(response):
+        assert _version_check(db_file, force) is outcome
+
+
+def test_version_check_incompat(tmp_path):
+    """It should fail for a corrupted or invalid database file."""
+    db_file = tmp_path / 'db'  # invalid DB file
+    db_file.touch()
+    with pytest.raises(ServiceFileError):
+        _version_check(db_file, False)


### PR DESCRIPTION
* Closes #4039
* When restarting a workflow, check the version it previously ran under
  against the current version in order to determine if the change is
  sensible.
  * Restart normally if the restart would:
    * Not change the version.
    * Increase the maintenance number.
  * Prompt (override with --yes) for confirmation if the restart would:
    * Reduce the maintenance number.
    * Increase the minor number.
  * Exit with nasty error (override with --force or --yes --yes?) if
    the restart would:
    * Decrease the minor number.
    * Change the major number.
* This also moves the pre-existing workflow DB check from post-detatch
  to pre-detach.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.