### PR TITLE
remote-install: add "ana/" to the default install list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,9 @@ Maintenance release.
 
 ### Fixes
 
+[#5137](https://github.com/cylc/cylc-flow/pull/5137) -
+Install the `ana/` directory to remote platforms by default.
+
 [#5131](https://github.com/cylc/cylc-flow/pull/5131) - Infer workflow run number
 for `workflow_state` xtrigger.
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -222,10 +222,17 @@ with Conf(
 
                The following directories already get installed by default:
 
-               * ``app/``
-               * ``bin/``
-               * ``etc/``
-               * ``lib/``
+               ``ana/``
+                  Rose ana analysis modules
+               ``app/``
+                  Rose applications
+               ``bin/``
+                  Cylc bin directory (added to PATH)
+               ``etc/``
+                  Miscellaneous resources
+               ``lib/``
+                  Cylc lib directory (lib/python added to PYTHONPATH for
+                  workflow config)
 
                These should be located in the top level of your Cylc workflow,
                i.e. the directory that contains your ``flow.cylc`` file.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -227,12 +227,12 @@ with Conf(
                ``app/``
                   Rose applications
                ``bin/``
-                  Cylc bin directory (added to PATH)
+                  Cylc bin directory (added to ``PATH``)
                ``etc/``
                   Miscellaneous resources
                ``lib/``
-                  Cylc lib directory (lib/python added to PYTHONPATH for
-                  workflow config)
+                  Cylc lib directory (``lib/python`` added to ``PYTHONPATH``
+                  for workflow config)
 
                These should be located in the top level of your Cylc workflow,
                i.e. the directory that contains your ``flow.cylc`` file.

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -172,6 +172,15 @@ DEFAULT_RSYNC_OPTS = [
     '--no-t'
 ]
 
+DEFAULT_INCLUDES = [
+    '/ana/***',  # Rose ana analysis modules
+    '/app/***',  # Rose applications
+    '/bin/***',  # Cylc bin directory (added to PATH)
+    '/etc/***',  # Miscellaneous resources
+    '/lib/***',  # Cylc lib directory (lib/python added to PYTHONPATH for
+                 # workflow config)
+]
+
 
 def construct_rsync_over_ssh_cmd(
     src_path: str, dst_path: str, platform: Dict[str, Any],
@@ -209,12 +218,7 @@ def construct_rsync_over_ssh_cmd(
     rsync_cmd.extend(rsync_options)
     for exclude in ['log', 'share', 'work']:
         rsync_cmd.append(f"--exclude={exclude}")
-    default_includes = [
-        '/app/***',
-        '/bin/***',
-        '/etc/***',
-        '/lib/***']
-    for include in default_includes:
+    for include in DEFAULT_INCLUDES:
         rsync_cmd.append(f"--include={include}")
     for include in get_includes_to_rsync(rsync_includes):
         rsync_cmd.append(f"--include={include}")

--- a/tests/functional/remote/01-file-install.t
+++ b/tests/functional/remote/01-file-install.t
@@ -23,7 +23,7 @@ set_test_number 6
 
 create_files () {
     # dump some files into the run dir
-    for DIR in "bin" "app" "etc" "lib" "dir1" "dir2"
+    for DIR in "bin" "ana" "app" "etc" "lib" "dir1" "dir2"
     do
         mkdir -p "${WORKFLOW_RUN_DIR}/${DIR}"
         touch "${WORKFLOW_RUN_DIR}/${DIR}/moo"
@@ -35,7 +35,7 @@ create_files () {
 }
 
 # Test configured files/directories along with default files/directories
-# (app, bin, etc, lib) are correctly installed on the remote platform.
+# (ana, app, bin, etc, lib) are correctly installed on the remote platform.
 TEST_NAME="${TEST_NAME_BASE}-default-paths"
 init_workflow "${TEST_NAME}" <<__FLOW_CONFIG__
 [scheduling]
@@ -59,8 +59,9 @@ workflow_run_ok "${TEST_NAME}-run1" cylc play "${WORKFLOW_NAME}" \
 # ensure these files get installed on the remote platform
 SSH="$(cylc config -d -i "[platforms][$CYLC_TEST_PLATFORM]ssh command")"
 ${SSH} "${CYLC_TEST_HOST}" \
-    find "${RUN_DIR_REL}/"{app,bin,etc,lib} -type f | sort > 'find.out'
+    find "${RUN_DIR_REL}/"{ana,app,bin,etc,lib} -type f | sort > 'find.out'
 cmp_ok 'find.out'  <<__OUT__
+${RUN_DIR_REL}/ana/moo
 ${RUN_DIR_REL}/app/moo
 ${RUN_DIR_REL}/bin/moo
 ${RUN_DIR_REL}/etc/moo
@@ -93,8 +94,9 @@ workflow_run_ok "${TEST_NAME}-run2" cylc play "${WORKFLOW_NAME}" \
     -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'"
 
 ${SSH} "${CYLC_TEST_HOST}" \
-    find "${RUN_DIR_REL}/"{app,bin,dir1,dir2,file1,file2,etc,lib} -type f | sort > 'find.out'
+    find "${RUN_DIR_REL}/"{ana,app,bin,dir1,dir2,file1,file2,etc,lib} -type f | sort > 'find.out'
 cmp_ok 'find.out'  <<__OUT__
+${RUN_DIR_REL}/ana/moo
 ${RUN_DIR_REL}/app/moo
 ${RUN_DIR_REL}/bin/moo
 ${RUN_DIR_REL}/dir1/moo

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -63,11 +63,26 @@ def test_construct_rsync_over_ssh_cmd():
         }
     )
     assert host == 'miklegard'
-    assert ' '.join(cmd) == (
-        'rsync command --delete --rsh=strange_ssh --include=/.service/ '
-        '--include=/.service/server.key -a --checksum '
-        '--out-format=%o %n%L --no-t --exclude=log --exclude=share '
-        '--exclude=work --include=/app/*** --include=/bin/*** '
-        '--include=/etc/*** --include=/lib/*** --exclude=* '
-        '/foo/ miklegard:/bar/'
-    )
+    assert cmd == [
+        'rsync',
+        'command',
+        '--delete',
+        '--rsh=strange_ssh',
+        '--include=/.service/',
+        '--include=/.service/server.key',
+        '-a',
+        '--checksum',
+        '--out-format=%o %n%L',
+        '--no-t',
+        '--exclude=log',
+        '--exclude=share',
+        '--exclude=work',
+        '--include=/ana/***',
+        '--include=/app/***',
+        '--include=/bin/***',
+        '--include=/etc/***',
+        '--include=/lib/***',
+        '--exclude=*',
+        '/foo/',
+        'miklegard:/bar/',
+    ]


### PR DESCRIPTION
* The `ana/` directory is used by `rose_ana` to load "compotators" (custom comparison thinggies).
* These are typically run where the data is generated which is often remote.
* These directories typically contain a small number of Python files.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/535
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
