### PR TITLE
parsec: keep whitespace inside quoted single-line values

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -455,7 +455,7 @@ def read_and_proc(
     if do_contin:
         flines = _concatenate(flines)
 
-    # return rstripped lines
+    # return rstripped lines (does not affect quoted values)
     return [fl.rstrip() for fl in flines]
 
 

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -527,7 +527,10 @@ class ParsecValidator:
 
         # Note strip() removes leading and trailing whitespace, including
         # initial newlines on a multiline string:
-        return dedent(value).strip()
+        if '\n' in value:
+            return dedent(value).strip()
+        else:
+            return value
 
     @classmethod
     def strip_and_unquote_list(cls, keys, value):


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

Address #5080 - parsec should only dedent and strip multi-line string values.


- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
