### PR TITLE
upgrade cylc message internal help with details of severity levels

### DIFF
--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -59,6 +59,20 @@ Each message can be prefixed with a severity level using the syntax
 The default message severity is INFO. The --severity=SEVERITY option can be
 used to set the default severity level for all unprefixed messages.
 
+Increased severity will make messages more visible in workflow logs, using
+colour and format changes. DEBUG messages will not be shown in logs by default.
+
+The severity levels are those of the Python Logging Library
+https://docs.python.org/3/library/logging.html#logging-levels:
+
+- CRITICAL
+- ERROR
+- WARNING
+- INFO
+- DEBUG
+- NOTSET
+
+
 Note:
   To abort a job script with a custom error message, use cylc__job_abort:
     cylc__job_abort 'message...'

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -70,8 +70,6 @@ https://docs.python.org/3/library/logging.html#logging-levels:
 - WARNING
 - INFO
 - DEBUG
-- NOTSET
-
 
 Note:
   To abort a job script with a custom error message, use cylc__job_abort:


### PR DESCRIPTION
List possible severity levels for Cylc message in `cylc message --help` doc.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] This is a script documentation change which required no updates to tests/documentation/dependencies

I believe that it's small enough for 1 review.

I am intending to do a PR to cylc-doc with details of how to use messages to add info to workflow logs (as opposed to triggering task outputs.)