### PR TITLE
cache get_platform

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -166,7 +166,6 @@ def get_platform(
 @lru_cache(100)
 def platform_from_name(
     platform_name: Optional[str] = None,
-    platforms: Optional[Dict[str, Dict[str, Any]]] = None,
     bad_hosts: Optional[Set[str]] = None
 ) -> Dict[str, Any]:
     """
@@ -179,14 +178,12 @@ def platform_from_name(
 
     Args:
         platform_name: name of platform to be retrieved.
-        platforms: global.cylc platforms given as a dict.
 
     Returns:
         platform: object containing settings for a platform, loaded from
             Global Config.
     """
-    if platforms is None:
-        platforms = glbl_cfg().get(['platforms'])
+    platforms = glbl_cfg().get(['platforms'])
     platform_groups = glbl_cfg().get(['platform groups'])
 
     if platform_name is None:

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -16,6 +16,7 @@
 #
 """Functions relating to (job) platforms."""
 
+from functools import lru_cache
 import random
 import re
 from copy import deepcopy
@@ -162,6 +163,7 @@ def get_platform(
             )
 
 
+@lru_cache(100)
 def platform_from_name(
     platform_name: Optional[str] = None,
     platforms: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1080,6 +1080,7 @@ class Scheduler:
         fields = workflow_files.ContactFileFields
         proc = psutil.Process()
         # fmt: off
+        localhost = get_platform()
         return {
             fields.API:
                 str(API),
@@ -1104,11 +1105,11 @@ class Scheduler:
             fields.VERSION:
                 CYLC_VERSION,
             fields.SCHEDULER_SSH_COMMAND:
-                str(get_platform()['ssh command']),
+                str(localhost['ssh command']),
             fields.SCHEDULER_CYLC_PATH:
-                str(get_platform()['cylc path']),
+                str(localhost['cylc path']),
             fields.SCHEDULER_USE_LOGIN_SHELL:
-                str(get_platform()['use login shell'])
+                str(localhost['use login shell'])
         }
         # fmt: on
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,12 @@ def capcall(monkeypatch):
         return calls
 
     return _capcall
+
+
+@pytest.fixture
+def clean_platform_cache():
+    """Clears cached platforms responses between tests."""
+    from cylc.flow.platforms import platform_from_name
+    platform_from_name.cache_clear()
+    yield
+    platform_from_name.cache_clear()

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -53,7 +53,7 @@ def test_get_variable_value_definition(in_value, out_value):
 
 
 @pytest.fixture
-def fixture_get_platform():
+def fixture_get_platform(clean_platform_cache):
     """ Allows pytest to cache default platform dictionary.
 
     Args:

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -40,7 +40,7 @@ def test_get_platform_no_args():
         'localhost, xylophone\\d{1,5}'
     ]
 )
-def test_get_localhost_platform(mock_glbl_cfg, platform_re):
+def test_get_localhost_platform(mock_glbl_cfg, clean_platform_cache, platform_re):
     # Check that an arbitrary string name returns a sensible platform
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
@@ -70,7 +70,11 @@ def test_get_localhost_platform(mock_glbl_cfg, platform_re):
         'sumac|asafoetida, saffron',
     ]
 )
-def test_get_platform_from_platform_name_str(mock_glbl_cfg, platform_re):
+def test_get_platform_from_platform_name_str(
+    mock_glbl_cfg,
+    clean_platform_cache,
+    platform_re,
+):
     # Check that an arbitrary string name returns a sensible platform
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
@@ -119,7 +123,10 @@ def test_get_platform_from_platform_name_str(mock_glbl_cfg, platform_re):
     ]
 )
 def test_get_platform_cylc7_8_syntax_mix_fails(
-    task_conf: dict, err_expected: bool, mock_glbl_cfg: Callable
+    task_conf: dict,
+    err_expected: bool,
+    mock_glbl_cfg: Callable,
+    clean_platform_cache,
 ):
     """If a task with a mix of Cylc7 and 8 syntax is passed to get_platform
     this should return an error.
@@ -145,7 +152,10 @@ def test_get_platform_cylc7_8_syntax_mix_fails(
         get_platform(task_conf)
 
 
-def test_get_platform_from_config_with_platform_name(mock_glbl_cfg):
+def test_get_platform_from_config_with_platform_name(
+    mock_glbl_cfg,
+    clean_platform_cache,
+):
     # A platform name is present, and no clashing cylc7 configs are:
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
@@ -209,7 +219,10 @@ def test_get_platform_from_config_with_platform_name(mock_glbl_cfg):
     ]
 )
 def test_get_platform_using_platform_name_from_job_info(
-    mock_glbl_cfg, task_conf, expected_platform_name
+    mock_glbl_cfg,
+    clean_platform_cache,
+    task_conf,
+    expected_platform_name,
 ):
     """Calculate platform from Cylc 7 config: n.b. If this fails we don't
     warn because this might lead to many thousands of warnings
@@ -236,7 +249,7 @@ def test_get_platform_using_platform_name_from_job_info(
     assert get_platform(task_conf)['name'] == expected_platform_name
 
 
-def test_get_platform_groups_basic(mock_glbl_cfg):
+def test_get_platform_groups_basic(mock_glbl_cfg, clean_platform_cache):
     # get platform from group works.
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
@@ -280,7 +293,7 @@ def test_get_localhost_install_target():
     assert get_localhost_install_target() == 'localhost'
 
 
-def test_localhost_different_install_target(mock_glbl_cfg):
+def test_localhost_different_install_target(mock_glbl_cfg, clean_platform_cache):
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
         '''

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -1314,7 +1314,8 @@ def test_remote_clean(
     exc_expected: bool,
     expected_err_msgs: List[str],
     monkeymock: MonkeyMock, monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture, log_filter: Callable
+    caplog: pytest.LogCaptureFixture, log_filter: Callable,
+    clean_platform_cache,
 ) -> None:
     """Test remote_clean() logic.
 


### PR DESCRIPTION
Spotted that the `get_platform_from_name` function was using a lot of CPU.

<details>
<summary>Turns out that it was called 7662 times for this sample workflow:</summary>

```ini
[task parameters]
    a = 1..5
    b = 1..5
    c = 1..5

[scheduling]
    initial cycle point = 2000
    final cycle point = 20000110T00Z
    runahead limit = P5
    [[queues]]
        [[[default]]]
            limit = 25
    [[graph]]
        P1D = """
            <a> => <b> => <c>
            <b>[-P1D] => <b>
        """

[runtime]
    [[<a>, <b>, <c>]]
        script = true
```
</details>

Embarrassingly this workflow only uses the localhost platform.

Added `lru_cache` to the function to reduce the impact:

Before:
![Screenshot from 2022-10-07 15-19-27](https://user-images.githubusercontent.com/16705946/194575963-da5c2c40-9386-48e2-8896-1f124970a09a.png)

After:
![Screenshot from 2022-10-07 15-19-38](https://user-images.githubusercontent.com/16705946/194575965-22d098f1-605f-41ba-897c-4a5f9424312c.png)

Caching does have an overhead, but inspecting the call tree it would appear this saved ~3 seconds of a ~35s run, which is ~10% of CPU!

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.