### PR TITLE
Tweak triggering when no flows present

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -132,13 +132,17 @@ workflows with many-to-many dependencies (e.g. `<a> => <b>`).
 - Allows Cylc commands (including validate, list, view, config, and graph) to load template variables
   configured by `cylc install` and `cylc play`.
 
-[#5184](https://github.com/cylc/cylc-flow/pull/5184) - scan for active
-runs of the same workflow at install time.
-
 [#5121](https://github.com/cylc/cylc-flow/pull/5121) - Added a single
 command to validate, install and play a workflow.
 
-[#5032](https://github.com/cylc/cylc-flow/pull/5032) - set a default limit of
+[#5184](https://github.com/cylc/cylc-flow/pull/5184) - Scan for active
+runs of the same workflow at install time.
+
+[#5084](https://github.com/cylc/cylc-flow/pull/5084) - Assign the most recent
+previous flow numbers to tasks triggered when no flows are present (e.g. on
+restarting a finished workflow).
+
+[#5032](https://github.com/cylc/cylc-flow/pull/5032) - Set a default limit of
 100 for the "default" queue.
 
 [#5055](https://github.com/cylc/cylc-flow/pull/5055) and

--- a/cylc/flow/flow_mgr.py
+++ b/cylc/flow/flow_mgr.py
@@ -75,6 +75,10 @@ class FlowMgr:
 
     def _log(self) -> None:
         """Write current flow info to log."""
+        if not self.flows:
+            LOG.info("Flows: (none)")
+            return
+
         LOG.info(
             "Flows:\n" + "\n".join(
                 (

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -785,12 +785,9 @@ class CylcWorkflowDAO:
 
     def select_latest_flow_nums(self):
         """Return a list of the most recent previous flow numbers."""
-        # Ignore bandit false positive: B608: hardcoded_sql_expressions
-        # Not an injection, simply putting the table name in the SQL query
-        # expression as a string constant local to this module.
-        stmt = (  # nosec
-            r"SELECT flow_nums, MAX(time_created) FROM %(name)s"
-        ) % {"name": self.TABLE_TASK_STATES}
+        stmt = rf'''
+            SELECT flow_nums, MAX(time_created) FROM {self.TABLE_TASK_STATES}
+        '''  # nosec (table name is code constant)
         flow_nums_str = list(self.connect().execute(stmt))[0][0]
         return deserialise(flow_nums_str)
 

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -783,6 +783,19 @@ class CylcWorkflowDAO:
             ret[submit_num] = (flow_wait == 1, deserialise(flow_nums_str))
         return ret
 
+    def select_all_flow_nums(self):
+        """Return a set of all previous flow numbers."""
+        # Ignore bandit false positive: B608: hardcoded_sql_expressions
+        # Not an injection, simply putting the table name in the SQL query
+        # expression as a string constant local to this module.
+        stmt = (  # nosec
+            r"SELECT flow_num FROM %(name)s"
+        ) % {"name": self.TABLE_WORKFLOW_FLOWS}
+        ret = set()
+        for flow_num_str in self.connect().execute(stmt):
+            ret.add(int(flow_num_str[0]))
+        return ret
+
     def select_task_outputs(self, name, point):
         """Select task outputs for each flow.
 

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -783,18 +783,16 @@ class CylcWorkflowDAO:
             ret[submit_num] = (flow_wait == 1, deserialise(flow_nums_str))
         return ret
 
-    def select_all_flow_nums(self):
-        """Return a set of all previous flow numbers."""
+    def select_latest_flow_nums(self):
+        """Return a list of the most recent previous flow numbers."""
         # Ignore bandit false positive: B608: hardcoded_sql_expressions
         # Not an injection, simply putting the table name in the SQL query
         # expression as a string constant local to this module.
         stmt = (  # nosec
-            r"SELECT flow_num FROM %(name)s"
-        ) % {"name": self.TABLE_WORKFLOW_FLOWS}
-        ret = set()
-        for flow_num_str in self.connect().execute(stmt):
-            ret.add(int(flow_num_str[0]))
-        return ret
+            r"SELECT flow_nums, MAX(time_created) FROM %(name)s"
+        ) % {"name": self.TABLE_TASK_STATES}
+        flow_nums_str = list(self.connect().execute(stmt))[0][0]
+        return deserialise(flow_nums_str)
 
     def select_task_outputs(self, name, point):
         """Select task outputs for each flow.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1563,17 +1563,17 @@ class TaskPool:
                     self.spawn_on_output(itask, out, forced=True)
 
     def _get_active_flow_nums(self) -> Set[int]:
-        """Return all active, or all previous, flow numbers.
+        """Return all active, or most recent previous, flow numbers.
 
-        If there are any active flows, return all active flow numbers. If there
-        are no active flows (e.g. on restarting a completed workflow) return
-        all previous flow numbers.
+        If there are any active flows, return all active flow numbers.
+        Otherwise (e.g. on restarting a completed workflow) return
+        the flow numbers of the most recent previous active task.
         """
         fnums = set()
         for itask in self.get_all_tasks():
             fnums.update(itask.flow_nums)
         if not fnums:
-            fnums = self.workflow_db_mgr.pri_dao.select_all_flow_nums()
+            fnums = self.workflow_db_mgr.pri_dao.select_latest_flow_nums()
         return fnums
 
     def remove_tasks(self, items):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1562,10 +1562,18 @@ class TaskPool:
                     LOG.info(f"[{itask}] Forced spawning on {out}")
                     self.spawn_on_output(itask, out, forced=True)
 
-    def _get_active_flow_nums(self):
+    def _get_active_flow_nums(self) -> Set[int]:
+        """Return all active, or all previous, flow numbers.
+
+        If there are any active flows, return all active flow numbers. If there
+        are no active flows (e.g. on restarting a completed workflow) return
+        all previous flow numbers.
+        """
         fnums = set()
         for itask in self.get_all_tasks():
             fnums.update(itask.flow_nums)
+        if not fnums:
+            fnums = self.workflow_db_mgr.pri_dao.select_all_flow_nums()
         return fnums
 
     def remove_tasks(self, items):

--- a/tests/integration/test_trigger.py
+++ b/tests/integration/test_trigger.py
@@ -44,17 +44,18 @@ async def test_trigger_invalid(mod_one, start, log_filter, flow_strs):
 async def test_trigger_no_flows(mod_one, start, log_filter):
     """Test triggering a task with no flows present.
 
-    It should get the most recent flow number.
+    It should get the flow numbers of the most recent active tasks.
     """
     async with start(mod_one):
+
         # Remove the task (flow 1) --> pool empty
         task = mod_one.pool.get_tasks()[0]
         mod_one.pool.remove(task)
         assert len(mod_one.pool.get_tasks()) == 0
 
-        # Trigger the task (with flow 5).
+        # Trigger the task, with new flow nums.
         time.sleep(2)  # The flows need different timestamps!
-        mod_one.pool.force_trigger_tasks([task.identity], [5])
+        mod_one.pool.force_trigger_tasks([task.identity], [5, 9])
         assert len(mod_one.pool.get_tasks()) == 1
 
         # Ensure the new flow is in the db.
@@ -65,8 +66,8 @@ async def test_trigger_no_flows(mod_one, start, log_filter):
         mod_one.pool.remove(task)
         assert len(mod_one.pool.get_tasks()) == 0
 
-        # Trigger the task; it should get the most recent flow (5).
+        # Trigger the task; it should get flow nums 5, 9
         mod_one.pool.force_trigger_tasks([task.identity], [FLOW_ALL])
         assert len(mod_one.pool.get_tasks()) == 1
         task = mod_one.pool.get_tasks()[0]
-        assert task.flow_nums == {5}
+        assert task.flow_nums == {5, 9}

--- a/tests/integration/test_trigger.py
+++ b/tests/integration/test_trigger.py
@@ -41,33 +41,33 @@ async def test_trigger_invalid(mod_one, start, log_filter, flow_strs):
         assert len(log_filter(log, level=logging.WARN)) == 1
 
 
-async def test_trigger_no_flows(mod_one, start, log_filter):
+async def test_trigger_no_flows(one, start, log_filter):
     """Test triggering a task with no flows present.
 
     It should get the flow numbers of the most recent active tasks.
     """
-    async with start(mod_one):
+    async with start(one):
 
         # Remove the task (flow 1) --> pool empty
-        task = mod_one.pool.get_tasks()[0]
-        mod_one.pool.remove(task)
-        assert len(mod_one.pool.get_tasks()) == 0
+        task = one.pool.get_tasks()[0]
+        one.pool.remove(task)
+        assert len(one.pool.get_tasks()) == 0
 
         # Trigger the task, with new flow nums.
         time.sleep(2)  # The flows need different timestamps!
-        mod_one.pool.force_trigger_tasks([task.identity], [5, 9])
-        assert len(mod_one.pool.get_tasks()) == 1
+        one.pool.force_trigger_tasks([task.identity], [5, 9])
+        assert len(one.pool.get_tasks()) == 1
 
         # Ensure the new flow is in the db.
-        mod_one.pool.workflow_db_mgr.process_queued_ops()
+        one.pool.workflow_db_mgr.process_queued_ops()
 
         # Remove the task --> pool empty
-        task = mod_one.pool.get_tasks()[0]
-        mod_one.pool.remove(task)
-        assert len(mod_one.pool.get_tasks()) == 0
+        task = one.pool.get_tasks()[0]
+        one.pool.remove(task)
+        assert len(one.pool.get_tasks()) == 0
 
         # Trigger the task; it should get flow nums 5, 9
-        mod_one.pool.force_trigger_tasks([task.identity], [FLOW_ALL])
-        assert len(mod_one.pool.get_tasks()) == 1
-        task = mod_one.pool.get_tasks()[0]
+        one.pool.force_trigger_tasks([task.identity], [FLOW_ALL])
+        assert len(one.pool.get_tasks()) == 1
+        task = one.pool.get_tasks()[0]
         assert task.flow_nums == {5, 9}


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->
 
Close #5079: if there are no active flows present (e.g. on restarting a finished workflow), triggered tasks should get (by default) the most recent previous flow numbers.

This is more of an enhancement than a bug fix, so targeting master.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/560
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch. 
