### PR TITLE
Silence flake8-bugbear B028

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,9 @@ ignore=
     W504
     ; "experimental" SIM9xx rules (flake8-simplify)
     SIM9
+    ; suggests using f"{!r}" instead of manual quotes (flake8-bugbear)
+    ; Doesn't work at 3.7
+    B028
 
 exclude=
     build,


### PR DESCRIPTION
This is a very small change designed to silence flake8-bugbear B028, which:
- Doesn't work with Python 3.7
- Isn't necessarily easier to read