### PR TITLE
poll/kill: don't retry on NoHosts error

### DIFF
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -952,8 +952,10 @@ class TaskJobManager:
                         cmd, platform, host
                     )
                 except NoHostsError:
-                    ctx.err = f'No available hosts for {platform["name"]}'
-                    callback_255(ctx, workflow, itasks)
+                    LOG.warn(
+                        f'{cmd_key} failed -'
+                        f' No available hosts for {platform["name"]}'
+                    )
                     continue
                 else:
                     ctx = SubProcContext(cmd_key, cmd, host=host)


### PR DESCRIPTION
* Closes #5276
* Fixes a bug where poll/kill commands were called in an infinite-recursion loop if a `NoHostsError` exception was raised for the platform.
* Bug introduced by this diff https://github.com/cylc/cylc-flow/commit/dc15ce4b89f801ee472e837cb532be5c6e3c50b6#diff-0b970d88e6ba8fe34ed659c20689046b5366912171e5157932ad5175c0468460R944-R960
  * Before this diff (8.0.2) the `NoHostsError` was raised and the scheduler shut down.
  * After this diff (8.0.3) the poll/kill would be retried until Python's recursion limit caused an error to be raised and the scheduler to shut down.
* This diff reverts to NOT retrying the poll/kill on another host if all hosts in the platform are un-available.

> **Aside:**
>
> This makes me more convinced that #5017 is necessary and important. The call-callback code is extremely difficult to follow. This has become a larger problem now that we have several layers of callback code (remote-init, remote-file-install, job-submit and a regular and 255 callbacks for everything).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
