### PR TITLE
Fix a bug preventing `cylc vip --workflow-name=foo` from working.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-8.1.2 (<span actions:bind='release-date'>Coming Soon</span>)__
+
+[#5349](https://github.com/cylc/cylc-flow/pull/5349) - Bugfix: `cylc vip --workflow-name`
+only worked when used with a space, not an `=`.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.1.1 (<span actions:bind='release-date'>Released 2023-01-31</span>)__
 
 ### Fixes

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -821,6 +821,7 @@ def cleanup_sysargv(
         for x in compound_script_opts
     }
     # Filter out non-cylc-play options.
+    args = [i.split('=')[0] for i in sys.argv]
     for unwanted_opt in (set(options.__dict__)) - set(script_opts_by_dest):
         for arg in compound_opts_by_dest[unwanted_opt].args:
             if arg in sys.argv:
@@ -831,8 +832,8 @@ def cleanup_sysargv(
                     not in ['store_true', 'store_false']
                 ):
                     sys.argv.pop(index)
-            elif arg in [i.split('=')[0] for i in sys.argv]:
-                index = [i.split('=')[0] for i in sys.argv].index(arg)
+            elif arg in args:
+                index = args.index(arg)
                 sys.argv.pop(index)
 
     # replace compound script name:

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -831,6 +831,9 @@ def cleanup_sysargv(
                     not in ['store_true', 'store_false']
                 ):
                     sys.argv.pop(index)
+            elif arg in [i.split('=')[0] for i in sys.argv]:
+                index = [i.split('=')[0] for i in sys.argv].index(arg)
+                sys.argv.pop(index)
 
     # replace compound script name:
     sys.argv[1] = script_name

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -397,6 +397,19 @@ def test_combine_options(inputs, expect):
             'play --foo something myworkflow'.split(),
             id='no path given'
         ),
+        param(
+            'vip --bar=something'.split(),
+            {
+                'script_name': 'play',
+                'workflow_id': 'myworkflow',
+                'compound_script_opts': [
+                    OptionSettings(['--bar', '-b'])],
+                'script_opts': [],
+                'source': './myworkflow',
+            },
+            'play myworkflow'.split(),
+            id='removes --key=value'
+        ),
     ]
 )
 def test_cleanup_sysargv(monkeypatch, argv_before, kwargs, expect):


### PR DESCRIPTION
`--workflow-name foo` was fine.
Caused by removal of unwanted sys.argv for Cylc VIP not removing items not exactly matching items in the Command line options arguments.

This is a small fix for a bug without an issue.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc)~ not req'd
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
