### PR TITLE
Don't skip reinstall if Rose CLI opts set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ Maintenance release.
 
 ### Fixes
 
+[#5175](https://github.com/cylc/cylc-flow/pull/5175) - Reinstall now runs if
+no file has changed, but Rose CLI options (`-O, -S, -D`, or
+`--clear-rose-install-options`) set.
+
 [#5023](https://github.com/cylc/cylc-flow/pull/5023) - tasks force-triggered
 after a shutdown was ordered should submit to run immediately on restart.
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -587,9 +587,7 @@ class Options:
 
 def has_rose_cli_opts(opts):
     """Rose options have been set on an options namespace."""
-    if opts.clear_rose_install_opts:
-        return True
-    if any(
+    return any(
         hasattr(opts, rose_opt) and getattr(opts, rose_opt)
         for rose_opt in [
             'opt_conf_keys',
@@ -597,6 +595,4 @@ def has_rose_cli_opts(opts):
             'rose_template_vars',
             'clear_rose_install_opts'
         ]
-    ):
-        return True
-    return False
+    )

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -583,3 +583,11 @@ class Options:
             setattr(opts, key, value)
 
         return opts
+
+
+def has_rose_cli_opts(opts):
+    """Rose options have been set on an options namespace."""
+    for rose_opt in ['opt_conf_keys', 'defines', 'rose_template_vars']:
+        if hasattr(opts, rose_opt) and getattr(opts, rose_opt):
+            return True
+    return False

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -587,7 +587,16 @@ class Options:
 
 def has_rose_cli_opts(opts):
     """Rose options have been set on an options namespace."""
-    for rose_opt in ['opt_conf_keys', 'defines', 'rose_template_vars']:
-        if hasattr(opts, rose_opt) and getattr(opts, rose_opt):
-            return True
+    if opts.clear_rose_install_opts:
+        return True
+    if any(
+        hasattr(opts, rose_opt) and getattr(opts, rose_opt)
+        for rose_opt in [
+            'opt_conf_keys',
+            'defines',
+            'rose_template_vars',
+            'clear_rose_install_opts'
+        ]
+    ):
+        return True
     return False

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -180,7 +180,6 @@ def reinstall_cli(
                     dry_run=True,
                 )
                 and not has_rose_cli_opts(opts)
-                and not opts.clear_rose_install_opts
             ):
                 # no rsync output == no changes => exit
                 print(cparse(

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -85,6 +85,7 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     Options,
     WORKFLOW_ID_ARG_DOC,
+    has_rose_cli_opts
 )
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.workflow_files import (
@@ -170,12 +171,16 @@ def reinstall_cli(
     try:
         if is_terminal():  # interactive mode - perform dry-run and prompt
             # dry-mode reinstall
-            if not reinstall(
-                opts,
-                workflow_id,
-                source,
-                run_dir,
-                dry_run=True,
+            if (
+                not reinstall(
+                    opts,
+                    workflow_id,
+                    source,
+                    run_dir,
+                    dry_run=True,
+                )
+                and not has_rose_cli_opts(opts)
+                and not opts.clear_rose_install_opts
             ):
                 # no rsync output == no changes => exit
                 print(cparse(

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -21,7 +21,12 @@ import sys
 import io
 from contextlib import redirect_stdout
 import cylc.flow.flags
-from cylc.flow.option_parsers import CylcOptionParser as COP, Options
+from cylc.flow.option_parsers import (
+    CylcOptionParser as COP,
+    Options,
+    has_rose_cli_opts
+)
+from types import SimpleNamespace
 
 
 USAGE_WITH_COMMENT = "usage \n # comment"
@@ -93,3 +98,24 @@ def test_Options_std_opts():
     MyOptions = Options(parser)
     MyValues = MyOptions(verbosity=1)
     assert MyValues.verbosity == 1
+
+
+@pytest.mark.parametrize(
+    'opts, expect',
+    [
+        ({'opt_conf_keys': 'A,B,C'}, True),
+        ({'defines': ['[env]BAR="HI"']}, True),
+        ({'rose_template_vars': ['FOO = 43']}, True),
+        (
+            {
+                'opt_conf_keys': 'A,B,C', 'defines': ['[env]BAR="HI"'],
+                'rose_template_vars': ['FOO = 43'], 'hello': 42
+            },
+            True
+        ),
+        ({'hello': 42}, False)
+    ]
+)
+def test_has_rose_cli_opts(opts, expect):
+    opts = SimpleNamespace(**opts)
+    assert has_rose_cli_opts(opts) == expect

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+from pytest import param
 from typing import List
 
 import sys
@@ -103,19 +104,27 @@ def test_Options_std_opts():
 @pytest.mark.parametrize(
     'opts, expect',
     [
-        ({'opt_conf_keys': 'A,B,C'}, True),
-        ({'defines': ['[env]BAR="HI"']}, True),
-        ({'rose_template_vars': ['FOO = 43']}, True),
-        (
+        param({'opt_conf_keys': 'A,B,C'}, True, id='opt_conf_keys'),
+        param({'defines': ['[env]BAR="HI"']}, True, id='defines'),
+        param(
+            {'rose_template_vars': ['FOO = 43']}, True,
+            id='rose_template_vars'
+        ),
+        param(
             {
                 'opt_conf_keys': 'A,B,C', 'defines': ['[env]BAR="HI"'],
                 'rose_template_vars': ['FOO = 43'], 'hello': 42
             },
-            True
+            True,
+            id='all-vars-set'
         ),
-        ({'hello': 42}, False)
+        param({'hello': 42}, False, id='irrelevant-var-set'),
+        param({'clear_rose_install_opts': True}, True, id='clear_opts_set'),
     ]
 )
 def test_has_rose_cli_opts(opts, expect):
+    """It returns true if any rose opts set"""
+    if 'clear_rose_install_opts' not in opts:
+        opts['clear_rose_install_opts'] = False
     opts = SimpleNamespace(**opts)
     assert has_rose_cli_opts(opts) == expect


### PR DESCRIPTION
This bug is not documented elsewhere.

Previous behavior was to ignore these if there is not file change.

However this does not work as expected in the case where a user changes rose command line arguments, or wishes to clear CLI args from a previous install.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests have been updated
- [x] `CHANGES.md` entry included if this is a change that can affect users
