### PR TITLE
Don't log duplicate config sections.

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -127,15 +127,11 @@ def _concatenate(lines):
 
 
 def addsect(cfig, sname, parents):
-    """Add a new section to a nested dict."""
+    """Add a new section to a nested dict, if it doesn't exist."""
     for p in parents:
         # drop down the parent list
         cfig = cfig[p]
-    if sname in cfig:
-        # this doesn't warrant a warning unless contained items are repeated
-        LOG.debug(
-            'Section already encountered: %s', itemstr(parents + [sname]))
-    else:
+    if sname not in cfig:
         cfig[sname] = OrderedDictWithDefaults()
 
 


### PR DESCRIPTION
@oliver-sanders - in response to your question on Element chat.  One review will do.

Stop logging of "Section already encountered" during config parsing.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
