### PR TITLE
fix docstring with literal unquoted

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -426,7 +426,7 @@ def parse_checks(check_args, ignores=None, max_line_len=None, reference=False):
                 regex = r"^.{" + str(max_line_len) + r"}"
                 if reference:
                     msg = (
-                        'line > ``{max_line_len}`` characters. Max line '
+                        'line > ``<max_line_len>`` characters. Max line '
                         ' length set in pyproject.toml (default 130)'
                     )
                 else:

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -426,8 +426,8 @@ def parse_checks(check_args, ignores=None, max_line_len=None, reference=False):
                 regex = r"^.{" + str(max_line_len) + r"}"
                 if reference:
                     msg = (
-                        'line > {max_line_len} characters. Max line length '
-                        'set in pyproject.toml (default 130)'
+                        'line > ``{max_line_len}`` characters. Max line '
+                        ' length set in pyproject.toml (default 130)'
                     )
                 else:
                     msg = f'line > {max_line_len} characters.'

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -487,7 +487,7 @@ def test_invalid_tomlfile(tmp_path):
 @pytest.mark.parametrize(
     'ref, expect',
     [
-        [True, 'line > {max_line_len} characters'],
+        [True, 'line > ``{max_line_len}`` characters'],
         [False, 'line > 130 characters']
     ]
 )

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -487,7 +487,7 @@ def test_invalid_tomlfile(tmp_path):
 @pytest.mark.parametrize(
     'ref, expect',
     [
-        [True, 'line > ``{max_line_len}`` characters'],
+        [True, 'line > ``<max_line_len>`` characters'],
         [False, 'line > 130 characters']
     ]
 )


### PR DESCRIPTION
Unbackticked code in docstring causing spellcheck failure

Seealso https://github.com/cylc/cylc-doc/pull/550

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Fix for tests failing in cylc-doc
