### PR TITLE
Fix clock trigger execution retry delay bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,11 @@ gets logged at "INFO" level in scheduler logs.
 [#5259](https://github.com/cylc/cylc-flow/pull/5259) - Add flow_nums
 to task_jobs table in the workflow database.
 
+### Fixes
+
+[#5286](https://github.com/cylc/cylc-flow/pull/5286) - Fix bug where
+`[scheduling][special tasks]clock-trigger` would skip execution retry delays.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.4 (<span actions:bind='release-date'>Released 2022-12-14</span>)__
 

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -250,9 +250,12 @@ class IntervalBase(metaclass=ABCMeta):
     def is_null(self):
         return (self == self.get_null())
 
-    def __str__(self):
+    def __str__(self) -> str:
         # Stringify.
         return self.value
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} {self}>"
 
     def __add__(self, other):
         # Add other (point or interval) to self.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1591,11 +1591,11 @@ class Scheduler:
                 ):
                     self.pool.queue_task(itask)
 
+                # Old-style clock-trigger tasks:
                 if (
                     itask.tdef.clocktrigger_offset is not None
-                    and itask.is_waiting_clock_done()
+                    and all(itask.is_ready_to_run())
                 ):
-                    # Old-style clock-trigger tasks.
                     self.pool.queue_task(itask)
 
             if housekeep_xtriggers:

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -36,7 +36,7 @@ from logging import (
 )
 from shutil import rmtree
 from time import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from cylc.flow import LOG
 from cylc.flow.job_runner_mgr import JobPollContext
@@ -947,38 +947,29 @@ class TaskJobManager:
             )
 
     @staticmethod
-    def _set_retry_timers(itask, rtconfig=None, retry=True):
+    def _set_retry_timers(
+        itask: 'TaskProxy',
+        rtconfig: Optional[dict] = None
+    ) -> None:
         """Set try number and retry delays."""
         if rtconfig is None:
             rtconfig = itask.tdef.rtconfig
-        if (
-            itask.tdef.run_mode + ' mode' in rtconfig and
-            'disable retries' in rtconfig[itask.tdef.run_mode + ' mode']
-        ):
-            retry = False
 
-        if retry:
-            if rtconfig['submission retry delays']:
-                submit_delays = rtconfig['submission retry delays']
-            else:
-                submit_delays = itask.platform['submission retry delays']
+        submit_delays = (
+            rtconfig['submission retry delays']
+            or itask.platform['submission retry delays']
+        )
 
-            for key, delays in [
-                    (
-                        TimerFlags.SUBMISSION_RETRY,
-                        submit_delays
-                    ),
-                    (
-                        TimerFlags.EXECUTION_RETRY,
-                        rtconfig['execution retry delays']
-                    )
-            ]:
-                if delays is None:
-                    delays = []
-                try:
-                    itask.try_timers[key].set_delays(delays)
-                except KeyError:
-                    itask.try_timers[key] = TaskActionTimer(delays=delays)
+        for key, delays in [
+            (TimerFlags.SUBMISSION_RETRY, submit_delays),
+            (TimerFlags.EXECUTION_RETRY, rtconfig['execution retry delays'])
+        ]:
+            if delays is None:
+                delays = []
+            try:
+                itask.try_timers[key].set_delays(delays)
+            except KeyError:
+                itask.try_timers[key] = TaskActionTimer(delays=delays)
 
     def _simulation_submit_task_jobs(self, itasks, workflow):
         """Simulation mode task jobs submission."""
@@ -1168,7 +1159,6 @@ class TaskJobManager:
                 itask.summary['platforms_used'][itask.submit_num] = ''
                 # Retry delays, needed for the try_num
                 self._create_job_log_path(workflow, itask)
-                self._set_retry_timers(itask, rtconfig, False)
                 self._prep_submit_task_job_error(
                     workflow, itask, '(platform not defined)', exc)
                 return False

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -409,7 +409,7 @@ class TaskProxy:
         """Are ALL prerequisites satisfied?"""
         return (
             all(pre.is_satisfied() for pre in self.state.prerequisites)
-            and all(tri for tri in self.state.external_triggers.values())
+            and self.state.external_triggers_all_satisfied()
             and self.state.xtriggers_all_satisfied()
         )
 

--- a/tests/functional/special/08-clock-trigger-retry.t
+++ b/tests/functional/special/08-clock-trigger-retry.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Old-style clock trigger should only go ahead if xtriggers are satisfied
+# https://github.com/cylc/cylc-flow/issues/5217
+
+. "$(dirname "$0")/test_header"
+set_test_number 4
+
+init_workflow "${TEST_NAME_BASE}" << __FLOW__
+[scheduling]
+    initial cycle point = 2015
+    final cycle point = PT1S
+    [[special tasks]]
+        clock-trigger = foo(PT1H)
+    [[graph]]
+        T00 = foo
+
+[runtime]
+    [[foo]]
+        execution retry delays = PT5S # hopefully enough time to check task doesn't resubmit immediately
+        script = ((CYLC_TASK_TRY_NUMBER > 1))
+__FLOW__
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "$WORKFLOW_NAME"
+
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --no-detach "$WORKFLOW_NAME"
+
+log_scan "${TEST_NAME_BASE}-log-scan" \
+    "${WORKFLOW_RUN_DIR}/log/scheduler/log" 2 1 \
+    "\[20150101.*/foo .* job:01 .* retrying in PT5S" \
+    "xtrigger satisfied: _cylc_retry_20150101"
+# (if task resubmits immediately instead of waiting PT5S, xtrigger msg will not appear)
+
+purge


### PR DESCRIPTION
Closes #5217

Fix bug where old-style clock triggered tasks would skip execution retry delays and just retry immediately.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed