### PR TITLE
rundb: use sqlite3.Cursor.execute not Connection.execute.

### DIFF
--- a/tests/unit/test_rundb.py
+++ b/tests/unit/test_rundb.py
@@ -122,7 +122,8 @@ def test_remove_columns():
         dao = CylcWorkflowDAO(temp_db)
         dao.remove_columns('foo', ['bar', 'baz'])
 
-        conn = dao.connect()
+        dao.connect()
+        conn = dao.con
         data = list(conn.execute(r'SELECT * from foo'))
         assert data == [('PUB',)]
 


### PR DESCRIPTION
* Closes #5005
* Follow the documented approach, use one cursor per transaction.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
