### PR TITLE
Stop searching platform groups after first match.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ ones in. -->
 
 ### Fixes
 
+[5398](https://github.com/cylc/cylc-flow/pull/5398) - Fix platform from
+group selection order bug.
+
 [#5384](https://github.com/cylc/cylc-flow/pull/5384) -
 Fixes `cylc set-verbosity`.
 

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -191,6 +191,9 @@ def platform_from_name(
         platform_name = 'localhost'
 
     platform_group = None
+    # The list is reversed to allow user-set platform groups (which are loaded
+    # later than site set platforms) to be matched first and override site
+    # defined platforms.
     for platform_name_re in reversed(list(platform_groups)):
         # Platform is member of a group.
         if re.fullmatch(platform_name_re, platform_name):
@@ -198,6 +201,7 @@ def platform_from_name(
                 platform_groups[platform_name_re], group_name=platform_name,
                 bad_hosts=bad_hosts
             )
+            break
 
     for platform_name_re in list(platforms):
         if (

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -254,6 +254,9 @@ def test_get_platform_groups_basic(mock_glbl_cfg):
                 [[[selection]]]
                     method = definition order
             [[aleph]]
+            # Group with same name as platform to try and
+            # trip up the platform selection logic after it
+            # has processed [[.*_letters]] below
                 platforms = alpha
             [[.*_letters]]
                 platforms = aleph, bet

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -237,18 +237,25 @@ def test_get_platform_using_platform_name_from_job_info(
 
 
 def test_get_platform_groups_basic(mock_glbl_cfg):
-    # get platform from group works.
+    """get platform from group works.
+
+    Additionally, ensure that we stop after selecting the first
+    appropriate platform.
+    """
     mock_glbl_cfg(
         'cylc.flow.platforms.glbl_cfg',
         '''
         [platforms]
-            [[aleph]]
-                hosts = aleph
-            [[bet]]
-                hosts = bet
+            [[aleph, bet, alpha, beta]]
 
         [platform groups]
             [[hebrew_letters]]
+                platforms = alpha, beta
+                [[[selection]]]
+                    method = definition order
+            [[aleph]]
+                platforms = alpha
+            [[.*_letters]]
                 platforms = aleph, bet
                 [[[selection]]]
                     method = definition order


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

Platform selection from a platform group was missing a `break` in the `for` loop, leading to the possibility of the wrong platform being selected.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
