### PR TITLE
job runner handlers: docs++

### DIFF
--- a/cylc/flow/job_runner_handlers/documentation.py
+++ b/cylc/flow/job_runner_handlers/documentation.py
@@ -214,6 +214,20 @@ class ExampleHandler():
 
     """
 
+    POLL_CMD: str
+    """Command for checking job submissions.
+
+    A list of job IDs to poll will be provided as arguments.
+
+    The command should write valid submitted/running job IDs to stdout.
+
+    * To filter out invalid/failed jobs use
+      :py:meth:`ExampleHandler.filter_poll_many_output`.
+    * To build a more advanced command than is possible with this configuration
+      use :py:meth:`ExampleHandler.get_poll_many_cmd`.
+
+    """
+
     POLL_CANT_CONNECT_ERR: str
     """String for detecting communication errors in poll command output.
 
@@ -283,7 +297,7 @@ class ExampleHandler():
     def filter_poll_many_output(self, out: str) -> List[str]:
         """Filter job ides out of poll output.
 
-        Called after the job runner's poll many command. The method should read
+        Called after the job runner's poll command. The method should read
         the output and return a list of job IDs that are still in the
         job runner.
 
@@ -332,6 +346,9 @@ class ExampleHandler():
 
     def get_poll_many_cmd(self, job_id_list: List[str]) -> List[str]:
         """Return a command to poll the specified jobs.
+
+        If specified, this will be called instead of
+        :py:attr:`ExampleHandler.POLL_CMD`.
 
         Args:
             job_id_list: The list of job IDs to poll.


### PR DESCRIPTION
Spotted some missing entries in the job runner handler docs.

Attempted to fill in the blanks from an inspection of the code:

https://github.com/cylc/cylc-flow/blob/edc60e9774923400a0a64b23093615b96d1372dd/cylc/flow/job_runner_mgr.py#L484-L528

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.