### PR TITLE
Fix deprecation warning format.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Maintenance release.
 
 ### Fixes
 
+[#5119](https://github.com/cylc/cylc-flow/pull/5119) - Fix formatting of
+deprecation warnings at validation.
+
 [#5067](https://github.com/cylc/cylc-flow/pull/5067) - Datastore fix for
 taskdefs removed before restart.
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1722,7 +1722,7 @@ def upg(cfg, descr):
     u.obsolete('8.0.0', ['cylc', 'abort if any task fails'])
     u.obsolete('8.0.0', ['cylc', 'disable automatic shutdown'])
     u.obsolete('8.0.0', ['cylc', 'environment'], is_section=True)
-    u.obsolete('8.0.0', ['cylc', 'reference test'])
+    u.obsolete('8.0.0', ['cylc', 'reference test'], is_section=True)
     u.obsolete(
         '8.0.0',
         ['cylc', 'simulation', 'disable suite event handlers'])

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -122,8 +122,14 @@ class upgrader:
         del item[keys[-1]]
 
     @staticmethod
-    def show_keys(keys):
-        return '[' + ']['.join(keys) + ']'
+    def show_keys(keys, is_section):
+        res = ""
+        for key in keys:
+            if key != keys[-1] or is_section:
+                res += f"[{key}]"
+            else:
+                res += key
+        return res
 
     def expand(self, upg):
         """Expands __MANY__ items."""
@@ -158,6 +164,7 @@ class upgrader:
                         'new': None,
                         'cvt': upg['cvt'],
                         'silent': upg['silent'],
+                        'is_section': upg['is_section'],
                     })
                 return exp_upgs
             npre = []
@@ -175,6 +182,7 @@ class upgrader:
                     'new': npre + [m] + npost,
                     'cvt': upg['cvt'],
                     'silent': upg['silent'],
+                    'is_section': upg['is_section'],
                 })
         return exp_upgs
 
@@ -194,9 +202,10 @@ class upgrader:
                         # OK: deprecated item not found
                         pass
                     else:
-                        msg = self.show_keys(upg['old'])
+                        msg = self.show_keys(upg['old'], upg['is_section'])
                         if upg['new']:
-                            msg += ' -> ' + self.show_keys(upg['new'])
+                            msg += ' -> ' + self.show_keys(upg['new'],
+                                                           upg['is_section'])
                         msg += " - " + upg['cvt'].describe()
                         if not upg['silent']:
                             warnings.setdefault(vn, [])

--- a/tests/functional/deprecations/00-pre-cylc8.t
+++ b/tests/functional/deprecations/00-pre-cylc8.t
@@ -29,10 +29,10 @@ TEST_NAME=${TEST_NAME_BASE}-cmp
 cylc validate -v "${WORKFLOW_NAME}" 2>&1 \
     | sed  -n -e 's/^WARNING - \( \* (.*$\)/\1/p' > 'val.out'
 cmp_ok val.out <<__END__
- * (7.8.0) [runtime][foo, cat, dog][suite state polling][template] - DELETED (OBSOLETE)
- * (7.8.1) [cylc][events][reset timer] - DELETED (OBSOLETE)
- * (7.8.1) [cylc][events][reset inactivity timer] - DELETED (OBSOLETE)
- * (7.8.1) [runtime][foo, cat, dog][events][reset timer] - DELETED (OBSOLETE)
+ * (7.8.0) [runtime][foo, cat, dog][suite state polling]template - DELETED (OBSOLETE)
+ * (7.8.1) [cylc][events]reset timer - DELETED (OBSOLETE)
+ * (7.8.1) [cylc][events]reset inactivity timer - DELETED (OBSOLETE)
+ * (7.8.1) [runtime][foo, cat, dog][events]reset timer - DELETED (OBSOLETE)
  * (8.0.0) [runtime][foo, cat, dog][suite state polling] -> [runtime][foo, cat, dog][workflow state polling] - value unchanged
  * (8.0.0) [cylc] -> [scheduler] - value unchanged
 __END__

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -1,51 +1,51 @@
 WARNING - deprecated items were automatically upgraded in "workflow definition"
-WARNING -  * (8.0.0) [cylc][force run mode] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc]force run mode - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][authentication] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][log resolved dependencies] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][required run mode] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail retry delays] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][extra log files] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][shell] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][abort if any task fails] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][disable automatic shutdown] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc]log resolved dependencies - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc]required run mode - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail retry delays - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog]extra log files - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]shell - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc]abort if any task fails - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc]disable automatic shutdown - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][environment] - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][reference test] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][simulation][disable suite event handlers] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][simulation]disable suite event handlers - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc][simulation] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][task event mail interval] -> [cylc][mail][task event batch interval] - value unchanged
+WARNING -  * (8.0.0) [cylc]task event mail interval -> [cylc][mail]task event batch interval - value unchanged
 WARNING -  * (8.0.0) [cylc][parameters] -> [task parameters] - value unchanged
 WARNING -  * (8.0.0) [cylc][parameter templates] -> [task parameters][templates] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][mail to] -> [cylc][mail][to] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][mail from] -> [cylc][mail][from] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][mail footer] -> [cylc][mail][footer] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail to] -> [runtime][foo, cat, dog][mail][to] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail from] -> [runtime][foo, cat, dog][mail][from] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][mail smtp] - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][events][mail smtp] - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
-WARNING -  * (8.0.0) [scheduling][max active cycle points] -> [scheduling][runahead limit] - "n" -> "Pn"
-WARNING -  * (8.0.0) [scheduling][hold after point] -> [scheduling][hold after cycle point] - value unchanged
+WARNING -  * (8.0.0) [cylc][events]mail to -> [cylc][mail]to - value unchanged
+WARNING -  * (8.0.0) [cylc][events]mail from -> [cylc][mail]from - value unchanged
+WARNING -  * (8.0.0) [cylc][events]mail footer -> [cylc][mail]footer - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail to -> [runtime][foo, cat, dog][mail]to - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail from -> [runtime][foo, cat, dog][mail]from - value unchanged
+WARNING -  * (8.0.0) [cylc][events]mail smtp - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail smtp - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
+WARNING -  * (8.0.0) [scheduling]max active cycle points -> [scheduling]runahead limit - "n" -> "Pn"
+WARNING -  * (8.0.0) [scheduling]hold after point -> [scheduling]hold after cycle point - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][suite state polling] -> [runtime][foo, cat, dog][workflow state polling] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution polling intervals] -> [runtime][foo, cat, dog][execution polling intervals] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution retry delays] -> [runtime][foo, cat, dog][execution retry delays] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][execution time limit] -> [runtime][foo, cat, dog][execution time limit] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission polling intervals] -> [runtime][foo, cat, dog][submission polling intervals] - value unchanged
-WARNING -  * (8.0.0) [runtime][foo, cat, dog][job][submission retry delays] -> [runtime][foo, cat, dog][submission retry delays] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][timeout] -> [cylc][events][stall timeout] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][abort on timeout] -> [cylc][events][abort on stall timeout] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][inactivity] -> [cylc][events][inactivity timeout] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][abort on inactivity] -> [cylc][events][abort on inactivity timeout] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][startup handler] -> [cylc][events][startup handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][shutdown handler] -> [cylc][events][shutdown handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][timeout handler] -> [cylc][events][stall timeout handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][stalled handler] -> [cylc][events][stall handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][aborted handler] -> [cylc][events][abort handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][inactivity handler] -> [cylc][events][inactivity timeout handlers] - value unchanged
-WARNING -  * (8.0.0) [cylc][events][abort on stalled] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][events][abort if startup handler fails] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][events][abort if shutdown handler fails] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][events][abort if timeout handler fails] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][events][abort if inactivity handler fails] - DELETED (OBSOLETE)
-WARNING -  * (8.0.0) [cylc][events][abort if stalled handler fails] - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]execution polling intervals -> [runtime][foo, cat, dog]execution polling intervals - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]execution retry delays -> [runtime][foo, cat, dog]execution retry delays - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]execution time limit -> [runtime][foo, cat, dog]execution time limit - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]submission polling intervals -> [runtime][foo, cat, dog]submission polling intervals - value unchanged
+WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]submission retry delays -> [runtime][foo, cat, dog]submission retry delays - value unchanged
+WARNING -  * (8.0.0) [cylc][events]timeout -> [cylc][events]stall timeout - value unchanged
+WARNING -  * (8.0.0) [cylc][events]abort on timeout -> [cylc][events]abort on stall timeout - value unchanged
+WARNING -  * (8.0.0) [cylc][events]inactivity -> [cylc][events]inactivity timeout - value unchanged
+WARNING -  * (8.0.0) [cylc][events]abort on inactivity -> [cylc][events]abort on inactivity timeout - value unchanged
+WARNING -  * (8.0.0) [cylc][events]startup handler -> [cylc][events]startup handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]shutdown handler -> [cylc][events]shutdown handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]timeout handler -> [cylc][events]stall timeout handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]stalled handler -> [cylc][events]stall handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]aborted handler -> [cylc][events]abort handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]inactivity handler -> [cylc][events]inactivity timeout handlers - value unchanged
+WARNING -  * (8.0.0) [cylc][events]abort on stalled - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][events]abort if startup handler fails - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][events]abort if shutdown handler fails - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][events]abort if timeout handler fails - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][events]abort if inactivity handler fails - DELETED (OBSOLETE)
+WARNING -  * (8.0.0) [cylc][events]abort if stalled handler fails - DELETED (OBSOLETE)
 WARNING -  * (8.0.0) [cylc] -> [scheduler] - value unchanged
 WARNING - deprecated graph items were automatically upgraded in "workflow definition":
      * (8.0.0) [scheduling][dependencies][X]graph -> [scheduling][graph]X - for X in:

--- a/tests/unit/parsec/test_upgrade.py
+++ b/tests/unit/parsec/test_upgrade.py
@@ -199,6 +199,7 @@ class TestUpgrade(unittest.TestCase):
             'new': None,
             'cvt': None,
             'silent': True,
+            'is_section': False,
             'old': [
             ]
         }
@@ -209,6 +210,7 @@ class TestUpgrade(unittest.TestCase):
             'new': None,
             'cvt': None,
             'silent': True,
+            'is_section': True,
             'old': [
                 'section', '__MANY__', '__MANY__'
             ]
@@ -225,6 +227,7 @@ class TestUpgrade(unittest.TestCase):
             ],
             'cvt': None,
             'silent': True,
+            'is_section': False,
             'old': [
                 'section', '__MANY__', 'b'
             ]
@@ -245,6 +248,7 @@ class TestUpgrade(unittest.TestCase):
             ],
             'cvt': c,
             'silent': True,
+            'is_section': False,
             'old': [
                 'section', '__MANY__', 'c'
             ]
@@ -259,6 +263,7 @@ class TestUpgrade(unittest.TestCase):
             'new': None,
             'cvt': None,
             'silent': True,
+            'is_section': False,
             'old': [
                 'section', '__MANY__', 'a'
             ]

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -46,8 +46,9 @@ TEST_FILE = """
     abort if any task fails = true
     suite definition directory = '/woo'
     disable automatic shutdown = false
-    reference test = true
     spawn to max active cycle points = false
+    [[reference test]]
+        allow task failures = true
     [[simulation]]
         disable suite event handlers = true
     [[authentication]]


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

Partially address #5116 

Deprecation warnings are being printed with section brackets, even for non-section items: 
`[cat][dog][fish]` instead of `[cat][dog]fish`


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
