### PR TITLE
Run GH Actions tests on push to `8.*.x` branches

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -14,7 +14,9 @@ on:
       - '**.md'
       - '**/README*/**'
   push:
-    branches: [master]
+    branches:
+      - master
+      - '8.*.x'
     paths-ignore:
       - '.github/workflows/*.ya?ml'
       - '!.github/workflows/bash.yml'

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches:
+      - master
+      - '8.*.x'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -13,7 +13,9 @@ on:
       - '**.md'
       - '**/README*/**'
   push:
-    branches: [master]
+    branches:
+      - master
+      - '8.*.x'
     paths-ignore:
       - '.github/workflows/*.ya?ml'
       - '!.github/workflows/test_functional.yml'

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -2,7 +2,9 @@ name: test-tutorial-workflow
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - '8.*.x'
   pull_request:
     paths-ignore:
       - '.github/workflows/*.ya?ml'


### PR DESCRIPTION
I think without this the Codecov patch coverage figure for PRs on 8.0.x branch were not accurate as it was using the wrong base commit (because it didn't have coverage for any of the merge commits, including squash-merges).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
