### PR TITLE
Ensure queued deltas are published before shutdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ taskdefs removed before restart.
 [#5091](https://github.com/cylc/cylc-flow/pull/5091) - Fix problems with
 tutorial workflows.
 
+[#5098](https://github.com/cylc/cylc-flow/pull/5098) - Fix bug where final task
+status updates were not being sent to UI before shutdown.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.1 (<span actions:bind='release-date'>Released 2022-08-16</span>)__
 

--- a/cylc/flow/network/publisher.py
+++ b/cylc/flow/network/publisher.py
@@ -81,12 +81,11 @@ class WorkflowPublisher(ZMQSocketBase):
 
         """
         if self.socket:
-            # don't attempt to send anything if we are in the process of
-            # shutting down
             self.topics.add(topic)
             self.socket.send_multipart(
                 [topic, serialize_data(data, serializer)]
             )
+        # else we are in the process of shutting down - don't send anything
 
     async def publish(self, items):
         """Publish topics.
@@ -98,4 +97,4 @@ class WorkflowPublisher(ZMQSocketBase):
         try:
             await gather_coros(self.send_multi, items)
         except Exception as exc:
-            LOG.error('publish: %s', exc)
+            LOG.exception(f"publish: {exc}")

--- a/cylc/flow/network/replier.py
+++ b/cylc/flow/network/replier.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Server for workflow runtime API."""
 
-import getpass  # noqa: F401
 from queue import Queue
 
 import zmq

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -205,7 +205,7 @@ class WorkflowRuntimeServer:
 
         self.operate()
 
-    async def stop(self, reason: Union[Exception, str]) -> None:
+    async def stop(self, reason: Union[BaseException, str]) -> None:
         """Stop the TCP servers, and clean up authentication.
 
         This method must be called/awaited from a different thread to the
@@ -385,12 +385,19 @@ class WorkflowRuntimeServer:
         if executed.errors:
             errors: List[Any] = []
             for error in executed.errors:
+                LOG.error(error)
                 if hasattr(error, '__traceback__'):
                     import traceback
-                    errors.append({'error': {
-                        'message': str(error),
-                        'traceback': traceback.format_exception(
-                            error.__class__, error, error.__traceback__)}})
+                    formatted_tb = traceback.format_exception(
+                        type(error), error, error.__traceback__
+                    )
+                    LOG.error("".join(formatted_tb))
+                    errors.append({
+                        'error': {
+                            'message': str(error),
+                            'traceback': formatted_tb
+                        }
+                    })
                     continue
                 errors.append(getattr(error, 'message', None))
             return errors

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -205,22 +205,30 @@ class WorkflowRuntimeServer:
 
         self.operate()
 
-    async def stop(self, reason):
-        """Stop the TCP servers, and clean up authentication."""
+    async def stop(self, reason: Union[Exception, str]) -> None:
+        """Stop the TCP servers, and clean up authentication.
+
+        This method must be called/awaited from a different thread to the
+        server's self.thread in order to interrupt the self.operate() loop
+        and wait for self.thread to terminate.
+        """
         self.queue.put('STOP')
         if self.thread and self.thread.is_alive():
             while not self.stopping:
-                # Non-async sleep - yield to other threads rather
-                # than event loop.
+                # Non-async sleep - yield to other threads rather than
+                # event loop (allows self.operate() running in different
+                # thread to return)
                 sleep(self.STOP_SLEEP_INTERVAL)
 
         if self.replier:
             self.replier.stop(stop_loop=False)
         if self.publisher:
+            await self.publish_queued_items()
             await self.publisher.publish(
                 [(b'shutdown', str(reason).encode('utf-8'))]
             )
             self.publisher.stop(stop_loop=False)
+            self.publisher = None
         if self.curve_auth:
             self.curve_auth.stop()  # stop the authentication thread
         if self.loop and self.loop.is_running():
@@ -230,8 +238,11 @@ class WorkflowRuntimeServer:
 
         self.stopped = True
 
-    def operate(self):
+    def operate(self) -> None:
         """Orchestrate the receive, send, publish of messages."""
+        # Note: this cannot be an async method because the response part
+        # of the listener runs the event loop synchronously
+        # (in graphql AsyncioExecutor)
         while True:
             # process messages from the scheduler.
             if self.queue.qsize():
@@ -243,14 +254,17 @@ class WorkflowRuntimeServer:
 
             # Gather and respond to any requests.
             self.replier.listener()
-
             # Publish all requested/queued.
-            while self.publish_queue.qsize():
-                articles = self.publish_queue.get()
-                self.loop.run_until_complete(self.publisher.publish(articles))
+            self.loop.run_until_complete(self.publish_queued_items())
 
             # Yield control to other threads
             sleep(self.OPERATE_SLEEP_INTERVAL)
+
+    async def publish_queued_items(self):
+        """Publish all queued items."""
+        while self.publish_queue.qsize():
+            articles = self.publish_queue.get()
+            await self.publisher.publish(articles)
 
     def receiver(self, message):
         """Process incoming messages and coordinate response.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1698,7 +1698,7 @@ class Scheduler:
                 self.timers[self.EVENT_STALL_TIMEOUT].reset()
         return self.is_stalled
 
-    async def shutdown(self, reason: Exception) -> None:
+    async def shutdown(self, reason: BaseException) -> None:
         """Gracefully shut down the scheduler."""
         # At the moment this method must be called from the main_loop.
         # In the future it should shutdown the main_loop itself but
@@ -1719,7 +1719,7 @@ class Scheduler:
             # Re-raise exception to be caught higher up (sets the exit code)
             raise exc from None
 
-    async def _shutdown(self, reason: Exception) -> None:
+    async def _shutdown(self, reason: BaseException) -> None:
         """Shutdown the workflow."""
         shutdown_msg = "Workflow shutting down"
         if isinstance(reason, SchedulerStop):
@@ -1977,7 +1977,7 @@ class Scheduler:
                         f"option --{opt}=reload is only valid for restart"
                     )
 
-    async def handle_exception(self, exc: Exception) -> NoReturn:
+    async def handle_exception(self, exc: BaseException) -> NoReturn:
         """Gracefully shut down the scheduler given a caught exception.
 
         Re-raises the exception to be caught higher up (sets the exit code).

--- a/tests/integration/test_zmq.py
+++ b/tests/integration/test_zmq.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from time import sleep
-
 import pytest
 import zmq
 

--- a/tests/unit/network/test_publisher.py
+++ b/tests/unit/network/test_publisher.py
@@ -14,9 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from time import sleep
-
-from cylc.flow.network.publisher import WorkflowPublisher, serialize_data
+from cylc.flow.network.publisher import serialize_data
 
 
 def test_serialize_data():


### PR DESCRIPTION
Closes #5092 

Fix bug where the final deltas were not being published before stopping the `WorkflowRuntimeServer` at shutdown

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
