### PR TITLE
Revert order of scheduler `configure()` & `log_start()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@ taskdefs removed before restart.
 [#5091](https://github.com/cylc/cylc-flow/pull/5091) - Fix problems with
 tutorial workflows.
 
+[#5114](https://github.com/cylc/cylc-flow/pull/5114) - Fix bug where
+validation errors during workflow startup were not printed to stderr before
+daemonisation.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.1 (<span actions:bind='release-date'>Released 2022-08-16</span>)__
 

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """Logging utilities.
 
 This module provides:
@@ -21,7 +22,8 @@ This module provides:
   Note: The ISO date time bit is redundant in Python 3,
   because "time.strftime" will handle time zone from "localtime" properly.
 """
-from contextlib import suppress
+
+from contextlib import contextmanager, suppress
 from glob import glob
 import logging
 import os
@@ -414,3 +416,19 @@ def get_reload_start_number(config_logs: List[str]) -> str:
         except Exception:
             return '01'
         return f'{start_num:02d}'
+
+
+@contextmanager
+def patch_log_level(logger: logging.Logger, level: int = logging.INFO):
+    """Temporarily patch the logging level of a logger if the specified level
+    is less severe than the current level.
+
+    Defaults to INFO.
+    """
+    orig_level = logger.getEffectiveLevel()
+    if level < orig_level:
+        logger.setLevel(level)
+        yield
+        logger.setLevel(orig_level)
+    else:  # No need to patch
+        yield

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -67,7 +67,8 @@ from cylc.flow.loggingutil import (
     ReferenceLogFileHandler,
     get_next_log_number,
     get_reload_start_number,
-    get_sorted_logs_by_time
+    get_sorted_logs_by_time,
+    patch_log_level
 )
 from cylc.flow.timer import Timer
 from cylc.flow.network import API
@@ -386,7 +387,8 @@ class Scheduler:
         """
         # Print workflow name to disambiguate in case of inferred run number
         # while in no-detach mode
-        LOG.info(f"Workflow: {self.workflow}")
+        with patch_log_level(LOG):
+            LOG.info(f"Workflow: {self.workflow}")
 
         self.profiler.log_memory("scheduler.py: start configure")
 
@@ -522,73 +524,65 @@ class Scheduler:
 
         Note: daemonize polls for 2 of these headers before detaching.
         """
-        is_quiet = (cylc.flow.flags.verbosity < 0)
-        log_level = LOG.getEffectiveLevel()
-        if is_quiet:
-            # Temporarily change logging level to log important info
-            LOG.setLevel(logging.INFO)
-
-        # `daemonize` polls for these next 2 before detaching:
-        LOG.info(
-            self.START_MESSAGE_TMPL % {
-                'comms_method': 'tcp',
-                'host': self.host,
-                'port': self.server.port,
-                'pid': os.getpid()},
-            extra=RotatingLogFileHandler.header_extra,
-        )
-        LOG.info(
-            self.START_PUB_MESSAGE_TMPL % {
-                'comms_method': 'tcp',
-                'host': self.host,
-                'port': self.server.pub_port},
-            extra=RotatingLogFileHandler.header_extra,
-        )
-
-        restart_num = self.get_restart_num() + 1
-        LOG.info(
-            f'Run: (re)start number={restart_num}, log rollover=%d',
-            # Hard code 1 in args, gets updated on log rollover (NOTE: this
-            # must be the only positional arg):
-            1,
-            extra={
-                **RotatingLogFileHandler.header_extra,
-                RotatingLogFileHandler.ROLLOVER_NUM: 1
-            }
-        )
-        LOG.info(
-            f'Cylc version: {CYLC_VERSION}',
-            extra=RotatingLogFileHandler.header_extra
-        )
-
-        # Note that the following lines must be present at the top of
-        # the workflow log file for use in reference test runs.
-        LOG.info(
-            f'Run mode: {self.config.run_mode()}',
-            extra=RotatingLogFileHandler.header_extra
-        )
-        LOG.info(
-            f'Initial point: {self.config.initial_point}',
-            extra=RotatingLogFileHandler.header_extra
-        )
-        if self.config.start_point != self.config.initial_point:
+        # Temporarily lower logging level if necessary to log important info
+        with patch_log_level(LOG):
+            # `daemonize` polls for these next 2 before detaching:
             LOG.info(
-                f'Start point: {self.config.start_point}',
-                extra=RotatingLogFileHandler.header_extra
+                self.START_MESSAGE_TMPL % {
+                    'comms_method': 'tcp',
+                    'host': self.host,
+                    'port': self.server.port,
+                    'pid': os.getpid()},
+                extra=RotatingLogFileHandler.header_extra,
             )
-        LOG.info(
-            f'Final point: {self.config.final_point}',
-            extra=RotatingLogFileHandler.header_extra
-        )
-        if self.config.stop_point:
             LOG.info(
-                f'Stop point: {self.config.stop_point}',
+                self.START_PUB_MESSAGE_TMPL % {
+                    'comms_method': 'tcp',
+                    'host': self.host,
+                    'port': self.server.pub_port},
+                extra=RotatingLogFileHandler.header_extra,
+            )
+
+            restart_num = self.get_restart_num() + 1
+            LOG.info(
+                f'Run: (re)start number={restart_num}, log rollover=%d',
+                # Hard code 1 in args, gets updated on log rollover (NOTE: this
+                # must be the only positional arg):
+                1,
+                extra={
+                    **RotatingLogFileHandler.header_extra,
+                    RotatingLogFileHandler.ROLLOVER_NUM: 1
+                }
+            )
+            LOG.info(
+                f'Cylc version: {CYLC_VERSION}',
                 extra=RotatingLogFileHandler.header_extra
             )
 
-        if is_quiet:
-            LOG.info("Quiet mode on")
-            LOG.setLevel(log_level)
+            # Note that the following lines must be present at the top of
+            # the workflow log file for use in reference test runs.
+            LOG.info(
+                f'Run mode: {self.config.run_mode()}',
+                extra=RotatingLogFileHandler.header_extra
+            )
+            LOG.info(
+                f'Initial point: {self.config.initial_point}',
+                extra=RotatingLogFileHandler.header_extra
+            )
+            if self.config.start_point != self.config.initial_point:
+                LOG.info(
+                    f'Start point: {self.config.start_point}',
+                    extra=RotatingLogFileHandler.header_extra
+                )
+            LOG.info(
+                f'Final point: {self.config.final_point}',
+                extra=RotatingLogFileHandler.header_extra
+            )
+            if self.config.stop_point:
+                LOG.info(
+                    f'Stop point: {self.config.stop_point}',
+                    extra=RotatingLogFileHandler.header_extra
+                )
 
     async def run_scheduler(self):
         """Start the scheduler main loop."""
@@ -1728,25 +1722,29 @@ class Scheduler:
     async def _shutdown(self, reason: Exception) -> None:
         """Shutdown the workflow."""
         shutdown_msg = "Workflow shutting down"
-        if isinstance(reason, SchedulerStop):
-            LOG.info(f'{shutdown_msg} - {reason.args[0]}')
-            # Unset the "paused" status of the workflow if not auto-restarting
-            if self.auto_restart_mode != AutoRestartMode.RESTART_NORMAL:
-                self.resume_workflow(quiet=True)
-        elif isinstance(reason, SchedulerError):
-            LOG.error(f"{shutdown_msg} - {reason}")
-        elif isinstance(reason, CylcError) or (
-            isinstance(reason, ParsecError) and reason.schd_expected
-        ):
-            LOG.error(f"{shutdown_msg} - {type(reason).__name__}: {reason}")
-            if cylc.flow.flags.verbosity > 1:
-                # Print traceback
+        with patch_log_level(LOG):
+            if isinstance(reason, SchedulerStop):
+                LOG.info(f'{shutdown_msg} - {reason.args[0]}')
+                # Unset the "paused" status of the workflow if not
+                # auto-restarting
+                if self.auto_restart_mode != AutoRestartMode.RESTART_NORMAL:
+                    self.resume_workflow(quiet=True)
+            elif isinstance(reason, SchedulerError):
+                LOG.error(f"{shutdown_msg} - {reason}")
+            elif isinstance(reason, CylcError) or (
+                isinstance(reason, ParsecError) and reason.schd_expected
+            ):
+                LOG.error(
+                    f"{shutdown_msg} - {type(reason).__name__}: {reason}"
+                )
+                if cylc.flow.flags.verbosity > 1:
+                    # Print traceback
+                    LOG.exception(reason)
+            else:
                 LOG.exception(reason)
-        else:
-            LOG.exception(reason)
-            if str(reason):
-                shutdown_msg += f" - {reason}"
-            LOG.critical(shutdown_msg)
+                if str(reason):
+                    shutdown_msg += f" - {reason}"
+                LOG.critical(shutdown_msg)
 
         if hasattr(self, 'proc_pool'):
             self.proc_pool.close()

--- a/tests/functional/logging/05-validation-detach.t
+++ b/tests/functional/logging/05-validation-detach.t
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----------------------------------------------------------------------------
+# Test that validation errors on play are logged before daemonisation
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW__'
+[scheduler]
+    horse = dorothy
+__FLOW__
+
+run_fail "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+
+TEST_NAME="${TEST_NAME_BASE}-run"
+workflow_run_fail "$TEST_NAME" cylc play "${WORKFLOW_NAME}"
+
+grep_ok "IllegalItemError: [scheduler]horse" "${TEST_NAME}.stderr" -F
+
+purge


### PR DESCRIPTION
Closes #4982, follow-up to #4836

Fix bug where a validation error on workflow startup was not being printed before demonization (aka detach), which made it look like nothing was wrong. Also the return code was zero instead of non-zero as it should be.

This partially reverts some of the logging re-ordering from #4836

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
