### PR TITLE
Fix flake8-comprehensions C419

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -104,7 +104,7 @@ class OptionSettings():
     def _in_list(self, others):
         """CLI arguments for this option found in any of a list of
         other options."""
-        return any([self & other for other in others])
+        return any(self & other for other in others)
 
     def _update_sources(self, other):
         """Update the sources from this and 1 other OptionSettings object"""

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -487,10 +487,10 @@ def generic_items_match(
         # Get a set of items actually set in both platform and task_section.
         shared_items = set(task_section).intersection(set(platform_spec))
         # If any set items do not match, we can't use this platform.
-        if not all([
+        if not all(
             platform_spec[item] == task_section[item]
             for item in shared_items
-        ]):
+        ):
             return False
     return True
 

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -273,7 +273,7 @@ def get_pyproject_toml(dir_):
             raise CylcError(f'pyproject.toml did not load: {exc}')
 
         if any(
-            [i in loadeddata for i in ['cylc-lint', 'cylclint', 'cylc_lint']]
+            i in loadeddata for i in ['cylc-lint', 'cylclint', 'cylc_lint']
         ):
             for key in keys:
                 tomldata[key] = loadeddata.get('cylc-lint').get(key, [])


### PR DESCRIPTION
This is a small fix following flake8-comprehension https://github.com/adamchainz/flake8-comprehensions/pull/427

Don't use any([i for i in iterable])
use
any(i for i in iterable).
It's more efficient because we don't have to expand the entire thing.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] This is a small syntax change which does not require changlog/testing/docs...