### PR TITLE
tui: add vr

### DIFF
--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -114,6 +114,17 @@ REINSTALL_CYLC_ROSE_OPTIONS = [
     )
 ]
 
+REINSTALL_OPTIONS = [
+    OptionSettings(
+        ["--yes"],
+        help='Skip interactive prompts.',
+        action="store_true",
+        default=False,
+        dest="skip_interactive",
+        sources={'reinstall'}
+    ),
+]
+
 
 def get_option_parser() -> COP:
     parser = COP(
@@ -121,14 +132,17 @@ def get_option_parser() -> COP:
     )
 
     parser.add_cylc_rose_options()
+    options = REINSTALL_OPTIONS
     try:
         # If cylc-rose plugin is available
         __import__('cylc.rose')
+        options.extend(REINSTALL_CYLC_ROSE_OPTIONS)
     except ImportError:
         pass
-    else:
-        for option in REINSTALL_CYLC_ROSE_OPTIONS:
-            parser.add_option(*option.args, **option.kwargs)
+
+    for option in options:
+        parser.add_option(*option.args, **option.kwargs)
+
     return parser
 
 
@@ -177,7 +191,8 @@ def reinstall_cli(
 
     usr: str = ''
     try:
-        if is_terminal():  # interactive mode - perform dry-run and prompt
+        if is_terminal() and not opts.skip_interactive:
+            # interactive mode - perform dry-run and prompt
             # dry-mode reinstall
             if not reinstall(
                 opts,

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -61,7 +61,9 @@ from cylc.flow.scripts.validate import (
     _main as cylc_validate
 )
 from cylc.flow.scripts.reinstall import (
-    REINSTALL_CYLC_ROSE_OPTIONS, reinstall_cli as cylc_reinstall
+    REINSTALL_CYLC_ROSE_OPTIONS,
+    REINSTALL_OPTIONS,
+    reinstall_cli as cylc_reinstall,
 )
 from cylc.flow.scripts.reload import (
     reload_cli as cylc_reload
@@ -73,6 +75,7 @@ from cylc.flow.workflow_files import detect_old_contact_file
 CYLC_ROSE_OPTIONS = COP.get_cylc_rose_options()
 VR_OPTIONS = combine_options(
     VALIDATE_OPTIONS,
+    REINSTALL_OPTIONS,
     REINSTALL_CYLC_ROSE_OPTIONS,
     PLAY_OPTIONS,
     CYLC_ROSE_OPTIONS,

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -481,6 +481,7 @@ class TuiApp:
                 See `urwid` docs for details.
 
         """
+        # create the overlay
         kwargs = {'width': 'pack', 'height': 'pack', **kwargs}
         overlay = urwid.Overlay(
             urwid.LineBox(
@@ -503,8 +504,14 @@ class TuiApp:
             top=self.stack * 5,
             **kwargs,
         )
+
+        # add it into the overlay stack
         self.loop.widget = overlay
         self.stack += 1
+
+        # force urwid to render the overlay now rather than waiting until the
+        # event loop becomes idle
+        self.loop.draw_screen()
 
     def close_topmost(self):
         """Remove the topmost frame or uit the app if none present."""

--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -151,7 +151,7 @@ def cli_cmd(*cmd):
     )
     out, err = proc.communicate()
     if proc.returncode != 0:
-        raise ClientError(err)
+        raise ClientError(f'Error in command {" ".join(cmd)}\n{err}')
 
 
 def _clean(workflow):


### PR DESCRIPTION
Response to user feedback:

* Add a `--yes` option to `cylc reinstall` / `cylc vr`.
* Add `cylc vr` into `cylc tui`.

This also presents a box which tells the user that a command is running to avoid confusion with longer-running commands e.g. `play`, `clean`, `validate-reinstall`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] There is no interactive test harness for `cylc tui` at present.
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
