### PR TITLE
fix an error handling bug in Cylc Scan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,15 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-8.0.4 (<span actions:bind='release-date'>Pending YYYY-MM-DD</span>)__
+
+Maintenance release.
+
+### Fixes
+
+[#5196](https://github.com/cylc/cylc-flow/pull/5196) - Replace traceback
+with warning for scan error messages where Workflow is stopped.
+
 ## __cylc-8.0.3 (<span actions:bind='release-date'>Released 2022-10-17</span>)__
 
 Maintenance release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@ Maintenance release.
 ### Fixes
 
 [#5196](https://github.com/cylc/cylc-flow/pull/5196) - Replace traceback
-with warning for scan error messages where Workflow is stopped.
+with warning, for scan errors where workflow is stopped.
 
 ## __cylc-8.0.3 (<span actions:bind='release-date'>Released 2022-10-17</span>)__
 

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -297,7 +297,7 @@ class WorkflowRuntimeClient(ZMQSocketBase):
             host (str): host name
             port (Union[int, str]): port number
         Raises:
-            ClientError: if the workflow has already stopped.
+            WorkflowStopped: if the workflow has already stopped.
         """
         if workflow is None:
             return

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -451,6 +451,7 @@ async def graphql_query(flow, fields, filters=None):
     """
     query = f'query {{ workflows(ids: ["{flow["name"]}"]) {{ {fields} }} }}'
     try:
+
         client = WorkflowRuntimeClient(
             flow['name'],
             # use contact_info data if present for efficiency
@@ -468,6 +469,9 @@ async def graphql_query(flow, fields, filters=None):
                 'variables': {}
             }
         )
+    except WorkflowStopped:
+        LOG.warning(f'Workflow not running: {flow["name"]}')
+        return False
     except ClientTimeout:
         LOG.exception(
             f'Timeout: name: {flow["name"]}, '

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -183,7 +183,6 @@ class Scheduler:
     is_restart: bool
 
     # directories
-    workflow_dir: str
     workflow_log_dir: str
     workflow_run_dir: str
     workflow_share_dir: str


### PR DESCRIPTION
This fixes a bug found by @dpmatthews and not recorded elsewhere.

## How to reproduce
- Create a simple workflow with a long running task on a remote host.
- Start workflow, noting the PID.
- Copy the workflow contact file
- Kill the workflow using the PID
- Restore the workflow contact file
- Run Cylc Scan

## What you see

Traceback from an uncaught Exception.

```
    Traceback (most recent call last):
      File "/home/h03/fcm/cylc-8.0.2-1/lib/python3.9/site-
    packages/cylc/flow/network/scan.py", line 464, in graphql_query
        ret = await client.async_request(
      File "/home/h03/fcm/cylc-8.0.2-1/lib/python3.9/site-
    packages/cylc/flow/network/client.py", line 198, in async_request
        self.timeout_handler()
      File "/home/h03/fcm/cylc-8.0.2-1/lib/python3.9/site-
    packages/cylc/flow/network/client.py", line 331, in _timeout_handler
        raise WorkflowStopped(workflow)
    cylc.flow.exceptions.WorkflowStopped: test/migration/run6 is not running
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
