### PR TITLE
Set minimum compatible restart version to 8.1.0.dev

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,6 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
-
 -------------------------------------------------------------------------------
 
 ## __cylc-8.1.0 (<span actions:bind='release-date'>Upcoming</span>)__
@@ -28,15 +27,17 @@ ones in. -->
 [#5081](https://github.com/cylc/cylc-flow/pull/5081) - Reduced amount that
 gets logged at "INFO" level in scheduler logs.
 
+### Fixes
+
+[#5023](https://github.com/cylc/cylc-flow/pull/5023) - tasks force-triggered
+after a shutdown was ordered should submit to run immediately on restart.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.3 (<span actions:bind='release-date'>Upcoming</span>)__
 
 Maintenance release.
 
 ### Fixes
-
-[#5023](https://github.com/cylc/cylc-flow/pull/5023) - tasks force-triggered
-after a shutdown was ordered should submit to run immediately on restart.
 
 [#5137](https://github.com/cylc/cylc-flow/pull/5137) -
 Install the `ana/` directory to remote platforms by default.

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -170,7 +170,7 @@ class CylcWorkflowDAO:
     CONN_TIMEOUT = 0.2
     DB_FILE_BASE_NAME = "db"
     MAX_TRIES = 100
-    RESTART_INCOMPAT_VERSION = "8.0b3"  # Can't restart if <= this version
+    RESTART_MIN_COMPAT_VERSION = "8.1.0.dev"  # Can't restart if < this version
     TABLE_BROADCAST_EVENTS = "broadcast_events"
     TABLE_BROADCAST_STATES = "broadcast_states"
     TABLE_INHERITANCE = "inheritance"

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -715,9 +715,9 @@ class WorkflowDatabaseManager:
             pri_dao.close()
         last_run_ver = parse_version(last_run_ver)
         restart_incompat_ver = parse_version(
-            CylcWorkflowDAO.RESTART_INCOMPAT_VERSION
+            CylcWorkflowDAO.RESTART_MIN_COMPAT_VERSION
         )
-        if last_run_ver <= restart_incompat_ver:
+        if last_run_ver < restart_incompat_ver:
             raise ServiceFileError(
                 f"{incompat_msg} (workflow last run with Cylc {last_run_ver})."
                 f"\n{manual_rm_msg}"

--- a/tests/functional/cylc-clean/05-old-remote-contact.t
+++ b/tests/functional/cylc-clean/05-old-remote-contact.t
@@ -41,7 +41,7 @@ workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "$WORKFLOW_NAME" --no-detach
 # Create a fake old contact file on the remote host
 echo | $SSH_CMD "cat > \$HOME/cylc-run/${WORKFLOW_NAME}/.service/contact" << EOF
 CYLC_API=5
-CYLC_VERSION=8.0.0
+CYLC_VERSION=8.1.0
 CYLC_WORKFLOW_COMMAND=echo Hello John
 CYLC_WORKFLOW_HOST=unreachable.isla_nublar.ingen
 CYLC_WORKFLOW_ID=${WORKFLOW_NAME}

--- a/tests/functional/job-submission/01-job-nn-localhost/db.sqlite3
+++ b/tests/functional/job-submission/01-job-nn-localhost/db.sqlite3
@@ -6,7 +6,7 @@ CREATE TABLE inheritance(namespace TEXT, inheritance TEXT, PRIMARY KEY(namespace
 INSERT INTO inheritance VALUES('root','["root"]');
 INSERT INTO inheritance VALUES('foo','["foo", "root"]');
 CREATE TABLE workflow_params(key TEXT, value TEXT, PRIMARY KEY(key));
-INSERT INTO workflow_params VALUES('cylc_version', '8.0rc1.dev0');
+INSERT INTO workflow_params VALUES('cylc_version', '8.1.0.dev0');
 CREATE TABLE workflow_template_vars(key TEXT, value TEXT, PRIMARY KEY(key));
 CREATE TABLE task_action_timers(cycle TEXT, name TEXT, ctx_key TEXT, ctx TEXT, delays TEXT, num INTEGER, delay TEXT, timeout TEXT, PRIMARY KEY(cycle, name, ctx_key));
 INSERT INTO task_action_timers VALUES('1','foo','"poll_timer"','["tuple", [[99, "running"]]]','[]',0,NULL,NULL);

--- a/tests/functional/restart/57-ghost-job/db.sqlite3
+++ b/tests/functional/restart/57-ghost-job/db.sqlite3
@@ -27,7 +27,7 @@ CREATE TABLE workflow_flows(flow_num INTEGER, start_time TEXT, description TEXT,
 INSERT INTO workflow_flows VALUES(1,'2022-07-25 16:18:23','original flow from 1');
 CREATE TABLE workflow_params(key TEXT, value TEXT, PRIMARY KEY(key));
 INSERT INTO workflow_params VALUES('uuid_str','4972bc10-a016-46b0-b313-b10f3cb63bf5');
-INSERT INTO workflow_params VALUES('cylc_version','8.0rc4.dev');
+INSERT INTO workflow_params VALUES('cylc_version','8.1.0.dev');
 INSERT INTO workflow_params VALUES('UTC_mode','0');
 INSERT INTO workflow_params VALUES('n_restart','0');
 INSERT INTO workflow_params VALUES('cycle_point_tz','Z');


### PR DESCRIPTION
#5023 (merged into master via #5158) means that the new minimum compatible version for restarting a workflow is 8.1.0.dev

**Depends on**

- #5173 on 8.0.x branch

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs
- [x] Master branch only
