### PR TITLE
efficiency: pass tokens instances to get_broadcast

### DIFF
--- a/cylc/flow/broadcast_mgr.py
+++ b/cylc/flow/broadcast_mgr.py
@@ -28,7 +28,6 @@ from cylc.flow.broadcast_report import (
     get_broadcast_bad_options_report,
 )
 from cylc.flow.cfgspec.workflow import SPEC
-
 from cylc.flow.cycling.loader import get_point, standardise_point_string
 from cylc.flow.exceptions import PointParsingError
 from cylc.flow.parsec.util import listjoin

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1153,7 +1153,7 @@ class DataStoreMgr:
             fp_delta.runtime.CopyFrom(
                 runtime_from_config(
                     self._apply_broadcasts_to_runtime(
-                        tokens.relative_id,
+                        tokens,
                         self.schd.config.cfg['runtime'][fam.name]
                     )
                 )
@@ -1312,15 +1312,15 @@ class DataStoreMgr:
         tproxy.runtime.CopyFrom(
             runtime_from_config(
                 self._apply_broadcasts_to_runtime(
-                    itask.identity,
+                    itask.tokens,
                     itask.tdef.rtconfig
                 )
             )
         )
 
-    def _apply_broadcasts_to_runtime(self, relative_id, rtconfig):
+    def _apply_broadcasts_to_runtime(self, tokens, rtconfig):
         # Handle broadcasts
-        overrides = self.schd.broadcast_mgr.get_broadcast(relative_id)
+        overrides = self.schd.broadcast_mgr.get_broadcast(tokens)
         if overrides:
             rtconfig = pdeepcopy(rtconfig)
             poverride(rtconfig, overrides, prepend=True)
@@ -1375,7 +1375,7 @@ class DataStoreMgr:
         # Not all fields are populated with some submit-failures,
         # so use task cfg as base.
         j_cfg = pdeepcopy(self._apply_broadcasts_to_runtime(
-            tp_tokens.relative_id,
+            tp_tokens,
             self.schd.config.cfg['runtime'][tproxy.name]
         ))
         for key, val in job_conf.items():
@@ -1887,7 +1887,7 @@ class DataStoreMgr:
             tokens = Tokens(node_id)
             new_runtime = runtime_from_config(
                 self._apply_broadcasts_to_runtime(
-                    tokens.relative_id,
+                    tokens,
                     cfg['runtime'][node.name]
                 )
             )

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -152,12 +152,16 @@ class Tokens(dict):
         return f'<id: {id_}>'
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return all(
             self[key] == other[key]
             for key in self._KEYS
         )
 
     def __ne__(self, other):
+        if not isinstance(other, self.__class__):
+            return True
         return any(
             self[key] != other[key]
             for key in self._KEYS

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -430,7 +430,7 @@ class TaskEventsManager():
 
     def _get_remote_conf(self, itask, key):
         """Get deprecated "[remote]" items that default to platforms."""
-        overrides = self.broadcast_mgr.get_broadcast(itask.identity)
+        overrides = self.broadcast_mgr.get_broadcast(itask.tokens)
         SKEY = 'remote'
         if SKEY not in overrides:
             overrides[SKEY] = {}
@@ -442,7 +442,7 @@ class TaskEventsManager():
 
     def _get_workflow_platforms_conf(self, itask, key):
         """Return top level [runtime] items that default to platforms."""
-        overrides = self.broadcast_mgr.get_broadcast(itask.identity)
+        overrides = self.broadcast_mgr.get_broadcast(itask.tokens)
         return (
             overrides.get(key) or
             itask.tdef.rtconfig[key] or
@@ -923,7 +923,7 @@ class TaskEventsManager():
     def _get_events_conf(self, itask, key, default=None):
         """Return an events setting from workflow then global configuration."""
         for getter in [
-                self.broadcast_mgr.get_broadcast(itask.identity).get("events"),
+                self.broadcast_mgr.get_broadcast(itask.tokens).get("events"),
                 itask.tdef.rtconfig["mail"],
                 itask.tdef.rtconfig["events"],
                 glbl_cfg().get(["scheduler", "mail"]),

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1084,7 +1084,7 @@ class TaskJobManager:
 
         # Handle broadcasts
         overrides = self.task_events_mgr.broadcast_mgr.get_broadcast(
-            itask.identity
+            itask.tokens
         )
         if overrides:
             rtconfig = pdeepcopy(itask.tdef.rtconfig)

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -320,12 +320,19 @@ def test_tokens():
     with pytest.raises(ValueError):
         Tokens()['foo'] = 'a'
 
+    # test equality
     assert Tokens('a') == Tokens('a')
     assert Tokens('a') != Tokens('b')
     assert Tokens('a', relative=True) == Tokens('a', relative=True)
     assert Tokens('a', relative=True) != Tokens('b', relative=True)
     assert Tokens() != Tokens('a')
     assert Tokens(workflow='a') == Tokens('a')
+
+    # test equality with non Tokens objects
+    assert Tokens('a') != 'a'
+    assert not Tokens('a') == 'a'
+    assert Tokens('a') != 1
+    assert not Tokens('a') == 1
 
     tokens = Tokens('a//b')
     tokens.update({'cycle': 'c', 'task': 'd'})


### PR DESCRIPTION
A small efficiency improvement which reduces the number of times the tokenise/detokenise interfaces get hit by passing the parsed objects around as arguments.

Profiling results for a workflow with a single task:

| Method | Before (calls) | After (calls) |
| --- | --- | --- |
| tokenise | 21 | 6 |
| detokenise | 37 | 36 |

So that's a reduction of 15 tokenise and 1 detokenise call per task. The tokenise calls take 7.095e-06s so not a big deal, but collectively they can add up.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.