### PR TITLE
Restore default for PBS max job name len.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,14 +18,18 @@ ones in. -->
 Fixes `cylc set-verbosity`.
 
 -------------------------------------------------------------------------------
-## __cylc-8.1.2 (<span actions:bind='release-date'>Released 2023-02-20</span>)__
+## __cylc-8.1.3 (<span actions:bind='release-date'>Coming Soon</span>)__
 
 ### Fixes
-
 
 [#5386](https://github.com/cylc/cylc-flow/pull/5386) Fix bug where
 absence of `job name length maximum` in PBS platform settings would cause
 Cylc to crash when preparing the job script.
+
+-------------------------------------------------------------------------------
+## __cylc-8.1.2 (<span actions:bind='release-date'>Released 2023-02-20</span>)__
+
+### Fixes
 
 [#5349](https://github.com/cylc/cylc-flow/pull/5349) - Bugfix: `cylc vip --workflow-name`
 only worked when used with a space, not an `=`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,11 +17,6 @@ ones in. -->
 [#5384](https://github.com/cylc/cylc-flow/pull/5384) -
 Fixes `cylc set-verbosity`.
 
--------------------------------------------------------------------------------
-## __cylc-8.1.3 (<span actions:bind='release-date'>Coming Soon</span>)__
-
-### Fixes
-
 [#5386](https://github.com/cylc/cylc-flow/pull/5386) Fix bug where
 absence of `job name length maximum` in PBS platform settings would cause
 Cylc to crash when preparing the job script.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,11 @@ Fixes `cylc set-verbosity`.
 
 ### Fixes
 
+
+[#5386](https://github.com/cylc/cylc-flow/pull/5386) Fix bug where
+absence of `job name length maximum` in PBS platform settings would cause
+Cylc to crash when preparing the job script.
+
 [#5349](https://github.com/cylc/cylc-flow/pull/5349) - Bugfix: `cylc vip --workflow-name`
 only worked when used with a space, not an `=`.
 

--- a/cylc/flow/job_runner_handlers/pbs.py
+++ b/cylc/flow/job_runner_handlers/pbs.py
@@ -96,7 +96,10 @@ class PBSHandler:
             f'{tokens["task"]}.{tokens["cycle"]}'
             f".{job_conf['workflow_name'].replace('/', '-')}"
         )
-        job_name_len_max = job_conf['platform']["job name length maximum"]
+        job_name_len_max = job_conf['platform'].get(
+            "job name length maximum",
+            self.JOB_NAME_LEN_MAX
+        )
         if job_name_len_max:
             directives["-N"] = directives["-N"][0:job_name_len_max]
 

--- a/tests/unit/job_runner_handlers/test_pbs.py
+++ b/tests/unit/job_runner_handlers/test_pbs.py
@@ -57,7 +57,7 @@ VERY_LONG_STR = 'x' * 240
                 }
             },
             [
-                f'#PBS -N None.{VERY_LONG_STR[:231]}',
+                f'#PBS -N None.{VERY_LONG_STR[:PBSHandler.JOB_NAME_LEN_MAX - 5]}',
                 '#PBS -o cylc-run/chop/log/job/1/axe/01/job.out',
                 '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
                 '#PBS -l walltime=180',

--- a/tests/unit/job_runner_handlers/test_pbs.py
+++ b/tests/unit/job_runner_handlers/test_pbs.py
@@ -19,7 +19,7 @@ import pytest
 from cylc.flow.job_runner_handlers.pbs import JOB_RUNNER_HANDLER
 
 
-VERY_LONG_STR = 'x'.join(['' for i in range(240)])
+VERY_LONG_STR = 'x' * 240
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/job_runner_handlers/test_pbs.py
+++ b/tests/unit/job_runner_handlers/test_pbs.py
@@ -16,7 +16,10 @@
 
 import pytest
 
-from cylc.flow.job_runner_handlers.pbs import JOB_RUNNER_HANDLER
+from cylc.flow.job_runner_handlers.pbs import (
+    JOB_RUNNER_HANDLER,
+    PBSHandler
+)
 
 
 VERY_LONG_STR = 'x' * 240

--- a/tests/unit/job_runner_handlers/test_pbs.py
+++ b/tests/unit/job_runner_handlers/test_pbs.py
@@ -43,7 +43,7 @@ VERY_LONG_STR = 'x' * 240
                 '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
                 '#PBS -l walltime=180',
             ],
-            id='it sets basic directives'
+            id='basic'
         ),
         pytest.param(
             {
@@ -62,7 +62,7 @@ VERY_LONG_STR = 'x' * 240
                 '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
                 '#PBS -l walltime=180',
             ],
-            id='it handles job name len max unset in config'
+            id='long-job-name'
         ),
         pytest.param(
             {
@@ -82,7 +82,7 @@ VERY_LONG_STR = 'x' * 240
                 '#PBS -e cylc-run/chop/log/job/1/axe/01/job.err',
                 '#PBS -l walltime=180',
             ],
-            id='it truncates a long job name'
+            id='truncate-job-name'
         ),
         pytest.param(
             {
@@ -109,7 +109,7 @@ VERY_LONG_STR = 'x' * 240
                 '#PBS -V',
                 '#PBS -l mem=256gb',
             ],
-            id='it adds custom directives'
+            id='custom-directives'
         ),
     ],
 )


### PR DESCRIPTION
This is a pull request describing the issue to be fixed.

### Issue

If `global.cylc[platforms][<platform>]job name length maximum` is unset `cylc.flow.job_runner_handlers.pbs.PBSHandler.format_directives` will fail with a key error.

Instead it should fall back to the value contained in `JOB_NAME_LEN_MAX`.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
