### PR TITLE
platforms: use cached global config

### DIFF
--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -166,7 +166,7 @@ def get_platform(
                 task_conf['remote'] if 'remote' in task_conf else {})
             return platform_from_name(
                 platform_name_from_job_info(
-                    glbl_cfg(cached=False).get(['platforms']),
+                    glbl_cfg().get(['platforms']),
                     task_job_section,
                     task_remote_section
                 ),


### PR DESCRIPTION
Use the cached global config for platform selection.

Spotted whilst profiling the "complex" workflow as `get_platform` accounted for ~19% of the main_loop runtime.

We are currently reloading the global config for platform selection which wasn't the plan. I'm not sure why we're using the cached config, the change was made a while back in a commit with "fixed caching problem" in the description:

https://github.com/cylc/cylc-flow/commit/91be2ffb1c61e616c09fa01d177be325b0d272fd#diff-f2c9506863bbbf888bfe92fe41bcd6f87f64f6a7818180cc3b7ace81848ba6b1R449

But that doesn't make much sense to me? The tests seem to agree.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.