### PR TITLE
Fix broken `cylc help license` command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Inspect
         run: |
           unzip -l dist/*.whl | tee files
+          grep 'cylc_flow.*.dist-info/COPYING' files
           grep 'cylc/flow/py.typed' files
           grep 'cylc/flow/etc' files
           grep 'cylc/flow/etc/cylc-completion.bash' files

--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         manylinux: ['1']
-        os: ['ubuntu-18.04']  # run on the oldest linux we have access to
+        os: ['ubuntu-20.04']  # run on the oldest linux we have access to
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
@@ -73,7 +73,7 @@ jobs:
             >> _manylinux.py
 
       - name: Install
-        timeout-minutes: 25
+        timeout-minutes: 35
         run: |
           PYTHONPATH="$PWD:$PYTHONPATH" pip install ."[all]"
 
@@ -84,6 +84,6 @@ jobs:
           import cylc.flow.scheduler
 
       - name: Test
-        timeout-minutes: 15
+        timeout-minutes: 5
         run: |
           pytest -n 5

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ shuts down if all hosts for all platforms in a platform group are unreachable.
 [#5384](https://github.com/cylc/cylc-flow/pull/5384) -
 Fixes `cylc set-verbosity`.
 
+[#5479](https://github.com/cylc/cylc-flow/pull/5479) -
+Fixes `cylc help license`
+
 [#5394](https://github.com/cylc/cylc-flow/pull/5394) -
 Fixes a possible scheduler traceback observed with remote task polling.
 

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -17,10 +17,9 @@ dependencies:
   - python
   - pyzmq >=22,<23
   - setuptools >=49, <67
-  - importlib_metadata
+  - importlib_metadata # [py<3.8]
   - urwid >=2,<3
-  # Add # [py<3.11] for tomli once Python 3.11 Released
-  - tomli >=2
+  - tomli >=2 # [py<3.11]
 
 # optional dependencies
   #- empy >=3.3,<3.4

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - python
   - pyzmq >=22,<23
   - setuptools >=49, <67
+  - importlib_metadata
   - urwid >=2,<3
   # Add # [py<3.11] for tomli once Python 3.11 Released
   - tomli >=2

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -23,6 +23,7 @@ import sys
 from typing import Iterator, NoReturn, Optional, Tuple
 
 from ansimarkup import parse as cparse
+from importlib_metadata import files
 import pkg_resources
 
 from cylc.flow import __version__, iter_entry_points
@@ -391,12 +392,11 @@ def print_id_help():
     print(ID_HELP)
 
 
-def print_license():
-    print(
-        pkg_resources.get_distribution('cylc-flow').get_resource_string(
-            __name__, 'COPYING'
-        ).decode()
-    )
+def print_license() -> None:
+    license_file = next(filter(
+        lambda f: f.name == 'COPYING', files('cylc-flow')
+    ))
+    print(license_file.read_text())
 
 
 def print_command_list(commands=None, indent=0):

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -23,7 +23,6 @@ import sys
 from typing import Iterator, NoReturn, Optional, Tuple
 
 from ansimarkup import parse as cparse
-from importlib_metadata import files
 import pkg_resources
 
 from cylc.flow import __version__, iter_entry_points
@@ -393,6 +392,10 @@ def print_id_help():
 
 
 def print_license() -> None:
+    try:
+        from importlib.metadata import files
+    except ImportError:
+        from importlib_metadata import files
     license_file = next(filter(
         lambda f: f.name == 'COPYING', files('cylc-flow')
     ))

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ install_requires =
     pyzmq==22.*
     # https://github.com/pypa/setuptools/issues/3802
     setuptools>=49, <67
+    importlib_metadata
     urwid==2.*
     # unpinned transient dependencies used for type checking
     rx

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     pyzmq==22.*
     # https://github.com/pypa/setuptools/issues/3802
     setuptools>=49, <67
-    importlib_metadata
+    importlib_metadata; python_version < "3.8"
     urwid==2.*
     # unpinned transient dependencies used for type checking
     rx


### PR DESCRIPTION
Fixes
```
$ cylc help license
Traceback (most recent call last):
  File "~/.conda/envs/tmp/bin/cylc", line 8, in <module>
    sys.exit(main())
  File "~/.conda/envs/tmp/lib/python3.10/site-packages/cylc/flow/scripts/cylc.py", line 626, in main
    print_license()
  File "~/.conda/envs/tmp/lib/python3.10/site-packages/cylc/flow/scripts/cylc.py", line 396, in print_license
    pkg_resources.get_distribution('cylc-flow').get_resource_string(
  File "~/.conda/envs/tmp/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1456, in get_resource_string
    return self._get(self._fn(self.module_path, resource_name))
  File "~/.conda/envs/tmp/lib/python3.10/site-packages/pkg_resources/__init__.py", line 1684, in _get
    with open(path, 'rb') as stream:
FileNotFoundError: [Errno 2] No such file or directory: '~/.conda/envs/tmp/lib/python3.10/site-packages/COPYING'
```

You can do (in a throwaway env)
```
pip install git+https://github.com/MetRonnie/cylc-flow.git@license
```
and `cylc help license` to test this

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are sort of already present (we're testing with an editable install (needed for coverage/Codecov), it's a bit of faff to test with non-editable install).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs change needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
