### PR TITLE
remote: add note about sys.exit behaviour

### DIFF
--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -78,7 +78,7 @@ def run_cmd(
     manage=False,
     text=True,
 ):
-    """Run a given cylc command on another account and/or host.
+    """Run a given cylc command on another host.
 
     Arguments:
         command (list):
@@ -107,6 +107,10 @@ def run_cmd(
         * Else True if the remote command is executed successfully, or
           if unsuccessful and capture_status=True the remote command exit code.
         * Otherwise exit with an error message.
+
+    Exits:
+        1: In the event of certain command errors.
+
     """
     # CODACY ISSUE:
     #   subprocess call - check for execution of untrusted input.
@@ -385,6 +389,9 @@ def remote_cylc_cmd(
     Raises:
         NoHostsError: If the platform is not contactable.
 
+    Exits:
+        1: In the event of certain command errors.
+
     """
     if not host:
         # no host selected => perform host selection from platform config
@@ -425,6 +432,9 @@ def cylc_server_cmd(cmd, host=None, **kwargs):
 
     Raises:
         NoHostsError: If the platform is not contactable.
+
+    Exits:
+        1: In the event of certain command errors.
 
     """
     return remote_cylc_cmd(

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -388,8 +388,7 @@ def remote_cylc_cmd(
     Raises:
         NoHostsError: If the platform is not contactable.
 
-    Exits:
-        1: In the event of certain command errors.
+    Exits with code 1 in the event of certain command errors.
 
     """
     if not host:
@@ -432,8 +431,7 @@ def cylc_server_cmd(cmd, host=None, **kwargs):
     Raises:
         NoHostsError: If the platform is not contactable.
 
-    Exits:
-        1: In the event of certain command errors.
+    Exits with code 1 in the event of certain command errors.
 
     """
     return remote_cylc_cmd(

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -108,8 +108,7 @@ def run_cmd(
           if unsuccessful and capture_status=True the remote command exit code.
         * Otherwise exit with an error message.
 
-    Exits:
-        1: In the event of certain command errors.
+    Exits with code 1 in the event of certain command errors.
 
     """
     # CODACY ISSUE:


### PR DESCRIPTION
Add a note about `sys.exit` behaviour in the remote interfaces.