### PR TITLE
Slightly different warning for preparing tasks on reload

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -886,9 +886,14 @@ class TaskPool:
                 itask.copy_to_reload_successor(new_task)
                 self._swap_out(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
-                if itask.state(*TASK_STATUSES_ACTIVE, TASK_STATUS_PREPARING):
+                if itask.state(*TASK_STATUSES_ACTIVE):
                     LOG.warning(
                         f"[{itask}] active with pre-reload settings"
+                    )
+                elif itask.state(TASK_STATUS_PREPARING):
+                    # Job file might have been written at this point?
+                    LOG.warning(
+                        f"[{itask}] may be active with pre-reload settings"
                     )
 
         # Reassign live tasks to the internal queue


### PR DESCRIPTION
These changes partially address #4990

Preparing tasks might have written their job file at time of reload (we're not sure), so amend the warning that preparing tasks get at reload to say they "may" be active with pre-reload config.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests not needed
- [x] No changelog entry (minor change)
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
