### PR TITLE
Install scan sort

### DIFF
--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -215,12 +215,16 @@ async def scan(wf_name: str, ping: bool = True) -> None:
         'source': False,
         'ping': ping,  # get status of scanned workflows
     })
-    active = [
-        item async for item in get_pipe(
-            opts, None,
-            scan_dir=get_workflow_run_dir(wf_name)  # restricted scan
-        )
-    ]
+    active = sorted(
+        [
+            item async for item in get_pipe(
+                opts,
+                None,
+                scan_dir=get_workflow_run_dir(wf_name)  # restricted scan
+            )
+        ],
+        key=lambda flow: flow['name']
+    )
     if active:
         n = len(active)
         grammar = (


### PR DESCRIPTION
Sort the scan results displayed by `install` so that the runs are in order:

```
NOTE: 3 runs of "generic" are already active:
  ▶ generic/run1 vld601.cmpd1.metoffice.gov.uk:43072
  ▶ generic/run2 vld601.cmpd1.metoffice.gov.uk:43137
  ▶ generic/run3 vld601.cmpd1.metoffice.gov.uk:43141
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` and `conda-environment.yml`.
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
