### PR TITLE
Cherry pick #5056

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -254,9 +254,17 @@ class XtriggerConfigError(WorkflowConfigError):
 
 class ClientError(CylcError):
 
-    def __init__(self, message: str, traceback: Optional[str] = None):
+    def __init__(
+        self,
+        message: str,
+        traceback: Optional[str] = None,
+        workflow: Optional[str] = None
+    ):
         self.message = message
         self.traceback = traceback
+        # Workflow not included in string representation but useful bit of
+        # info to attach to the exception object
+        self.workflow = workflow
 
     def __str__(self) -> str:
         ret = self.message
@@ -277,7 +285,13 @@ class WorkflowStopped(ClientError):
 
 
 class ClientTimeout(CylcError):
-    pass
+
+    def __init__(self, message: str, workflow: Optional[str] = None):
+        self.message = message
+        self.workflow = workflow
+
+    def __str__(self) -> str:
+        return self.message
 
 
 class CyclingError(CylcError):

--- a/cylc/flow/network/__init__.py
+++ b/cylc/flow/network/__init__.py
@@ -18,6 +18,7 @@
 import asyncio
 import getpass
 import json
+from typing import Tuple
 
 import zmq
 import zmq.asyncio
@@ -59,17 +60,17 @@ def decode_(message):
     return msg
 
 
-def get_location(workflow: str):
+def get_location(workflow: str) -> Tuple[str, int, int]:
     """Extract host and port from a workflow's contact file.
 
     NB: if it fails to load the workflow contact file, it will exit.
 
     Args:
-        workflow (str): workflow name
+        workflow: workflow name
     Returns:
-        Tuple[str, int, int]: tuple with the host name and port numbers.
+        tuple with the host name and port numbers.
     Raises:
-        ClientError: if the workflow is not running.
+        WorkflowStopped: if the workflow is not running.
         CylcVersionError: if target is a Cylc 7 (or earlier) workflow.
     """
     try:

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -101,7 +101,7 @@ class WorkflowRuntimeClient(ZMQSocketBase):
           "args": {...}}
 
     Raises:
-        ClientError: if the workflow is not running.
+        WorkflowStopped: if the workflow is not running.
 
     Call server "endpoints" using:
         ``__call__``, ``serial_request``


### PR DESCRIPTION
Add workflow field to `ClientError`, `ClientTimeout`

As https://github.com/cylc/cylc-uiserver/pull/379 has changed milestone from cylc-uiserver-1.2.0 to cylc-uiserver-1.1.1, this change needs to be on cylc-flow-8.0.x
