### PR TITLE
Cylc lint fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-8.1.2 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#5363](https://github.com/cylc/cylc-flow/pull/5363) Improvements and bugfixes
+for `cylc lint`.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.1.1 (<span actions:bind='release-date'>Released 2023-01-31</span>)__
 
 ### Fixes

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -125,7 +125,8 @@ STYLE_CHECKS = {
         'url': STYLE_GUIDE + 'trailing-whitespace',
         'index': 6
     },
-    re.compile(r'inherit\s*=\s*[a-z].*$'): {
+    # Look for families both from inherit=FAMILY and FAMILY:trigger-all/any
+    re.compile(r'(inherit\s*=\s*.*[a-z].*)|(\w[a-z]\w:.+?-a(ll|ny))'): {
         'short': 'Family name contains lowercase characters.',
         'url': STYLE_GUIDE + 'task-naming-conventions',
         'index': 7

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -135,6 +135,18 @@ STYLE_CHECKS = {
         'short': JINJA2_FOUND_WITHOUT_SHEBANG,
         'url': '',
         'index': 8
+    },
+    re.compile(r'platform\s*=\s*\$\(.*?\)'): {
+        'short': 'Host Selection Script may be redundant with platform',
+        'url': (
+            'https://cylc.github.io/cylc-doc/stable/html/7-to-8/'
+            'major-changes/platforms.html'
+        ),
+        'index': 9
+    },
+    re.compile(r'platform\s*=\s*(`.*?`)'): {
+        'short': 'Using backticks to invoke subshell is deprecated',
+        'url': 'https://github.com/cylc/cylc-flow/issues/3825'
     }
     # re.compile(r'^.{{maxlen},}'): {
     #     'short': 'line > {maxlen} characters.',
@@ -176,6 +188,10 @@ MANUAL_DEPRECATIONS = {
             '``global.cylc[platforms][<platform name>]job runner``'
         )
     },
+    re.compile(r'host\s*=\s*(`.*?`)'): {
+        'short': 'Using backticks to invoke subshell will fail at Cylc 8.',
+        'url': 'https://github.com/cylc/cylc-flow/issues/3825'
+    }
 }
 RULESETS = ['728', 'style', 'all']
 EXTRA_TOML_VALIDATION = {

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -146,7 +146,13 @@ STYLE_CHECKS = {
     },
     re.compile(r'platform\s*=\s*(`.*?`)'): {
         'short': 'Using backticks to invoke subshell is deprecated',
-        'url': 'https://github.com/cylc/cylc-flow/issues/3825'
+        'url': 'https://github.com/cylc/cylc-flow/issues/3825',
+        'index': 10
+    },
+    re.compile(r'#.*?{[{%].*[}%]}'): {
+        'short': 'Cylc will process commented Jinja2!',
+        'url': '',
+        'index': 11
     }
     # re.compile(r'^.{{maxlen},}'): {
     #     'short': 'line > {maxlen} characters.',
@@ -486,7 +492,13 @@ def check_cylc_file(
             ):
                 continue
 
-            if check.findall(line) and not line.strip().startswith('#'):
+            if (
+                check.findall(line)
+                and (
+                    not line.strip().startswith('#')
+                    or (
+                        'Cylc will process commented Jinja2!' in message['short'] and check.findall(line)
+            ))):
                 count += 1
                 if modify:
                     if message['url'].startswith('http'):

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -126,12 +126,12 @@ STYLE_CHECKS = {
         'index': 6
     },
     # Look for families both from inherit=FAMILY and FAMILY:trigger-all/any
-    re.compile(r'(inherit\s*=\s*.*[a-z].*)|(\w[a-z]\w:.+?-a(ll|ny))'): {
+    re.compile(r'(inherit\s*=\s*.*[a-z].*)|(\w[a-z]\w:\w+?-a(ll|ny))'): {
         'short': 'Family name contains lowercase characters.',
         'url': STYLE_GUIDE + 'task-naming-conventions',
         'index': 7
     },
-    re.compile(r'({%.*%})|({{.*}})'): {
+    re.compile(r'{[{%]'): {
         'short': JINJA2_FOUND_WITHOUT_SHEBANG,
         'url': '',
         'index': 8
@@ -149,7 +149,7 @@ STYLE_CHECKS = {
         'url': 'https://github.com/cylc/cylc-flow/issues/3825',
         'index': 10
     },
-    re.compile(r'#.*?{[{%].*[}%]}'): {
+    re.compile(r'#.*?{[{%]'): {
         'short': 'Cylc will process commented Jinja2!',
         'url': '',
         'index': 11

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -497,8 +497,11 @@ def check_cylc_file(
                 and (
                     not line.strip().startswith('#')
                     or (
-                        'Cylc will process commented Jinja2!' in message['short'] and check.findall(line)
-            ))):
+                        'commented Jinja2!' in message['short']
+                        and check.findall(line)
+                    )
+                )
+            ):
                 count += 1
                 if modify:
                     if message['url'].startswith('http'):

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -131,6 +131,11 @@ STYLE_CHECKS = {
         'url': STYLE_GUIDE + 'task-naming-conventions',
         'index': 7
     },
+    re.compile(r'({%.*%})|({{.*}})'): {
+        'short': JINJA2_FOUND_WITHOUT_SHEBANG,
+        'url': '',
+        'index': 8
+    }
     # re.compile(r'^.{{maxlen},}'): {
     #     'short': 'line > {maxlen} characters.',
     #     'url': STYLE_GUIDE + 'line-length-and-continuation',

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -132,6 +132,9 @@ TEST_FILE = """
      [[remote]]
 
  [meta]
+    [[and_another_thing]]
+        [[[remote]]]
+            host = `rose host-select thingy`
 """
 
 
@@ -150,6 +153,10 @@ LINT_TEST_FILE = """
         inherit = hello
      [[[job]]]
 something\t
+    [[bar]]
+        platform = $(some-script foo)
+    [[baz]]
+        platform = `no backticks`
 """
 
 LINT_TEST_FILE += (

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -92,10 +92,10 @@ TEST_FILE = """
     hold after point = 20220101T0000Z
     [[dependencies]]
         [[[R1]]]
-            graph = foo
+            graph = MyFaM:finish-all => remote
 
 [runtime]
-    [[MYFAM]]
+    [[MyFaM]]
         extra log files = True
         {% from 'cylc.flow' import LOG %}
         script = {{HELLOWORLD}}
@@ -127,6 +127,7 @@ TEST_FILE = """
 
 # Shouldn't object to a comment, unlike the terrible indents below:
    [[bad indent]]
+        inherit = MyFaM
 
      [[remote]]
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -142,6 +142,9 @@ LINT_TEST_FILE = """
 
 [[dependencies]]
 
+{% foo %}
+{{foo}}
+
 [runtime]
           [[foo]]
         inherit = hello

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -147,6 +147,7 @@ LINT_TEST_FILE = """
 
 {% foo %}
 {{foo}}
+# {{quix}}
 
 [runtime]
           [[foo]]


### PR DESCRIPTION
A ticket combining a number of small fixes for Cylc lint:

Closes: 
- Closes #5362 - With style check warn user that `platform = $(some script)` is still possible, but platform logic means that it's probably not a great idea. Additionally with 728 check warns that ``host=\`some script\` ` will break at Cylc 8.
- Closes #5356 - Lint to check family names contain _no_ lowercase letters. Additionally checks for family names by searching for `FAMILY:trigger-all` and `trigger-any`.
- Closes #5355 - Lint wasn't checking for Jinja2 at all, although I'd written in the switch to turn such tests off in the absence of a shebang line.
- Closes #5226 - Lint warns that apparently commented jinja2 will be processed.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
