### PR TITLE
Rsync Fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@ management and does not bundle Jinja2.
 
 ### Fixes
 
+[#5132](https://github.com/cylc/cylc-flow/pull/5132) - Updates rsync command
+to make it compatible with latest (and patched older) rsync releases.
+
 [#5016](https://github.com/cylc/cylc-flow/pull/5016) - fix bug where
 polling failure on restart would cause Cylc to assume task is running.
 

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -580,9 +580,14 @@ class TaskEventsManager(object):
             includes.add("/%s/%s/%02d/**" % (point, name, submit_num))
         cmd += ["--include=%s" % (include) for include in sorted(includes)]
         cmd.append("--exclude=/**")  # exclude everything else
-        # Remote source
-        cmd.append(ctx.user_at_host + ":" + glbl_cfg().get_derived_host_item(
-            schd_ctx.suite, "suite job log directory", s_host, s_user) + "/")
+        remote_source = (ctx.user_at_host +
+                         ":" +
+                         glbl_cfg().get_derived_host_item(
+                             schd_ctx.suite, "suite job log directory",
+                             s_host, s_user
+                         ) +
+                         "/").replace("$HOME/", "")
+        cmd.append(remote_source)
         # Local target
         cmd.append(glbl_cfg().get_derived_host_item(
             schd_ctx.suite, "suite job log directory") + "/")


### PR DESCRIPTION
Rsync has backported an update which breaks job log retrieval due to $HOME being present in the command.

This is essentially the Cylc 7 fix for: https://github.com/cylc/cylc-flow/pull/5115 


<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request not required.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
