### PR TITLE
Restrict `--set` & `--set-file`  options in `cylc vr`

### DIFF
--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -106,13 +106,11 @@ def check_tvars_and_workflow_stopped(
         tvars: options.tvars, from `--set`
         tvars_file: options.tvars_file, from `--set-file`
     """
-    if is_running and (tvars or [] or tvars_file or []):
-        msg = (
-            'Template variables can only be changed if a'
-            ' workflow is stopped. You tried to change:')
-        for tvar in tvars or [] + tvars_file or []:
-            msg += f'\n * {tvar}'
-        LOG.warning(msg)
+    if is_running and (tvars or tvars_file):
+        LOG.warning(
+            'Template variables (from --set/--set-file) can '
+            'only be changed if the workflow is stopped.'
+        )
         return False
     return True
 

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -92,6 +92,31 @@ def get_option_parser() -> COP:
     return parser
 
 
+def check_tvars_and_workflow_stopped(
+    is_running: bool, tvars: list, tvars_file: list
+) -> bool:
+    """are template variables set and workflow stopped?
+
+    Template vars set by --set (options.templatevars) or --set-file
+    (optiions.templatevars_file) are only valid if the workflow is stopped
+    and vr will play it.
+
+    args:
+        is_running: Is workflow running?
+        tvars: options.tvars, from `--set`
+        tvars_file: options.tvars_file, from `--set-file`
+    """
+    if is_running and (tvars or [] or tvars_file or []):
+        msg = (
+            'Template variables can only be changed if a'
+            ' workflow is stopped. You tried to change:')
+        for tvar in tvars or [] + tvars_file or []:
+            msg += f'\n * {tvar}'
+        LOG.warning(msg)
+        return False
+    return True
+
+
 @cli_function(get_option_parser)
 def main(parser: COP, options: 'Values', workflow_id: str):
     sys.exit(vro_cli(parser, options, workflow_id))
@@ -117,6 +142,13 @@ def vro_cli(parser: COP, options: 'Values', workflow_id: str):
     else:
         # Workflow is definately stopped:
         workflow_running = False
+
+    # options.tvars and tvars_file are _only_ valid when playing a stopped
+    # workflow: Fail if they are set and workflow running:
+    if not check_tvars_and_workflow_stopped(
+        workflow_running, options.templatevars, options.templatevars_file
+    ):
+        return 1
 
     # Force on the against_source option:
     options.against_source = True   # Make validate check against source.

--- a/tests/unit/scripts/test_validate_reinstall_units.py
+++ b/tests/unit/scripts/test_validate_reinstall_units.py
@@ -1,0 +1,49 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for cylc.flow.scripts.validate_reinstall.py
+"""
+
+import pytest
+
+from cylc.flow.scripts.validate_reinstall import (
+    check_tvars_and_workflow_stopped)
+
+
+@pytest.mark.parametrize(
+    'is_running, tvars, tvars_file, expect',
+    [
+        (True, None, None, True),
+        (True, [], [], True),
+        (True, ['FOO="Bar"'], None, False),
+        (True, None, ['bar.txt'], False),
+        (True, ['FOO="Bar"'], ['bar.txt'], False),
+        (False, None, None, True),
+        (False, ['FOO="Bar"'], ['bar.txt'], True),
+        (False, None, ['bar.txt'], True),
+        (False, ['FOO="Bar"'], ['bar.txt'], True),
+    ]
+)
+def test_check_tvars_and_workflow_stopped(
+    caplog, is_running, tvars, tvars_file, expect
+):
+    """It returns true if workflow is running and tvars or tvars_file is set.
+    """
+    result = check_tvars_and_workflow_stopped(is_running, tvars, tvars_file)
+    assert result == expect
+    if expect is False:
+        warn = 'Template variables can only be changed'
+        assert warn in caplog.records[0].msg

--- a/tests/unit/scripts/test_validate_reinstall_units.py
+++ b/tests/unit/scripts/test_validate_reinstall_units.py
@@ -26,14 +26,13 @@ from cylc.flow.scripts.validate_reinstall import (
 @pytest.mark.parametrize(
     'is_running, tvars, tvars_file, expect',
     [
-        (True, None, None, True),
-        (True, [], [], True),
+        (True, [], None, True),
         (True, ['FOO="Bar"'], None, False),
-        (True, None, ['bar.txt'], False),
+        (True, [], ['bar.txt'], False),
         (True, ['FOO="Bar"'], ['bar.txt'], False),
-        (False, None, None, True),
+        (False, [], None, True),
         (False, ['FOO="Bar"'], ['bar.txt'], True),
-        (False, None, ['bar.txt'], True),
+        (False, [], ['bar.txt'], True),
         (False, ['FOO="Bar"'], ['bar.txt'], True),
     ]
 )
@@ -45,5 +44,5 @@ def test_check_tvars_and_workflow_stopped(
     result = check_tvars_and_workflow_stopped(is_running, tvars, tvars_file)
     assert result == expect
     if expect is False:
-        warn = 'Template variables can only be changed'
+        warn = 'can only be changed if'
         assert warn in caplog.records[0].msg


### PR DESCRIPTION
This PR documents the bug as well as fixing it. There is no related issue. Follow-up to #5229

## Synopsis

`--set` and `--set-file` were included by mistake in `cylc vr` because I copied the general form of VR from `cylc vip` where it makes sense. Reinstall doesn't use these CLI variables so they won't change the workflow. This is potentially misleading to users.

## Code to try

```ini
#!jinja2
# Cylc Workflow
[scheduler]
    allow implicit tasks = ture
[scheduling]
    [[graph]]
        {{CYCLE}}= foo => bar => baz
```

then,

On the command line

```bash
cylc vip --set 'CYCLE="PT1H"'
...

# Does not change the running workflow!
cylc vr --set 'CYCLE="PT2H"' 
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] No tests, change is specification rather than tests.
- [x] No `CHANGES.md` entry - this effectively fixes a recently added PR before relase.
- [x] NO [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
