### PR TITLE
Document final try fail behaviour.

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -395,8 +395,14 @@ so you may want to configure more frequent polling.
 SUBMISSION_RETY_DESCR = f'''
 Cylc can automatically resubmit jobs after submission failures.
 
-A list of intervals which define when the scheduler will resubmit jobs if
-submission fails.
+Submission retry delays is a list of ISO 8601 durations which tell Cylc
+how long to wait before the next try.
+
+The job environment variable ``$CYLC_TASK_SUBMIT_NUMBER`` increments with each
+job submission attempt.
+
+Tasks only go to the ``submit-failed`` state if job submission fails with no
+retries left.
 
 .. versionchanged:: 8.0.0
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1092,15 +1092,15 @@ with Conf(
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc=f'''
                 Cylc can automate resubmission of failed jobs.
 
-                Execution retry delays are a list of ISO 8601 durations which
-                tell Cylc how long to wait before resubmitting a failed job.
+                Execution retry delays is a list of ISO 8601 durations which
+                tell Cylc how long to wait before the next try.
 
                 The job environment variable ``$CYLC_TASK_TRY_NUMBER``
-                increments with each try, allowing you to vary task behaviour
-                between submission attempts.
+                increments with each automatic retry, allowing you to vary task
+                behaviour between retries.
 
-                Tasks only go to the ``failed`` state if their jobs fail with
-                no retries left.
+                Tasks only go to the ``failed`` state if job execution fails
+                with no retries left.
 
                 .. versionchanged:: 8.0.0
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1090,16 +1090,17 @@ with Conf(
                 )
             )
             Conf('execution retry delays', VDR.V_INTERVAL_LIST, None, desc=f'''
-                Cylc can automate resubmission of a failed job.
+                Cylc can automate resubmission of failed jobs.
 
-                Execution retry delays are a list of ISO 8601
-                durations/intervals which tell Cylc how long to wait before
-                resubmitting a failed job.
+                Execution retry delays are a list of ISO 8601 durations which
+                tell Cylc how long to wait before resubmitting a failed job.
 
-                Each time Cylc resubmits a job it will increment the
-                variable ``$CYLC_TASK_TRY_NUMBER`` in the task execution
-                environment. ``$CYLC_TASK_TRY_NUMBER`` allows you to vary task
-                behaviour between submission attempts.
+                The job environment variable ``$CYLC_TASK_TRY_NUMBER``
+                increments with each try, allowing you to vary task behaviour
+                between submission attempts.
+
+                Tasks only go to the ``failed`` state if their jobs fail with
+                no retries left.
 
                 .. versionchanged:: 8.0.0
 


### PR DESCRIPTION

Tasks only go to the failed state if the job fails with no retries left.

Companion of https://github.com/cylc/cylc-doc/pull/571

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
