### PR TITLE
swarm: fix docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ __pycache__
 !cylc
 !dockerfiles/*
 !setup*
+!MANIFEST.in

--- a/dockerfiles/cylc-dev/Dockerfile
+++ b/dockerfiles/cylc-dev/Dockerfile
@@ -1,51 +1,49 @@
-# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
-# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 1) The Mamba image
+#    This image has mamba installed, we use it to create and pack
+#    the required Conda environment.
+FROM mambaorg/micromamba AS mamba
 
-FROM conda/miniconda3:latest
+# create the environment
+COPY conda-environment.yml .
+RUN micromamba env create -f conda-environment.yml --prefix ./env
 
-LABEL version="1.0" \
-      description="Image with Cylc installed with Conda from a working copy."
+# pack the environment
+RUN \
+    micromamba create -c conda-forge -n conda-pack conda-pack && \
+    micromamba run -n conda-pack conda-pack --prefix ./env -o ./packed-env.tar && \
+    pwd && \
+    mkdir ./venv && \
+    cd ./venv && \
+    tar -xf ../packed-env.tar && \
+    rm ../packed-env.tar
 
-ARG CONDA_ENV="cylc-dev"
-ARG CYLC_FLOW_DIR="./"
 
-# suppress bizarre error messages
-# mesg: ttyname failed: Inappropriate ioctl for device
-RUN sed -i 's/mesg.*/tty -s \&\& &/' "$HOME/.profile"
+# 2) The Cylc image
+#    This has the Cylc Mamba environment installed and activated by default in
+#    Bash shells. However, it does not have Mamba installed.
+FROM ubuntu:latest as cylc-dev
 
-# copy in cylc source files
-COPY "$CYLC_FLOW_DIR" "cylc"
+COPY --from=mamba /tmp/venv /venv
+COPY ./ /cylc
 
-# install cylc dependencies
-RUN apt-get update && \
-    # build-deps: build-essential
-    # run deps: procps, rsync
-    apt-get -qq -y install build-essential procps rsync tree && \
-    # install conda stuff
-    conda init bash && \
-    . ./usr/local/etc/profile.d/conda.sh && \
-    conda env create -n "${CONDA_ENV}" -f './cylc/conda-environment.yml' && \
-    conda clean -y --all && \
-    apt-get -y remove build-essential && \
-    apt-get autoclean && \
-    echo "conda activate $CONDA_ENV" >> $HOME/.bashrc && \
-    # tests require TMPDIR
+SHELL ["/bin/bash", "-c", "-l"]
+ENTRYPOINT /bin/bash
+
+# wipe the default crud then auto-activate the Cylc Mamba environment
+RUN \
+    rm $HOME/.bashrc && \
+    echo '. /venv/bin/activate' >> $HOME/.bashrc && \
     echo "export TMPDIR=/tmp" >> $HOME/.bashrc
 
-# run setup logic
-RUN . $HOME/.bashrc && \
-    pip install -e ./cylc[all] && \
-    cylc version
+# unpack the Mamba environment, then install Cylc into it from source
+RUN \
+    /venv/bin/conda-unpack && \
+    pip install --no-deps -e /cylc coverage && \
+    pip cache purge && \
+    cylc version --long
+
+# install system dependencies
+RUN \
+    apt-get update && \
+    apt-get -qq -y install procps rsync tree at && \
+    apt-get autoclean

--- a/dockerfiles/cylc-remote/Dockerfile
+++ b/dockerfiles/cylc-remote/Dockerfile
@@ -20,14 +20,16 @@ LABEL version="1.0" \
       description="Cylc remote job host for background & at jobs."
 
 # install deps
-RUN apt-get -qq -y install at ssh && \
+RUN  \
+    apt-get -qq -y install ssh iputils-ping && \
     apt-get autoclean
 
 # copy public ssh key (don't setup two way ssh)
 COPY .docker-ssh-keys/*.pub .ssh/
 
 # authorise that key
-RUN mkdir ~/.ssh -p && \
+RUN \
+    mkdir ~/.ssh -p && \
     chmod 700 ~/.ssh && \
     touch ~/.ssh/authorized_keys && \
     chmod 600 ~/.ssh/authorized_keys && \
@@ -40,7 +42,8 @@ EXPOSE 22
 COPY dockerfiles/cylc-remote/configure bin/host-configure
 
 # configure on boot and start the required services
-ENTRYPOINT service ssh start && \
+ENTRYPOINT \
+    service ssh start && \
     atd && \
     /bin/host-configure && \
     /usr/bin/env bash

--- a/tests/functional/events/11-cycle-task-event-job-logs-retrieve.t
+++ b/tests/functional/events/11-cycle-task-event-job-logs-retrieve.t
@@ -23,6 +23,18 @@ set_test_number 3
 
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
+create_test_global_config '' "
+[platforms]
+    [[_retrieve]]
+        $(cylc config -i "[platforms][$CYLC_TEST_PLATFORM]")
+        retrieve job logs = True
+        install target = $CYLC_TEST_PLATFORM
+    [[_no_retrieve]]
+        $(cylc config -i "[platforms][$CYLC_TEST_PLATFORM]")
+        retrieve job logs = False
+        install target = $CYLC_TEST_PLATFORM
+"
+
 run_ok "${TEST_NAME_BASE}-validate" \
     cylc validate -s "HOST='${CYLC_TEST_HOST}'" "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \

--- a/tests/functional/events/11-cycle-task-event-job-logs-retrieve/flow.cylc
+++ b/tests/functional/events/11-cycle-task-event-job-logs-retrieve/flow.cylc
@@ -1,4 +1,3 @@
-#!jinja2
 [meta]
     title = Task Event Job Log Retrieve
 
@@ -16,13 +15,9 @@
     [[T]]
         script = test "${CYLC_TASK_TRY_NUMBER}" -eq 3
         execution retry delays = PT0S, 2*PT1S
-        [[[remote]]]
-            host = {{ environ['CYLC_TEST_HOST'] }}
     [[t1]]
         inherit = T
-        [[[remote]]]
-            retrieve job logs = True
+        platform = _retrieve
     [[t2]]
         inherit = T
-        [[[remote]]]
-            retrieve job logs = False
+        platform = _no_retrieve


### PR DESCRIPTION
> This fixes the remote CI tests, it's not strictly necessary for 8.1.3 so don't let it get in the way of release.

We were using the minconda Docker image which is now dead it seams.

Switch to the superior and less deceased Mamba image.

This also switches up the build process:

* Before we started with a Conda image, created the Cylc environment and committed it as a layer on that image.
* Now we start with a Mamba image, create the Cylc environment, then conda-pack it onto a base image of our choice.

This means we have free choice of base image and we don't have to have Mamba installed on the final image which slims it down a little (no more base env).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.