### PR TITLE
reinstall changes to `rose-suite.conf`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ Maintenance release.
 
 ### Fixes
 
+[#5125](https://github.com/cylc/cylc-flow/pull/5125) - Allow rose-suite.conf
+changes to be considered by ``cylc reinstall``.
+
 [#5023](https://github.com/cylc/cylc-flow/pull/5023) - tasks force-triggered
 after a shutdown was ordered should submit to run immediately on restart.
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1469,7 +1469,6 @@ def get_rsync_rund_cmd(src, dst, reinstall=False, dry_run=False):
         '.git',
         '.svn',
         '.cylcignore',
-        'rose-suite.conf',
         'opt/rose-suite-cylc-install.conf',
         WorkflowFiles.LOG_DIR,
         WorkflowFiles.WORK_DIR,

--- a/tests/integration/test_reinstall.py
+++ b/tests/integration/test_reinstall.py
@@ -62,7 +62,7 @@ def non_interactive(monkeypatch):
 def one_src(tmp_path):
     src_dir = tmp_path
     (src_dir / 'flow.cylc').touch()
-    # (src_dir / 'rose-suite.conf').touch()
+    (src_dir / 'rose-suite.conf').touch()
     return SimpleNamespace(path=src_dir)
 
 
@@ -242,14 +242,14 @@ def test_rose_warning(one_src, one_run, capsys, interactive, monkeypatch):
     )
     (one_src.path / 'a').touch()  # give it something to install
 
-    # reinstall (no rose-suite.conf file)
-    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
-    assert rose_message not in capsys.readouterr().err
-
     # reinstall (with rose-suite.conf file)
-    (one_src.path / 'rose-suite.conf').touch()
     reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
     assert rose_message in capsys.readouterr().err
+
+    # reinstall (no rose-suite.conf file)
+    (one_src.path / 'rose-suite.conf').unlink()
+    reinstall_cli(opts=ReInstallOptions(), args=one_run.id)
+    assert rose_message not in capsys.readouterr().err
 
 
 def test_keyboard_interrupt(


### PR DESCRIPTION
Fixes two separate, but related bugs (one of which was partially protecting us from the other, except when using rose stem):

## 1. Rsync Output
`cylc reinstall` relied on the rsync stdout being empty to choose not to reinstall. Under some circumstances messages such as `cannot delete dirctory: opt` were causing re-installations unnecessarily.

## 2. `rose-suite.conf` reinstallation
Under many circumstances the first bug was allowing re-installation to be triggered when only the `rose-suite.conf` had changed, despite `rose-suite.conf` being on the list of files excluded from the rsync.

With the first bug fixed users could change the source `rose-suite.conf` and have Cylc tell them that nothing required re-installing.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests will be in a Cylc Rose PR https://github.com/cylc/cylc-rose/pull/178
- [x] `CHANGES.md` entry included if this is a change that can affect users
