### PR TITLE
update Gedit syntax highlighting instructions

### DIFF
--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -10,8 +10,7 @@
  /usr/share/gtksourceview-2.0/language-specs/
 
  If your installation uses GNOME 3, the '2.0' in the paths will need
- to be '3.0', and the version="2.0" string below will need changing
- as well.
+ to be '3.0'.
 
  If using gedit, gedit will need to be totally closed down and reloaded.
 

--- a/tests/functional/platforms/02-host-to-platform-upgrade.t
+++ b/tests/functional/platforms/02-host-to-platform-upgrade.t
@@ -45,6 +45,7 @@ grep_ok "\[T2\]\[remote\]host = ${CYLC_TEST_HOST}"\
     "${TEST_NAME_BASE}-run.stderr"
 
 # Run the workflow
+echo $CYLC_TEST_HOST >&2
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach --reference-test \
     -s CYLC_TEST_HOST="'$CYLC_TEST_HOST'" \


### PR DESCRIPTION
The "2.0" referred to by the removed sentence refers to the XML version, not the GTK version, as implied.

https://gitlab.gnome.org/GNOME/gtksourceview/-/blob/master/docs/lang-tutorial.md#a-language-definition-for-the-c-language

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] No tests, a documentation change.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
