### PR TITLE
add upgrade switch to a test using an older db

### DIFF
--- a/tests/functional/job-submission/03-job-nn-remote-host-with-shared-fs.t
+++ b/tests/functional/job-submission/03-job-nn-remote-host-with-shared-fs.t
@@ -25,7 +25,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 mkdir "${WORKFLOW_RUN_DIR}/.service"
 sqlite3 "${WORKFLOW_RUN_DIR}/.service/db" <'db.sqlite3'
 workflow_run_ok "${TEST_NAME_BASE}-restart" \
-    cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}"
+    cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}" --upgrade
 
 purge
 exit


### PR DESCRIPTION
Minor issue, documented in this PR

This test requires an `--upgrade` switch because it relies on an older database.

Found on 8.1.x when checking that my setup can run tests.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Change to a test ~Tests are included (or explain why tests are not needed).~
- [x] NO ~`CHANGES.md` entry included if this is a change that can affect users~
- [x] NO ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
