### PR TITLE
terms: settle on "task" and "job" but not "task job"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 **See the [Cylc installation guide](https://cylc.github.io/cylc-doc/stable/html/installation.html)
 for more detailed information.**
 
-Cylc must be installed on workflow and task job hosts. Third-party dependencies
+Cylc must be installed on workflow and job hosts. Third-party dependencies
 are not required on job hosts.
 
 ## Cylc 7

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -355,7 +355,7 @@ Supported for use with job runners:
 - slurm_packjob
 - moab
 
-Directives are written to the top of the task job script in the correct format
+Directives are written to the top of the job script in the correct format
 for the job runner.
 
 Specifying directives individually like this allows use of default directives
@@ -1082,7 +1082,7 @@ with Conf('global.cylc', desc='''
         A platform consists of a group of one or more hosts which share a
         file system and a job runner (batch system).
 
-        A platform must allow interaction with the same task job from *any*
+        A platform must allow interaction with the same job from *any*
         of its hosts.
 
         .. versionadded:: 8.0.0
@@ -1535,7 +1535,7 @@ with Conf('global.cylc', desc='''
                 We recommend using a clean job submission environment for
                 consistent handling of local and remote jobs. However,
                 this is not the default behavior because it prevents
-                local task jobs from running, unless ``$PATH`` contains the
+                local jobs from running, unless ``$PATH`` contains the
                 ``cylc`` wrapper script.
 
                 Specific environment variables can be singled out to pass
@@ -1655,7 +1655,7 @@ with Conf('global.cylc', desc='''
         all be suitable for a given job.
 
 
-        When Cylc sets up a task job it will pick a platform from a group.
+        When Cylc submits a job it will pick a platform from a group.
         Cylc will then use the selected platform for all interactions with
         that job.
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -970,7 +970,7 @@ with Conf(
                 If no parents are listed default is ``root``.
             ''')
             Conf('script', VDR.V_STRING, desc=dedent('''
-                The main custom script run from the task job script.
+                The main custom script run from the job script.
 
                 It can be an external command or script, or inlined scripting.
 
@@ -980,7 +980,7 @@ with Conf(
                 this='script', example='my_script.sh'
             ))
             Conf('init-script', VDR.V_STRING, desc=dedent('''
-                Custom script run by the task job script before the task
+                Custom script run by the job script before the task
                 execution environment is configured.
 
                 By running before the task execution environment is configured,
@@ -992,7 +992,7 @@ with Conf(
                 this should no longer be necessary.
             ''') + get_script_common_text(this='init-script'))
             Conf('env-script', VDR.V_STRING, desc=dedent('''
-                Custom script run by the task job script between the
+                Custom script run by the job script between the
                 cylc-defined environment (workflow and task identity, etc.) and
                 the user-defined task runtime environment.
 
@@ -1001,10 +1001,10 @@ with Conf(
                 It can be an external command or script, or inlined scripting.
             ''') + get_script_common_text(this='env-script'))
             Conf('err-script', VDR.V_STRING, desc=('''
-                Script run when a task job error is detected.
+                Script run when a job error is detected.
 
                 Custom script to be run at the end of the error trap,
-                which is triggered due to failure of a command in the task job
+                which is triggered due to failure of a command in the job
                 script or trappable job kill.
 
                 The output of this script will always
@@ -1029,7 +1029,7 @@ with Conf(
                 this='exit-script', example='rm -f "$TMP_FILES"'
             ))
             Conf('pre-script', VDR.V_STRING, desc=dedent('''
-                Custom script run by the task job script immediately
+                Custom script run by the job script immediately
                 before :cylc:conf:`[..]script`.
 
                 The pre-script can be an external command or script, or
@@ -1039,7 +1039,7 @@ with Conf(
                 example='echo "Hello from workflow ${CYLC_WORKFLOW_ID}!"'
             ))
             Conf('post-script', VDR.V_STRING, desc=dedent('''
-                Custom script run by the task job script immediately
+                Custom script run by the job script immediately
                 after :cylc:conf:`[..]script`.
 
                 The post-script can be an external
@@ -1049,7 +1049,7 @@ with Conf(
             Conf('work sub-directory', VDR.V_STRING, desc='''
                 The directory from which tasks are executed.
 
-                Task job scripts are executed from within *work directories*
+                Job scripts are executed from within *work directories*
                 created automatically under the workflow run directory. A task
                 can get its own work directory from ``$CYLC_TASK_WORK_DIR``
                 (or ``$PWD`` if it does not ``cd`` elsewhere at
@@ -1083,13 +1083,13 @@ with Conf(
                 )
             )
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc=f'''
-                Cylc can automate resubmission of a failed task job.
+                Cylc can automate resubmission of a failed job.
 
                 Execution retry delays are a list of ISO 8601
                 durations/intervals which tell Cylc how long to wait before
                 resubmitting a failed job.
 
-                Each time Cylc resubmits a task job it will increment the
+                Each time Cylc resubmits a job it will increment the
                 variable ``$CYLC_TASK_TRY_NUMBER`` in the task execution
                 environment. ``$CYLC_TASK_TRY_NUMBER`` allows you to vary task
                 behavior between submission attempts.
@@ -1101,13 +1101,13 @@ with Conf(
             ''')
             Conf('execution time limit', VDR.V_INTERVAL, desc=f'''
                 Set the execution (:term:`wallclock <wallclock time>`) time
-                limit of a task job.
+                limit of a job.
 
                 For ``background`` and ``at`` job runners Cylc runs the
                 job's script using the timeout command. For other job runners
                 Cylc will convert execution time limit to a :term:`directive`.
 
-                If a task job exceeds its execution time limit Cylc can
+                If a job exceeds its execution time limit Cylc can
                 poll the job multiple times. You can set polling
                 intervals using :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
@@ -1573,7 +1573,7 @@ with Conf(
                 The user defined task execution environment.
 
                 Variables defined here can refer to cylc workflow and task
-                identity variables, which are exported earlier in the task job
+                identity variables, which are exported earlier in the job
                 script. Variable assignment expressions can use cylc
                 utility commands because access to cylc is also configured
                 earlier in the script.
@@ -1591,7 +1591,7 @@ with Conf(
 
                     The order of definition is preserved that each variable can
                     refer to previously defined
-                    variables. Values are passed through to the task job
+                    variables. Values are passed through to the job
                     script without evaluation or manipulation by Cylc
                     (with the exception of valid Python string templates
                     that match parameterized task names - see below), so any

--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -19,11 +19,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ###############################################################################
-# Bash functions for a cylc task job.
+# Bash functions for a cylc job.
 ###############################################################################
 
 ###############################################################################
-# The main function for a cylc task job.
+# The main function for a cylc job.
 cylc__job__main() {
     # Export CYLC_ workflow and task environment variables
     cylc__job__inst__cylc_env
@@ -50,7 +50,7 @@ cylc__job__main() {
         trap "cylc__job_vacation ${signal_name}" "${signal_name}"
     done
     set -euo pipefail
-    # Write task job self-identify
+    # Write job self-identify
     USER="${USER:-$(whoami)}"
     typeset host="${HOSTNAME:-}"
     if [[ -z "${host}" ]]; then
@@ -65,7 +65,7 @@ cylc__job__main() {
     # We were using a HERE document for writing info here until we notice that
     # Bash uses temporary files for HERE documents, which can be inefficient.
     echo "Workflow : ${CYLC_WORKFLOW_ID}"
-    echo "Task Job : ${CYLC_TASK_JOB} (try ${CYLC_TASK_TRY_NUMBER})"
+    echo "Job : ${CYLC_TASK_JOB} (try ${CYLC_TASK_TRY_NUMBER})"
     echo "User@Host: ${USER}@${host}"
     echo
     # Derived environment variables
@@ -229,7 +229,7 @@ cylc__job__poll_grep_workflow_log() {
 }
 
 ###############################################################################
-# Run a function in the task job instance file, if possible.
+# Run a function in the job instance file, if possible.
 # Arguments:
 #   func_name: name of function without the "cylc__job__inst__" prefix
 # Returns:

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -150,7 +150,7 @@ class HostUtil:
 
         As specified by the "[scheduler][host self-identification]" settings in
         the site/user global.cylc files. This is mainly used for workflow host
-        identification by task jobs.
+        identification by tasks.
 
         """
         if self._host is None:

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Write task job files."""
+"""Write job files."""
 
 from contextlib import suppress
 import os
@@ -31,7 +31,7 @@ from cylc.flow.config import interpolate_template, ParamExpandError
 
 class JobFileWriter:
 
-    """Write task job files."""
+    """Write job files."""
 
     def __init__(self):
         self.workflow_env = {}
@@ -120,7 +120,7 @@ class JobFileWriter:
     def _write_header(handle, job_conf):
         """Write job script header."""
         handle.write("#!/bin/bash -l\n")
-        handle.write("#\n# ++++ THIS IS A CYLC TASK JOB SCRIPT ++++")
+        handle.write("#\n# ++++ THIS IS A CYLC JOB SCRIPT ++++")
         for prefix, value in [
                 ("# Workflow: ", job_conf['workflow_name']),
                 ("# Task: ", job_conf['task_id']),

--- a/cylc/flow/job_runner_handlers/at.py
+++ b/cylc/flow/job_runner_handlers/at.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to the rudimentary Unix ``at`` scheduler.
+"""Submits job scripts to the rudimentary Unix ``at`` scheduler.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 

--- a/cylc/flow/job_runner_handlers/background.py
+++ b/cylc/flow/job_runner_handlers/background.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Runs task job scripts as Unix background processes.
+"""Runs job scripts as Unix background processes.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 

--- a/cylc/flow/job_runner_handlers/loadleveler.py
+++ b/cylc/flow/job_runner_handlers/loadleveler.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to loadleveler by the ``llsubmit`` command.
+"""Submits job scripts to loadleveler by the ``llsubmit`` command.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -37,7 +37,7 @@ Loadleveler directives can be provided in the flow.cylc file:
                foo = bar
                baz = qux
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_handlers/lsf.py
+++ b/cylc/flow/job_runner_handlers/lsf.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to IBM Platform LSF by the ``bsub`` command.
+"""Submits job scripts to IBM Platform LSF by the ``bsub`` command.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -36,7 +36,7 @@ LSF directives can be provided in the flow.cylc file:
            [[[directives]]]
                -q = foo
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_handlers/moab.py
+++ b/cylc/flow/job_runner_handlers/moab.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to the Moab workload manager with ``msub``.
+"""Submits job scripts to the Moab workload manager with ``msub``.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -39,7 +39,7 @@ very similar to PBS:
                -q = foo
                -l nodes = 1
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_handlers/pbs.py
+++ b/cylc/flow/job_runner_handlers/pbs.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to PBS (or Torque) by the ``qsub`` command.
+"""Submits job scripts to PBS (or Torque) by the ``qsub`` command.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -38,7 +38,7 @@ PBS directives can be provided in the flow.cylc file:
                -q = foo
                -l nodes = 1
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_handlers/sge.py
+++ b/cylc/flow/job_runner_handlers/sge.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to Sun/Oracle Grid Engine with ``qsub``.
+"""Submits job scripts to Sun/Oracle Grid Engine with ``qsub``.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -39,7 +39,7 @@ SGE directives can be provided in the flow.cylc file:
                -l h_data = 1024M
                -l h_rt = 24:00:00
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_handlers/slurm.py
+++ b/cylc/flow/job_runner_handlers/slurm.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Submits task job scripts to Simple Linux Utility for Resource Management.
+"""Submits job scripts to Simple Linux Utility for Resource Management.
 
 .. cylc-scope:: flow.cylc[runtime][<namespace>]
 
@@ -43,7 +43,7 @@ file:
    Since not all SLURM commands have a short form, cylc requires
    the long form directives.
 
-These are written to the top of the task job script like this:
+These are written to the top of the job script like this:
 
 .. code-block:: bash
 

--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -282,7 +282,7 @@ class JobRunnerManager():
         """Kill multiple jobs.
 
         job_log_root -- The log/job/ sub-directory of the workflow.
-        job_log_dirs -- A list containing point/name/submit_num for task jobs.
+        job_log_dirs -- A list containing point/name/submit_num for jobs.
 
         """
         # Note: The more efficient way to do this is to group the jobs by their
@@ -311,7 +311,7 @@ class JobRunnerManager():
         """Poll multiple jobs.
 
         job_log_root -- The log/job/ sub-directory of the workflow.
-        job_log_dirs -- A list containing point/name/submit_num for task jobs.
+        job_log_dirs -- A list containing point/name/submit_num for jobs.
 
         """
         if "$" in job_log_root:
@@ -368,7 +368,7 @@ class JobRunnerManager():
         """Submit multiple jobs.
 
         job_log_root -- The log/job/ sub-directory of the workflow.
-        job_log_dirs -- A list containing point/name/submit_num for task jobs.
+        job_log_dirs -- A list containing point/name/submit_num for jobs.
         remote_mode -- am I running on the remote job host?
         utc_mode -- is the workflow running in UTC mode?
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -647,7 +647,7 @@ class Workflow(ObjectType):
         resolver=get_nodes_by_ids)
     jobs = graphene.List(
         lambda: Job,
-        description="""Task jobs.""",
+        description="""Jobs.""",
         args=JOB_ARGS,
         strip_null=STRIP_NULL_DEFAULT,
         delta_store=DELTA_STORE_DEFAULT,
@@ -899,7 +899,7 @@ class TaskProxy(ObjectType):
     prerequisites = graphene.List(Prerequisite)
     jobs = graphene.List(
         Job,
-        description="""Task jobs.""",
+        description="""Jobs.""",
         args=JOB_ARGS,
         strip_null=STRIP_NULL_DEFAULT,
         delta_store=DELTA_STORE_DEFAULT,
@@ -1518,7 +1518,7 @@ class Pause(Mutation):
         description = sstrip('''
             Pause a workflow.
 
-            This prevents submission of any task jobs.
+            This suspends submission of tasks.
         ''')
         resolver = partial(mutator, command='pause')
 
@@ -1531,15 +1531,15 @@ class Pause(Mutation):
 class Message(Mutation):
     class Meta:
         description = sstrip('''
-            Record task job messages.
+            Record task messages.
 
-            Send task job messages to:
+            Send messages to:
             - The job stdout/stderr.
             - The job status file, if there is one.
             - The scheduler, if communication is possible.
 
-            Task jobs use this to record and report status such
-            as success and failure. Applications run by task jobs can use
+            Jobs use this to record and report status such
+            as success and failure. Applications run by jobs can use
             this command to report messages and to report registered task
             outputs.
         ''')
@@ -1795,7 +1795,7 @@ class Kill(Mutation, TaskMutation):
 class Poll(Mutation, TaskMutation):
     class Meta:
         description = sstrip('''
-            Poll (query) task jobs to verify and update their statuses.
+            Poll (query) jobs to verify and update their statuses.
 
             This checks the job status file and queries the
             job runner on the job platform.
@@ -1992,7 +1992,7 @@ class Delta(Interface):
     )
     jobs = graphene.List(
         Job,
-        description="""Task jobs.""",
+        description="""Jobs.""",
         args=JOB_ARGS,
         strip_null=Boolean(),
         delta_store=Boolean(default_value=True),
@@ -2067,7 +2067,7 @@ class Updated(ObjectType):
     )
     jobs = graphene.List(
         Job,
-        description="""Task jobs.""",
+        description="""Jobs.""",
         args=JOB_ARGS,
         strip_null=Boolean(),
         delta_store=Boolean(default_value=True),

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -20,7 +20,7 @@
 
 View Cylc workflow and job log files.
 
-Print, tail-follow, print path, or list directory, of local or remote task job
+Print, tail-follow, print path, or list directory, of local or remote job
 and scheduler logs. Job runner view commands (e.g. 'qcat') are used if defined
 in global config and the job is running.
 
@@ -35,7 +35,7 @@ config '[JOB-HOST]retrieve job logs = True') and the job is not currently
 running, the local (retrieved) log will be accessed unless '-o/--force-remote'
 is used.
 
-The correct cycle point format of the workflow must be used for task job logs,
+The correct cycle point format of the workflow must be used for job logs,
 but can be discovered with '--mode=d' (print-dir).
 
 Examples:

--- a/cylc/flow/scripts/jobs_submit.py
+++ b/cylc/flow/scripts/jobs_submit.py
@@ -18,7 +18,7 @@
 
 (This command is for internal use.)
 
-Submit task jobs to relevant job runners.
+Submit jobs to relevant job runners.
 On a remote job host, this command reads the job files from STDIN.
 """
 

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -17,15 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 r"""cylc message [OPTIONS] -- ARGS
 
-Record task job messages.
+Record task messages.
 
-Send task job messages to:
+Send messages to:
 - The job stdout/stderr.
 - The job status file, if there is one.
 - The scheduler, if communication is possible.
 
-Task jobs use this command to record and report status such as success and
-failure. Applications run by task jobs can use this command to report messages
+Jobs use this command to record and report status such as success and
+failure. Applications run by jobs can use this command to report messages
 and to report registered task outputs.
 
 Messages can be specified as arguments. A '-' indicates that the command should
@@ -50,7 +50,7 @@ Examples:
   > WARNING:Hey!
   >__STDIN__
 
-Note "${CYLC_WORKFLOW_ID}" and "${CYLC_TASK_JOB}" are available in task job
+Note "${CYLC_WORKFLOW_ID}" and "${CYLC_TASK_JOB}" are available in job
 environments - you do not need to write their actual values in task scripting.
 
 Each message can be prefixed with a severity level using the syntax
@@ -66,7 +66,7 @@ Note:
 
 For backward compatibility, if number of arguments is less than or equal to 2,
 the command assumes the classic interface, where all arguments are messages.
-Otherwise, the first 2 arguments are assumed to be workflow name and task job
+Otherwise, the first 2 arguments are assumed to be workflow name and job
 identifier.
 """
 
@@ -98,7 +98,7 @@ def get_option_parser() -> COP:
             # TODO
             COP.optional(WORKFLOW_ID_ARG_DOC),
             COP.optional(
-                ('TASK-JOB', 'Task job identifier CYCLE/TASK_NAME/SUBMIT_NUM')
+                ('JOB', 'Job ID - CYCLE/TASK_NAME/SUBMIT_NUM')
             ),
             COP.optional(
                 ('[SEVERITY:]MESSAGE ...', 'Messages')

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -20,7 +20,7 @@
 
 Pause a workflow.
 
-This prevents submission of any task jobs.
+This suspends submission of tasks.
 
 Examples:
   # pause my_flow

--- a/cylc/flow/scripts/poll.py
+++ b/cylc/flow/scripts/poll.py
@@ -18,7 +18,7 @@
 
 """cylc poll [OPTIONS] ARGS
 
-Poll (query) task jobs to verify and update their statuses.
+Poll (query) jobs to verify and update their statuses.
 
 This checks the job status file and queries the job runner on the job platform.
 

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -17,7 +17,7 @@
 
 This module provides logic to:
 * Manage task messages (internal, polled or received).
-* Set up retries on task job failures (submission or execution).
+* Set up retries on job failures (submission or execution).
 * Generate task event handlers.
   * Retrieval of log files for completed remote jobs.
   * Email notification.

--- a/cylc/flow/task_job_logs.py
+++ b/cylc/flow/task_job_logs.py
@@ -13,14 +13,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Define task job log filenames and option names."""
+"""Define job log filenames and option names."""
 
 import os
 
 from cylc.flow.id import Tokens
 from cylc.flow.pathutil import get_workflow_run_job_dir
 
-# Task job log filenames.
+# job log filenames.
 JOB_LOG_JOB = "job"
 JOB_LOG_OUT = "job.out"
 JOB_LOG_ERR = "job.err"

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -13,15 +13,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Manage task jobs.
+"""Manage jobs.
 
 This module provides logic to:
 * Set up the directory structure on remote job hosts.
   * Copy workflow service files to remote job hosts for communication clients.
   * Clean up of service files on workflow shutdown.
-* Prepare task job files.
-* Prepare task jobs submission, and manage the callbacks.
-* Prepare task jobs poll/kill, and manage the callbacks.
+* Prepare job files.
+* Prepare jobs submission, and manage the callbacks.
+* Prepare jobs poll/kill, and manage the callbacks.
 """
 
 from contextlib import suppress
@@ -121,9 +121,9 @@ class TaskJobManager:
     """Manage task job submit, poll and kill.
 
     This class provides logic to:
-    * Submit task jobs.
-    * Poll task jobs.
-    * Kill task jobs.
+    * Submit jobs.
+    * Poll jobs.
+    * Kill jobs.
     * Set up the directory structure on job hosts.
     * Install workflow communicate client files on job hosts.
     * Remove workflow contact files on job hosts.

--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -13,9 +13,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Allow a task job to record its messages.
+"""Allow a task to record its messages.
 
-Send task job messages to:
+Send messages to:
 - The stdout/stderr.
 - The job status file, if there is one.
 - The scheduler, if communication is possible.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -982,7 +982,7 @@ class TaskPool:
                     orphans.append(itask)
         if orphans_kill_failed:
             LOG.warning(
-                "Orphaned task jobs (kill failed):\n"
+                "Orphaned tasks (kill failed):\n"
                 + "\n".join(
                     f"* {itask.identity} ({itask.state.status})"
                     for itask in orphans_kill_failed
@@ -990,7 +990,7 @@ class TaskPool:
             )
         if orphans:
             LOG.warning(
-                "Orphaned task jobs:\n"
+                "Orphaned tasks:\n"
                 + "\n".join(
                     f"* {itask.identity} ({itask.state.status})"
                     for itask in orphans

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -89,7 +89,7 @@ class RemoteTidyQueueTuple(NamedTuple):
 
 
 class TaskRemoteMgr:
-    """Manage task job remote initialisation, tidy, selection."""
+    """Manage task remote initialisation, tidy, selection."""
 
     def __init__(self, workflow, proc_pool, bad_hosts):
         self.workflow = workflow

--- a/tests/functional/restart/41-auto-restart-local-jobs.t
+++ b/tests/functional/restart/41-auto-restart-local-jobs.t
@@ -109,7 +109,7 @@ log_scan "${TEST_NAME}-stop-log-scan" "${LOG_FILE}" 40 1 \
     'The Cylc workflow host will soon become un-available' \
     'This workflow will be shutdown as the workflow host is unable to continue' \
     'Workflow shutting down - REQUEST(NOW)' \
-    'Orphaned task jobs:' \
+    'Orphaned tasks:' \
     '* 1/bar (running)'
 
 cylc stop "${WORKFLOW_NAME}" --now --now 2>/dev/null || true

--- a/tests/functional/shutdown/09-now2.t
+++ b/tests/functional/shutdown/09-now2.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --no-detach "${WORKFLOW_NAME}"
 LOGD="$RUN_DIR/${WORKFLOW_NAME}/log"
 grep_ok 'INFO - Workflow shutting down - REQUEST(NOW-NOW)' "${LOGD}/scheduler/log"
-grep_ok 'WARNING - Orphaned task jobs' "${LOGD}/scheduler/log"
+grep_ok 'WARNING - Orphaned tasks' "${LOGD}/scheduler/log"
 grep_ok '\* 1/t1 (running)' "${LOGD}/scheduler/log"
 JLOGD="${LOGD}/job/1/t1/01"
 # Check that 1/t1 event handler runs

--- a/tests/functional/shutdown/22-stop-now.t
+++ b/tests/functional/shutdown/22-stop-now.t
@@ -43,7 +43,7 @@ run_ok "${TEST_NAME_BASE}" cylc play "${WORKFLOW_NAME}" --no-detach --debug
 WORKFLOW_LOG="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 log_scan "${TEST_NAME_BASE}-orphaned" "${WORKFLOW_LOG}" 1 1 \
-    'Orphaned task jobs.*' \
+    'Orphaned tasks.*' \
     '1/.*foo'
 
 purge

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -242,7 +242,7 @@ async def test_no_poll_waiting_tasks(
         task.state.status = TASK_STATUS_RUNNING
 
     # For good measure, check the faked running task is reported at shutdown.
-    assert "Orphaned task jobs:\n* 1/one (running)" in log.messages
+    assert "Orphaned tasks:\n* 1/one (running)" in log.messages
 
 
 @pytest.mark.parametrize('reload', [False, True])

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -116,7 +116,7 @@ def test_write(fixture_get_platform):
 
     """Test the header is correctly written"""
 
-    expected = ('#!/bin/bash -l\n#\n# ++++ THIS IS A CYLC TASK JOB SCRIPT '
+    expected = ('#!/bin/bash -l\n#\n# ++++ THIS IS A CYLC JOB SCRIPT '
                 '++++\n# Workflow: farm_noises\n# Task: 1/baa\n# Job '
                 'log directory: 1/baa/01\n# Job runner: '
                 'background\n# Job runner command template: woof\n#'


### PR DESCRIPTION
* Retire "task job" as a user-facing term in favour of the canonical
  "task" and "job" terms.
* Closes https://github.com/cylc/cylc-doc/issues/352
* The ID structure is `workflow//cycle/task/job`, they are tasks and jobs
  not "task-jobs" or "cycle-tasks" or "workflow-cycles".

Sibling: https://github.com/cylc/cylc-doc/pull/528

Note this is just about using "task" and "job" in user-facing documentation and a couple of docstrings or whathaveyou.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.