### PR TITLE
clock-expire: experimental main-loop implementation

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -270,7 +270,7 @@ class WorkflowConfig:
         self.start_point: 'PointBase'
         self.stop_point: Optional['PointBase'] = None
         self.final_point: Optional['PointBase'] = None
-        self.sequences: List['SequenceBase'] = []
+        self.sequences: Dict['SequenceBase', List[str]] = {}
         self.actual_first_point: Optional['PointBase'] = None
         self._start_point_for_actual_first_point: Optional['PointBase'] = None
 
@@ -1661,6 +1661,7 @@ class WorkflowConfig:
             elif not suicide:
                 # "foo => !bar" does not define a sequence for bar
                 taskdef.add_sequence(seq)
+                self.sequences[seq].append(name)
 
     def generate_triggers(self, lexpression, left_nodes, right, seq,
                           suicide, task_triggers):
@@ -2095,7 +2096,7 @@ class WorkflowConfig:
                 if isinstance(exc, CylcError):
                     msg += ' %s' % exc.args[0]
                 raise WorkflowConfigError(msg)
-            self.sequences.append(seq)
+            self.sequences.setdefault(seq, [])
             parser = GraphParser(
                 family_map,
                 self.parameters,

--- a/cylc/flow/main_loop/clock_expire.py
+++ b/cylc/flow/main_loop/clock_expire.py
@@ -1,0 +1,128 @@
+from typing import TYPE_CHECKING
+
+from cylc.flow import LOG
+from cylc.flow.cycling.loader import get_point
+from cylc.flow.main_loop import (
+    periodic,
+    startup,
+    submit,
+)
+from cylc.flow.task_state import (
+    TASK_STATUS_EXPIRED,
+    TASK_STATUS_WAITING,
+)
+from cylc.flow.wallclock import now
+
+from metomi.isodatetime.data import get_timepoint_for_now
+from metomi.isodatetime.parsers import DurationParser
+
+if TYPE_CHECKING:
+    from cylc.flow.scheduler import Scheduler
+
+
+@startup
+async def setup(schd: 'Scheduler', state: dict):
+    # the greatest clock-expire offset from the cycle point
+    # (this is the furthest ahead of the current time that we need to
+    # look for expired tasks)
+    state['max_offset'] = max(
+        offset
+        for offset in schd.config.expiration_offsets.values()
+    )
+    # all clock-expire'able tasks within the window 
+    state['timeouts'] = {}
+    # the point we have populated the timouts list up to
+    state['expire_point'] = schd.config.initial_point
+
+
+@periodic
+async def check_clock_expires(schd: 'Scheduler', state: dict):
+    """Check for clock-expired tasks."""
+    time = get_timepoint_for_now()
+    add_timeouts(schd, state, time)
+    check_timeouts(schd, state, time)
+
+
+@submit
+async def remove_timeout(schd, state, itasks):
+    """Remove a task from expire timeouts, called when tasks are submitted."""
+    for itask in itasks:
+        key = (itask.tokens['cycle'], itask.tokens['task'])
+        if key in state['timeouts']:
+            state['timeouts'].pop(key)
+
+
+def check_timeouts(schd: 'Scheduler', state, time):
+    """Check for expired tasks in the timeouts dict."""
+    time = get_point(str(time))
+    timeouts = state['timeouts']
+
+    pop = []
+    for (point, task), timeout in timeouts.items():
+        if time > timeout:
+            if clock_expire_task(schd, point, task):
+                pop.append((point, task))
+
+    for point, task in pop:
+        timeouts.pop((point, task))
+
+
+def add_timeouts(schd: 'Scheduler', state: dict, time):
+    """Expand the expire window and add new tasks to the timeouts dict."""
+    # the furthest we have looked ahead so far
+    old_expire_point = state['expire_point']
+    # the furthest we should look ahead now
+    new_expire_point = time + DurationParser().parse(state['max_offset'].value)
+
+    # expand the window out to "new_expire_point"
+    timeouts = state['timeouts']
+    for recurrence, tasks in schd.config.sequences.items():
+        point = recurrence.get_next_point(old_expire_point)
+        if point is None:
+            # end of sequence => skip
+            continue
+        while point <= get_point(str(new_expire_point)):
+            # TODO: avoid looping all tasks in each sequence
+            for task in tasks:
+                if task in schd.config.expiration_offsets:
+                    # add expiration timeout
+                    timeouts[(point, task)] = (
+                        schd.config.expiration_offsets[task]
+                        + point
+                    )
+            point = recurrence.get_next_point(point)
+    
+    state['expire_point'] = get_point(str(new_expire_point))
+
+
+def clock_expire_task(schd, point, task):
+    """Expire a task."""
+    print(f'clock_expire_task({point}, {task})')
+    itask = schd.pool.get_task(point, task)
+    if (
+        itask
+        and not itask.state(
+            TASK_STATUS_WAITING,
+            is_held=False
+        )
+    ):
+        # don't expire this task, it is held
+        return False
+
+    if not itask:
+        itask = schd.pool.spawn_task(
+            task,
+            point,
+            {1},  # TODO use flow=all?
+            # TODO: wait=true?
+        )
+
+    msg = 'Task expired (skipping job).'
+    LOG.warning(f"[{point}/{task}] {msg}")
+    schd.task_events_mgr.setup_event_handlers(itask, "expired", msg)
+    # TODO succeeded and expired states are useless due to immediate
+    # removal under all circumstances (unhandled failed is still used).
+    if itask.state_reset(TASK_STATUS_EXPIRED, is_held=False):
+        schd.data_store_mgr.delta_task_state(itask)
+        schd.data_store_mgr.delta_task_held(itask)
+    return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -207,6 +207,7 @@ cylc.main_loop =
     log_main_loop = cylc.flow.main_loop.log_main_loop [main_loop-log_main_loop]
     log_memory = cylc.flow.main_loop.log_memory [main_loop-log_memory]
     reset_bad_hosts = cylc.flow.main_loop.reset_bad_hosts
+    clock_expire = cylc.flow.main_loop.clock_expire
 # NOTE: all entry points should be listed here even if Cylc Flow does not
 # provide any implementations, to make entry point scraping easier
 cylc.pre_configure =


### PR DESCRIPTION
PR for the purpose of debate...

* The current clock-expire implementation uses task pool logic.
* This means that tasks can only become expired when they enter the pool.
* Consequently expire events are retroactive and might not occur at all. This means they are not useful for triggering in the way they were at Cylc 7.
* This alternative implementation maintains a moving window for detecting clock expired tasks which is separate to the task_pool so is not dependent on tasks being in the task_pool for expired events to be generated.
* It works by using a "periodic" main loop plugin to extend the expiry window, adding any clock-expire tasks within that window into a list of timeouts.
* It then checks that list of timeouts via the same "periodic" main loop plugin to see if any tasks have expired.
* To avoid expiring tasks which have submitted successfully it uses a [new] "submit" main loop plugin to remove timeouts for tasks which have submitted.

Advantages:
* Expired events are raised close to the time of expiry (according to the interval the main loop plugin is configured to run on).
* Expired outputs are generated whether the workflkow has made it as far as the task or not, allowing for effective triggering e.g: `foo:expire? => special_action`.
* The same methodology could also be applied to late tasks.

Challenges:
* Removing this logic from the task_pool makes interfacing with multiple flows tricky.
* What flow(s) do we expire the tasks in?
* Graph branching!!!

TODO:
* Activate the clock_expire plugin if there are clock-expired tasks in the workflow.
* Make the logic more efficient.
* Fix old & write new tests, tidy, etc.

<!--
Thanks for your contribution:
* Please list any related issues with a "closes" or "addresses" tag.
* Please add a helpful description.
* For bugfixes we have maintenance branches e.g. `8.0.x`, please raise separate
  pull requests against master and the maintenance release branches as appropriate.
-->

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
