### PR TITLE
prerequsite: remove target_point_strings attribute

### DIFF
--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -44,7 +44,6 @@ class Prerequisite:
     __slots__ = (
         "satisfied",
         "_all_satisfied",
-        "target_point_strings",
         "start_point",
         "conditional_expression",
         "point",

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -41,9 +41,14 @@ class Prerequisite:
     """
 
     # Memory optimization - constrain possible attributes to this list.
-    __slots__ = ["satisfied", "_all_satisfied",
-                 "target_point_strings", "start_point",
-                 "conditional_expression", "point"]
+    __slots__ = (
+        "satisfied",
+        "_all_satisfied",
+        "target_point_strings",
+        "start_point",
+        "conditional_expression",
+        "point",
+    )
 
     # Extracts T from "foo.T succeeded" etc.
     SATISFIED_TEMPLATE = 'bool(self.satisfied[("%s", "%s", "%s")])'
@@ -61,9 +66,6 @@ class Prerequisite:
         # Start point for prerequisite validity.
         # cylc.flow.cycling.PointBase
         self.start_point = start_point
-
-        # List of cycle point strings that this prerequisite depends on.
-        self.target_point_strings = []
 
         # Dictionary of messages pertaining to this prerequisite.
         # {('point string', 'task name', 'output'): DEP_STATE_X, ...}
@@ -99,8 +101,6 @@ class Prerequisite:
             self.satisfied[message] = self.DEP_STATE_UNSATISFIED
         if self._all_satisfied is not None:
             self._all_satisfied = False
-        if point and str(point) not in self.target_point_strings:
-            self.target_point_strings.append(str(point))
 
     def get_raw_conditional_expression(self):
         """Return a representation of this prereq as a string.
@@ -240,7 +240,9 @@ class Prerequisite:
             satisfied=self.is_satisfied(),
         )
         prereq_buf.conditions.extend(conds)
-        prereq_buf.cycle_points.extend(self.target_point_strings)
+        prereq_buf.cycle_points.extend(
+            sorted(self.iter_target_point_strings())
+        )
         return prereq_buf
 
     def set_satisfied(self):
@@ -272,10 +274,18 @@ class Prerequisite:
         else:
             self._all_satisfied = self._conditional_is_satisfied()
 
+    def iter_target_point_strings(self):
+        yield from {
+            message[0]
+            for message in self.satisfied
+        }
+
     def get_target_points(self):
         """Return a list of cycle points target by each prerequisite,
         including each component of conditionals."""
-        return [get_point(p) for p in self.target_point_strings]
+        return [
+            get_point(p) for p in self.iter_target_point_strings()
+        ]
 
     def get_resolved_dependencies(self):
         """Return a list of satisfied dependencies.

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -1,0 +1,116 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from cylc.flow.cycling.loader import ISO8601_CYCLING_TYPE, get_point
+from cylc.flow.prerequisite import Prerequisite
+
+
+@pytest.fixture
+def prereq(set_cycling_type):
+    set_cycling_type(ISO8601_CYCLING_TYPE, "Z")
+    prereq = Prerequisite(
+        get_point('2000'),
+        start_point=get_point('2000')
+    )
+    prereq.add(
+        'a',
+        '1999',
+        'succeeded',
+        True
+    )
+    prereq.add(
+        'b',
+        '2000',
+        'succeeded',
+        False
+    )
+    prereq.add(
+        'c',
+        '2000',
+        'succeeded',
+        False
+    )
+    prereq.add(
+        'd',
+        '2001',
+        'custom',
+        False
+    )
+    return prereq
+
+
+def test_satisfied(prereq):
+    assert prereq.satisfied == {
+        # the pre-initial dependency should be marked as satisfied
+        ('1999', 'a', 'succeeded'): 'satisfied naturally',
+        # all others should not
+        ('2000', 'b', 'succeeded'): False,
+        ('2000', 'c', 'succeeded'): False,
+        ('2001', 'd', 'custom'): False,
+    }
+    # mark two prerequisites as satisfied
+    prereq.satisfy_me({
+        ('2000', 'b', 'succeeded'),
+        ('2000', 'c', 'succeeded'),
+    })
+    assert prereq.satisfied == {
+        # the pre-initial dependency should be marked as satisfied
+        ('1999', 'a', 'succeeded'): 'satisfied naturally',
+        # the two newly-satisfied dependency should be satisfied
+        ('2000', 'b', 'succeeded'): 'satisfied naturally',
+        ('2000', 'c', 'succeeded'): 'satisfied naturally',
+        # the remaining dependency should not
+        ('2001', 'd', 'custom'): False,
+    }
+    # mark all prereqs as satisfied
+    prereq.set_satisfied()
+    assert prereq.satisfied == {
+        # the pre-initial dependency should be marked as satisfied
+        ('1999', 'a', 'succeeded'): 'satisfied naturally',
+        # the two newly-satisfied dependency should be satisfied
+        ('2000', 'b', 'succeeded'): 'satisfied naturally',
+        ('2000', 'c', 'succeeded'): 'satisfied naturally',
+        # the remaining dependency should be marked as forse-satisfied
+        ('2001', 'd', 'custom'): 'force satisfied',
+    }
+    # mark all prereqs as unsatisfied
+    prereq.set_not_satisfied()
+    assert prereq.satisfied == {
+        # all prereqs INCLUDING the pre-initial should be marked as nnot
+        # satisfied
+        ('1999', 'a', 'succeeded'): False,
+        ('2000', 'b', 'succeeded'): False,
+        ('2000', 'c', 'succeeded'): False,
+        ('2001', 'd', 'custom'): False,
+    }
+
+
+def test_iter_target_point_strings(prereq):
+    assert set(prereq.iter_target_point_strings()) == {
+        '1999',
+        '2000',
+        '2001',
+    }
+
+
+def test_get_target_points(prereq):
+    assert set(prereq.get_target_points()) == {
+        get_point('1999'),
+        get_point('2000'),
+        get_point('2001'),
+    }


### PR DESCRIPTION
The `Prerequisite` class contains two attributes with overlapping information, `target_point_strings` and `satisfied`.

See https://github.com/cylc/cylc-flow/pull/5466#discussion_r1178887978

Remove `target_point_strings` (only used internally) to save memory.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.