### PR TITLE
poll/kill: don't retry on NoHosts error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,12 @@ gets logged at "INFO" level in scheduler logs.
 [#5259](https://github.com/cylc/cylc-flow/pull/5259) - Add flow_nums
 to task_jobs table in the workflow database.
 
+### Fixes
+
+[#5292](https://github.com/cylc/cylc-flow/pull/5292) -
+Fix an issue where polling could be repeated if the job's platform
+was not available.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.0.4 (<span actions:bind='release-date'>Released 2022-12-14</span>)__
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -663,7 +663,13 @@ class TaskJobManager:
 
     def _kill_task_job_callback_255(self, workflow, itask, cmd_ctx, line):
         """Helper for _kill_task_jobs_callback, on one task job."""
-        self.kill_task_jobs(workflow, [itask])
+        with suppress(NoHostsError):
+            # if there is another host to kill on, try again, otherwise fail
+            get_host_from_platform(
+                itask.platform,
+                bad_hosts=self.task_remote_mgr.bad_hosts
+            )
+            self.kill_task_jobs(workflow, [itask])
 
     def _kill_task_job_callback(self, workflow, itask, cmd_ctx, line):
         """Helper for _kill_task_jobs_callback, on one task job."""
@@ -791,7 +797,13 @@ class TaskJobManager:
              self._poll_task_job_message_callback})
 
     def _poll_task_job_callback_255(self, workflow, itask, cmd_ctx, line):
-        self.poll_task_jobs(workflow, [itask])
+        with suppress(NoHostsError):
+            # if there is another host to poll on, try again, otherwise fail
+            get_host_from_platform(
+                itask.platform,
+                bad_hosts=self.task_remote_mgr.bad_hosts
+            )
+            self.poll_task_jobs(workflow, [itask])
 
     def _poll_task_job_callback(self, workflow, itask, cmd_ctx, line):
         """Helper for _poll_task_jobs_callback, on one task job."""


### PR DESCRIPTION
* Closes #5276
* Poll and kill will retry on another host if one is availible but will not reset bad_hosts.

> Note that even if polling fails, Cylc still reports `Command succeeded: poll_tasks` in the log which is a different issue - #5293.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
