### PR TITLE
task_job_mgr: move compute out of open call

### DIFF
--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -628,11 +628,12 @@ class TaskJobManager:
             line = "%s %s" % (timestamp, content)
         job_activity_log = get_task_job_activity_log(
             workflow, itask.point, itask.tdef.name)
+        if not line.endswith("\n"):
+            line += "\n"
+        line = host + line
         try:
-            with open(os.path.expandvars(job_activity_log), "ab") as handle:
-                if not line.endswith("\n"):
-                    line += "\n"
-                handle.write((host + line).encode())
+            with open(os.path.expandvars(job_activity_log), "a") as handle:
+                handle.write(line)
         except IOError as exc:
             LOG.warning("%s: write failed\n%s" % (job_activity_log, exc))
             LOG.warning(f"[{itask}] {host}{line}")


### PR DESCRIPTION
Spotted whilst reviewing #5475, writing to the activity log takes ~0.035 seconds per task which is ~8% of the `main_loop` runtime.

This PR reduces that to ~0.025s (~28% saving), not entirely sure why this is faster, but, meh.

I profiled this with:

```
# b = 1..100
a => <b> => c
```

Although you don't need 100 tasks and you could just time the method call.

**Before:**

![Screenshot from 2023-04-24 12-43-38](https://user-images.githubusercontent.com/16705946/233986616-a53b65ca-5589-407c-98ae-5ee699528097.png)

**After:**

![Screenshot from 2023-04-24 12-43-52](https://user-images.githubusercontent.com/16705946/233986621-6f8527f8-5f37-4991-8454-c4901eebc913.png)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.