### PR TITLE
Apply prerequisite changes to spawned tasks, on reload & restart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,15 @@ Rose options (`-O`, `-S` & `-D`) with `cylc view`.
 for `cylc lint`.
 
 -------------------------------------------------------------------------------
+## __cylc-8.1.2 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#5334](https://github.com/cylc/cylc-flow/pull/5334) - Fix to prevent scheduler
+crash if an already-spawned tasks has new prerequisites added before restart.
+
+
+-------------------------------------------------------------------------------
 ## __cylc-8.1.1 (<span actions:bind='release-date'>Released 2023-01-31</span>)__
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,7 +74,7 @@ for `cylc lint`.
 ### Fixes
 
 [#5334](https://github.com/cylc/cylc-flow/pull/5334) - Fix to prevent scheduler
-crash if an already-spawned tasks has new prerequisites added before restart.
+crash if already-spawned tasks have new prerequisites added before a restart.
 
 
 -------------------------------------------------------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,8 +73,8 @@ for `cylc lint`.
 
 ### Fixes
 
-[#5334](https://github.com/cylc/cylc-flow/pull/5334) - Fix to prevent scheduler
-crash if already-spawned tasks have new prerequisites added before a restart.
+[#5334](https://github.com/cylc/cylc-flow/pull/5334) - Apply graph prerequisite 
+changes to already-spawned tasks after reload or restart.
 
 
 -------------------------------------------------------------------------------

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1229,7 +1229,12 @@ class DataStoreMgr:
                     self.db_load_task_proxies[ikey][0].state.prerequisites
             ):
                 for key in itask_prereq.satisfied.keys():
-                    itask_prereq.satisfied[key] = prereqs[key]
+                    try:
+                        itask_prereq.satisfied[key] = prereqs[key]
+                    except KeyError:
+                        # This prereq is not in the DB: new dependencies
+                        # added to an already-spawned task before restart.
+                        itask_prereq.satisfied[key] = False
 
         # Extract info from itasks to data-store.
         for task_info in self.db_load_task_proxies.values():

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -510,12 +510,19 @@ class TaskPool:
                         flow_nums,
                     )
             ):
-                key = (prereq_cycle, prereq_name, prereq_output)
-                sat[key] = satisfied if satisfied != '0' else False
+                # Prereq satisfaction as recorded in the DB.
+                sat[
+                    (prereq_cycle, prereq_name, prereq_output)
+                ] = satisfied if satisfied != '0' else False
 
             for itask_prereq in itask.state.prerequisites:
-                for key, _ in itask_prereq.satisfied.items():
-                    itask_prereq.satisfied[key] = sat[key]
+                for key in itask_prereq.satisfied.keys():
+                    try:
+                        itask_prereq.satisfied[key] = sat[key]
+                    except KeyError:
+                        # This prereq is not in the DB: new dependencies
+                        # added to an already-spawned task before restart.
+                        itask_prereq.satisfied[key] = False
 
             if itask.state_reset(status, is_runahead=True):
                 self.data_store_mgr.delta_task_runahead(itask)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -444,7 +444,7 @@ class TaskPool:
                 # this task is in the right flow
                 task_outputs = json.loads(task_outputs)
                 return (
-                    'satisfied naturally'
+                    'satisfied from database'
                     if output in task_outputs
                     else False
                 )
@@ -970,6 +970,7 @@ class TaskPool:
                     self.check_task_output,
                 )
                 self._swap_out(new_task)
+                self.data_store_mgr.delta_task_prerequisite(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
                 if itask.state(*TASK_STATUSES_ACTIVE):
                     LOG.warning(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -21,8 +21,14 @@ from collections import Counter
 import json
 from time import time
 from typing import (
-    Dict, Iterable, List, Optional,
-    Set, TYPE_CHECKING, Tuple
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    TYPE_CHECKING,
+    Tuple,
+    Union,
 )
 import logging
 
@@ -422,6 +428,30 @@ class TaskPool:
         cycle, name, output = row
         self.abs_outputs_done.add((cycle, name, output))
 
+    def check_task_output(
+        self,
+        cycle: str,
+        task: str,
+        output: str,
+        flow_nums: 'FlowNums',
+    ) -> Union[str, bool]:
+        """Returns truthy if the specified output is satisfied in the DB."""
+        for task_outputs, task_flow_nums in (
+            self.workflow_db_mgr.pri_dao.select_task_outputs(task, cycle)
+        ).items():
+            # loop through matching tasks
+            if flow_nums.intersection(task_flow_nums):
+                # this task is in the right flow
+                task_outputs = json.loads(task_outputs)
+                return (
+                    'satisfied naturally'
+                    if output in task_outputs
+                    else False
+                )
+        else:
+            # no matching entries
+            return False
+
     def load_db_task_pool_for_restart(self, row_idx, row):
         """Load tasks from DB task pool/states/jobs tables.
 
@@ -522,7 +552,17 @@ class TaskPool:
                     except KeyError:
                         # This prereq is not in the DB: new dependencies
                         # added to an already-spawned task before restart.
-                        itask_prereq.satisfied[key] = False
+                        # Look through task outputs to see if is has been
+                        # satisfied
+                        prereq_cycle, prereq_task, prereq_output = key
+                        itask_prereq.satisfied[key] = (
+                            self.check_task_output(
+                                prereq_cycle,
+                                prereq_task,
+                                prereq_output,
+                                itask.flow_nums,
+                            )
+                        )
 
             if itask.state_reset(status, is_runahead=True):
                 self.data_store_mgr.delta_task_runahead(itask)
@@ -925,7 +965,10 @@ class TaskPool:
                 new_task = TaskProxy(
                     self.config.get_taskdef(itask.tdef.name),
                     itask.point, itask.flow_nums, itask.state.status)
-                itask.copy_to_reload_successor(new_task)
+                itask.copy_to_reload_successor(
+                    new_task,
+                    self.check_task_output,
+                )
                 self._swap_out(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
                 if itask.state(*TASK_STATUSES_ACTIVE):

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -18,7 +18,6 @@
 
 from collections import Counter
 from copy import copy
-from contextlib import suppress
 from fnmatch import fnmatchcase
 from time import time
 from typing import (

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -719,6 +719,9 @@ async def test_restart_prereqs(
         )
         assert list_tasks(schd) == expected_3
 
+        # To cover some code for loading prereqs from the DB at restart:
+        schd.data_store_mgr.update_data_structure()
+
         # Check resulting dependencies of task z
         task_z = schd.pool.get_all_tasks()[0]
         assert sorted(

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -593,3 +593,96 @@ async def test_load_db_bad_platform(
             False, 1, '', 'culdee-fell-summit', '', '', '', '{}'
         ))
         assert result == 'culdee-fell-summit'
+
+
+def list_tasks(schd):
+    """Return a list of task pool tasks (incl hidden pool tasks).
+
+    Returns a list in the format:
+        [
+            (cycle, task, state)
+        ]
+
+    """
+    return sorted(
+        (itask.tokens['cycle'], itask.tokens['task'], itask.state.status)
+        for itask in schd.pool.get_all_tasks()
+    )
+
+
+async def tests_restart_graph_change(flow, scheduler, start):
+    """It should handle prerequisite changes on restart.
+
+    If the graph has changed when a workflow is restarted those changes should
+    be applied to tasks already in the pool.
+
+    See https://github.com/cylc/cylc-flow/pull/5334
+
+    """
+
+    conf = {
+        'scheduler': {'allow implicit tasks': 'True'},
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    a => z
+                    b => z
+                ''',
+            }
+        }
+    }
+    id_ = flow(conf)
+    schd = scheduler(id_, run_mode='simulation', paused_start=False)
+
+    async with start(schd):
+        # release tasks 1/a and 1/b
+        schd.pool.release_runahead_tasks()
+        schd.release_queued_tasks()
+        assert list_tasks(schd) == [
+            ('1', 'a', 'running'),
+            ('1', 'b', 'running'),
+        ]
+
+        # mark 1/a as succeeded and spawn 1/z
+        schd.pool.get_all_tasks()[0].state_reset('succeeded')
+        schd.pool.spawn_on_output(schd.pool.get_all_tasks()[0], 'succeeded')
+        assert list_tasks(schd) == [
+            ('1', 'b', 'running'),
+            ('1', 'z', 'waiting'),
+        ]
+
+        # save our progress
+        schd.workflow_db_mgr.put_task_pool(schd.pool)
+
+    # edit the workflow to add a new dependency on "z"
+    conf['scheduling']['graph']['R1'] += '\n c => z'
+    id_ = flow(conf, id_=id_)
+
+    # and restart it
+    schd = scheduler(id_, run_mode='simulation', paused_start=False)
+    async with start(schd):
+        # load jobs from db
+        schd.pool.reload_taskdefs()
+        schd.workflow_db_mgr.pri_dao.select_jobs_for_restart(
+            schd.data_store_mgr.insert_db_job
+        )
+        assert list_tasks(schd) == [
+            ('1', 'b', 'running'),
+            ('1', 'z', 'waiting'),
+        ]
+
+        # ensure the new dependency 1/c has been added to 1/z
+        # and is *not* satisfied
+        task_z = schd.pool.get_all_tasks()[0]
+        assert sorted(
+            (
+                p.satisfied
+                for p in task_z.state.prerequisites
+            ),
+            key=lambda d: tuple(d.keys())[0],
+        ) == [
+            {('1', 'a', 'succeeded'): 'satisfied naturally'},
+            {('1', 'b', 'succeeded'): False},
+            {('1', 'c', 'succeeded'): False},
+
+        ]

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -55,11 +55,15 @@ def _make_flow(
     test_dir: Path,
     conf: Union[dict, str],
     name: Optional[str] = None,
+    id_: Optional[str] = None,
 ) -> str:
     """Construct a workflow on the filesystem."""
-    if name is None:
-        name = str(uuid1())
-    flow_run_dir = (test_dir / name)
+    if id_:
+        flow_run_dir = (cylc_run_dir / id_)
+    else:
+        if name is None:
+            name = str(uuid1())
+        flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
     reg = str(flow_run_dir.relative_to(cylc_run_dir))
     if isinstance(conf, dict):


### PR DESCRIPTION
On restart we assume that all prerequisites of a spawned task are recorded in the DB. This will not be the case on restarting after adding new dependencies to that task.

Example:

```ini
[scheduling]
    [[graph]]
        R1 = """
            a => z
            b => z
            # c => z
        """
[runtime]
    [[a]]
         script = "sleep 20"
    [[b, c, z]]
```

To reproduce the bug:

- install and play
- do `cylc stop --now` when `a` is still running and `z` has been spawned by `b:succeeded`
- uncomment `# c => z` to add a new prerequisite (`c`) task for `z`
- reinstall and play: scheduler will crash

The fix: if a prerequisite does not exist in the DB, assume that it is unsatisfied.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
