### PR TITLE
graphql subs initial burst fix

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -541,7 +541,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             w_ids = workflow_ids
             sub_resolver = SUB_RESOLVERS.get(to_snake_case(info.field_name))
             interval = args['ignore_interval']
-            old_time = time()
+            old_time = 0.0
             while True:
                 if not workflow_ids:
                     old_ids = w_ids


### PR DESCRIPTION
closes https://github.com/cylc/cylc-uiserver/issues/384

Even though this is a fix, the bug has no impact on the current UI.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Tests aren't included, we don't have subscriptions at the scheduler yet.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
