### PR TITLE
data store: support unsatisfied ext_trigger

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -2094,7 +2094,7 @@ class DataStoreMgr:
         tp_delta.stamp = f'{tp_id}@{update_time}'
         ext_trigger = tp_delta.external_triggers[trig]
         ext_trigger.message = message
-        ext_trigger.satisfied = True
+        ext_trigger.satisfied = satisfied
         ext_trigger.time = update_time
         self.updates_pending = True
 


### PR DESCRIPTION
Something I spotted whilst doing #5328.

This doesn't matter at the moment as the only use of this function calls it with `satisfied=True`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.