### PR TITLE
Upload coverage to Codecov in separate job

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -35,20 +35,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Brew Install
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          # speed up install (https://docs.brew.sh/Manpage#environment)
-          export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
-          echo "[command]brew update"
-          brew update
-          echo "[command]brew install ..."
-          brew install bash coreutils
-          # add GNU coreutils and sed to the user PATH
-          # (see instructions in brew install output)
-          echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" \
-            >> "${GITHUB_PATH}"
-
       - name: Apt-Get Install
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           pytest tests/integration
 
-      - name: Upload artifact
+      - name: Upload failed tests artifact
         if: failure()
         uses: actions/upload-artifact@v3
         with:
@@ -105,15 +105,32 @@ jobs:
           coverage xml
           coverage report
 
-      - name: Codecov upload
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: '${{ github.workflow }} ${{ matrix.os }} py-${{ matrix.python-version }}'
-          flags: fast-tests
-          fail_ci_if_error: true
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?
+          name: coverage_${{ matrix.os }}_py-${{ matrix.python-version }}
+          path: coverage.xml
+          retention-days: 7
 
       - name: Linkcheck
         if: startsWith(matrix.python-version, '3.10')
         run: pytest -m linkcheck --dist=load tests/unit
+
+  codecov:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Codecov upload
+        uses: codecov/codecov-action@v3
+        with:
+          name: ${{ github.workflow }}
+          flags: fast-tests
+          fail_ci_if_error: true
+          verbose: true
+          # Token not required for public repos, but avoids upload failure due
+          # to rate-limiting (but not for PRs opened from forks)
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -248,14 +248,13 @@ jobs:
               -exec echo '====== {} ======' \; -exec cat '{}' \;
 
       - name: Set artifact upload name
-        if: failure() && steps.test.outcome == 'failure'
         id: uploadname
         run: |
           # artifact name cannot contain '/' characters
           CID="$(sed 's|/|-|g' <<< "${{ matrix.name || matrix.chunk }}")"
           echo "uploadname=$CID" >> $GITHUB_OUTPUT
 
-      - name: Upload artifact
+      - name: Upload failed tests artifact
         if: failure() && steps.test.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
@@ -294,11 +293,28 @@ jobs:
           coverage xml
           coverage report
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_${{ steps.uploadname.outputs.uploadname }}
+          path: coverage.xml
+          retention-days: 7
+
+  codecov:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
       - name: Codecov upload
         uses: codecov/codecov-action@v3
         with:
-          name: '${{ github.workflow }} ${{ matrix.name }} ${{ matrix.chunk }}'
+          name: ${{ github.workflow }}
           flags: functional-tests
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }} # Token not required for public repos, but might reduce chance of random 404 error?
+          # Token not required for public repos, but avoids upload failure due
+          # to rate-limiting (but not for PRs opened from forks)
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Workaround https://github.com/codecov/codecov-action/issues/837

- Reduces how hard we hit Codecov API
- Allows easy re-attempt to upload
- Makes clear the separation between test status and Codecov upload failures

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests N/A
- [x] Changelog N/A
- [x] Docs N/A
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
