### PR TITLE
play: upgrade DB *after* user upgrade confirmation 

### DIFF
--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -232,6 +232,7 @@ class CylcWorkflowDAO:
             ["delay"],
             ["timeout"],
         ],
+        # NOTE: this table is used by `cylc clean`, don't rename me!
         TABLE_TASK_JOBS: [
             ["cycle", {"is_primary_key": True}],
             ["name", {"is_primary_key": True}],
@@ -246,6 +247,7 @@ class CylcWorkflowDAO:
             ["time_run_exit"],
             ["run_signal"],
             ["run_status", {"datatype": "INTEGER"}],
+            # NOTE: this field is used by `cylc clean` don't rename me!
             ["platform_name"],
             ["job_runner_name"],
             ["job_id"],
@@ -716,7 +718,16 @@ class CylcWorkflowDAO:
             callback(row_idx, list(row))
 
     def select_task_job_platforms(self):
-        """Return the set of platform names from task_jobs table."""
+        """Return the set of platform names from task_jobs table.
+
+        Warning:
+            This interface is used by `cylc clean` which does not upgrade the
+            DB first (it could, this would only extend backwards
+            compatibility but would not help with forwards compatibility).
+            Keep this query to the minimum of tables/fields to avoid
+            breaking compatibility with older/newer versions of Cylc.
+
+        """
         stmt = rf'''
             SELECT DISTINCT
                 platform_name

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -382,6 +382,9 @@ def scheduler_cli(options: 'Values', workflow_id_raw: str) -> None:
     ):
         sys.exit(1)
 
+    # upgrade the workflow DB (after user has confirmed upgrade)
+    _upgrade_database(db_file)
+
     # re-execute on another host if required
     _distribute(options.host, workflow_id_raw, workflow_id)
 
@@ -519,6 +522,18 @@ def _version_check(
             # restart would INCREASE the Cylc version in a little way
             return True
     return True
+
+
+def _upgrade_database(db_file):
+    """Upgrade the workflow database if needed.
+
+    Note:
+        Do this after the user has confirmed that they want to upgrade!
+
+    """
+    if db_file.is_file():
+        wdbm = WorkflowDatabaseManager(db_file.parent)
+        wdbm.upgrade()
 
 
 def _print_startup_message(options):

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -318,7 +318,7 @@ def prompt(message, options, default=None, process=None):
     default_ = ''
     if default:
         default_ = f'[{default}] '
-    message += f': {default_}{",".join(options)}?'
+    message += f': {default_}{",".join(options)}? '
     usr = None
     while usr not in options:
         usr = input(f'{message}')

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -775,10 +775,6 @@ class WorkflowDatabaseManager:
 
     def upgrade(self):
         """Upgrade this database to this Cylc version.
-
-        Args:
-            pri_dao: Open private database connection object.
-
         """
         with self.get_pri_dao() as pri_dao:
             last_run_ver = self._get_last_run_ver(pri_dao)

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -55,6 +55,9 @@ DbUpdateTuple = Tuple[DbArgDict, DbArgDict]
 PERM_PRIVATE = 0o600  # -rw-------
 
 
+INCOMPAT_MSG = f"Workflow database is incompatible with Cylc {CYLC_VERSION}"
+
+
 class WorkflowDatabaseManager:
     """Manage the workflow runtime private and public databases."""
 
@@ -757,42 +760,55 @@ class WorkflowDatabaseManager:
         )
         conn.commit()
 
-    def upgrade(self, last_run_ver, pri_dao):
-        if last_run_ver < parse_version("8.0.3.dev"):
-            self.upgrade_pre_803(pri_dao)
-        if last_run_ver < parse_version("8.1.0.dev"):
-            self.upgrade_pre_810(pri_dao)
+    def _get_last_run_ver(self, pri_dao):
+        """Return the version of Cylc this DB was last run with.
+
+        Args:
+            pri_dao: Open private database connection object.
+
+        """
+        try:
+            last_run_ver = self._get_last_run_version(pri_dao)
+        except TypeError:
+            raise ServiceFileError(f"{INCOMPAT_MSG}, or is corrupted.")
+        return parse_version(last_run_ver)
+
+    def upgrade(self):
+        """Upgrade this database to this Cylc version.
+
+        Args:
+            pri_dao: Open private database connection object.
+
+        """
+        with self.get_pri_dao() as pri_dao:
+            last_run_ver = self._get_last_run_ver(pri_dao)
+            if last_run_ver < parse_version("8.0.3.dev"):
+                self.upgrade_pre_803(pri_dao)
+            if last_run_ver < parse_version("8.1.0.dev"):
+                self.upgrade_pre_810(pri_dao)
 
     def check_workflow_db_compatibility(self):
-        """Raises ServiceFileError if the existing workflow database is
-        incompatible with the current version of Cylc."""
+        """Check this DB is compatible with this Cylc version.
+
+        Raises:
+            ServiceFileError:
+                If the existing workflow database is incompatible with the
+                current version of Cylc.
+
+        """
         if not os.path.isfile(self.pri_path):
             raise FileNotFoundError(self.pri_path)
-        incompat_msg = (
-            f"Workflow database is incompatible with Cylc {CYLC_VERSION}"
-        )
-        manual_rm_msg = (
-            "If you are sure you want to operate on this workflow, please "
-            f"delete the database file at {self.pri_path}"
-        )
+
         with self.get_pri_dao() as pri_dao:
-            try:
-                last_run_ver = self._get_last_run_version(pri_dao)
-            except TypeError:
-                raise ServiceFileError(
-                    f"{incompat_msg}, or is corrupted.\n{manual_rm_msg}"
-                )
-            last_run_ver = parse_version(last_run_ver)
-            restart_incompat_ver = parse_version(
-                CylcWorkflowDAO.RESTART_INCOMPAT_VERSION
+            last_run_ver = self._get_last_run_ver(pri_dao)
+            # WARNING: Do no upgrade the DB here
+
+        restart_incompat_ver = parse_version(
+            CylcWorkflowDAO.RESTART_INCOMPAT_VERSION
+        )
+        if last_run_ver <= restart_incompat_ver:
+            raise ServiceFileError(
+                f"{INCOMPAT_MSG} (workflow last run with "
+                f"Cylc {last_run_ver})."
             )
-            if last_run_ver <= restart_incompat_ver:
-                raise ServiceFileError(
-                    f"{incompat_msg} (workflow last run with "
-                    f"Cylc {last_run_ver})."
-                    f"\n{manual_rm_msg}"
-                )
-
-            self.upgrade(last_run_ver, pri_dao)
-
         return last_run_ver

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -29,6 +29,7 @@ import re
 from subprocess import Popen, PIPE, DEVNULL, TimeoutExpired
 import shlex
 import shutil
+import sqlite3
 from time import sleep
 from typing import (
     Any, Container, Deque, Dict, Iterable, List, NamedTuple, Optional, Set,
@@ -770,21 +771,22 @@ def _clean_check(opts: 'Values', reg: str, run_dir: Path) -> None:
         )
 
 
-def init_clean(reg: str, opts: 'Values') -> None:
+def init_clean(id_: str, opts: 'Values') -> None:
     """Initiate the process of removing a stopped workflow from the local
     scheduler filesystem and remote hosts.
 
     Args:
-        reg: Workflow name/ID.
+        id_: Workflow ID.
         opts: CLI options object for cylc clean.
+
     """
-    local_run_dir = Path(get_workflow_run_dir(reg))
+    local_run_dir = Path(get_workflow_run_dir(id_))
     with suppress(InputError):
-        local_run_dir, reg = infer_latest_run(
+        local_run_dir, id_ = infer_latest_run(
             local_run_dir, implicit_runN=False, warn_runN=False
         )
     try:
-        _clean_check(opts, reg, local_run_dir)
+        _clean_check(opts, id_, local_run_dir)
     except FileNotFoundError as exc:
         LOG.info(exc)
         return
@@ -794,31 +796,46 @@ def init_clean(reg: str, opts: 'Values') -> None:
 
     if not opts.local_only:
         platform_names = None
-        try:
-            platform_names = get_platforms_from_db(local_run_dir)
-        except FileNotFoundError:
+        db_file = Path(get_workflow_srv_dir(id_), 'db')
+        if not db_file.is_file():
+            # no DB -> do nothing
             if opts.remote_only:
                 raise ServiceFileError(
-                    f"No workflow database for {reg} - cannot perform "
+                    f"No workflow database for {id_} - cannot perform "
                     "remote clean"
                 )
             LOG.info(
-                f"No workflow database for {reg} - will only clean locally"
+                f"No workflow database for {id_} - will only clean locally"
             )
-        except ServiceFileError as exc:
-            raise ServiceFileError(f"Cannot clean {reg} - {exc}")
+        else:
+            # DB present -> load platforms
+            try:
+                platform_names = get_platforms_from_db(local_run_dir)
+            except ServiceFileError as exc:
+                raise ServiceFileError(f"Cannot clean {id_} - {exc}")
+            except sqlite3.OperationalError as exc:
+                # something went wrong with the query
+                # e.g. the table/field we need isn't there
+                LOG.warning(
+                    'This database is either corrupted or not compatible with'
+                    ' this version of "cylc clean".'
+                    '\nTry using the version of Cylc the workflow was last ran'
+                    ' with to remove it.'
+                    '\nOtherwise please delete the database file.'
+                )
+                raise ServiceFileError(f"Cannot clean {id_} - {exc}")
 
         if platform_names and platform_names != {'localhost'}:
             remote_clean(
-                reg, platform_names, opts.rm_dirs, opts.remote_timeout
+                id_, platform_names, opts.rm_dirs, opts.remote_timeout
             )
 
     if not opts.remote_only:
         # Must be after remote clean
-        clean(reg, local_run_dir, rm_dirs)
+        clean(id_, local_run_dir, rm_dirs)
 
 
-def clean(reg: str, run_dir: Path, rm_dirs: Optional[Set[str]] = None) -> None:
+def clean(id_: str, run_dir: Path, rm_dirs: Optional[Set[str]] = None) -> None:
     """Remove a stopped workflow from the local filesystem only.
 
     Deletes the workflow run directory and any symlink dirs, or just the
@@ -828,11 +845,12 @@ def clean(reg: str, run_dir: Path, rm_dirs: Optional[Set[str]] = None) -> None:
     possible to clean any symlink dirs.
 
     Args:
-        reg: Workflow name.
+        id_: Workflow ID.
         run_dir: Absolute path of the workflow's run dir.
         rm_dirs: Set of sub dirs to remove instead of the whole run dir.
+
     """
-    symlink_dirs = get_symlink_dirs(reg, run_dir)
+    symlink_dirs = get_symlink_dirs(id_, run_dir)
     if rm_dirs is not None:
         # Targeted clean
         for pattern in rm_dirs:
@@ -841,7 +859,7 @@ def clean(reg: str, run_dir: Path, rm_dirs: Optional[Set[str]] = None) -> None:
         # Wholesale clean
         LOG.debug(f"Cleaning {run_dir}")
         for symlink in symlink_dirs:
-            # Remove <symlink_dir>/cylc-run/<reg>/<symlink>
+            # Remove <symlink_dir>/cylc-run/<id>/<symlink>
             remove_dir_and_target(run_dir / symlink)
         if '' not in symlink_dirs:
             # if run dir isn't a symlink dir and hasn't been deleted yet
@@ -866,10 +884,10 @@ def clean(reg: str, run_dir: Path, rm_dirs: Optional[Set[str]] = None) -> None:
         if cylc_install_dir.is_dir():
             remove_dir_or_file(cylc_install_dir)
     # Remove any empty parents of run dir up to ~/cylc-run/
-    remove_empty_parents(run_dir, reg)
+    remove_empty_parents(run_dir, id_)
     for symlink, target in symlink_dirs.items():
         # Remove empty parents of symlink target up to <symlink_dir>/cylc-run/
-        remove_empty_parents(target, Path(reg, symlink))
+        remove_empty_parents(target, Path(id_, symlink))
 
 
 def get_symlink_dirs(reg: str, run_dir: Union[Path, str]) -> Dict[str, Path]:
@@ -1180,17 +1198,30 @@ def get_workflow_title(reg):
 
 
 def get_platforms_from_db(run_dir):
-    """Load the set of names of platforms (that jobs ran on) from the
-    workflow database.
+    """Return the set of names of platforms (that jobs ran on) from the DB.
+
+    Warning:
+        This does NOT upgrade the workflow database!
+
+        We could upgrade the DB for backward compatiblity, but we haven't
+        got any upgraders for this table yet so there's no point.
+
+        Note that upgrading the DB here would not help with forward
+        compatibility. We can't apply upgraders which don't exist yet.
 
     Args:
         run_dir (str): The workflow run directory.
+
+    Raises:
+        sqlite3.OperationalError: in the event the table/field required for
+        cleaning is not present.
+
     """
     workflow_db_mgr = WorkflowDatabaseManager(
         os.path.join(run_dir, WorkflowFiles.Service.DIRNAME))
-    workflow_db_mgr.check_workflow_db_compatibility()
     with workflow_db_mgr.get_pri_dao() as pri_dao:
         platform_names = pri_dao.select_task_job_platforms()
+
     return platform_names
 
 

--- a/tests/functional/cylc-clean/03-multi.t
+++ b/tests/functional/cylc-clean/03-multi.t
@@ -75,13 +75,13 @@ ${HOME}/cylc-run/${CYLC_TEST_REG_BASE}
 __TREE__
 
 mkdir "${WORKFLOW_RUN_DIR}/run1/.service"
-touch "${WORKFLOW_RUN_DIR}/run1/.service/db"  # corrupted db!
+echo 'x' > "${WORKFLOW_RUN_DIR}/run1/.service/db"  # corrupted db!
 
 TEST_NAME="${TEST_NAME_BASE}-yes-no"
 run_fail "${TEST_NAME}" \
     cylc clean -y "$WORKFLOW_NAME/run1" "$WORKFLOW_NAME/run2"
 
-grep_ok "Cannot clean .*/run1" "${TEST_NAME}.stderr" -e
+grep_ok "file is not a database" "${TEST_NAME}.stderr" -e
 
 TEST_NAME="tree-post-clean-2"
 run_ok "${TEST_NAME}" tree --noreport --charset=ascii -L 4 "${HOME}/cylc-run/${CYLC_TEST_REG_BASE}"

--- a/tests/functional/database/07-incompatible.t
+++ b/tests/functional/database/07-incompatible.t
@@ -29,12 +29,17 @@ sqlite3 "${SRV_DIR}/db" < 'db.sqlite3'
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "$WORKFLOW_NAME"
 
-for cmd in play clean; do
-    TEST_NAME="${TEST_NAME_BASE}-${cmd}-fail"
-    run_fail "$TEST_NAME" cylc "$cmd" "$WORKFLOW_NAME"
+TEST_NAME="${TEST_NAME_BASE}-play-fail"
+run_fail "$TEST_NAME" cylc play "$WORKFLOW_NAME"
+grep_ok \
+    'Workflow database is incompatible with Cylc .*, or is corrupted' \
+    "${TEST_NAME}.stderr"
 
-    grep_ok 'Workflow database is incompatible' "${TEST_NAME}.stderr"
-done
+TEST_NAME="${TEST_NAME_BASE}-clean-fail"
+run_fail "$TEST_NAME" cylc clean "$WORKFLOW_NAME"
+grep_ok \
+    'This database is either corrupted or not compatible with this' \
+    "${TEST_NAME}.stderr"
 
 purge
 

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -448,7 +448,8 @@ def test_init_clean(
         remote_clean_called: If a remote clean is expected to go ahead.
     """
     reg = 'foo/bar/'
-    tmp_run_dir(reg, installed=True)
+    rdir = tmp_run_dir(reg, installed=True)
+    Path(rdir, WorkflowFiles.Service.DIRNAME, WorkflowFiles.Service.DB).touch()
     mock_clean = monkeymock('cylc.flow.workflow_files.clean')
     mock_remote_clean = monkeymock('cylc.flow.workflow_files.remote_clean')
     monkeypatch.setattr('cylc.flow.workflow_files.get_platforms_from_db',
@@ -547,6 +548,7 @@ def test_init_clean__rm_dirs(
     """
     reg = 'dagobah'
     run_dir: Path = tmp_run_dir(reg)
+    Path(run_dir, WorkflowFiles.Service.DIRNAME, WorkflowFiles.Service.DB).touch()
     mock_clean = monkeymock('cylc.flow.workflow_files.clean')
     mock_remote_clean = monkeymock('cylc.flow.workflow_files.remote_clean')
     platforms = {'platform_one'}


### PR DESCRIPTION
* Closes #5270
* Only upgrade the database after the user has answered th prompt saying that they want to upgrade!
* Remove the DB upgrade from the logic used by `cylc clean` as this is currently pointless.
* Add notes and comments to ensure we preserve clean compatibility with newer versions of Cylc (or at least so we know when we break compat).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [x] No changelog (unreleased bug)
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
