### PR TITLE
auto-restart: improve robustness to DNS errors

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -24,6 +24,7 @@ import os
 from pathlib import Path
 from queue import Empty, Queue
 from shlex import quote
+from socket import gaierror
 from subprocess import Popen, PIPE, DEVNULL
 import sys
 from threading import Barrier, Thread
@@ -64,7 +65,10 @@ from cylc.flow.exceptions import (
     InputError,
 )
 import cylc.flow.flags
-from cylc.flow.host_select import select_workflow_host
+from cylc.flow.host_select import (
+    HostSelectException,
+    select_workflow_host,
+)
 from cylc.flow.hostuserutil import (
     get_host,
     get_user,
@@ -1480,27 +1484,32 @@ class Scheduler:
         if self.options.abort_if_any_task_fails:
             cmd.append('--abort-if-any-task-fails')
         for attempt_no in range(max_retries):
-            new_host = select_workflow_host(cached=False)[0]
-            LOG.info(f'Attempting to restart on "{new_host}"')
-            # proc will start with current env (incl CYLC_HOME etc)
-            proc = Popen(  # nosec
-                [*cmd, f'--host={new_host}'],
-                stdin=DEVNULL,
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True
-            )
+            error: Optional[str] = None
+            proc = None
+            try:
+                new_host = select_workflow_host(cached=False)[0]
+            except (gaierror, HostSelectException) as exc:
+                error = str(exc)
+            else:
+                LOG.info(f'Attempting to restart on "{new_host}"')
+                # proc will start with current env (incl CYLC_HOME etc)
+                proc = Popen(  # nosec
+                    [*cmd, f'--host={new_host}'],
+                    stdin=DEVNULL,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True
+                )
+                if proc.wait():
+                    error = proc.communicate()[1]
             # * new_host comes from internal interface which can only return
             #   host names
-            if proc.wait():
+            if error is not None:
                 msg = 'Could not restart workflow'
                 if attempt_no < max_retries:
                     msg += (
                         f' will retry in {self.INTERVAL_AUTO_RESTART_ERROR}s')
-                LOG.critical(
-                    f"{msg}. Restart error:\n",
-                    f"{proc.communicate()[1]}"
-                )
+                LOG.critical(f"{msg}. Restart error:\n{error}")
                 sleep(self.INTERVAL_AUTO_RESTART_ERROR)
             else:
                 LOG.info(f'Workflow now running on "{new_host}".')

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -128,7 +128,7 @@ def test_auto_restart_DNS_error(monkeypatch, caplog, log_filter):
     )
     schd = Mock(
         workflow='myworkflow',
-        options=Mock(abort_if_any_task_fails=False),
+        options=RunOptions(abort_if_any_task_fails=False),
         INTERVAL_AUTO_RESTART_ERROR=0,
     )
     caplog.set_level(logging.ERROR, CYLC_LOG)
@@ -161,7 +161,7 @@ def test_auto_restart_popen_error(monkeypatch, caplog, log_filter):
 
     schd = Mock(
         workflow='myworkflow',
-        options=Mock(abort_if_any_task_fails=False),
+        options=RunOptions(abort_if_any_task_fails=False),
         INTERVAL_AUTO_RESTART_ERROR=0,
     )
     caplog.set_level(logging.ERROR, CYLC_LOG)

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for Cylc scheduler server."""
 
+import logging
+import socket
 from time import time
 from types import SimpleNamespace
 from typing import List
@@ -22,6 +24,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
+from cylc.flow import CYLC_LOG
 from cylc.flow.exceptions import InputError
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.scheduler_cli import RunOptions
@@ -109,3 +112,58 @@ def test_release_queued_tasks__auto_restart():
     # preparing ones
     mock_schd.pool.release_queued_tasks.assert_not_called()
     mock_schd.task_job_mgr.submit_task_jobs.assert_called()
+
+
+def test_auto_restart_DNS_error(monkeypatch, caplog, log_filter):
+    """Ensure that DNS errors in host selection are caught."""
+    def _select_workflow_host(cached=False):
+        # fake a "get address info" error
+        # this error can occur due to an unknown host resulting from broken
+        # DNS or an invalid host name in the global config
+        raise socket.gaierror('elephant')
+
+    monkeypatch.setattr(
+        'cylc.flow.scheduler.select_workflow_host',
+        _select_workflow_host,
+    )
+    schd = Mock(
+        workflow='myworkflow',
+        options=Mock(abort_if_any_task_fails=False),
+        INTERVAL_AUTO_RESTART_ERROR=0,
+    )
+    caplog.set_level(logging.ERROR, CYLC_LOG)
+    assert not Scheduler.workflow_auto_restart(schd, max_retries=2)
+    assert log_filter(caplog, contains='elephant')
+
+
+def test_auto_restart_popen_error(monkeypatch, caplog, log_filter):
+    """Ensure that subprocess errors are handled."""
+    def _select_workflow_host(cached=False):
+        # mock a host-select return value
+        return ('foo', 'foo')
+
+    monkeypatch.setattr(
+        'cylc.flow.scheduler.select_workflow_host',
+        _select_workflow_host,
+    )
+
+    def _popen(*args, **kwargs):
+        # mock an auto-restart command failure
+        return Mock(
+            wait=lambda: 1,
+            communicate=lambda: ('mystdout', 'mystderr'),
+        )
+
+    monkeypatch.setattr(
+        'cylc.flow.scheduler.Popen',
+        _popen,
+    )
+
+    schd = Mock(
+        workflow='myworkflow',
+        options=Mock(abort_if_any_task_fails=False),
+        INTERVAL_AUTO_RESTART_ERROR=0,
+    )
+    caplog.set_level(logging.ERROR, CYLC_LOG)
+    assert not Scheduler.workflow_auto_restart(schd, max_retries=2)
+    assert log_filter(caplog, contains='mystderr')


### PR DESCRIPTION
If an error occurs during auto-restart then the scheduler will wait a little while, then try again up to two more times before finally giving in and falling over.

This PR extends this retry mechanism to cover DNS errors in order to make the auto-restart logic more robust to transient DNS issues.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.