### PR TITLE
Remove HOME Env Variable from get_remote_workflow_run_dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Maintenance release.
 
 ### Fixes
 
+[#5115](https://github.com/cylc/cylc-flow/pull/5115) - Updates rsync commands
+to make them compatible with latest rsync releases.
+
 [#5067](https://github.com/cylc/cylc-flow/pull/5067) - Datastore fix for
 taskdefs removed before restart.
 

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -193,6 +193,7 @@ def construct_rsync_over_ssh_cmd(
         ``rsync_cmd[0] == 'rsync'``. Please check that changes to this funtion
         do not break ``rsync_255_fail``.
     """
+    dst_path = dst_path.replace('$HOME/', '')
     dst_host = get_host_from_platform(platform, bad_hosts=bad_hosts)
     ssh_cmd = platform['ssh command']
     command = platform['rsync command']

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -549,7 +549,7 @@ class SubProcPool:
         """Tests context for rsync failing to communicate with a host.
 
         If there has been a failure caused by rsync being unable to connect
-        try a test of ssh connectivity. Necessary becuase loss of connectivity
+        try a test of ssh connectivity. Necessary because loss of connectivity
         may cause different rsync failures depending on version, and some of
         the failures may be caused by other problems.
         """

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -957,7 +957,9 @@ class TaskEventsManager():
         # Remote source
         cmd.append("%s:%s/" % (
             host,
-            get_remote_workflow_run_job_dir(schd.workflow)))
+            get_remote_workflow_run_job_dir(
+                schd.workflow).replace('$HOME/', ''))
+        )
         # Local target
         cmd.append(get_workflow_run_job_dir(schd.workflow) + "/")
         self.proc_pool.put_command(

--- a/tests/functional/events/17-task-event-job-logs-retrieve-command.t
+++ b/tests/functional/events/17-task-event-job-logs-retrieve-command.t
@@ -52,7 +52,7 @@ sed 's/^.* -v //' "${WORKFLOW_LOG_D}/scheduler/my-rsync.log" >'my-rsync.log.edit
 
 OPT_HEAD='--include=/1 --include=/1/t1'
 OPT_TAIL='--exclude=/**'
-ARGS="${CYLC_TEST_HOST}:\$HOME/cylc-run/${WORKFLOW_NAME}/log/job/ ${WORKFLOW_LOG_D}/job/"
+ARGS="${CYLC_TEST_HOST}:cylc-run/${WORKFLOW_NAME}/log/job/ ${WORKFLOW_LOG_D}/job/"
 cmp_ok 'my-rsync.log.edited' <<__LOG__
 ${OPT_HEAD} --include=/1/t1/01 --include=/1/t1/01/** ${OPT_TAIL} ${ARGS}
 ${OPT_HEAD} --include=/1/t1/02 --include=/1/t1/02/** ${OPT_TAIL} ${ARGS}


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5113

 rsync version 3.2.4 version drops (seemingly undocumented) support for use of `$HOME` in the command. This is historically the implementation we have been using for some time, without issue but requires fixing due to this rsync change.

Note $HOME is only removed for rsync (remote file installation and log retrieval), not for other use cases of the remote run directory, e.g. job submission.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests have been adapted.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] Cylc-doc pr not needed (change log should be sufficient for those encountering bug)
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
