### PR TITLE
Make shutdown more robust

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1731,45 +1731,25 @@ class Scheduler:
 
     async def _shutdown(self, reason: BaseException) -> None:
         """Shutdown the workflow."""
-        shutdown_msg = "Workflow shutting down"
-        with patch_log_level(LOG):
-            if isinstance(reason, SchedulerStop):
-                LOG.info(f'{shutdown_msg} - {reason.args[0]}')
-                # Unset the "paused" status of the workflow if not
-                # auto-restarting
-                if self.auto_restart_mode != AutoRestartMode.RESTART_NORMAL:
-                    self.resume_workflow(quiet=True)
-            elif isinstance(reason, SchedulerError):
-                LOG.error(f"{shutdown_msg} - {reason}")
-            elif isinstance(reason, CylcError) or (
-                isinstance(reason, ParsecError) and reason.schd_expected
-            ):
-                LOG.error(
-                    f"{shutdown_msg} - {type(reason).__name__}: {reason}"
-                )
-                if cylc.flow.flags.verbosity > 1:
-                    # Print traceback
-                    LOG.exception(reason)
-            else:
-                LOG.exception(reason)
-                if str(reason):
-                    shutdown_msg += f" - {reason}"
-                LOG.critical(shutdown_msg)
+        self._log_shutdown_reason(reason)
 
         if hasattr(self, 'proc_pool'):
-            self.proc_pool.close()
-            if self.proc_pool.is_not_done():
-                # e.g. KeyboardInterrupt
-                self.proc_pool.terminate()
-            self.proc_pool.process()
+            try:
+                self.proc_pool.close()
+                if self.proc_pool.is_not_done():
+                    # e.g. KeyboardInterrupt
+                    self.proc_pool.terminate()
+                self.proc_pool.process()
+            except Exception as exc:
+                LOG.exception(exc)
 
         if hasattr(self, 'pool'):
-            if not self.is_stalled:
-                # (else already logged)
-                # Log partially satisfied dependencies and incomplete tasks.
-                self.pool.is_stalled()
-            self.pool.warn_stop_orphans()
             try:
+                if not self.is_stalled:
+                    # (else already logged)
+                    # Log partially satisfied dependencies and incomplete tasks
+                    self.pool.is_stalled()
+                self.pool.warn_stop_orphans()
                 self.workflow_db_mgr.put_task_event_timers(
                     self.task_events_mgr
                 )
@@ -1822,6 +1802,33 @@ class Scheduler:
                 self.run_event_handlers(self.EVENT_SHUTDOWN, reason.args[0])
             else:
                 self.run_event_handlers(self.EVENT_ABORTED, str(reason))
+
+    def _log_shutdown_reason(self, reason: BaseException) -> None:
+        """Appropriately log the reason for scheduler shutdown."""
+        shutdown_msg = "Workflow shutting down"
+        with patch_log_level(LOG):
+            if isinstance(reason, SchedulerStop):
+                LOG.info(f'{shutdown_msg} - {reason.args[0]}')
+                # Unset the "paused" status of the workflow if not
+                # auto-restarting
+                if self.auto_restart_mode != AutoRestartMode.RESTART_NORMAL:
+                    self.resume_workflow(quiet=True)
+            elif isinstance(reason, SchedulerError):
+                LOG.error(f"{shutdown_msg} - {reason}")
+            elif isinstance(reason, CylcError) or (
+                isinstance(reason, ParsecError) and reason.schd_expected
+            ):
+                LOG.error(
+                    f"{shutdown_msg} - {type(reason).__name__}: {reason}"
+                )
+                if cylc.flow.flags.verbosity > 1:
+                    # Print traceback
+                    LOG.exception(reason)
+            else:
+                LOG.exception(reason)
+                if str(reason):
+                    shutdown_msg += f" - {reason}"
+                LOG.critical(shutdown_msg)
 
     def set_stop_clock(self, unix_time):
         """Set stop clock time."""


### PR DESCRIPTION
Fixes a problem where an unexpected exception raised during the scheduler shutdown - before it gets to closing the workflow runtime server thread - would cause Cylc to hang because Python doesn't like that.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dep changes
- [x] No tests are included
- [x] No changelog entry as it's pretty hard to hit
- [x] No docs needed
- [ ] If this is a bug fix, PRs raised to both master and the relevant maintenance branch.
