### PR TITLE
fix to make setup.cfg work with setuptools v67.0.0

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - psutil >=5.6.0
   - python
   - pyzmq >=22,<23
-  - setuptools >=49
+  - setuptools >=49, <67
   - urwid >=2,<3
   # Add # [py<3.11] for tomli once Python 3.11 Released
   - tomli >=2

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - setuptools >=49
   - urwid >=2,<3
   # Add # [py<3.11] for tomli once Python 3.11 Released
-  - tomli >=2.0.0
+  - tomli >=2
 
 # optional dependencies
   #- empy >=3.3,<3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ install_requires =
     rx
     promise
     # Once Python 3.11 released -'; python_version<"3.11"'
-    tomli>=2.*
+    tomli>=2
 
 [options.packages.find]
 include = cylc*

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,13 +72,12 @@ install_requires =
     protobuf>=4.21.2,<4.22.0
     psutil>=5.6.0
     pyzmq==22.*
-    setuptools>=49
+    setuptools>=49, <67
     urwid==2.*
     # unpinned transient dependencies used for type checking
     rx
     promise
-    # Once Python 3.11 released -'; python_version<"3.11"'
-    tomli>=2
+    tomli>=2; python_version < "3.11"
 
 [options.packages.find]
 include = cylc*

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
     protobuf>=4.21.2,<4.22.0
     psutil>=5.6.0
     pyzmq==22.*
+    # https://github.com/pypa/setuptools/issues/3802
     setuptools>=49, <67
     urwid==2.*
     # unpinned transient dependencies used for type checking


### PR DESCRIPTION
A very small change to the format of the setup.cfg to make it work with the latest version of setuptools.

Non fast-tests cancelled.


See also https://github.com/pypa/setuptools/blob/v67.0.0/CHANGES.rst

(Still digging to find out what part of PEP508 or 440 was the problem)

Caused by [this PR](https://github.com/pypa/packaging/pull/634) fixing.

[Reference: Using setuptools comments to make requirements py version dependent](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html)