### PR TITLE
show: ensure stable expression output

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2004,7 +2004,7 @@ class WorkflowConfig:
         # the graph (which would probably be quite reasonable).
         family_map = {
             family: [
-                task for task in tasks
+                task for task in sorted(tasks)
                 if (
                     task in self.runtime['parents'] and
                     task not in self.runtime['descendants']

--- a/cylc/flow/task_trigger.py
+++ b/cylc/flow/task_trigger.py
@@ -149,6 +149,8 @@ class TaskTrigger:
         else:
             return '%s:%s' % (self.task_name, self.output)
 
+    __repr__ = __str__
+
     @staticmethod
     def standardise_name(name):
         """Replace trigger name aliases with standard names.

--- a/tests/functional/triggering/16-fam-expansion.t
+++ b/tests/functional/triggering/16-fam-expansion.t
@@ -31,7 +31,7 @@ workflow_run_ok "${TEST_NAME}" \
     cylc play --debug --no-detach --set="SHOW_OUT='$SHOW_OUT'" "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 contains_ok "$SHOW_OUT" <<'__SHOW_DUMP__'
-  + (((3 | 2) & (5 | 4) & (1 | 0)) & (2 | 4 | 0))
+  + (((1 | 0) & (3 | 2) & (5 | 4)) & (0 | 2 | 4))
   + 	0 = 1/foo1 failed
   - 	1 = 1/foo1 succeeded
   + 	2 = 1/foo2 failed


### PR DESCRIPTION
Addresses https://github.com/cylc/cylc-flow/pull/5245#discussion_r1054704471

Ensure that conditional expressions output by `cylc show` aren't random by sorting tasks within families by name. This isn't technically a requirement of `cylc show`, but it does make the functional tests more deterministic and seems like a nice thing to do in general (tasks will now appear in expressions in name order).

Note, this extra sort shouldn't impact on performance too badly for large families as this sorting is performed once per family with a worst-case complexity of `O(nlogn)`whereas before it was checking for duplicates before each insertion which is `O(n^2)`.

Using the example which started this off the impact of this change is within the uncertainty of results.


### Cylc 7                                                                           
   
    User time (seconds): 121.79
    System time (seconds): 1.16
    Elapsed (wall clock) time (h:mm:ss or m:ss): 2:07.32
    Maximum resident set size (kbytes): 1098652
   
### Before optimisation (57833b4095dfa6eb68e66439fa00e35ba75feee4)
    
    User time (seconds): 77.45
    System time (seconds): 1.29
    Elapsed (wall clock) time (h:mm:ss or m:ss): 1:25.39
    Maximum resident set size (kbytes): 675596
    
### After optimisation (c68864b6f2f5e63045d18c4ee652d965052fc529)
    
    User time (seconds): 41.77
    System time (seconds): 0.81
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:46.58
    Maximum resident set size (kbytes): 682952
    
    
### This PR (27ac134cb5995029a9b7c6c3b917046d5c52c912)
                
    User time (seconds): 41.96
    System time (seconds): 0.75                 
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:44.87       
    Maximum resident set size (kbytes): 679116   

> **Note:** Some of the `cylc show` tests will likely need updating to match the new sort order.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
