### PR TITLE
linkcheck only happens on one fast test

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -115,5 +115,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?
 
       - name: Linkcheck
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.python-version, 3.9)
         run: pytest -m linkcheck tests/unit


### PR DESCRIPTION
This is a small change to the working of our CI tests.

The check that links in docstrings and comments are valid does not need to be run in all 5 fast_test scenarios.