### PR TITLE
Avoid creating task proxies

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1079,6 +1079,7 @@ class Scheduler:
         """
         fields = workflow_files.ContactFileFields
         proc = psutil.Process()
+        localhost = get_platform()
         # fmt: off
         return {
             fields.API:
@@ -1104,11 +1105,11 @@ class Scheduler:
             fields.VERSION:
                 CYLC_VERSION,
             fields.SCHEDULER_SSH_COMMAND:
-                str(get_platform()['ssh command']),
+                str(localhost['ssh command']),
             fields.SCHEDULER_CYLC_PATH:
-                str(get_platform()['cylc path']),
+                str(localhost['cylc path']),
             fields.SCHEDULER_USE_LOGIN_SHELL:
-                str(get_platform()['use login shell'])
+                str(localhost['use login shell'])
         }
         # fmt: on
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -239,7 +239,7 @@ class TaskPool:
         # Register pool node reference
         self.data_store_mgr.add_pool_node(itask.tdef.name, itask.point)
         # Create new data-store n-distance graph window about this task
-        self.data_store_mgr.increment_graph_window(itask)
+        self.data_store_mgr.increment_graph_window(itask, self)
         self.data_store_mgr.delta_task_state(itask)
         self.data_store_mgr.delta_task_held(itask)
         self.data_store_mgr.delta_task_queued(itask)
@@ -740,6 +740,14 @@ class TaskPool:
                 point_itasks[point] += list(itask_id_map.values())
 
         return point_itasks
+
+    def get_task(self, point, name):
+        """Retrieve a task from the pool."""
+        rel_id = f'{point}/{name}'
+        for pool in (self.main_pool, self.hidden_pool):
+            tasks = pool.get(point)
+            if tasks and rel_id in tasks:
+                return tasks[rel_id]
 
     def _get_hidden_task_by_id(self, id_: str) -> Optional[TaskProxy]:
         """Return runahead pool task by ID if it exists, or None."""


### PR DESCRIPTION
Reduces the impact of #5315 a bit.

* There is a significant overhead to initiating a `TaskProxy` object.
* Avoid doing this where it is not necessary.
* In my test with the example in https://github.com/cylc/cylc-flow/issues/5315
  with `-s TASKS=15 -s CYCLES=1` this reduced the time taken by
  `expand_graph_window` by ~38% from from 12.2s to `7.54`.

Also avoid duplicate `get_platform` calls.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
