### PR TITLE
Stop Cylc Reinstall modifying global variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,13 +17,15 @@ ones in. -->
 [#5291](https://github.com/cylc/cylc-flow/pull/5291) - re-implement old-style
 clock triggers as wall_clock xtriggers.
 
--------------------------------------------------------------------------------
-## __cylc-8.2.0 (<span actions:bind='release-date'>Upcoming</span>)__
-
 [#5439](https://github.com/cylc/cylc-flow/pull/5439) - Small CLI short option chages:
 Add the `-n` short option for `--workflow-name` to `cylc vip`; rename the `-n`
 short option for `--no-detach` to `-N`; add `-r` as a short option for
 `--run-name`.
+
+### Fixes
+
+[#5458](https://github.com/cylc/cylc-flow/pull/5458) - Fix a small bug
+causing option parsing to fail with Cylc Reinstall.
 
 -------------------------------------------------------------------------------
 ## __cylc-8.1.3 (<span actions:bind='release-date'>Upcoming</span>)__

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -87,7 +87,6 @@ from cylc.flow.id_cli import parse_id
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     OptionSettings,
-    Options,
     WORKFLOW_ID_ARG_DOC,
 )
 from cylc.flow.pathutil import get_workflow_run_dir
@@ -131,22 +130,19 @@ def get_option_parser() -> COP:
         __doc__, comms=True, argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
-    parser.add_cylc_rose_options()
-    options = REINSTALL_OPTIONS
     try:
         # If cylc-rose plugin is available
         __import__('cylc.rose')
-        options.extend(REINSTALL_CYLC_ROSE_OPTIONS)
     except ImportError:
-        pass
+        options = REINSTALL_OPTIONS
+    else:
+        parser.add_cylc_rose_options()
+        options = REINSTALL_CYLC_ROSE_OPTIONS + REINSTALL_OPTIONS
 
     for option in options:
         parser.add_option(*option.args, **option.kwargs)
 
     return parser
-
-
-ReInstallOptions = Options(get_option_parser())
 
 
 @cli_function(get_option_parser)

--- a/tests/integration/test_reinstall.py
+++ b/tests/integration/test_reinstall.py
@@ -28,14 +28,18 @@ from cylc.flow.exceptions import (
 from cylc.flow.install import (
     reinstall_workflow,
 )
+from cylc.flow.option_parsers import Options
 from cylc.flow.scripts.reinstall import (
-    ReInstallOptions,
+    get_option_parser as reinstall_gop,
     reinstall_cli,
 )
+from cylc.flow.terminal import cli_function
 from cylc.flow.workflow_files import (
     WorkflowFiles,
 )
 
+
+ReInstallOptions = Options(reinstall_gop())
 
 # cli opts
 


### PR DESCRIPTION
This caused the same variable to be added multiple times causing errors from clashing options.

Related to questions asked by @MetRonnie in https://github.com/cylc/cylc-rose/pull/219

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are not included because:
    - In the case of the change to `get_option_parser` we would largely be testing Python functionality.
    - In the case of moving ReinstallOptions we haven't done anything except move it to the test where it's used.
    - You can manually test before/after with `cylc reinstall --help`.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] This is a bug-fix for a bug existing only on master