### PR TITLE
deps: loosen pyzmq dependency

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - protobuf >=4.21.2,<4.22.0
   - psutil >=5.6.0
   - python
-  - pyzmq >=22,<23
+  - pyzmq >=22
   - setuptools >=49, <67
   - urwid >=2,<3
   # Add # [py<3.11] for tomli once Python 3.11 Released

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -305,7 +305,9 @@ class WorkflowRuntimeClient(  # type: ignore[misc]
         if msg['command'] in PB_METHOD_MAP:
             response = {'data': res}
         else:
-            response = decode_(res.decode())
+            response = decode_(
+                res.decode() if isinstance(res, bytes) else res
+            )
         LOG.debug('zmq:recv %s', response)
 
         try:
@@ -316,8 +318,8 @@ class WorkflowRuntimeClient(  # type: ignore[misc]
                 {'message': f'Received invalid response: {response}'},
             )
             raise ClientError(
-                error.get('message'),
-                error.get('traceback'),
+                error.get('message'),  # type: ignore
+                error.get('traceback'),  # type: ignore
             )
 
     def get_header(self) -> dict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
     protobuf>=4.21.2,<4.22.0
     psutil>=5.6.0
-    pyzmq==22.*
+    pyzmq>=22
     # https://github.com/pypa/setuptools/issues/3802
     setuptools>=49, <67
     urwid==2.*


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/5272
* Closes https://github.com/cylc/cylc-flow/issues/5311
* Unblocks https://github.com/cylc/cylc-uiserver/issues/411

tldr; We should be good to loosen off on this requirement, full rationale in the issue.

* The ZMTP protocol provides robust forward & backward compatibilit from libzmq version 3.2.2 onwards.
* Since this is the minimum version compatible with pyzmq, we can safely loosen this version coupling.
* For more information see the rationale in https://github.com/cylc/cylc-flow/issues/5311#issuecomment-1414073472

