### PR TITLE
id: preserve selectors for "task" and "workflow" properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ Maintenance release.
 after use of `cylc remove`.
 
 [#5188](https://github.com/cylc/cylc-flow/pull/5188) -
-Fix task state selectors in the `cylc trigger` command.
+Fix task state selectors in `cylc trigger` and other commands.
 
 [#5125](https://github.com/cylc/cylc-flow/pull/5125) - Allow rose-suite.conf
 changes to be considered by ``cylc reinstall``.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@ Maintenance release.
 [#5192](https://github.com/cylc/cylc-flow/pull/5192) - Recompute runahead limit
 after use of `cylc remove`.
 
+[#5188](https://github.com/cylc/cylc-flow/pull/5188) -
+Fix task state selectors in the `cylc trigger` command.
+
 [#5125](https://github.com/cylc/cylc-flow/pull/5125) - Allow rose-suite.conf
 changes to be considered by ``cylc reinstall``.
 

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -183,6 +183,19 @@ class Tokens(dict):
         return detokenise(self.task, relative=True)
 
     @property
+    def relative_id_with_selectors(self) -> str:
+        """The relative ID (without the workflow part), with selectors.
+
+        Examples:
+            >>> Tokens('~u/w//c/t:failed/01').relative_id
+            'c/t/01'
+            >>> Tokens('~u/w//c/t:failed/01').relative_id_with_selectors
+            'c/t:failed/01'
+
+        """
+        return detokenise(self.task, relative=True, selectors=True)
+
+    @property
     def workflow_id(self) -> str:
         """The workflow id (without the relative part).
 
@@ -192,7 +205,6 @@ class Tokens(dict):
             >>> Tokens('c/t/01', relative=True).workflow_id
             Traceback (most recent call last):
             ValueError: No tokens provided
-
 
         """
         return detokenise(self.workflow)

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -284,12 +284,12 @@ class Tokens(dict):
             **{
                 key: value
                 for key, value in self.items()
-                if key in (
-                    enum.value
-                    for enum in (
-                        {*IDTokens} - {IDTokens.User, IDTokens.Workflow}
-                    )
-                )
+                if key in {
+                    key
+                    for key in self._KEYS
+                    if not key.startswith(IDTokens.User.value)
+                    and not key.startswith(IDTokens.Workflow.value)
+                }
             }
         )
 
@@ -306,12 +306,12 @@ class Tokens(dict):
             **{
                 key: value
                 for key, value in self.items()
-                if key not in (
-                    enum.value
-                    for enum in (
-                        {*IDTokens} - {IDTokens.User, IDTokens.Workflow}
-                    )
-                )
+                if key in {
+                    key
+                    for key in self._KEYS
+                    if key.startswith(IDTokens.User.value)
+                    or key.startswith(IDTokens.Workflow.value)
+                }
             }
         )
 

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -142,7 +142,7 @@ async def run(options, workflow_id, *tokens_list):
         mutation = HOLD_MUTATION
         args = {
             'tasks': [
-                id_.relative_id
+                id_.relative_id_with_selectors
                 for id_ in tokens_list
             ]
         }

--- a/cylc/flow/scripts/kill.py
+++ b/cylc/flow/scripts/kill.py
@@ -81,7 +81,10 @@ async def run(options: 'Values', workflow_id: str, *tokens_list: Tokens):
         'request_string': MUTATION,
         'variables': {
             'wFlows': [workflow_id],
-            'tasks': [tokens.relative_id for tokens in tokens_list],
+            'tasks': [
+                tokens.relative_id_with_selectors
+                for tokens in tokens_list
+            ]
         }
     }
 

--- a/cylc/flow/scripts/poll.py
+++ b/cylc/flow/scripts/poll.py
@@ -82,7 +82,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
         'variables': {
             'wFlows': [workflow_id],
             'tasks': [
-                tokens.relative_id
+                tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ],
         }

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -124,7 +124,7 @@ async def run(options: 'Values', workflow_id, *tokens_list):
         mutation = RELEASE_MUTATION
         args = {
             'tasks': [
-                tokens.relative_id
+                tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ]
         }

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -71,7 +71,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
         'variables': {
             'wFlows': [workflow_id],
             'tasks': [
-                tokens.relative_id
+                tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ],
         }

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -107,7 +107,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list) -> None:
         'variables': {
             'wFlows': [workflow_id],
             'tasks': [
-                tokens.relative_id
+                tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ],
             'outputs': options.outputs,

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -220,7 +220,7 @@ def prereqs_and_outputs_query(
 ):
     ids_list = [
         # convert the tokens into standardised IDs
-        tokens.relative_id
+        tokens.relative_id_with_selectors
         for tokens in tokens_list
     ]
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -146,7 +146,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
         'variables': {
             'wFlows': [workflow_id],
             'tasks': [
-                tokens.relative_id
+                tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ],
             'flow': options.flow,

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -347,3 +347,27 @@ def test_no_look_behind():
     """
     assert '?<=' not in UNIVERSAL_ID.pattern
     assert '?<!' not in UNIVERSAL_ID.pattern
+
+
+def test_workflow_property():
+    """The workflow property should provide the workflow part of the ID.
+
+    The relevant selectors should be preserved
+    """
+    assert (
+        Tokens('~u/w:ws//c:cs/t:ts/j:js').workflow
+    ) == (
+        Tokens('~u/w:ws')
+    )
+
+
+def test_task_property():
+    """The task property should provide the task part of the ID.
+
+    The relevant selectors should be preserved
+    """
+    assert (
+        Tokens('~u/w:ws//c:cs/t:ts/j:js').task
+    ) == (
+        Tokens('//c:cs/t:ts/j:js', relative=True)
+    )


### PR DESCRIPTION
* Selectors were not correctly preserved for the `task` and `workflow` properties of `Tokens` objects.
* This effectively stripped cycle/task selectors from IDs passed to `cylc trigger`.
* Closes https://github.com/cylc/cylc-flow/issues/5186

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.