### PR TITLE
Scan workflow name during install.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ ones in. -->
 
 ### Enhancements
 
+[#5284](https://github.com/cylc/cylc-flow/pull/5184) - scan for active
+workflows at install time.
+
 [#5032](https://github.com/cylc/cylc-flow/pull/5032) - set a default limit of
 100 for the "default" queue.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,8 @@ ones in. -->
 
 ### Enhancements
 
-[#5284](https://github.com/cylc/cylc-flow/pull/5184) - scan for active
-workflows at install time.
+[#5184](https://github.com/cylc/cylc-flow/pull/5184) - scan for active
+runs of the same workflow at install time.
 
 [#5032](https://github.com/cylc/cylc-flow/pull/5032) - set a default limit of
 100 for the "default" queue.

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -211,7 +211,7 @@ async def scan(wf_name: str, ping: bool = True) -> None:
         )
         print(
             CylcLogFormatter.COLORS['WARNING'].format(
-                f'WARNING: {n} run%s of "{wf_name}"'
+                f'NOTE: {n} run%s of "{wf_name}"'
                 ' %s already active:' % tuple(grammar[:2])
             )
         )

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -99,9 +99,15 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     Options
 )
-from cylc.flow.pathutil import EXPLICIT_RELATIVE_PATH_REGEX, expand_path
+from cylc.flow.pathutil import (
+    EXPLICIT_RELATIVE_PATH_REGEX,
+    expand_path,
+    get_workflow_run_dir
+)
 from cylc.flow.workflow_files import (
-    install_workflow, search_install_source_dirs, parse_cli_sym_dirs
+    install_workflow,
+    parse_cli_sym_dirs,
+    search_install_source_dirs
 )
 from cylc.flow.terminal import cli_function
 
@@ -200,12 +206,15 @@ async def scan(wf_name: str, ping: bool = True) -> None:
         'ping': ping,  # get status of scanned workflows
     })
     active = [
-        item async for item in get_pipe(opts, None, scan_dir=None)
+        item async for item in get_pipe(
+            opts, None,
+            scan_dir=get_workflow_run_dir(wf_name)  # restricted scan
+        )
     ]
     if active:
         n = len(active)
         grammar = (
-            ["s", "are", "them"]
+            ["s", "are", "them all"]
             if n > 1 else
             ["", "is", "it"]
         )
@@ -229,8 +238,8 @@ async def scan(wf_name: str, ping: bool = True) -> None:
             f"{item['name']}"
         )
         print(
-            f'You can stop %s with "cylc stop [options] {pattern}".\n'
-            'See "cylc stop --help" for options.' % grammar[-1]
+            f'You can stop %s with:\n  cylc stop {pattern}'
+            '\nSee "cylc stop --help" for options.' % grammar[-1]
         )
 
 

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -1,0 +1,88 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test cylc install."""
+
+from pathlib import Path
+from shutil import rmtree
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from .test_scan import init_flows
+
+from cylc.flow.workflow_files import WorkflowFiles
+from cylc.flow.scripts.install import (
+    InstallOptions,
+    install_cli
+)
+
+
+SRV_DIR = Path(WorkflowFiles.Service.DIRNAME)
+CONTACT = Path(WorkflowFiles.Service.CONTACT)
+RUN_N = Path(WorkflowFiles.RUN_N)
+INSTALL = Path(WorkflowFiles.Install.DIRNAME)
+
+
+@pytest.fixture()
+def src_run_dirs(mock_glbl_cfg, monkeypatch):
+    """Create some workflow source and run dirs for testing.
+
+    Source dirs:
+      <tmp-src>/w1
+      <tmp-src>/w2
+
+    Run dir:
+      <tmp-run>/w1/run1
+
+    """
+    tmp_src_path = Path(TemporaryDirectory().name)
+    tmp_run_path = Path(TemporaryDirectory().name)
+    tmp_src_path.mkdir()
+    tmp_run_path.mkdir()
+
+    init_flows(
+        tmp_run_path=tmp_run_path,
+        running=('w1/run1',),
+        tmp_src_path=tmp_src_path,
+        src=('w1', 'w2')
+    )
+    mock_glbl_cfg(
+        'cylc.flow.workflow_files.glbl_cfg',
+        f'''
+            [install]
+                source dirs = {tmp_src_path}
+        '''
+    )
+    monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', tmp_run_path)
+
+    yield tmp_src_path, tmp_run_path
+    rmtree(tmp_src_path)
+    rmtree(tmp_run_path)
+
+
+def test_install_scan(src_run_dirs, capsys):
+    """At install, any running intances should be reported."""
+
+    opts = InstallOptions()
+    # Don't ping the scheduler: it's not really running here.
+    opts.no_ping = True
+
+    install_cli(opts, reg='w1')
+    assert '1 run of "w1" is already active:' in capsys.readouterr().out
+
+    install_cli(opts, reg='w2')
+    assert '1 run of "w2" is already active:' not in capsys.readouterr().out

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -17,8 +17,6 @@
 """Test cylc install."""
 
 from pathlib import Path
-from shutil import rmtree
-from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -38,7 +36,7 @@ INSTALL = Path(WorkflowFiles.Install.DIRNAME)
 
 
 @pytest.fixture()
-def src_run_dirs(mock_glbl_cfg, monkeypatch):
+def src_run_dirs(mock_glbl_cfg, monkeypatch, tmp_path: Path):
     """Create some workflow source and run dirs for testing.
 
     Source dirs:
@@ -49,8 +47,8 @@ def src_run_dirs(mock_glbl_cfg, monkeypatch):
       <tmp-run>/w1/run1
 
     """
-    tmp_src_path = Path(TemporaryDirectory().name)
-    tmp_run_path = Path(TemporaryDirectory().name)
+    tmp_src_path = tmp_path / 'cylc-src'
+    tmp_run_path = tmp_path / 'cylc-run'
     tmp_src_path.mkdir()
     tmp_run_path.mkdir()
 
@@ -69,9 +67,7 @@ def src_run_dirs(mock_glbl_cfg, monkeypatch):
     )
     monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', tmp_run_path)
 
-    yield tmp_src_path, tmp_run_path
-    rmtree(tmp_src_path)
-    rmtree(tmp_run_path)
+    return tmp_src_path, tmp_run_path
 
 
 def test_install_scan(src_run_dirs, capsys):

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -29,6 +29,7 @@ from cylc.flow.scripts.install import (
     install_cli
 )
 
+from typing import Callable, Tuple
 
 SRV_DIR = Path(WorkflowFiles.Service.DIRNAME)
 CONTACT = Path(WorkflowFiles.Service.CONTACT)
@@ -42,7 +43,7 @@ BAD_CONTACT_MSG = "Bad contact file:"
 
 @pytest.fixture()
 def patch_graphql_query(
-    monkeypatch
+    monkeypatch: pytest.MonkeyPatch
 ):
     # Define a mocked graphql_query pipe function.
     @pipe
@@ -59,10 +60,10 @@ def patch_graphql_query(
 
 @pytest.fixture()
 def src_run_dirs(
-    mock_glbl_cfg,
-    monkeypatch,
+    mock_glbl_cfg: Callable,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path
-):
+) -> Tuple[Path, Path]:
     """Create some workflow source and run dirs for testing.
 
     Source dirs:
@@ -97,10 +98,10 @@ def src_run_dirs(
 
 
 def test_install_scan_no_ping(
-    src_run_dirs,
-    capsys,
-    caplog
-):
+    src_run_dirs: Callable,
+    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture
+) -> None:
     """At install, running intances should be reported.
 
     Ping = False case: don't query schedulers.
@@ -123,11 +124,11 @@ def test_install_scan_no_ping(
 
 
 def test_install_scan_ping(
-    src_run_dirs,
-    capsys,
-    caplog,
-    patch_graphql_query
-):
+    src_run_dirs: Callable,
+    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
+    patch_graphql_query: Callable
+) -> None:
     """At install, running intances should be reported.
 
     Ping = True case: but mock scan's scheduler query method.

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -35,6 +35,31 @@ CONTACT = Path(WorkflowFiles.Service.CONTACT)
 RUN_N = Path(WorkflowFiles.RUN_N)
 INSTALL = Path(WorkflowFiles.Install.DIRNAME)
 
+INSTALLED_MSG = "INSTALLED {wfrun} from"
+WF_ACTIVE_MSG = '1 run of "{wf}" is already active:'
+BAD_CONTACT_MSG = "Bad contact file:"
+
+
+class graphql_query_mock:
+    """Context manager to mock network.scan.graphql_query().
+
+    (In the scripts.scan namepace, where it is used below).
+
+    """
+    def __enter__(self):
+        """Replace the original function."""
+        @pipe
+        async def mock_graphql_query(flow, fields, filters=None):
+            """The fake function."""
+            flow.update({"status": "running"})
+            return flow
+        self.orig_func = scan.graphql_query
+        scan.graphql_query = mock_graphql_query
+
+    def __exit__(self, *args, **kwargs):
+        """Restore the original function."""
+        scan.graphql_query = self.orig_func
+
 
 @pytest.fixture()
 def src_run_dirs(mock_glbl_cfg, monkeypatch, tmp_path: Path):
@@ -71,11 +96,6 @@ def src_run_dirs(mock_glbl_cfg, monkeypatch, tmp_path: Path):
     return tmp_src_path, tmp_run_path
 
 
-INSTALLED_MSG = "INSTALLED {wfrun} from"
-WF_ACTIVE_MSG = '1 run of "{wf}" is already active:'
-BAD_CONTACT_MSG = "Bad contact file:"
-
-
 def test_install_scan_no_ping(src_run_dirs, capsys, caplog):
     """At install, running intances should be reported.
 
@@ -103,25 +123,18 @@ def test_install_scan_ping(src_run_dirs, capsys, caplog):
     Ping = True case: but mock scan's scheduler query method.
     """
 
-    @pipe
-    async def mock_graphql_query(flow, fields, filters=None):
-        """Mock cylc.flow.network.scan.graphql_query."""
-        flow.update({"status": "running"})
-        return flow
+    with graphql_query_mock():
+        opts = InstallOptions()
+        opts.no_ping = False
 
-    scan.graphql_query = mock_graphql_query
+        install_cli(opts, reg='w1')
+        out = capsys.readouterr().out
+        assert INSTALLED_MSG.format(wfrun='w1/run2') in out
+        assert WF_ACTIVE_MSG.format(wf='w1') in out
+        assert scan.FLOW_STATE_SYMBOLS["running"] in out
+        assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
 
-    opts = InstallOptions()
-    opts.no_ping = False
-
-    install_cli(opts, reg='w1')
-    out = capsys.readouterr().out
-    assert INSTALLED_MSG.format(wfrun='w1/run2') in out
-    assert WF_ACTIVE_MSG.format(wf='w1') in out
-    assert scan.FLOW_STATE_SYMBOLS["running"] in out
-    assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
-
-    install_cli(opts, reg='w2')
-    out = capsys.readouterr().out
-    assert INSTALLED_MSG.format(wfrun='w2/run1') in out
-    assert WF_ACTIVE_MSG.format(wf='w2') not in out
+        install_cli(opts, reg='w2')
+        out = capsys.readouterr().out
+        assert INSTALLED_MSG.format(wfrun='w2/run1') in out
+        assert WF_ACTIVE_MSG.format(wf='w2') not in out

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -109,6 +109,7 @@ def test_install_scan_no_ping(src_run_dirs, capsys, caplog):
     out = capsys.readouterr().out
     assert INSTALLED_MSG.format(wfrun='w1/run2') in out
     assert WF_ACTIVE_MSG.format(wf='w1') in out
+    # Empty contact file faked with "touch":
     assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
 
     install_cli(opts, reg='w2')
@@ -132,6 +133,7 @@ def test_install_scan_ping(src_run_dirs, capsys, caplog):
         assert INSTALLED_MSG.format(wfrun='w1/run2') in out
         assert WF_ACTIVE_MSG.format(wf='w1') in out
         assert scan.FLOW_STATE_SYMBOLS["running"] in out
+        # Empty contact file faked with "touch":
         assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
 
         install_cli(opts, reg='w2')


### PR DESCRIPTION
<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

Close #5127

Scan and report any running instances of a workflow at install time.

![Screenshot from 2022-10-10 15-26-43](https://user-images.githubusercontent.com/2362137/194792659-860b2dc9-26a1-4d4b-be88-0ec1e5c32c47.png)


(Note I've used the WARNING color, but without saying "WARNING:" on grounds that already-running instances of an installed  workflow might possibly indicate user error, but probably do not ... but I'm not particularly invested in this coloring!).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
