### PR TITLE
Fix assorted cylc review bugs

### DIFF
--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -86,7 +86,8 @@ class CylcReviewService(object):
         'suite.rc.processed',
         'flow.cylc',
         'rose-suite.info',
-        'opt/rose-suite-cylc-install.conf'
+        'opt/rose-suite-cylc-install.conf',
+        'rose-suite.conf'
     ]
 
     def __init__(self, *args, **kwargs):

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -329,7 +329,8 @@ class CylcReviewService(object):
         # Set list of task states depending on Cylc version 7 or 8
         task_statuses_ordered = TASK_STATUSES_ORDERED
         try:
-            if self.suite_dao.is_cylc8(user, suite):
+            is_c8 = self.suite_dao.is_cylc8(user, suite)
+            if is_c8:
                 task_statuses_ordered = CYLC8_TASK_STATUSES_ORDERED
         except ProgrammingError:
             pass

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -36,7 +36,7 @@ import os
 import pwd
 import re
 import shlex
-from sqlite3 import ProgrammingError
+from sqlite3 import ProgrammingError, OperationalError
 import tarfile
 from tempfile import NamedTemporaryFile
 from time import gmtime, strftime
@@ -151,8 +151,13 @@ class CylcReviewService(object):
         data["states"]["last_activity_time"] = (
             self.get_last_activity_time(user, suite))
         data.update(self._get_suite_logs_info(user, suite))
-        data["broadcast_states"] = (
-            self.suite_dao.get_suite_broadcast_states(user, suite))
+
+        try:
+            data["broadcast_states"] = (
+                self.suite_dao.get_suite_broadcast_states(user, suite))
+        except OperationalError:
+            data["broadcast_states"] = ()
+
         if form == "json":
             return json.dumps(data)
         try:
@@ -180,8 +185,13 @@ class CylcReviewService(object):
         data["states"].update(
             self.suite_dao.get_suite_state_summary(user, suite))
         data.update(self._get_suite_logs_info(user, suite))
-        data["broadcast_events"] = (
-            self.suite_dao.get_suite_broadcast_events(user, suite))
+
+        try:
+            data["broadcast_events"] = (
+                self.suite_dao.get_suite_broadcast_events(user, suite))
+        except OperationalError:
+            data["broadcast_events"] = ()
+
         if form == "json":
             return json.dumps(data)
         try:

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -619,12 +619,14 @@ class CylcReviewService(object):
                     if entry["submit_num"] == int(submit_num):
                         job_entry = entry
                         break
+
+        # Set the file_content type for syntax highlighting.
         if (
             fnmatch(os.path.basename(path), "suite*.rc*")
             or fnmatch(os.path.basename(path), "*.cylc")
         ):
             file_content = "cylc-suite-rc"
-        elif fnmatch(os.path.basename(path), "rose*.conf"):
+        elif fnmatch(os.path.basename(path), "*rose*.conf"):
             file_content = "rose-conf"
         else:
             file_content = None
@@ -704,6 +706,7 @@ class CylcReviewService(object):
         # Log files with +TZ in name end up with space instead of plus sign, so
         # put plus sign back in (https://github.com/cylc/cylc-flow/issues/4260)
         path = re.sub(r"(log\.\S+\d{2})\s(\d{2,4})$", r"\1+\2", path)
+        path = re.sub(r"(log\/config\/\d*T?\d*)\s(\d*-rose-suite.conf)", r"\1+\2", path)
         suite = suite.replace('%2F', '/')
 
         # get file or serve raw data


### PR DESCRIPTION
Closes #5108 

@datamel tagged for code review.
@dpmatthews tagged for functional review as originator of the bug report.

## Fixes:
### Broadcast States pages

Installing a workflow (Cylc 7 or 8) without starting it causes no `broadcast_events` or `broadcast_states` tables to be created in the suite database, but I don't see why this should lead to error messages in the table. I suspect it's not come up before because I doubt anyone has run `rose suite-run -i` and then moved straight to Cylc Review.

### Show `rose-suite.conf` in the log files menu

The log files menus have become a touch confused. To keep things simple I have set up Cylc review to put all log items in the "cylc" menu if it's a Cylc 8 workflow, but to maintain existing behavior otherwise. If the reviewer insists I'll create a new issue to tidy up the menu items. One could even split up the different log directories into their own menus quite easily. Now the logic is there to distinguish Cylc 8 workflows we can do what we like.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Testing for Cylc Review is manual because the product is deprecated.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
