### PR TITLE
completion: increase timeout

### DIFF
--- a/cylc/flow/scripts/completion_server.py
+++ b/cylc/flow/scripts/completion_server.py
@@ -647,7 +647,7 @@ def get_option_parser() -> COP:
     parser.add_option(
         '--timeout',
         type='int',
-        default='300',
+        default=900,  # PT15M
         help=(
             'The maximum idle time before the server shuts down in seconds.'
         )


### PR DESCRIPTION
A couple of small things:

* Increase the timeout of the completion server from 5 to 15 mins.
  * Server timeouts are a little annoying when they happen so often.
  * Could potentially increase further? We can always change this later (no reinstallation required).
* ~Rename "cat-log" to "log":
  * ~"log" used to be an alias for "cat-log".~
  * ~But "log" seems clearer and is easier to type.~
  * ~Maintain "cat-log" as an alias.~

~Will `s/cat-log/log` in the docs if approved.~

**I have bailed out of the `cat-log` change as the way aliases are handled changed whilst this PR was under review. Can come back to that later**

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.