### PR TITLE
Assume Jinja2 used in global-tests.cylc.

### DIFF
--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -143,8 +143,9 @@
 #         Expect 1 OK test.
 #     create_test_global_config [PRE [POST]]
 #         Create a new global config file $PWD/etc from global-tests.cylc
-#         with PRE and POST pre- and ap-pended (PRE for e.g. jinja2 shebang).
+#         with PRE and POST pre- and ap-pended.
 #         PRE and POST are strings.
+#         The global config starts with #!Jinja2 in case Jinja2 is used.
 #     localhost_fqdn
 #         Get the FQDN of the current host using the same mechanism Cylc uses.
 #     get_fqdn [TARGET]
@@ -902,8 +903,9 @@ create_test_global_config() {
     # Tidy in case of previous use of this function.
     rm -fr 'etc'
     mkdir 'etc'
-    # Scheduler host self-identification method.
-    echo "$PRE" >'etc/global.cylc'
+    # Start with Jinja2 hashbang. Harmless if not needed.
+    echo "#!Jinja2" >'etc/global.cylc'
+    echo "$PRE" >>'etc/global.cylc'
     # add defaults
     cat >>'etc/global.cylc' <<__HERE__
     # set a default timeout for all flow runs to avoid hanging tests


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->


The test function `create_test_global_config` should create a valid global config file even if `global-tests.cylc` contains Jinja2 code.

This only affects tests, and is a trivial fix, so I don't think it needs a test itself, or a change log entry.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
