### PR TITLE
portability: permit arpa address

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -120,10 +120,11 @@ class HostUtil:
                 target = socket.getfqdn()
             if (
                 IS_MAC_OS
-                and target == (
+                and target in {
                     '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.'
-                    '0.0.0.0.0.0.ip6.arpa'
-                )
+                    '0.0.0.0.0.0.ip6.arpa',
+                    '1.0.0.127.in-addr.arpa'
+                }
             ):
                 # Python's socket bindings don't play nicely with mac os
                 # so by default we get the above ip6.arpa address from


### PR DESCRIPTION
Closes #6147

Frustratingly, the arpa address returned by `socket.getfqdn` on Mac OS is different with Python 3.9 than 3.7 (conda-forge).

For context see https://github.com/cylc/cylc-flow/pull/4296

I'm not especially keen on fiddling this exception every time it changes, but can't really think of a better way to do this safely.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.