### PR TITLE
data_store: remove unnecessary pdeepcopy

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1328,10 +1328,10 @@ class DataStoreMgr:
         )
         # Not all fields are populated with some submit-failures,
         # so use task cfg as base.
-        j_cfg = pdeepcopy(self._apply_broadcasts_to_runtime(
+        j_cfg = self._apply_broadcasts_to_runtime(
             tp_tokens.relative_id,
             self.schd.config.cfg['runtime'][tproxy.name]
-        ))
+        )
         for key, val in job_conf.items():
             j_cfg[key] = val
         j_buf.runtime.CopyFrom(runtime_from_config(j_cfg))


### PR DESCRIPTION
I think this `pdeepcopy` call is not needed because it is already being performed lower down in the stack:

Here's the call being removed:

https://github.com/cylc/cylc-flow/blob/a52943a034b195c08ffd0195636a80d94e7401b1/cylc/flow/data_store_mgr.py#L1279-L1282

And here's what is was being called on the output of:

https://github.com/cylc/cylc-flow/blob/a52943a034b195c08ffd0195636a80d94e7401b1/cylc/flow/data_store_mgr.py#L1222-L1228

Here's a `--profile` result from the same workflow used in #5328 which shows the `pdeepcopy` to be about half the cost of `insert_job`:

<img width="813" alt="Screenshot 2023-01-25 at 13 39 54" src="https://user-images.githubusercontent.com/16705946/214590701-b6d46d6e-4446-491d-afb8-5145fa089bc7.png">

So worth stripping out if it's not needed.

Some of the Parsec methods are pretty expensive, particularly replicate unfortunately.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.