### PR TITLE
Log tidy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ ones in. -->
 numbers of Cylc Lint's style issues and allow users to ignore Cylc Lint issues
 using `--ignore <Issue Code>`.
 
+[#5081](https://github.com/cylc/cylc-flow/pull/5081) - Reduced amount that
+gets logged at "INFO" level in scheduler logs.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.3 (<span actions:bind='release-date'>Upcoming</span>)__
 

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -115,6 +115,13 @@ class WorkflowEventError(CylcError):
 
 class CommandFailedError(CylcError):
     """Exception for when scheduler commands fail."""
+    def __init__(self, value: Union[str, Exception]):
+        self.value = value
+
+    def __str__(self) -> str:
+        if isinstance(self.value, Exception):
+            return f"{type(self.value).__name__}: {self.value}"
+        return self.value
 
 
 class ServiceFileError(CylcError):

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -311,7 +311,7 @@ async def parse_ids_async(
     return workflows, multi_mode
 
 
-def parse_id(*args, **kwargs):
+def parse_id(*args, **kwargs) -> Tuple[str, Optional[Tokens], Any]:
     return asyncio.run(parse_id_async(*args, **kwargs))
 
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -106,6 +106,30 @@ def verbosity_to_log_level(verb: int) -> int:
     return logging.INFO
 
 
+def log_level_to_verbosity(lvl: int) -> int:
+    """Convert log severity level to Cylc verbosity.
+
+    Examples:
+        >>> log_level_to_verbosity(logging.NOTSET)
+        2
+        >>> log_level_to_verbosity(logging.DEBUG)
+        1
+        >>> log_level_to_verbosity(logging.INFO)
+        0
+        >>> log_level_to_verbosity(logging.WARNING)
+        -1
+        >>> log_level_to_verbosity(logging.ERROR)
+        -1
+    """
+    if lvl < logging.DEBUG:
+        return 2
+    if lvl < logging.INFO:
+        return 1
+    if lvl == logging.INFO:
+        return 0
+    return -1
+
+
 def verbosity_to_opts(verb: int) -> List[str]:
     """Convert Cylc verbosity to the CLI opts required to replicate it.
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -19,7 +19,6 @@ import asyncio
 from contextlib import suppress
 from collections import deque
 from dataclasses import dataclass
-import logging
 from optparse import Values
 import os
 from pathlib import Path
@@ -82,9 +81,14 @@ from cylc.flow.loggingutil import (
 from cylc.flow.timer import Timer
 from cylc.flow.network import API
 from cylc.flow.network.authentication import key_housekeeping
+from cylc.flow.network.resolvers import TaskMsg
 from cylc.flow.network.schema import WorkflowStopMode
 from cylc.flow.network.server import WorkflowRuntimeServer
-from cylc.flow.option_parsers import verbosity_to_env, verbosity_to_opts
+from cylc.flow.option_parsers import (
+    log_level_to_verbosity,
+    verbosity_to_env,
+    verbosity_to_opts,
+)
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.parsec.OrderedDict import DictTree
 from cylc.flow.parsec.validate import DurationFloat
@@ -204,7 +208,7 @@ class Scheduler:
 
     # queues
     command_queue: 'Queue[Tuple[str, tuple, dict]]'
-    message_queue: Queue
+    message_queue: 'Queue[TaskMsg]'
     ext_trigger_queue: Queue
 
     # configuration
@@ -785,24 +789,23 @@ class Scheduler:
         except (KeyError, ValueError, AttributeError):
             return
 
-    def process_queued_task_messages(self):
+    def process_queued_task_messages(self) -> None:
         """Handle incoming task messages for each task proxy."""
-        messages = {}
+        messages: Dict[str, List[Tuple[Optional[int], TaskMsg]]] = {}
         while self.message_queue.qsize():
             try:
-                task_job, event_time, severity, message = (
-                    self.message_queue.get(block=False))
+                task_msg = self.message_queue.get(block=False)
             except Empty:
                 break
             self.message_queue.task_done()
-            tokens = Tokens(task_job, relative=True)
+            tokens = Tokens(task_msg.job_id, relative=True)
             # task ID (job stripped)
             task_id = tokens.duplicate(job=None).relative_id
             messages.setdefault(task_id, [])
             # job may be None (e.g. simulation mode)
             job = int(tokens['job']) if tokens['job'] else None
             messages[task_id].append(
-                (job, event_time, severity, message)
+                (job, task_msg)
             )
         # Note on to_poll_tasks: If an incoming message is going to cause a
         # reverse change to task state, it is desirable to confirm this by
@@ -813,10 +816,11 @@ class Scheduler:
             if message_items is None:
                 continue
             should_poll = False
-            for submit_num, event_time, severity, message in message_items:
+            for submit_num, tm in message_items:
                 if self.task_events_mgr.process_message(
-                        itask, severity, message, event_time,
-                        self.task_events_mgr.FLAG_RECEIVED, submit_num):
+                    itask, tm.severity, tm.message, tm.event_time,
+                    self.task_events_mgr.FLAG_RECEIVED, submit_num
+                ):
                     should_poll = True
             if should_poll:
                 to_poll_tasks.append(itask)
@@ -841,7 +845,7 @@ class Scheduler:
         LOG.info(f"Processing {qsize} queued command(s)")
         while True:
             try:
-                command = (self.command_queue.get(False))
+                command = self.command_queue.get(False)
                 name, args, kwargs = command
             except Empty:
                 break
@@ -948,15 +952,15 @@ class Scheduler:
         """Resume paused workflow."""
         self.resume_workflow()
 
-    def command_poll_tasks(self, items: List[str]):
+    def command_poll_tasks(self, items: List[str]) -> int:
         """Poll pollable tasks or a task or family if options are provided."""
         if self.config.run_mode('simulation'):
-            return
+            return 0
         itasks, _, bad_items = self.pool.filter_task_proxies(items)
         self.task_job_mgr.poll_task_jobs(self.workflow, itasks)
         return len(bad_items)
 
-    def command_kill_tasks(self, items: List[str]):
+    def command_kill_tasks(self, items: List[str]) -> int:
         """Kill all tasks or a task/family if options are provided."""
         itasks, _, bad_items = self.pool.filter_task_proxies(items)
         if self.config.run_mode('simulation'):
@@ -987,23 +991,16 @@ class Scheduler:
         self.pause_workflow()
 
     @staticmethod
-    def command_set_verbosity(lvl):
+    def command_set_verbosity(lvl: Union[int, str]) -> None:
         """Set workflow verbosity."""
         try:
-            LOG.setLevel(int(lvl))
-        except (TypeError, ValueError):
-            return
-        if lvl <= logging.DEBUG:
-            cylc.flow.flags.verbosity = 2
-        elif lvl < logging.INFO:
-            cylc.flow.flags.verbosity = 1
-        elif lvl == logging.INFO:
-            cylc.flow.flags.verbosity = 0
-        else:
-            cylc.flow.flags.verbosity = -1
-        return True, 'OK'
+            lvl = int(lvl)
+            LOG.setLevel(lvl)
+        except (TypeError, ValueError) as exc:
+            raise CommandFailedError(exc)
+        cylc.flow.flags.verbosity = log_level_to_verbosity(lvl)
 
-    def command_remove_tasks(self, items):
+    def command_remove_tasks(self, items) -> int:
         """Remove tasks."""
         return self.pool.remove_tasks(items)
 
@@ -1018,7 +1015,7 @@ class Scheduler:
         try:
             self.load_flow_file(is_reload=True)
         except (ParsecError, CylcConfigError) as exc:
-            raise CommandFailedError(f"{type(exc).__name__}: {exc}")
+            raise CommandFailedError(exc)
         self.broadcast_mgr.linearized_ancestors = (
             self.config.get_linearized_ancestors())
         self.pool.set_do_reload(self.config)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -842,7 +842,7 @@ class Scheduler:
         qsize = self.command_queue.qsize()
         if qsize <= 0:
             return
-        LOG.info(f"Processing {qsize} queued command(s)")
+        LOG.debug(f"Processing {qsize} queued command(s)")
         while True:
             try:
                 command = self.command_queue.get(False)
@@ -858,9 +858,6 @@ class Scheduler:
             try:
                 n_warnings: Optional[int] = self.get_command_method(name)(
                     *args, **kwargs)
-            except SchedulerStop:
-                LOG.info(f"Command succeeded: {cmdstr}")
-                raise
             except Exception as exc:
                 # Don't let a bad command bring the workflow down.
                 if (

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -95,7 +95,6 @@ def get_option_parser() -> COP:
         __doc__,
         comms=True,
         argdoc=[
-            # TODO
             COP.optional(WORKFLOW_ID_ARG_DOC),
             COP.optional(
                 ('JOB', 'Job ID - CYCLE/TASK_NAME/SUBMIT_NUM')
@@ -129,10 +128,15 @@ def main(parser: COP, options: 'Values', *args: str) -> None:
         # (As of Dec 2020 some functional tests still use the classic
         # two arg interface)
         workflow_id = os.getenv('CYLC_WORKFLOW_ID')
-        task_job = os.getenv('CYLC_TASK_JOB')
+        job_id = os.getenv('CYLC_TASK_JOB')
+        if not workflow_id or not job_id:
+            raise InputError(
+                "Must set $CYLC_WORKFLOW_ID and $CYLC_TASK_JOB if not "
+                "specified as arguments"
+            )
         message_strs = list(args)
     else:
-        workflow_id, task_job, *message_strs = args
+        workflow_id, job_id, *message_strs = args
         workflow_id, *_ = parse_id(
             workflow_id,
             constraint='workflows',
@@ -171,4 +175,4 @@ def main(parser: COP, options: 'Values', *args: str) -> None:
             messages.append([options.severity, message_str.strip()])
         else:
             messages.append([getLevelName(INFO), message_str.strip()])
-    record_messages(workflow_id, task_job, messages)
+    record_messages(workflow_id, job_id, messages)

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -33,13 +33,12 @@ import os
 from shlex import quote
 import shlex
 from time import time
-from typing import TYPE_CHECKING
-
-from cylc.flow.parsec.config import ItemNotFoundError
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 from cylc.flow import LOG, LOG_LEVELS
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.hostuserutil import get_host, get_user, is_remote_platform
+from cylc.flow.parsec.config import ItemNotFoundError
 from cylc.flow.pathutil import (
     get_remote_workflow_run_job_dir,
     get_workflow_run_job_dir)
@@ -523,13 +522,13 @@ class TaskEventsManager():
 
     def process_message(
         self,
-        itask,
-        severity,
-        message,
-        event_time=None,
-        flag=FLAG_INTERNAL,
-        submit_num=None,
-    ):
+        itask: 'TaskProxy',
+        severity: Union[str, int],
+        message: str,
+        event_time: Optional[str] = None,
+        flag: str = FLAG_INTERNAL,
+        submit_num: Optional[int] = None,
+    ) -> Optional[bool]:
         """Parse a task message and update task state.
 
         Incoming, e.g. "succeeded at <TIME>", may be from task job or polling.
@@ -545,16 +544,16 @@ class TaskEventsManager():
         somehow uniquely associating each poll with its result message.
 
         Arguments:
-            itask (cylc.flow.task_proxy.TaskProxy):
+            itask:
                 The task proxy object relevant for the message.
-            severity (str or int):
+            severity:
                 Message severity, should be a recognised logging level.
-            message (str):
+            message:
                 Message content.
-            event_time (str):
+            event_time:
                 Event time stamp. Expect ISO8601 date time string.
                 If not specified, use current time.
-            flag (str):
+            flag:
                 If specified, can be:
                     FLAG_INTERNAL (default):
                         To indicate an internal message.
@@ -563,7 +562,7 @@ class TaskEventsManager():
                         external source.
                     FLAG_POLLED:
                         To indicate a message resulted from a poll.
-            submit_num (int):
+            submit_num:
                 The submit number of the task relevant for the message.
                 If not specified, use latest submit number.
 
@@ -577,6 +576,9 @@ class TaskEventsManager():
             event_time = get_current_time_string()
         if submit_num is None:
             submit_num = itask.submit_num
+        if isinstance(severity, int):
+            severity = cast(str, getLevelName(severity))
+        lseverity = str(severity).lower()
 
         # Any message represents activity.
         self.reset_inactivity_timer_func()
@@ -623,8 +625,7 @@ class TaskEventsManager():
                 # one, so assume that a successful submission occurred and act
                 # accordingly. Note the submitted message is internal, whereas
                 # the started message comes in on the network.
-                self._process_message_submitted(
-                    itask, event_time, itask.submit_num)
+                self._process_message_submitted(itask, event_time)
                 self.spawn_func(itask, TASK_OUTPUT_SUBMITTED)
 
             self._process_message_started(itask, event_time)
@@ -667,7 +668,7 @@ class TaskEventsManager():
                 # If not in the preparing state we already assumed and handled
                 # job submission under the started event above...
                 # (sim mode does not have the job prep state)
-                self._process_message_submitted(itask, event_time, submit_num)
+                self._process_message_submitted(itask, event_time)
                 self.spawn_func(itask, TASK_OUTPUT_SUBMITTED)
 
             # ... but either way update the job ID in the job proxy (it only
@@ -736,24 +737,22 @@ class TaskEventsManager():
             # Note that all messages are logged already at the top.
             # No state change.
             LOG.debug(f"[{itask}] unhandled: {message}")
-            if severity in LOG_LEVELS.values():
-                severity = getLevelName(severity)
             self._db_events_insert(
-                itask, ("message %s" % str(severity).lower()), message)
-        lseverity = str(severity).lower()
+                itask, (f"message {lseverity}"), message)
         if lseverity in self.NON_UNIQUE_EVENTS:
             itask.non_unique_events.update({lseverity: 1})
             self.setup_event_handlers(itask, lseverity, message)
+        return None
 
     def _process_message_check(
         self,
-        itask,
-        severity,
-        message,
-        event_time,
-        flag,
-        submit_num,
-    ):
+        itask: 'TaskProxy',
+        severity: str,
+        message: str,
+        event_time: str,
+        flag: str,
+        submit_num: int,
+    ) -> bool:
         """Helper for `.process_message`.
 
         See `.process_message` for argument list
@@ -1187,7 +1186,9 @@ class TaskEventsManager():
 
         return no_retries
 
-    def _process_message_submitted(self, itask, event_time, submit_num):
+    def _process_message_submitted(
+        self, itask: 'TaskProxy', event_time: str
+    ) -> None:
         """Helper for process_message, handle a submit-succeeded message."""
         with suppress(KeyError):
             summary = itask.summary
@@ -1535,7 +1536,7 @@ class TaskEventsManager():
             timeout_str = None
         itask.poll_timer = TaskActionTimer(ctx=ctx, delays=delays)
         # Log timeout and polling schedule
-        message = 'health: %s=%s' % (timeout_key, timeout_str)
+        message = f"health: {timeout_key}={timeout_str}"
         # Attempt to group identical consecutive delays as N*DELAY,...
         if itask.poll_timer.delays:
             items = []  # [(number of item - 1, item), ...]

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -400,7 +400,7 @@ class TaskPool:
         if self.stop_point and limit_point > self.stop_point:
             limit_point = self.stop_point
             LOG.debug(f"{pre_adj_limit} -> {limit_point} (stop point)")
-        LOG.info(f"Runahead limit: {limit_point}")
+        LOG.debug(f"Runahead limit: {limit_point}")
 
         self.runahead_limit_point = limit_point
         return True
@@ -1655,10 +1655,10 @@ class TaskPool:
                     # Simulate message outputs.
                     for msg in itask.tdef.rtconfig['outputs'].values():
                         message_queue.put(
-                            TaskMsg(job_d, now_str, 'INFO', msg)
+                            TaskMsg(job_d, now_str, 'DEBUG', msg)
                         )
                     message_queue.put(
-                        TaskMsg(job_d, now_str, 'INFO', TASK_STATUS_SUCCEEDED)
+                        TaskMsg(job_d, now_str, 'DEBUG', TASK_STATUS_SUCCEEDED)
                     )
                 sim_task_state_changed = True
         return sim_task_state_changed

--- a/tests/flakyfunctional/cylc-poll/16-execution-time-limit.t
+++ b/tests/flakyfunctional/cylc-poll/16-execution-time-limit.t
@@ -31,7 +31,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 #-------------------------------------------------------------------------------
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --reference-test --no-detach "${WORKFLOW_NAME}"
+    cylc play --reference-test -v --no-detach "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 cmp_times () {
     # Test if the times $1 and $2 are within $3 seconds of each other.
@@ -65,7 +65,7 @@ PREDICTED_POLL_TIME=$(time_offset \
     "$(cut -d ' ' -f 1 <<< "${LINE}")" \
     "PT10S") # PT5S time limit + PT5S polling interval
 ACTUAL_POLL_TIME=$(sed -n \
-    's|\(.*\) INFO - \[1/foo running .* (polled)failed .*|\1|p' "${LOG}")
+    's|\(.*\) DEBUG - \[1/foo running .* (polled)failed .*|\1|p' "${LOG}")
 
 # Test execution timeout polling.
 # Main loop is roughly 1 second, but integer rounding may give an apparent 2

--- a/tests/functional/cylc-message/02-multi.t
+++ b/tests/functional/cylc-message/02-multi.t
@@ -57,7 +57,7 @@ sed -i 's/\(^.*\) at .*$/\1/;' 'sed.out'
 # Note: the continuation bit gets printed twice, because the message gets a
 # warning as being unhandled.
 cmp_ok 'sed.out' <<__LOG__
-INFO - [1/foo submitted job:01 flows:1] (received)started
+DEBUG - [1/foo submitted job:01 flows:1] (received)started
 WARNING - [1/foo running job:01 flows:1] (received)Warn this
 INFO - [1/foo running job:01 flows:1] (received)Greeting
 WARNING - [1/foo running job:01 flows:1] (received)Warn that
@@ -69,7 +69,7 @@ ${LOG_INDENT}badness
 ${LOG_INDENT}slowness
 ${LOG_INDENT}and other incorrectness.
 INFO - [1/foo running job:01 flows:1] (received)whatever
-INFO - [1/foo running job:01 flows:1] (received)succeeded
+DEBUG - [1/foo running job:01 flows:1] (received)succeeded
 __LOG__
 
 purge

--- a/tests/functional/reload/25-xtriggers.t
+++ b/tests/functional/reload/25-xtriggers.t
@@ -52,7 +52,7 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 __FLOW_CONFIG__
 
 run_ok "${TEST_NAME_BASE}-val" cylc validate "${WORKFLOW_NAME}"
-workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach -v
 
 # ensure the following order of events
 # 1. "1/broken" fails
@@ -66,7 +66,6 @@ log_scan "${TEST_NAME_BASE}-scan" \
     '1/broken .* (received)failed/ERR' \
     'Command succeeded: reload_workflow()' \
     'xtrigger satisfied: _cylc_retry_1/broken' \
-    '1/broken .* (received)succeeded'
+    '\[1/broken .* => succeeded'
 
 purge
-exit

--- a/tests/functional/remote/06-poll.t
+++ b/tests/functional/remote/06-poll.t
@@ -53,7 +53,7 @@ log_scan \
     10 \
     1 \
     '\[1/foo submitted .* (polled)foo' \
-    '\[1/foo submitted .* (polled)succeeded'
+    '\[1/foo .* (polled)succeeded'
 
 purge
 exit


### PR DESCRIPTION
Partially addresses https://github.com/cylc/cylc-flow/issues/3647#issuecomment-638763568

> **1) State change messages**
> ...

Before this PR we were logging most task state changes twice:
- once for the message sent by the task's job script (which calls `cylc message` to inform the scheduler when it starts, succeeds or fails)
- once when setting the `TaskProxy` object's state to the new value

This PR:
- Demotes scheduler log severity level of `(received)started` (was `INFO`), `(received)succeeded` (was `INFO`), `(received)failed/ERR` (was `CRITICAL`) and `(internal)submission failed` (was `CRITICAL`) all to `DEBUG`
- Likewise demotes poll results from `INFO` to `DEBUG` for tasks whose platform's communication method is `poll` (but manually polling a task whose communication method is not `poll` will still show the result at `INFO` level
- Demotes a few other `INFO` level log calls to `DEBUG`
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

```diff
--- before
+++ after
@@ -9,21 +9,16 @@
 INFO - Final point: None
 INFO - Cold start from 1
 INFO - New flow: 1 (original flow from 1) 2022-08-17 16:30:57
-INFO - Runahead limit: 1
 INFO - [1/foo waiting(runahead) job:00 flows:1] spawned
 INFO - [1/foo waiting(runahead) job:00 flows:1] => waiting
 INFO - [1/foo waiting job:00 flows:1] => waiting(queued)
 INFO - [1/foo waiting(queued) job:00 flows:1] => waiting
 INFO - [1/foo waiting job:01 flows:1] => preparing
-INFO - [1/foo preparing job:01 flows:1] host=hosty.hostface.co.uk
-INFO - [1/foo preparing job:01 flows:1] (internal)submitted at 2022-08-17T16:33:47+01:00
 INFO - [1/foo preparing job:01 flows:1] submitted to localhost:background[64299]
 INFO - [1/foo preparing job:01 flows:1] => submitted
 INFO - [1/foo submitted job:01 flows:1] health: submission timeout=P1D, polling intervals=PT1H,...
-INFO - [1/foo submitted job:01 flows:1] (received)started at 2022-08-17T16:33:49+01:00
 INFO - [1/foo submitted job:01 flows:1] => running
 INFO - [1/foo running job:01 flows:1] health: execution timeout=None, polling intervals=PT1H,...
-INFO - [1/foo running job:01 flows:1] (received)succeeded at 2022-08-17T16:33:51+01:00
 INFO - [1/foo running job:01 flows:1] => succeeded
```
```diff
--- before
+++ after
@@ -1,12 +1,9 @@
 INFO - [command] poll_tasks
-INFO - Processing 1 queued command(s)
 INFO - Command succeeded: poll_tasks(['1/foo'])
-INFO - [1/foo submitted job:01 flows:1] (received)started at 2022-08-17T16:45:43+01:00
 INFO - [1/foo submitted job:01 flows:1] => running
 INFO - [1/foo running job:01 flows:1] health: execution timeout=None, polling intervals=PT1H,...
 INFO - [1/foo running job:01 flows:1] (polled)started at 2022-08-17T16:45:43+01:00
-CRITICAL - [1/foo running job:01 flows:1] (received)failed/ERR at 2022-08-17T16:45:46+01:00
 INFO - [1/foo running job:01 flows:1] => failed
 CRITICAL - [1/foo failed job:01 flows:1] failed
-INFO - Processing 1 queued command(s)
 INFO - Command succeeded: stop(mode=Clean)
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests not needed
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed.
- [x] master branch only
