### PR TITLE
Optimize ID/tokens code

### DIFF
--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -25,6 +25,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -80,16 +81,21 @@ class Tokens(dict):
         <id: ~u/w//c/t/02>
 
     """
-    # valid dictionary keys
-    _KEYS = {
-        # regular tokens
-        *{token.value for token in IDTokens},
-        # selector tokens
-        *{
-            f'{token.value}_sel'
-            for token in IDTokens
-            if token != IDTokens.User
-        },
+    _REGULAR_KEYS: Set[str] = {token.value for token in IDTokens}
+    _SELECTOR_KEYS = {
+        f'{token.value}_sel'
+        for token in IDTokens
+        if token != IDTokens.User
+    }
+
+    # all valid dictionary keys
+    _KEYS = _REGULAR_KEYS | _SELECTOR_KEYS
+
+    _TASK_LIKE_KEYS = {
+        key for key in _KEYS if not (
+            key.startswith(IDTokens.User.value)
+            or key.startswith(IDTokens.Workflow.value)
+        )
     }
 
     def __init__(
@@ -278,9 +284,7 @@ class Tokens(dict):
 
         """
         return any(
-            bool(self[token.value])
-            for token in IDTokens
-            if token not in {IDTokens.User, IDTokens.Workflow}
+            self[key] for key in self._TASK_LIKE_KEYS
         )
 
     @property
@@ -296,12 +300,7 @@ class Tokens(dict):
             **{
                 key: value
                 for key, value in self.items()
-                if key in {
-                    key
-                    for key in self._KEYS
-                    if not key.startswith(IDTokens.User.value)
-                    and not key.startswith(IDTokens.Workflow.value)
-                }
+                if key in self._TASK_LIKE_KEYS
             }
         )
 
@@ -318,12 +317,7 @@ class Tokens(dict):
             **{
                 key: value
                 for key, value in self.items()
-                if key in {
-                    key
-                    for key in self._KEYS
-                    if key.startswith(IDTokens.User.value)
-                    or key.startswith(IDTokens.Workflow.value)
-                }
+                if key not in self._TASK_LIKE_KEYS
             }
         )
 
@@ -344,8 +338,7 @@ class Tokens(dict):
 
         """
         return not any(
-            bool(self[token.value])
-            for token in IDTokens
+            self[key] for key in self._REGULAR_KEYS
         )
 
     def update_tokens(
@@ -411,6 +404,10 @@ class Tokens(dict):
             Make a copy and modify it:
             >>> tokens1.duplicate(cycle='1').id
             '~u/w//1'
+
+            Original not changed
+            >>> tokens1.id
+            '~u/w'
         """
         ret = Tokens(self)
         ret.update_tokens(tokens, **kwargs)
@@ -742,44 +739,41 @@ def detokenise(
         ValueError: No tokens provided
 
     """
-    toks = {
-        token.value
-        for token in IDTokens
-        if tokens.get(token.value)
+    keys = {
+        key for key in Tokens._REGULAR_KEYS
+        if tokens.get(key)
     }
-    is_relative = not toks & {'user', 'workflow'}
-    is_partial = not toks & {'cycle', 'task', 'job'}
+    is_relative = keys.isdisjoint(('user', 'workflow'))
+    is_partial = keys.isdisjoint(('cycle', 'task', 'job'))
     if is_relative and is_partial:
         raise ValueError('No tokens provided')
 
     # determine the lowest token
     for lowest_token in reversed(IDTokens):
-        if lowest_token.value in toks:
+        if lowest_token.value in keys:
             break
 
-    highest_token: 'Optional[IDTokens]'
+    highest_token: Optional[IDTokens]
+    identifier = []
     if is_relative:
         highest_token = IDTokens.Cycle
-        identifier = []
         if not relative:
             identifier = ['/']
     else:
         highest_token = IDTokens.User
-        identifier = []
 
     for token in IDTokens:
-        if highest_token and token != highest_token:
-            continue
-        elif highest_token:
+        if highest_token:
+            if token != highest_token:
+                continue
             highest_token = None
-        value: 'Optional[str]'
-        value = tokens.get(token.value)
+        value: Optional[str] = tokens.get(token.value)
         if not value and token == IDTokens.User:
             continue
         elif token == IDTokens.User:
             value = f'~{value}'
         elif token == IDTokens.Job and value != 'NN':
-            value = f'{int(value):02}'  # type: ignore
+            value = f'{int(value):02}'  # type: ignore[arg-type]
         value = value or '*'
         if selectors and tokens.get(token.value + '_sel'):
             # include selectors


### PR DESCRIPTION
Profiling revealed `Tokens` computed properties and `detokenise()` were being called many times and so was acting as a bit of a bottleneck (within the bottleneck of data store manager's `increment_graph_window()` - #5315).

- Remove a couple of unnecessary nested comprehensions
- Precompute certain sets

Partially addresses #5315 & #5183

#### Context

<details>

<summary>Click to see `flow.cylc`</summary>

```
#!Jinja2

{% set TASKS = TASKS | default(100) %}
{% set CYCLES = CYCLES | default(1) %}
{% set SLEEP = SLEEP | default(1) %}

[meta]
    description = """
        Example scaling workflow with {{ (TASKS * 2) + 2 }} tasks and {{ (TASKS ** 2) + (TASKS * 2) }}
        dependencies per cycle which runs for {{ CYCLES }} cycles.
    """

[task parameters]
    x = 1..{{ TASKS }}
    y = 1..{{ TASKS }}

[scheduling]
    cycling mode = integer
    initial cycle point = 1
    final cycle point = {{ CYCLES }}
    [[graph]]
        P1 = """
            d[-P1] => a => b<x> => c<y> => d
        """

[runtime]
    [[b<x>, c<y>]]
        script = sleep {{ SLEEP }}
    [[a, d]]
```

</details>

```
$ cylc play efficiency/ --profile -s 'TASKS=16'
```

![c1](https://user-images.githubusercontent.com/61982285/214018772-23b80b8c-ae0a-4051-8021-9f9cfb332d45.png)

Expanded to `edge_id`:

![c2](https://user-images.githubusercontent.com/61982285/214019865-4bb56c32-7d86-407e-8084-4603ad80b45f.png)

#### After

![c3](https://user-images.githubusercontent.com/61982285/214019893-f5b3d6dc-338c-4b94-82a9-c19d06c7c65c.png)

#### Check list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No new tests needed
- [x] No changelog entry - presumably will be part of a bunch of efficiency improvements for 8.1.1
- [x] No docs
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
