### PR TITLE
fix no rose vars in cylc view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@ updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
 -------------------------------------------------------------------------------
+## __cylc-8.1.2 (<span actions:bind='release-date'>Coming Soon</span>)__
+
+### Fixes
+
+[#5367](https://github.com/cylc/cylc-flow/pull/5367) - Enable using
+Rose options (`-O`, `-S` & `-D`) with Cylc View.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.1.1 (<span actions:bind='release-date'>Released 2023-01-31</span>)__
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ ones in. -->
 ### Fixes
 
 [#5367](https://github.com/cylc/cylc-flow/pull/5367) - Enable using
-Rose options (`-O`, `-S` & `-D`) with Cylc View.
+Rose options (`-O`, `-S` & `-D`) with `cylc view`.
 
 -------------------------------------------------------------------------------
 ## __cylc-8.1.1 (<span actions:bind='release-date'>Released 2023-01-31</span>)__

--- a/cylc/flow/scripts/view.py
+++ b/cylc/flow/scripts/view.py
@@ -98,6 +98,8 @@ def get_option_parser():
     parser.add_option(
         *AGAINST_SOURCE_OPTION.args, **AGAINST_SOURCE_OPTION.kwargs)
 
+    parser.add_cylc_rose_options()
+
     return parser
 
 


### PR DESCRIPTION
This PR closes an issue documented in the PR.

## Issue Description

Cylc view does not have access to the Cylc Rose command line options (`-O`, `-S`, `-D`), when it ought to have.

## PR Information

I have added the Cylc Rose CLI options to `cylc view`. It works manually, but ought to be tested in Cylc Rose.

Question - do we want to test the Cylc Rose option adder in this repo by looking at the `--help` output?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are **not** included because they should be in Cylc Rose; https://github.com/cylc/cylc-rose/pull/209
- [x] `CHANGES.md` entry not included - this is not a change that can affect users
- [x] Cylc doc update considered - not required.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
