### PR TITLE
Allow for MyPy making --no-implicit-optional default

### DIFF
--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -186,7 +186,7 @@ class PlatformError(CylcError):
         message: str,
         platform_name: str,
         *,
-        ctx: SubFuncContext = None,
+        ctx: Optional[SubFuncContext] = None,
         cmd: Optional[Union[str, Iterable]] = None,
         ret_code: Optional[int] = None,
         out: Optional[str] = None,

--- a/cylc/flow/network/ssh_client.py
+++ b/cylc/flow/network/ssh_client.py
@@ -18,7 +18,7 @@ from async_timeout import timeout as ascyncto
 import asyncio
 import json
 import os
-from typing import Union, Dict
+from typing import Dict, Optional, Union
 
 from cylc.flow.exceptions import ClientError, ClientTimeout
 from cylc.flow.network.client_factory import CommsMeth
@@ -43,8 +43,8 @@ class WorkflowRuntimeClient():
     def __init__(
             self,
             workflow: str,
-            host: str = None,
-            timeout: Union[float, str] = None
+            host: Optional[str] = None,
+            timeout: Optional[Union[float, str]] = None
     ):
         self.workflow = workflow
         self.SLEEP_INTERVAL = 0.1

--- a/cylc/flow/network/subscriber.py
+++ b/cylc/flow/network/subscriber.py
@@ -18,7 +18,7 @@
 import asyncio
 import json
 import sys
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 
 import zmq
 
@@ -62,11 +62,11 @@ class WorkflowSubscriber(ZMQSocketBase):
     def __init__(
             self,
             workflow: str,
-            host: str = None,
-            port: Union[int, str] = None,
-            context: object = None,
-            srv_public_key_loc: str = None,
-            topics: Iterable[bytes] = None
+            host: Optional[str] = None,
+            port: Optional[Union[int, str]] = None,
+            context: Optional[object] = None,
+            srv_public_key_loc: Optional[str] = None,
+            topics: Optional[Iterable[bytes]] = None
     ):
         super().__init__(zmq.SUB, context=context)
         self.workflow = workflow

--- a/cylc/flow/parsec/empysupport.py
+++ b/cylc/flow/parsec/empysupport.py
@@ -30,7 +30,7 @@ def empyprocess(
     _fpath: str,
     flines: t.List[str],
     dir_: str,
-    template_vars: t.Dict[str, t.Any] = None,
+    template_vars: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.List[str]:
     """Pass configure file through EmPy processor.
 

--- a/cylc/flow/parsec/jinja2support.py
+++ b/cylc/flow/parsec/jinja2support.py
@@ -238,7 +238,7 @@ def jinja2process(
     fpath: str,
     flines: t.List[str],
     dir_: str,
-    template_vars: t.Dict[str, t.Any] = None,
+    template_vars: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.List[str]:
     """Pass configure file through Jinja2 processor.
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -66,7 +66,7 @@ HOST_SELECTION_METHODS = {
 def log_platform_event(
     event: str,
     platform: dict,
-    host: str = None,
+    host: Optional[str] = None,
     level: str = 'info'
 ):
     """Log a simple platform event."""

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -402,7 +402,7 @@ async def _setup(scheduler: Scheduler) -> None:
     try:
         await scheduler.install()
     except ServiceFileError as exc:
-        sys.exit(exc)
+        sys.exit(str(exc))
 
 
 async def _run(scheduler: Scheduler) -> int:

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -17,7 +17,7 @@
 """Task state related logic."""
 
 
-from typing import List
+from typing import List, Optional
 from cylc.flow.prerequisite import Prerequisite
 from cylc.flow.task_outputs import (
     TaskOutputs,
@@ -231,8 +231,8 @@ class TaskState:
         self._suicide_is_satisfied = None
 
         # Prerequisites.
-        self.prerequisites: List[Prerequisite] = []
-        self.suicide_prerequisites: List[Prerequisite] = []
+        self.prerequisites: [List[Prerequisite]] = []
+        self.suicide_prerequisites: Optional[List[Prerequisite]] = []
         self._add_prerequisites(point, tdef)
 
         # External Triggers.

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -17,7 +17,7 @@
 """Task state related logic."""
 
 
-from typing import List, Optional
+from typing import List
 from cylc.flow.prerequisite import Prerequisite
 from cylc.flow.task_outputs import (
     TaskOutputs,

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -231,8 +231,8 @@ class TaskState:
         self._suicide_is_satisfied = None
 
         # Prerequisites.
-        self.prerequisites: [List[Prerequisite]] = []
-        self.suicide_prerequisites: Optional[List[Prerequisite]] = []
+        self.prerequisites: List[Prerequisite] = []
+        self.suicide_prerequisites: List[Prerequisite] = []
         self._add_prerequisites(point, tdef)
 
         # External Triggers.

--- a/cylc/flow/timer.py
+++ b/cylc/flow/timer.py
@@ -81,7 +81,8 @@ class Timer:
     """
 
     def __init__(
-        self, name: str, interval: float, log_reset_func: Callable = None
+        self, name: str, interval: float,
+        log_reset_func: Optional[Callable] = None
     ) -> None:
         """Initialize a timer."""
         if log_reset_func is not None:


### PR DESCRIPTION
Fixes MyPy failing on master because `--no-implicit-options=True` is not default. See https://github.com/python/mypy/pull/13401

I think that this is a single reviewer change.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Change to code to handle update to MyPy - testing not required..
- [x] `CHANGES.md`/ Documentation - not edited - not user facing