### PR TITLE
remove use of get platform at itask.__init__

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1324,7 +1324,7 @@ class DataStoreMgr:
             name=tproxy.name,
             cycle_point=tproxy.cycle_point,
             execution_time_limit=job_conf.get('execution_time_limit'),
-            platform=job_conf.get('platform')['name'],
+            platform=job_conf.get('platform name'),
             job_runner_name=job_conf.get('job_runner_name'),
         )
         # Not all fields are populated with some submit-failures,

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1285,6 +1285,7 @@ class DataStoreMgr:
         Args:
             name (str): Corresponding task name.
             point_string (str): Cycle point string
+            status: ??
             job_conf (dic):
                 Dictionary of job configuration used to generate
                 the job script.

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1285,7 +1285,7 @@ class DataStoreMgr:
         Args:
             name (str): Corresponding task name.
             point_string (str): Cycle point string
-            status: ??
+            status: Job-state - i.e. running, submitted, failed, submit failed
             job_conf (dic):
                 Dictionary of job configuration used to generate
                 the job script.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -751,10 +751,10 @@ class Scheduler:
         """Remote init for all submitted/running tasks in the pool."""
         self.task_job_mgr.task_remote_mgr.is_restart = True
         distinct_install_target_platforms = []
-        for itask in self.pool.get_tasks():
 
+        for itask in self.pool.get_tasks():
             # get a platform if the task proxy hasn't got one:
-            if itask.platform is None:
+            if not itask.platform:
                 itask.platform = get_platform(
                     itask.tdef.rtconfig, bad_hosts=self.bad_hosts
                 )

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -754,6 +754,11 @@ class Scheduler:
 
         for itask in self.pool.get_tasks():
 
+            if not itask.platform:
+                itask.platform = get_platform(
+                    itask.tdef.rtconfig, bad_hosts=self.bad_hosts
+                )
+
             itask.platform['install target'] = (
                 get_install_target_from_platform(itask.platform))
             if (

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -752,6 +752,13 @@ class Scheduler:
         self.task_job_mgr.task_remote_mgr.is_restart = True
         distinct_install_target_platforms = []
         for itask in self.pool.get_tasks():
+
+            # get a platform if the task proxy hasn't got one:
+            if itask.platform is None:
+                itask.platform = get_platform(
+                    itask.tdef.rtconfig, bad_hosts=self.bad_hosts
+                )
+
             itask.platform['install target'] = (
                 get_install_target_from_platform(itask.platform))
             if (

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -753,11 +753,6 @@ class Scheduler:
         distinct_install_target_platforms = []
 
         for itask in self.pool.get_tasks():
-            # get a platform if the task proxy hasn't got one:
-            if not itask.platform:
-                itask.platform = get_platform(
-                    itask.tdef.rtconfig, bad_hosts=self.bad_hosts
-                )
 
             itask.platform['install target'] = (
                 get_install_target_from_platform(itask.platform))

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1284,6 +1284,13 @@ class TaskEventsManager():
         # not see previous submissions (so can't use itask.jobs[submit_num-1]).
         job_conf = itask.jobs[-1]
 
+        # Extract a resolved platform name if one is available from the itask
+        # else get an unresolved platform name from the task def:
+        if itask.platform:
+            platform_name = itask.platform['name']
+        else:
+            platform_name = itask.tdef.rtconfig['platform']
+
         # insert job into data store
         self.data_store_mgr.insert_job(
             itask.tdef.name,
@@ -1294,16 +1301,12 @@ class TaskEventsManager():
                 # NOTE: the platform name may have changed since task
                 # preparation started due to intelligent host (and or
                 # platform) selection
-                'platform': itask.platform,
+                'platform': platform_name,
             },
         )
         # update job in database
         # NOTE: the job must be added to the DB earlier so that Cylc can
         # reconnect with job submissions if the scheduler is restarted
-        if itask.platform:
-            platform_name = itask.platform['name']
-        else:
-            platform_name = itask.tdef.rtconfig['platform']
         self.workflow_db_mgr.put_update_task_jobs(
             itask,
             {

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1300,6 +1300,10 @@ class TaskEventsManager():
         # update job in database
         # NOTE: the job must be added to the DB earlier so that Cylc can
         # reconnect with job submissions if the scheduler is restarted
+        if itask.platform:
+            platform_name = itask.platform['name']
+        else:
+            platform_name = itask.tdef.rtconfig['platform']
         self.workflow_db_mgr.put_update_task_jobs(
             itask,
             {
@@ -1309,7 +1313,7 @@ class TaskEventsManager():
                 # NOTE: the platform name may have changed since task
                 # preparation started due to intelligent host (and or
                 # platform) selection
-                'platform_name': itask.platform['name'],
+                'platform_name': platform_name,
             }
         )
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -969,7 +969,7 @@ class TaskJobManager:
 
         submit_delays = (
             rtconfig['submission retry delays']
-            or itask.platform and itask.platform['submission retry delays']
+            or itask.platform.get('submission retry delays')
         )
 
         for key, delays in [

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -985,10 +985,8 @@ class TaskJobManager:
 
     def _simulation_submit_task_jobs(self, itasks, workflow):
         """Simulation mode task jobs submission."""
-        sim_platform = get_platform()
-        sim_platform['name'] = 'SIMULATION'
         for itask in itasks:
-            itask.platform = sim_platform
+            itask.platform = {'name': 'SIMULATION'}
             itask.waiting_on_job_prep = False
             itask.submit_num += 1
             self._set_retry_timers(itask)

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1241,7 +1241,7 @@ class TaskJobManager:
         })
 
         # create a DB entry for the submit-failed job
-        if itask.platform:
+        if itask.platform and itask.platform.get('name', None):
             platform_name = itask.platform['name']
         else:
             platform_name = itask.tdef.rtconfig['platform']

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -28,7 +28,6 @@ from metomi.isodatetime.timezone import get_local_time_zone
 
 from cylc.flow import LOG
 from cylc.flow.id import Tokens
-from cylc.flow.platforms import get_platform
 from cylc.flow.task_action_timer import TimerFlags
 from cylc.flow.task_state import TaskState, TASK_STATUS_WAITING
 from cylc.flow.taskdef import generate_graph_children
@@ -237,10 +236,7 @@ class TaskProxy:
 
         self.local_job_file_path: Optional[str] = None
 
-        if data_mode:
-            self.platform = {}
-        else:
-            self.platform = get_platform()
+        self.platform = {}
 
         self.job_vacated = False
         self.poll_timer: Optional['TaskActionTimer'] = None

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -21,7 +21,7 @@ from copy import copy
 from fnmatch import fnmatchcase
 from time import time
 from typing import (
-    Any, Callable, Dict, List, Set, Tuple, Optional, TYPE_CHECKING
+    Any, Callable, Dict, List, Set, Tuple, Optional, Union, TYPE_CHECKING
 )
 
 from metomi.isodatetime.timezone import get_local_time_zone
@@ -236,7 +236,9 @@ class TaskProxy:
 
         self.local_job_file_path: Optional[str] = None
 
-        self.platform = {}
+        self.platform: Union[None, Dict[str, 'Any']] = None
+        if data_mode:
+            self.platform = {}
 
         self.job_vacated = False
         self.poll_timer: Optional['TaskActionTimer'] = None

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -21,7 +21,7 @@ from copy import copy
 from fnmatch import fnmatchcase
 from time import time
 from typing import (
-    Any, Callable, Dict, List, Set, Tuple, Optional, Union, TYPE_CHECKING
+    Any, Callable, Dict, List, Set, Tuple, Optional, TYPE_CHECKING
 )
 
 from metomi.isodatetime.timezone import get_local_time_zone
@@ -236,9 +236,7 @@ class TaskProxy:
 
         self.local_job_file_path: Optional[str] = None
 
-        self.platform: Union[None, Dict[str, 'Any']] = None
-        if data_mode:
-            self.platform = {}
+        self.platform: Dict[str, 'Any'] = {}
 
         self.job_vacated = False
         self.poll_timer: Optional['TaskActionTimer'] = None

--- a/tests/functional/platforms/08-warn-if-regex-matches-localhost.t
+++ b/tests/functional/platforms/08-warn-if-regex-matches-localhost.t
@@ -19,7 +19,7 @@
 # not set in ``global.cylc``.
 . "$(dirname "$0")/test_header"
 
-set_test_number 4
+set_test_number 3
 
 # shellcheck disable=SC2016
 create_test_global_config '' '
@@ -46,16 +46,13 @@ __HEREDOC__
 ERR_STR='cannot be defined using a regular expression'
 
 TEST_NAME="${TEST_NAME_BASE}-validate"
-run_fail "${TEST_NAME}" cylc validate "${RND_WORKFLOW_SOURCE}"
-grep_ok "${ERR_STR}" \
-    "${TEST_NAME}.stderr" -F
+run_ok "${TEST_NAME}" cylc validate "${RND_WORKFLOW_SOURCE}"
 
 TEST_NAME="${TEST_NAME_BASE}-cylc-install"
 run_fail "${TEST_NAME}" cylc install \
     "${RND_WORKFLOW_SOURCE}" \
     --workflow-name "${RND_WORKFLOW_NAME}"
-grep_ok "${ERR_STR}" \
-    "${TEST_NAME}.stderr" -F
+grep_ok "${ERR_STR}" "${TEST_NAME}.stderr" -F
 
 purge_rnd_workflow
 exit

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -15,12 +15,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+
+from types import SimpleNamespace
 from typing import Any as Fixture
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_state import TASK_STATUS_RUNNING
-
 
 
 async def test_run_job_cmd_no_hosts_error(
@@ -118,7 +119,6 @@ async def test__run_job_cmd_logs_platform_lookup_fail(
     schd: 'Scheduler' = scheduler(reg, paused_start=True)
     # Run
     async with run(schd):
-        from types import SimpleNamespace
         schd.task_job_mgr._run_job_cmd(
             schd.task_job_mgr.JOBS_POLL,
             'foo',
@@ -128,3 +128,49 @@ async def test__run_job_cmd_logs_platform_lookup_fail(
         warning = caplog.records[-1]
         assert warning.levelname == 'ERROR'
         assert 'Unable to run command jobs-poll' in warning.msg
+
+
+async def test__prep_submit_task_job_error(
+    one_conf: Fixture, flow: Fixture, scheduler: Fixture, run: Fixture,
+    db_select: Fixture
+) -> None:
+    """function will always get a platform name to add to the database.
+    """
+    # Add a runtime section to one_conf:
+    one_conf.update({'runtime': {'one': {'platform': 'bar'}}})
+
+    # Setup scheduler:
+    reg: str = flow(one_conf)
+    schd: 'Scheduler' = scheduler(reg, paused_start=True)
+    messages = []
+
+    async with run(schd):
+        # Unhook real function we don't need to run as part of test:
+        schd.task_events_mgr.process_message = lambda a, b, c: None
+
+        # Fake function whose input we want to check:
+        schd.task_events_mgr.workflow_db_mgr.put_insert_task_jobs = (
+            lambda itask, info: messages.append(info['platform_name']))
+
+        # get a reference to the itask:
+        itask = schd.pool.get_tasks()[0]
+
+        # Check that without platform retrieval we get the platform name
+        # from config:
+        schd.task_job_mgr._prep_submit_task_job_error(
+            workflow='one',
+            itask=itask,
+            action=None,
+            exc=None
+        )
+
+        # Check that if the platform name is set because we've retrieved a
+        # platform's info, then we use that:
+        itask.platform['name'] = 'baz'
+        schd.task_job_mgr._prep_submit_task_job_error(
+            workflow='one',
+            itask=schd.pool.get_tasks()[0],
+            action=None,
+            exc=None
+        )
+    assert sorted(messages) == ['bar', 'baz']


### PR DESCRIPTION
A partial response to #5315 

Calling `get_platforms` when task proxies are created should not be necessary. That there are one or two places where it is implies some level of bug.

This PR attempts to deal with both these bugs and to provide a performance boost by not calling `get_platform` as often.

* If platform selection fails, `task_events_mgr._insert_task_job` and `task_job_mgr._prep_submit_task_job_error` want the platform name to put in the database, but if we haven't got a platform selected they need to get it from the task definition not itask.platform.
* Platform needs setting to localhost if in simulation mode.
* Platforms need to be got on restart.

Testing by @oliver-sanders  suggests that a branch like this has the potential to reduce CPU time:
![Figure_1](https://user-images.githubusercontent.com/26465611/214058437-f892ed76-74fe-40ea-bffd-18769a31ed28.png)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` unchanged