### PR TITLE
Fix `eval_host()` localhost bug & plug testing gap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,16 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.1.4 (<span actions:bind='release-date'>Upcoming</span>)__
 
+### Fixes
+
+[#5506](https://github.com/cylc/cylc-flow/pull/5506) -
+Fix bug introduced in 8.1.3 where specifying a subshell command for
+`flow.cylc[runtime][<namespace>][remote]host` (e.g. `$(rose host-select)`)
+would always result in localhost.
+
+-------------------------------------------------------------------------------
 ## __cylc-8.1.3 (<span actions:bind='release-date'>Released 2023-04-27</span>)__
 
 ### Enhancements

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -179,7 +179,9 @@ class TaskRemoteMgr:
         (e.g. localhost4.localdomain4).
         """
         host = self._subshell_eval(host_str, HOST_REC_COMMAND)
-        return host if is_remote_host(host) else 'localhost'
+        if host is not None and not is_remote_host(host):
+            return 'localhost'
+        return host
 
     def eval_platform(self, platform_str: str) -> Optional[str]:
         """Evaluate a platform from a possible subshell string.

--- a/tests/functional/job-submission/19-platform_select.t
+++ b/tests/functional/job-submission/19-platform_select.t
@@ -17,13 +17,7 @@
 #-------------------------------------------------------------------------------
 # Test recovery of a failed host select command for a group of tasks.
 . "$(dirname "$0")/test_header"
-set_test_number 5
-
-create_test_global_config "
-[platforms]
-    [[test platform]]
-        hosts = localhost
-"
+set_test_number 6
 
 install_workflow "${TEST_NAME_BASE}"
 
@@ -34,20 +28,22 @@ run_ok "${TEST_NAME_BASE}-run" \
 logfile="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 
-# Check that host = $(hostname) is correctly evaluated
+# Check that host = $(cmd) is correctly evaluated
 grep_ok \
-    "1/platform_subshell.*evaluated as improbable platform name" \
+    "1/host_subshell.* evaluated as improbable host name$" \
+    "${logfile}"
+grep_ok \
+    "1/localhost_subshell.* evaluated as localhost$" \
     "${logfile}"
 
-# Check that host = `hostname` is correctly evaluated
+# Check that host = `cmd` is correctly evaluated
 grep_ok \
-    "1/host_subshell_backticks.*\`hostname\` evaluated as localhost" \
+    "1/host_subshell_backticks.* evaluated as improbable host name$" \
     "${logfile}"
 
-# Check that platform = $(echo "improbable platform name") correctly evaluated
+# Check that platform = $(cmd) correctly evaluated
 grep_ok \
-    "1/platform_subshell.*evaluated as improbable platform name" \
+    "1/platform_subshell.* evaluated as improbable platform name$" \
     "${logfile}"
 
 purge
-exit

--- a/tests/functional/job-submission/19-platform_select/flow.cylc
+++ b/tests/functional/job-submission/19-platform_select/flow.cylc
@@ -13,11 +13,12 @@ purpose = """
 [scheduling]
     [[dependencies]]
         R1 = """
-            platform_subshell:submit-fail => fin
-            platform_no_subshell:submit-fail => fin
-            host_subshell
             host_no_subshell
-            host_subshell_backticks
+            localhost_subshell
+            platform_subshell:submit-fail => fin_platform
+            platform_no_subshell:submit-fail => fin_platform
+            host_subshell:submit-fail => fin_host
+            host_subshell_backticks:submit-fail => fin_host
         """
 
 [runtime]
@@ -36,11 +37,18 @@ purpose = """
 
     [[host_subshell]]
         [[[remote]]]
-            host = $(hostname)
+            host = $(echo "improbable host name")
 
     [[host_subshell_backticks]]
         [[[remote]]]
-            host = `hostname`
+            host = `echo "improbable host name"`
 
-    [[fin]]
-        script = cylc remove "${CYLC_SUITE_NAME}//1/platform_*"
+    [[localhost_subshell]]
+        [[[remote]]]
+            host = $(echo "localhost4.localdomain4")
+
+    [[fin_platform]]
+        script = cylc remove "${CYLC_WORKFLOW_ID}//1/platform_*"
+
+    [[fin_host]]
+        script = cylc remove "${CYLC_WORKFLOW_ID}//1/host_subshell*"


### PR DESCRIPTION
Fixes bug where `flow.cylc[runtime][X][remote]host = $(subshell cmd)` would always result in localhost.

Follow up to #5343
Closes #5462

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs change needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
