### PR TITLE
parsec: catch section/option conflict in validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ ones in. -->
 
 ### Fixes
 
+[5450](https://github.com/cylc/cylc-flow/pull/5450) - Validation provides
+better error messages if [sections] and settings are mixed up in a
+configuration.
+
 [5398](https://github.com/cylc/cylc-flow/pull/5398) - Fix platform from
 group selection order bug.
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -356,13 +356,6 @@ class WorkflowConfig:
         except KeyError:
             parameter_templates = {}
 
-        # Check that parameter templates are a section
-        if not hasattr(parameter_templates, 'update'):
-            raise WorkflowConfigError(
-                '[task parameters][templates] is a section. Don\'t use it '
-                'as a parameter.'
-            )
-
         # parameter values and templates are normally needed together.
         self.parameters = (parameter_values, parameter_templates)
 

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -104,7 +104,13 @@ class upgrader:
     def get_item(self, keys):
         item = self.cfg
         for key in keys:
-            item = item[key]
+            try:
+                item = item[key]
+            except TypeError:
+                raise UpgradeError(
+                    f'{self.show_keys(keys[:-1], True)}'
+                    f' ("{keys[-2]}" should be a [section] not a setting)'
+                )
         return item
 
     def put_item(self, keys, val):

--- a/tests/functional/validate/76-section-section-transpose.t
+++ b/tests/functional/validate/76-section-section-transpose.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test handling of mixed up sections vs settings
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 6
+
+# 1. section as setting (normal)
+TEST_NAME='section-as-setting-normal'
+cat > 'flow.cylc' <<__HEREDOC__
+[runtime]
+    [[foo]]
+        environment = 42
+__HEREDOC__
+run_fail "${TEST_NAME}-validate" cylc validate .
+grep_ok  \
+    'IllegalItemError: \[runtime\]\[foo\]environment - ("environment" should be a \[section\] not a setting)' \
+    "${TEST_NAME}-validate.stderr"
+
+
+# 2. section as setting (via upgrader)
+# NOTE: if this test fails it is likely because the upgrader for "scheduling"
+# has been removed, convert this to use a new deprecated section
+TEST_NAME='section-as-setting-upgrader'
+cat > 'flow.cylc' <<__HEREDOC__
+scheduling = 22
+__HEREDOC__
+
+run_fail "${TEST_NAME}-validate" cylc validate .
+grep_ok  \
+    'UpgradeError: \[scheduling\] ("scheduling" should be a \[section\] not a setting' \
+    "${TEST_NAME}-validate.stderr"
+
+
+# 3. setting as section
+TEST_NAME='setting-as-section'
+cat > 'flow.cylc' <<__HEREDOC__
+[scheduling]
+    [[initial cycle point]]
+__HEREDOC__
+
+run_fail "${TEST_NAME}-validate" cylc validate .
+grep_ok  \
+    'IllegalItemError: \[scheduling\]initial cycle point - ("initial cycle point" should be a setting not a \[section\])' \
+    "${TEST_NAME}-validate.stderr"

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -172,22 +172,6 @@ def test_no_graph(flow, validate):
     assert 'missing [scheduling][[graph]] section.' in str(exc_ctx.value)
 
 
-def test_parameter_templates_setting(flow, one_conf, validate):
-    """It should fail if [task parameter]templates is a setting.
-
-    It should be a section.
-    """
-    reg = flow({
-        **one_conf,
-        'task parameters': {
-            'templates': 'foo'
-        }
-    })
-    with pytest.raises(WorkflowConfigError) as exc_ctx:
-        validate(reg)
-    assert '[templates] is a section' in str(exc_ctx.value)
-
-
 @pytest.mark.parametrize(
     'section', [
         'external-trigger',


### PR DESCRIPTION
* Closes #4955
* If an item in the spec is a section but the user specified an option, raise an IllegalItemError if it is.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.