### PR TITLE
Handle comma separated ICP lists elegantly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ Maintenance release.
 
 ### Fixes
 
+[#5211](https://github.com/cylc/cylc-flow/pull/5211) - Provide better
+explanation of failure if `icp = next (T-02, T-32)` when list shoudl be
+semicolon separated.
+
 [#5196](https://github.com/cylc/cylc-flow/pull/5196) - Replace traceback
 with warning, for scan errors where workflow is stopped.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,7 @@ Maintenance release.
 ### Fixes
 
 [#5211](https://github.com/cylc/cylc-flow/pull/5211) - Provide better
-explanation of failure if `icp = next (T-02, T-32)` when list shoudl be
+explanation of failure if `icp = next (T-02, T-32)` when list should be
 semicolon separated.
 
 [#5196](https://github.com/cylc/cylc-flow/pull/5196) - Replace traceback

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -26,6 +26,7 @@ from metomi.isodatetime.dumpers import TimePointDumper
 from metomi.isodatetime.timezone import (
     get_local_time_zone, get_local_time_zone_format, TimeZoneFormatMode)
 from metomi.isodatetime.exceptions import IsodatetimeError
+from metomi.isodatetime.parsers import ISO8601SyntaxError
 from cylc.flow.time_parser import CylcTimeParser
 from cylc.flow.cycling import (
     PointBase, IntervalBase, SequenceBase, ExclusionBase, cmp
@@ -34,7 +35,8 @@ from cylc.flow.exceptions import (
     CylcConfigError,
     IntervalParsingError,
     PointParsingError,
-    SequenceDegenerateError
+    SequenceDegenerateError,
+    WorkflowConfigError
 )
 from cylc.flow.wallclock import get_current_time_string
 from cylc.flow.parsec.validate import IllegalValueError
@@ -739,7 +741,10 @@ def prev_next(
     for my_time in str_points:
         try:
             parsed_point = parser.parse(my_time.strip())
+        except ISO8601SyntaxError as exc:
+            raise exc
         except ValueError:
+            # If list is accidentally comma
             suggest = my_time.replace(',', ';')
             raise WorkflowConfigError(
                 f'Invalid offset: {my_time}:'

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -737,7 +737,15 @@ def prev_next(
     }
 
     for my_time in str_points:
-        parsed_point = parser.parse(my_time.strip())
+        try:
+            parsed_point = parser.parse(my_time.strip())
+        except ValueError:
+            suggest = my_time.replace(',', ';')
+            raise CylcConfigError(
+                f'Invalid offset: {my_time}:'
+                f' Offset lists are semicolon separated, try {suggest}'
+            )
+
         timepoints.append(parsed_point + now)
 
         if direction == 'previous':

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -741,7 +741,7 @@ def prev_next(
             parsed_point = parser.parse(my_time.strip())
         except ValueError:
             suggest = my_time.replace(',', ';')
-            raise CylcConfigError(
+            raise WorkflowConfigError(
                 f'Invalid offset: {my_time}:'
                 f' Offset lists are semicolon separated, try {suggest}'
             )

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -780,8 +780,15 @@ class TestRelativeCyclePoint(unittest.TestCase):
         output = ingest_time(timepoint_truncated, my_now)
         self.assertEqual("19951231T0630", output)
 
-    def test_validate_fails_comma_sep_offset_list(self):
-        """It raises an exception if validating a list separated by commas
-        """
-        with pytest.raises(CylcConfigError, match="T-00;T-30"):
-            ingest_time('next (T-00, T-30)')
+@pytest.mark.parametrize(
+    '_input, errortext',
+    (
+        ('next (T-00, T-30)', 'T-00;T-30'),
+        ('next (wildebeest)', 'Invalid ISO 8601 date')
+    )
+)
+def test_validate_fails_comma_sep_offset_list(_input, errortext):
+    """It raises an exception if validating a list separated by commas
+    """
+    with pytest.raises(Exception, match=errortext):
+        ingest_time(_input)

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -14,11 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
 import unittest
 from datetime import datetime
 
 from cylc.flow.cycling.iso8601 import init, ISO8601Sequence, ISO8601Point,\
     ISO8601Interval, ingest_time
+from cylc.flow.exceptions import CylcConfigError
 
 
 class TestISO8601Sequence(unittest.TestCase):
@@ -777,3 +779,9 @@ class TestRelativeCyclePoint(unittest.TestCase):
         timepoint_truncated = "19951231T0630"  # 19951231T0630
         output = ingest_time(timepoint_truncated, my_now)
         self.assertEqual("19951231T0630", output)
+
+    def test_validate_fails_comma_sep_offset_list(self):
+        """It raises an exception if validating a list separated by commas
+        """
+        with pytest.raises(CylcConfigError, match="T-00;T-30"):
+            ingest_time('next (T-00, T-30)')


### PR DESCRIPTION
Responds to comment at https://github.com/cylc/cylc-doc/issues/19#issuecomment-499054436

e.g. `icpt = now (T-15, T-45)` should be `icp = now (T-15; T-45)`
current behavour: Fail with scary traceback
new behaviour: Fail with helpful message

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
