### PR TITLE
`log_vc_info`: Redirect diff straight to file to avoid blocking pipe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,10 @@ Maintenance release.
 [#5104](https://github.com/cylc/cylc-flow/pull/5104) - Fix retriggering of
 failed tasks after a reload.
 
+[#5139](https://github.com/cylc/cylc-flow/pull/5139) - Fix bug where
+`cylc install` could hang if there was a large uncommitted diff in the
+source dir (for git/svn repos).
+
 [#5131](https://github.com/cylc/cylc-flow/pull/5131) - Infer workflow run number
 for `workflow_state` xtrigger.
 


### PR DESCRIPTION
Closes #5117. Fixes bug where `cylc install` would hang if the uncommitted diff of the source dir repo was large.

Instead of using `subprocess.PIPE` for the output of git/svn diff commands, use the file object itself. This avoids blocking the pipe if the diff is large, and also has the benefit of not loading large amounts of text into memory.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests updated
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs change needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
