### PR TITLE
efficiency: switch from list to deque

### DIFF
--- a/cylc/flow/parsec/util.py
+++ b/cylc/flow/parsec/util.py
@@ -20,6 +20,7 @@ The copy and override functions below assume values are either dicts
 """
 
 from copy import copy
+from collections import deque
 import re
 import sys
 
@@ -259,10 +260,10 @@ def m_override(target, sparse):
     """
     if not sparse:
         return
-    stack = [(sparse, target, [], OrderedDictWithDefaults())]
+    stack = deque([(sparse, target, [], OrderedDictWithDefaults())])
     defaults_list = []
     while stack:
-        source, dest, keylist, many_defaults = stack.pop(0)
+        source, dest, keylist, many_defaults = stack.popleft()
         if many_defaults:
             defaults_list.append((dest, many_defaults))
         for key, val in source.items():


### PR DESCRIPTION
Low-hanging fruit spotted when profiling a workflow with a very high number of tasks:

* `pop(0)` is `O(N)` for lists, but `O(1)` for deques.
* For a sample graph with ~37'000 nodes this halves `m_override` compute time from ~13s to ~6.3s.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
