### PR TITLE
make cylc view api importable

### DIFF
--- a/cylc/flow/scripts/view.py
+++ b/cylc/flow/scripts/view.py
@@ -98,6 +98,10 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser: COP, options: 'Values', workflow_id: str) -> None:
+    _main(options, workflow_id)
+
+
+def _main(options: 'Values', workflow_id: str) -> None:
     workflow_id, _, flow_file = parse_id(
         workflow_id,
         src=True,


### PR DESCRIPTION
Allow the removal of some instances of subprocess from Cylc Rose in https://github.com/cylc/cylc-rose/pull/196.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are not needed because there is no sig change in code.
