### PR TITLE
CLI: short option changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,15 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+
+-------------------------------------------------------------------------------
+## __cylc-8.2.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+[#5439](https://github.com/cylc/cylc-flow/pull/5439) - Small CLI short option chages:
+Add the `-n` short option for `--workflow-name` to `cylc vip`; rename the `-n`
+short option for `--no-detach` to `-N`; add `-r` as a short option for
+`--run-name`.
+
 -------------------------------------------------------------------------------
 ## __cylc-8.1.3 (<span actions:bind='release-date'>Upcoming</span>)__
 

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -134,7 +134,7 @@ PLAY_RUN_MODE.sources = {'play'}
 
 PLAY_OPTIONS = [
     OptionSettings(
-        ["-n", "--no-detach", "--non-daemon"],
+        ["-N", "--no-detach", "--non-daemon"],
         help="Do not daemonize the scheduler (infers --format=plain)",
         action='store_true', dest="no_detach", sources={'play'}),
     OptionSettings(

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -137,7 +137,7 @@ INSTALL_OPTIONS = [
         sources={'install'},
     ),
     OptionSettings(
-        ["--run-name"],
+        ["--run-name", "-r"],
         help=(
             "Give the run a custom name instead of automatically"
             " numbering it."),

--- a/tests/functional/cylc-trigger/06-already-active.t
+++ b/tests/functional/cylc-trigger/06-already-active.t
@@ -27,6 +27,6 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --debug -n "${WORKFLOW_NAME}"
+    cylc play --debug --no-detach "${WORKFLOW_NAME}"
 
 purge

--- a/tests/functional/optional-outputs/00-stall-on-partial.t
+++ b/tests/functional/optional-outputs/00-stall-on-partial.t
@@ -25,7 +25,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play -n --reference-test --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test --debug "${WORKFLOW_NAME}"
 
 LOG="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 grep_ok "Partially satisfied prerequisites" "${LOG}"

--- a/tests/functional/optional-outputs/01-stall-on-incomplete.t
+++ b/tests/functional/optional-outputs/01-stall-on-incomplete.t
@@ -26,7 +26,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play -n --reference-test --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test --debug "${WORKFLOW_NAME}"
 
 LOG="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 grep_ok "Incomplete tasks" "${LOG}"

--- a/tests/functional/optional-outputs/03-c7backcompat.t
+++ b/tests/functional/optional-outputs/03-c7backcompat.t
@@ -46,7 +46,7 @@ grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
 
 # And it should run without stalling with an incomplete task.
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play -n --reference-test --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test --debug "${WORKFLOW_NAME}"
 
 purge
 exit

--- a/tests/functional/optional-outputs/04-c7backcompat-blocked-task.t
+++ b/tests/functional/optional-outputs/04-c7backcompat-blocked-task.t
@@ -32,7 +32,7 @@ grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
 
 # Should stall and abort with an unsatisfied prerequisite.
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play -n --reference-test --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test --debug "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok grep-1 "WARNING - Partially satisfied prerequisites"
 grep_workflow_log_ok grep-2 "Workflow stalled"

--- a/tests/functional/optional-outputs/05-c7backcompat-blocked-task-2.t
+++ b/tests/functional/optional-outputs/05-c7backcompat-blocked-task-2.t
@@ -32,7 +32,7 @@ grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
 
 # Should stall and abort with an unsatisfied prerequisite.
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play -n --reference-test --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --reference-test --debug "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok grep-1 "WARNING - Partially satisfied prerequisites"
 grep_workflow_log_ok grep-2 "Workflow stalled"

--- a/tests/functional/optional-outputs/06-c7backcompat-family.t
+++ b/tests/functional/optional-outputs/06-c7backcompat-family.t
@@ -32,7 +32,7 @@ grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
 
 # Should stall and abort with unsatisfied "stall" tasks.
 workflow_run_fail "${TEST_NAME_BASE}-run" \
-    cylc play -n --debug "${WORKFLOW_NAME}"
+    cylc play --no-detach --debug "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok grep-1 "Workflow stalled"
 grep_workflow_log_ok grep-2 "WARNING - Partially satisfied prerequisites"

--- a/tests/functional/optional-outputs/07-finish-fail-c7-backcompat.t
+++ b/tests/functional/optional-outputs/07-finish-fail-c7-backcompat.t
@@ -33,7 +33,7 @@ DEPR_MSG_1=$(python -c \
 grep_ok "${DEPR_MSG_1}" "${TEST_NAME}.stderr"
 
 # Stall expected at FCP (but not at runahead limit).
-workflow_run_fail "${TEST_NAME_BASE}-run" cylc play -n --debug "${WORKFLOW_NAME}"
+workflow_run_fail "${TEST_NAME_BASE}-run" cylc play --no-detach --debug "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok grep-0 "Workflow stalled"
 grep_workflow_log_ok grep-1 "ERROR - Incomplete tasks:"

--- a/tests/functional/optional-outputs/08-finish-fail-c7-c8.t
+++ b/tests/functional/optional-outputs/08-finish-fail-c7-c8.t
@@ -36,6 +36,6 @@ DEPR_MSG="deprecated graph items were automatically upgraded"  # (not back-compa
 grep_ok "${DEPR_MSG}" "${TEST_NAME}.stderr"
 
 # No stall expected.
-workflow_run_ok "${TEST_NAME_BASE}-run" cylc play -n --debug "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play --no-detach --debug "${WORKFLOW_NAME}"
 
 purge

--- a/tests/functional/restart/58-removed-task.t
+++ b/tests/functional/restart/58-removed-task.t
@@ -30,14 +30,14 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate --set="INCL_B_C=True" "${WORKF
 run_ok "${TEST_NAME_BASE}-validate" cylc validate --set="INCL_B_C=False" "${WORKFLOW_NAME}"
 
 TEST_NAME="${TEST_NAME_BASE}-run"
-workflow_run_ok "${TEST_NAME}" cylc play -n "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME}" cylc play --no-detach "${WORKFLOW_NAME}"
 
 # Restart with removed tasks should not cause an error.
 # It should shut down cleanly after orphaned task a and incomplete failed task
 # b are polled (even though b has been removed from the graph) and a finishes
 # (after checking the poll results).
 TEST_NAME="${TEST_NAME_BASE}-restart"
-workflow_run_ok "${TEST_NAME}" cylc play --set="INCL_B_C=False" -n "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME}" cylc play --set="INCL_B_C=False" --no-detach "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok "grep-3" "\[1/a running job:01 flows:1\] (polled)started"
 grep_workflow_log_ok "grep-4" "\[1/b failed job:01 flows:1\] (polled)failed"

--- a/tests/functional/rnd/05-main-loop.t
+++ b/tests/functional/rnd/05-main-loop.t
@@ -55,7 +55,7 @@ __FLOW_CYLC__
 # run a workflow with all the development main-loop plugins turned on
 run_ok "${TEST_NAME_BASE}-run" \
     cylc play "${WORKFLOW_NAME}" \
-        -n \
+        --no-detach \
         --debug \
         --main-loop 'log data store' \
         --main-loop 'log db' \

--- a/tests/functional/triggering/18-suicide-active.t
+++ b/tests/functional/triggering/18-suicide-active.t
@@ -27,7 +27,7 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --debug -n "${WORKFLOW_NAME}"
+    cylc play --debug --no-detach "${WORKFLOW_NAME}"
 
 grep_workflow_log_ok "${TEST_NAME_BASE}-grep" "suiciding while active"
 


### PR DESCRIPTION
Closes #5227

* Rename `-n` for `--no-detach` to `-N`. This removes the conflict with `--workflow-name` allowing the option to be used in `cylc vip`.
* Add `-r` as a short option for `--run-name`.

Note, `-r` is used as a short option for the `--raw` output option, however, this doesn't conflict with install/play/clean/reload/reinstall/tui so shouldn't be a conflict risk with any future compound commands.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.