### PR TITLE
task_pool: avoid listing tasks where not necessary

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -128,7 +128,7 @@ class TaskPool:
         self.task_name_list = self.config.get_task_name_list()
         self.task_queue_mgr = IndepQueueManager(
             self.config.cfg['scheduling']['queues'],
-            self.config.get_task_name_list(),
+            self.task_name_list,
             self.config.runtime['descendants']
         )
         self.tasks_to_hold: Set[Tuple[str, 'PointBase']] = set()
@@ -137,7 +137,7 @@ class TaskPool:
         """Set stop after a task."""
         tokens = Tokens(task_id, relative=True)
         name = tokens['task']
-        if name in self.config.get_task_name_list():
+        if name in self.config.taskdefs:
             task_id = TaskID.get_standardised_taskid(task_id)
             LOG.info("Setting stop task: " + task_id)
             self.stop_task_id = task_id
@@ -174,7 +174,7 @@ class TaskPool:
         flow_num = self.flow_mgr.get_new_flow(
             f"original flow from {self.config.start_point}")
         self.compute_runahead()
-        for name in self.config.get_task_name_list():
+        for name in self.task_name_list:
             tdef = self.config.get_taskdef(name)
             point = tdef.first_point(self.config.start_point)
             self.spawn_to_rh_limit(tdef, point, {flow_num})
@@ -925,7 +925,7 @@ class TaskPool:
         del self.task_queue_mgr
         self.task_queue_mgr = IndepQueueManager(
             self.config.cfg['scheduling']['queues'],
-            self.config.get_task_name_list(),
+            self.task_name_list,
             self.config.runtime['descendants']
         )
 
@@ -1385,7 +1385,7 @@ class TaskPool:
     def can_spawn(self, name: str, point: 'PointBase') -> bool:
         """Return True if the task with the given name & point is within
         various workflow limits."""
-        if name not in self.config.get_task_name_list():
+        if name not in self.config.taskdefs:
             LOG.debug('No task definition %s', name)
             return False
         # Don't spawn outside of graph limits.


### PR DESCRIPTION
Some low-hanging fruit spotted whilst investigating #5435

The task_pool code was repeatedly requesting the same sorted list of tasks which was starting to bite for a 7001 task workflow.

* Re-use the cached task list where appropriate.
* Switch to using the task dictionary for "in" comparisons for faster performance.

I profiled this using the example in #5435 and the [flawed] patch from https://github.com/cylc/cylc-flow/issues/5435#issuecomment-1487031362. I pressed ctrl+c once the first `b<x>` task has submitted.

This diff brings the time taken by the `can_spawn` function down from 16.93s to 0.2046s which is a saving of ~5% of the overall runtime!

~Question: 8.1.3 or 8.2.0?~

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.