### PR TITLE
host select: allow unary operators in ranking expressions

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -16,6 +16,7 @@
 """Exceptions for "expected" errors."""
 
 import errno
+from textwrap import wrap
 from typing import (
     Callable,
     Iterable,
@@ -347,10 +348,57 @@ class HostSelectException(CylcError):
     def __str__(self):
         ret = 'Could not select host from:'
         for host, data in sorted(self.data.items()):
-            ret += f'\n    {host}:'
-            for key, value in data.items():
-                ret += f'\n        {key}: {value}'
+            if host != 'ranking':
+                ret += f'\n    {host}:'
+                for key, value in data.items():
+                    ret += f'\n        {key}: {value}'
+        hint = self.get_hint()
+        if hint:
+            ret += f'\n\n{hint}'
         return ret
+
+    def get_hint(self):
+        """Return a hint to explain this error for certain cases."""
+        if all(
+            # all procs came back with special SSH error code 255
+            datum.get('returncode') == 255
+            for key, datum in self.data.items()
+            if key != 'ranking'
+        ):
+            # likely SSH issues
+            return (
+                'Cylc could not establish SSH connection to the run hosts.'
+                '\nEnsure you can SSH to these hosts without having to'
+                ' answer any prompts.'
+            )
+
+        if (
+            # a ranking expression was used
+            self.data.get('ranking')
+            # and all procs came back with special 'cylc psutil' error code 2
+            # (which is used for errors relating to the extraction of metrics)
+            and all(
+                datum.get('returncode') == 2
+                for key, datum in self.data.items()
+                if key != 'ranking'
+            )
+        ):
+            # likely an issue with the ranking expression
+            ranking = "\n".join(
+                wrap(
+                    self.data.get("ranking"),
+                    initial_indent='    ',
+                    subsequent_indent='    ',
+                )
+            )
+            return (
+                'This is likely an error in the ranking expression:'
+                f'\n{ranking}'
+                '\n\nConfigured by:'
+                '\n    global.cylc[scheduler][run hosts]ranking'
+            )
+
+        return None
 
 
 class NoHostsError(CylcError):

--- a/cylc/flow/scripts/psutil.py
+++ b/cylc/flow/scripts/psutil.py
@@ -48,10 +48,17 @@ def get_option_parser():
 
 def _psutil(metrics_json):
     metrics = parse_dirty_json(metrics_json)
-    methods = [
-        getattr(psutil, key[0])
-        for key in metrics
-    ]
+
+    try:
+        methods = [
+            getattr(psutil, key[0])
+            for key in metrics
+        ]
+    except AttributeError as exc:
+        # error obtaining interfaces from psutil e.g:
+        # * requesting a method which does not exist
+        print(exc, file=sys.stderr)
+        sys.exit(2)
 
     try:
         ret = [
@@ -60,7 +67,6 @@ def _psutil(metrics_json):
         ]
     except Exception as exc:
         # error extracting metrics from psutil e.g:
-        # * requesting a method which does not exist
         # * requesting information on a resource which does not exist
         print(exc, file=sys.stderr)
         sys.exit(2)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -14,9 +14,67 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from cylc.flow.exceptions import CylcError
+from textwrap import dedent
+
+from cylc.flow.exceptions import (
+    CylcError,
+    HostSelectException,
+)
 
 
 def test_cylc_error_str():
     error = CylcError("abcd")
     assert str(error) == "abcd"
+
+
+def test_host_select_exception():
+    """Test exception used for host selection failures.
+
+    * Could not connect to hosts (e.g. SSH failure).
+    * Commands failed (e.g. configuration error).
+    * Could not obtain metrics (e.g. host ranking expression error).
+    * No available hosts (e.g. no hosts met ranking thresholds).
+
+    """
+    # it should format the selection results nicely
+    assert str(HostSelectException({
+        'ranking': 'virtual_memory().available > 1',
+        'host-1': {
+            'returncode': 1
+        },
+        'host-2': {
+            'returncode': 1
+        },
+    })) == dedent('''
+        Could not select host from:
+            host-1:
+                returncode: 1
+            host-2:
+                returncode: 1
+    ''').strip()
+
+    # it should give a useful hint for exit code "2"
+    # (error in the selection ranking expression)
+    assert 'This is likely an error in the ranking expression' in (
+        str(HostSelectException({
+            'ranking': 'virtual_memory().available > 1',
+            'host-1': {
+                'returncode': 2
+            },
+            'host-2': {
+                'returncode': 2
+            },
+        })))
+
+    # it should give a useful hint for the exit code "255"
+    # (ssh error)
+    assert 'Cylc could not establish SSH connection to the run hosts.' in (
+        str(HostSelectException({
+            'ranking': 'virtual_memory().available > 1',
+            'host-1': {
+                'returncode': 255
+            },
+            'host-2': {
+                'returncode': 255
+            },
+        })))

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -16,6 +16,8 @@
 
 from textwrap import dedent
 
+import pytest
+
 from cylc.flow.exceptions import (
     CylcError,
     HostSelectException,
@@ -53,28 +55,26 @@ def test_host_select_exception():
                 returncode: 1
     ''').strip()
 
-    # it should give a useful hint for exit code "2"
-    # (error in the selection ranking expression)
-    assert 'This is likely an error in the ranking expression' in (
-        str(HostSelectException({
-            'ranking': 'virtual_memory().available > 1',
-            'host-1': {
-                'returncode': 2
-            },
-            'host-2': {
-                'returncode': 2
-            },
-        })))
 
-    # it should give a useful hint for the exit code "255"
-    # (ssh error)
-    assert 'Cylc could not establish SSH connection to the run hosts.' in (
+@pytest.mark.parametrize(
+    'ret_code, expect',
+    [
+        # it should give a useful hint for exit code "2"
+        # (error in the selection ranking expression)
+        (2, 'This is likely an error in the ranking expression'),
+        # it should give a useful hint for the exit code "255"
+        # (ssh error)
+        (255, 'Cylc could not establish SSH connection to the run hosts.')
+    ]
+)
+def test_host_select_exception_returncodes(ret_code, expect):
+    assert expect in (
         str(HostSelectException({
             'ranking': 'virtual_memory().available > 1',
             'host-1': {
-                'returncode': 255
+                'returncode': ret_code
             },
             'host-2': {
-                'returncode': 255
+                'returncode': ret_code
             },
         })))

--- a/tests/unit/test_host_select.py
+++ b/tests/unit/test_host_select.py
@@ -128,9 +128,10 @@ def test_metric_command_failure():
                 elephant
             '''
         )
-    assert excinfo.value.data[localhost_fqdn]['get_metrics'] == (
-        'Command failed (exit: 1)'
-    )
+    # we should expect the special (2) returncode
+    # (i.e. the command ran fine but there was something wrong with the
+    # provided expression)
+    assert excinfo.value.data[localhost_fqdn]['returncode'] == 2
 
 
 def test_workflow_host_select(mock_glbl_cfg):

--- a/tests/unit/test_host_select_remote.py
+++ b/tests/unit/test_host_select_remote.py
@@ -177,7 +177,7 @@ def test_remote_workflow_host_rankings(mock_glbl_cfg):
     with pytest.raises(HostSelectException) as excinfo:
         select_workflow_host()
     # ensure that host selection actually evaluated rankings
-    assert set(excinfo.value.data[remote_platform_fqdn]) == {
+    assert set(excinfo.value.data[remote_platform_fqdn]) - {'returncode'} == {
         'virtual_memory().available > 123456789123456789',
         'cpu_count() > 512',
         "disk_usage('/').free > 123456789123456789"


### PR DESCRIPTION
Currently we can configure Cylc to select the host with the LEAST available memory:

```
virtual_memory().available
```

But not the most:

```
-1 * virtual_memory().available
```

Because the required operator is not on the whitelist. This PR adds the required operator to the whitelist allowing us to use it and adds more logging / error output for host selection to make it more transparent when things go wrong.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.