### PR TITLE
Fix setup.cfg for setuptools 67.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     rx
     promise
     # Once Python 3.11 released -'; python_version<"3.11"'
-    tomli>=2.*
+    tomli>=2.0
 
 [options.packages.find]
 include = cylc*


### PR DESCRIPTION

`pip install .` results in the latest `setuptools` (version 67) being installed, which rejects bad syntax in `setup.cfg`: `foo>=3.*` (the wildcard is only allowed with `==`).

This is calling CI to fail on GitHub, and reproduced locally.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
