### PR TITLE
config: descendants list -> set

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -284,10 +284,10 @@ class WorkflowConfig:
             'linearized ancestors': {},
             # lists of first-parent ancestor namespaces
             'first-parent ancestors': {},
-            # lists of all descendant namespaces
+            # sets of all descendant namespaces
             # (not including the final tasks)
             'descendants': {},
-            # lists of all descendant namespaces from the first-parent
+            # sets of all descendant namespaces from the first-parent
             # hierarchy (first parents are collapsible in visualization)
             'first-parent descendants': {},
         }
@@ -1179,16 +1179,12 @@ class WorkflowConfig:
         for name in self.cfg['runtime']:
             ancestors = self.runtime['linearized ancestors'][name]
             for p in ancestors[1:]:
-                if p not in self.runtime['descendants']:
-                    self.runtime['descendants'][p] = []
-                if name not in self.runtime['descendants'][p]:
-                    self.runtime['descendants'][p].append(name)
+                self.runtime['descendants'].setdefault(p, set()).add(name)
             first_ancestors = self.runtime['first-parent ancestors'][name]
             for p in first_ancestors[1:]:
-                if p not in self.runtime['first-parent descendants']:
-                    self.runtime['first-parent descendants'][p] = []
-                if name not in self.runtime['first-parent descendants'][p]:
-                    self.runtime['first-parent descendants'][p].append(name)
+                self.runtime['first-parent descendants'].setdefault(
+                    p, set()
+                ).add(name)
 
     def compute_inheritance(self):
         LOG.debug("Parsing the runtime namespace hierarchy")
@@ -2201,15 +2197,15 @@ class WorkflowConfig:
                           self.cfg['runtime']['root'])
                 if 'root' not in self.runtime['descendants']:
                     # (happens when no runtimes are defined in flow.cylc)
-                    self.runtime['descendants']['root'] = []
+                    self.runtime['descendants']['root'] = set()
                 if 'root' not in self.runtime['first-parent descendants']:
                     # (happens when no runtimes are defined in flow.cylc)
-                    self.runtime['first-parent descendants']['root'] = []
+                    self.runtime['first-parent descendants']['root'] = set()
                 self.runtime['parents'][name] = ['root']
                 self.runtime['linearized ancestors'][name] = [name, 'root']
                 self.runtime['first-parent ancestors'][name] = [name, 'root']
-                self.runtime['descendants']['root'].append(name)
-                self.runtime['first-parent descendants']['root'].append(name)
+                self.runtime['descendants']['root'].add(name)
+                self.runtime['first-parent descendants']['root'].add(name)
                 self.ns_defn_order.append(name)
 
             try:

--- a/tests/flakyfunctional/job-submission/19-chatty.t
+++ b/tests/flakyfunctional/job-submission/19-chatty.t
@@ -72,7 +72,8 @@ TEST_NAME="${TEST_NAME_BASE}-db-task-pool"
 DB_FILE="${WORKFLOW_RUN_DIR}/log/db"
 QUERY='SELECT cycle, name, status, is_held FROM task_pool'
 run_ok "$TEST_NAME" sqlite3 "$DB_FILE" "$QUERY"
-cmp_ok "${TEST_NAME}.stdout" << '__OUT__'
+sort "${TEST_NAME}.stdout" > "${TEST_NAME}.stdout.sorted"
+cmp_ok "${TEST_NAME}.stdout.sorted" << '__OUT__'
 1|nh0|submit-failed|0
 1|nh1|submit-failed|0
 1|nh2|submit-failed|0

--- a/tests/functional/hold-release/08-hold.t
+++ b/tests/functional/hold-release/08-hold.t
@@ -77,15 +77,15 @@ workflow_run_ok "${TEST_NAME_BASE}-run" \
 # finished and gone from the task pool.
 
 sqlite3 "${WORKFLOW_RUN_DIR}/log/db" \
-    'SELECT cycle, name, status, is_held FROM task_pool' > task-pool.out
+    'SELECT cycle, name, status, is_held FROM task_pool' | sort > task-pool.out
 cmp_ok task-pool.out <<__OUT__
-1|foo|waiting|1
 1|bar|waiting|1
-1|cheese|waiting|1
-1|jam|waiting|1
 1|cat1|waiting|1
 1|cat2|waiting|1
+1|cheese|waiting|1
 1|dog1|waiting|1
+1|foo|waiting|1
+1|jam|waiting|1
 __OUT__
 
 purge

--- a/tests/functional/triggering/16-fam-expansion.t
+++ b/tests/functional/triggering/16-fam-expansion.t
@@ -31,7 +31,7 @@ workflow_run_ok "${TEST_NAME}" \
     cylc play --debug --no-detach --set="SHOW_OUT='$SHOW_OUT'" "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 contains_ok "$SHOW_OUT" <<'__SHOW_DUMP__'
-  + (((1 | 0) & (3 | 2) & (5 | 4)) & (0 | 2 | 4))
+  + (((3 | 2) & (5 | 4) & (1 | 0)) & (2 | 4 | 0))
   + 	0 = 1/foo1 failed
   - 	1 = 1/foo1 succeeded
   + 	2 = 1/foo2 failed

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -277,8 +277,8 @@ def test_parse_special_tasks_families(flow, scheduler, validate, section):
         assert 'external triggers must be used only once' in str(exc_ctx.value)
     else:
         config = validate(reg)
-        assert config.cfg['scheduling']['special tasks'][section] == [
+        assert set(config.cfg['scheduling']['special tasks'][section]) == {
             # the family FOO has been expanded to the tasks foo, foot
             'foo(P1D)',
             'foot(P1D)'
-        ]
+        }


### PR DESCRIPTION
More low hanging fruit spotted whilst profiling a large workflow.

If you want a unique list, so long as order doesn't matter it's faster to use a set because the lookup time is so quick.

* Change the type of `descendants[<namespace>]` and `first-parent descendants[<namespace>]` fields from `list` to `set`.
* Set has faster lookup `O(1)` which makes additions faster (because the checking is faster).
* Lookups are common with these sets in `cylc.flow.config` so this may speed up a few methods.
* The method which gains the most is `compute_family_tree` where I've seen a reduction of ~34s down to ~1.75s for a workflow with a large number of task proxies.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
