### PR TITLE
GH Actions Codecov upload: try using token arg

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -112,3 +112,4 @@ jobs:
           name: '${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}'
           flags: fast-tests
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -111,6 +111,7 @@ jobs:
           name: '${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}'
           flags: fast-tests
           fail_ci_if_error: true
+          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?
 
       - name: Linkcheck

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -25,8 +25,7 @@ jobs:
           - os: 'macos-latest'
             python-version: '3.7'
     env:
-      PYTEST_ADDOPTS: --cov --cov-append -n 5 --color=yes -m "linktest or not linktest"
-
+      PYTEST_ADDOPTS: --cov --cov-append -n 5 --color=yes
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -113,3 +112,7 @@ jobs:
           flags: fast-tests
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?
+
+      - name: Linkcheck
+        if: startsWith(matrix.os, 'ubuntu')
+        run: pytest -m linkcheck tests/unit

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -293,4 +293,5 @@ jobs:
           name: '${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}'
           flags: functional-tests
           fail_ci_if_error: true
+          verbose: true
           token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -292,4 +292,5 @@ jobs:
         with:
           name: '${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}'
           flags: functional-tests
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?


### PR DESCRIPTION
The Codecov upload action is failing very flakily with 404 errors (https://github.com/codecov/codecov-action/issues/598). I have seen commits on other repos referencing that issue where they explicitly pass the Codecov token as an arg to the action, worth a shot. Apparently the 404 errors may be due to rate-limiting, so hopefully using the token will use an independent limit.

I've also skipped linkcheck on MacOS to help speed it up a bit.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests needed
- [x] No `CHANGES.md` entry 
- [x] No docs
- [x] 8.0.x will get merged to master soon
