### PR TITLE
Fix repeated stall when reloading a stalled workflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ taskdefs removed before restart.
 [#5091](https://github.com/cylc/cylc-flow/pull/5091) - Fix problems with
 tutorial workflows.
 
+[#5110](https://github.com/cylc/cylc-flow/pull/5110) - Fix bug where reloading
+a stalled workflow would cause it stall again.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.1 (<span actions:bind='release-date'>Released 2022-08-16</span>)__
 

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -76,7 +76,7 @@ class PointBase(metaclass=ABCMeta):
         """Used for comparison operations between different PointBase-derived
         class instances."""
 
-    def __init__(self, value):
+    def __init__(self, value: str):
         if not isinstance(value, str):
             raise TypeError(type(value))
         self.value = value

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -31,7 +31,16 @@ from threading import Barrier, Thread
 from time import sleep, time
 import traceback
 from typing import (
-    Callable, Iterable, NoReturn, Optional, List, Set, Dict, Tuple, Union
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    NoReturn,
+    Optional,
+    List,
+    Set,
+    Dict,
+    Tuple,
+    Union,
 )
 from uuid import uuid4
 
@@ -123,6 +132,9 @@ from cylc.flow.wallclock import (
     get_time_string_from_unix_time as time2str,
     get_utc_mode)
 from cylc.flow.xtrigger_mgr import XtriggerManager
+
+if TYPE_CHECKING:
+    from cylc.flow.task_proxy import TaskProxy
 
 
 class SchedulerStop(CylcError):
@@ -221,10 +233,10 @@ class Scheduler:
     stop_clock_time: Optional[int] = None
 
     # task event loop
-    is_paused: Optional[bool] = None
-    is_updated: Optional[bool] = None
-    is_stalled: Optional[bool] = None
-    is_reloaded: Optional[bool] = None
+    is_paused = False
+    is_updated = False
+    is_stalled = False
+    is_reloaded = False
 
     # main loop
     main_loop_intervals: deque = deque(maxlen=10)
@@ -457,7 +469,6 @@ class Scheduler:
             self.flow_mgr
         )
 
-        self.is_reloaded = False
         self.data_store_mgr.initiate_data_model()
 
         self.profiler.log_memory("scheduler.py: before load_tasks")
@@ -996,7 +1007,7 @@ class Scheduler:
         """Remove tasks."""
         return self.pool.remove_tasks(items)
 
-    def command_reload_workflow(self):
+    def command_reload_workflow(self) -> None:
         """Reload workflow configuration."""
         LOG.info("Reloading the workflow definition.")
         old_tasks = set(self.config.get_task_name_list())
@@ -1020,7 +1031,7 @@ class Scheduler:
         # logged by the TaskPool.
         add = set(self.config.get_task_name_list()) - old_tasks
         for task in add:
-            LOG.warning("Added task: '%s'" % (task,))
+            LOG.warning(f"Added task: '{task}'")
         self.workflow_db_mgr.put_workflow_template_vars(self.template_vars)
         self.workflow_db_mgr.put_runtime_inheritance(self.config)
         self.workflow_db_mgr.put_workflow_params(self)
@@ -1492,7 +1503,7 @@ class Scheduler:
                 self.count, get_current_time_string()))
         self.count += 1
 
-    async def main_loop(self):
+    async def main_loop(self) -> None:
         """The scheduler main loop."""
         while True:  # MAIN LOOP
             tinit = time()
@@ -1629,7 +1640,7 @@ class Scheduler:
                     quick_mode and elapsed >= self.INTERVAL_MAIN_LOOP_QUICK):
                 # Main loop has taken quite a bit to get through
                 # Still yield control to other threads by sleep(0.0)
-                duration = 0
+                duration: float = 0
             elif quick_mode:
                 duration = self.INTERVAL_MAIN_LOOP_QUICK - elapsed
             else:
@@ -1639,7 +1650,7 @@ class Scheduler:
             self.main_loop_intervals.append(time() - tinit)
             # END MAIN LOOP
 
-    async def update_data_structure(self):
+    async def update_data_structure(self) -> Union[bool, List['TaskProxy']]:
         """Update DB, UIS, Summary data elements"""
         updated_tasks = [
             t for t in self.pool.get_tasks() if t.state.is_updated]
@@ -1681,7 +1692,7 @@ class Scheduler:
             if self._get_events_conf(f"{event} handlers") is not None:
                 self.run_event_handlers(event)
 
-    def check_workflow_stalled(self):
+    def check_workflow_stalled(self) -> bool:
         """Check if workflow is stalled or not."""
         if self.is_stalled:  # already reported
             return True
@@ -1692,6 +1703,7 @@ class Scheduler:
             self.update_data_store()
             self.is_stalled = is_stalled
         if self.is_stalled:
+            LOG.critical("Workflow stalled")
             self.run_event_handlers(self.EVENT_STALL, 'workflow stalled')
             with suppress(KeyError):
                 # Start stall timeout timer

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1007,7 +1007,7 @@ class TaskPool:
             LOG.warning("%s/%s/%s: incomplete task event handler %s" % (
                 point, name, submit_num, key1))
 
-    def log_incomplete_tasks(self):
+    def log_incomplete_tasks(self) -> bool:
         """Log finished but incomplete tasks; return True if there any."""
         incomplete = []
         for itask in self.get_tasks():
@@ -1028,7 +1028,7 @@ class TaskPool:
             return True
         return False
 
-    def log_unsatisfied_prereqs(self):
+    def log_unsatisfied_prereqs(self) -> bool:
         """Log unsatisfied prerequisites in the hidden pool.
 
         Return True if any, ignoring:
@@ -1036,10 +1036,10 @@ class TaskPool:
             - dependence on tasks beyond the stop point
             (can be caused by future triggers)
         """
-        unsat = {}
+        unsat: Dict[str, List[str]] = {}
         for itask in self.get_hidden_tasks():
-            task_point = point = itask.point
-            if task_point > self.stop_point:
+            task_point = itask.point
+            if self.stop_point and task_point > self.stop_point:
                 continue
             for pre in itask.state.get_unsatisfied_prerequisites():
                 point, name, output = pre
@@ -1057,8 +1057,7 @@ class TaskPool:
                 )
             )
             return True
-        else:
-            return False
+        return False
 
     def is_stalled(self) -> bool:
         """Return whether the workflow is stalled.
@@ -1081,11 +1080,7 @@ class TaskPool:
 
         incomplete = self.log_incomplete_tasks()
         unsatisfied = self.log_unsatisfied_prereqs()
-        if incomplete or unsatisfied:
-            LOG.critical("Workflow stalled")
-            return True
-        else:
-            return False
+        return (incomplete or unsatisfied)
 
     def hold_active_task(self, itask: TaskProxy) -> None:
         if itask.state_reset(is_held=True):

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -17,6 +17,7 @@
 """Task state related logic."""
 
 
+from typing import List
 from cylc.flow.prerequisite import Prerequisite
 from cylc.flow.task_outputs import (
     TaskOutputs,
@@ -230,8 +231,8 @@ class TaskState:
         self._suicide_is_satisfied = None
 
         # Prerequisites.
-        self.prerequisites = []
-        self.suicide_prerequisites = []
+        self.prerequisites: List[Prerequisite] = []
+        self.suicide_prerequisites: List[Prerequisite] = []
         self._add_prerequisites(point, tdef)
 
         # External Triggers.

--- a/tests/functional/reload/26-stalled.t
+++ b/tests/functional/reload/26-stalled.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+
+# Test reloading a stalled workflow: it should not stall again
+# https://github.com/cylc/cylc-flow/issues/5103
+
+. "$(dirname "$0")/test_header"
+set_test_number 5
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW__'
+[scheduler]
+    [[events]]
+        stall handlers = cylc reload %(workflow)s
+        stall timeout = PT10S
+        abort on stall timeout = True
+        # Prevent infinite loop if the bug resurfaces
+        workflow timeout = PT3M
+        abort on workflow timeout = True
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = false
+__FLOW__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+
+workflow_run_fail "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach
+
+LOG_FILE="${WORKFLOW_RUN_DIR}/log/scheduler/log"
+
+# Should only stall once
+count_ok "CRITICAL - Workflow stalled" "$LOG_FILE" 1
+# Stall event handler should only run once
+count_ok "INFO - Reload completed" "$LOG_FILE" 1
+# Stall timer should not stop at any point
+grep_fail "stall timer stopped" "$LOG_FILE"
+
+purge


### PR DESCRIPTION
These changes close #5103

Reloading a stalled workflow was causing the workflow to stall again (twice). This PR prevents reloads from unstalling the workflow, so the subsequent stalls do not happen

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
