### PR TITLE
coverage: update config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,9 +13,9 @@ disable_warnings =
     no-data-collected
     module-not-measured
 omit =
-    tests/*
-    */cylc/flow/*_pb2.py
-    cylc/flow/etc/*
+    tests/**
+    **_pb2.py
+    cylc/flow/etc/**
 parallel = True
 source = ./cylc
 timid = False
@@ -41,9 +41,9 @@ exclude_lines =
 fail_under=0
 ignore_errors = False
 omit =
-    tests/*
-    */cylc/flow/*_pb2.py
-    cylc/flow/etc/*
+    tests/**
+    **_pb2.py
+    cylc/flow/etc/**
 precision = 2
 show_missing = False
 skip_covered = False

--- a/.coveragerc
+++ b/.coveragerc
@@ -14,7 +14,7 @@ disable_warnings =
     module-not-measured
 omit =
     tests/**
-    **_pb2.py
+    ./**_pb2.py
     cylc/flow/etc/**
 parallel = True
 source = ./cylc
@@ -42,7 +42,7 @@ fail_under=0
 ignore_errors = False
 omit =
     tests/**
-    **_pb2.py
+    ./**_pb2.py
     cylc/flow/etc/**
 precision = 2
 show_missing = False

--- a/.coveragerc
+++ b/.coveragerc
@@ -14,7 +14,7 @@ disable_warnings =
     module-not-measured
 omit =
     tests/**
-    ./**_pb2.py
+    *_pb2.py
     cylc/flow/etc/**
 parallel = True
 source = ./cylc
@@ -42,7 +42,7 @@ fail_under=0
 ignore_errors = False
 omit =
     tests/**
-    ./**_pb2.py
+    *_pb2.py
     cylc/flow/etc/**
 precision = 2
 show_missing = False


### PR DESCRIPTION
This might help with a coverage error [reported on Element](https://matrix.to/#/!hwZqSYihGPuhDdIzIP:matrix.org/$167164934811296mZdsf:matrix.org?via=matrix.org)

According to the [changelog](https://coverage.readthedocs.io/en/stable/changes.html#version-7-0-0b1-2022-12-03):

> Changes to file pattern matching, which might require updating your configuration:
>
> Previously, * would incorrectly match directory separators, making precise matching difficult. This is now fixed, closing [issue 1407](https://github.com/nedbat/coveragepy/issues/1407).
>
> Now ** matches any number of nested directories, including none.

So I think our use of `*` is now broken? Not sure.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
