### PR TITLE
Fix flaky test

### DIFF
--- a/tests/functional/platforms/11-platform-gone-on-restart.t
+++ b/tests/functional/platforms/11-platform-gone-on-restart.t
@@ -36,7 +36,7 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONF__'
 [scheduling]
     initial cycle point = 2934
     [[graph]]
-        R1 = foo
+        R1 = foo => bar
 
 [runtime]
     [[foo]]
@@ -44,6 +44,8 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONF__'
             cylc stop ${CYLC_WORKFLOW_ID} --now --now
         """
         platform = myplatform
+    [[bar]]
+        script = true  # only runs on restart
 __FLOW_CONF__
 
 run_ok "${TEST_NAME_BASE}-play" \
@@ -63,5 +65,3 @@ named_grep_ok \
     "${RUN_DIR}/${WORKFLOW_NAME}/log/scheduler/log"
 
 purge
-exit 0
-


### PR DESCRIPTION
Closes #5500

> @wxtim - that test was added pretty recently in #5395
> 
> It looks to me like it will fail unless the restart happens so quickly that the task `foo` is still running (or more likely the shutdown is quick enough that the task hasn't returned success status yet). Otherwise the restart will auto-shutdown with nothing to do rather than complain about missing platforms. To avoid adding a flaky sleep you could probably a one quick downstream task to the graph, which would run on the restart ...

https://github.com/cylc/cylc-flow/pull/5466#issuecomment-1524930266

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency change
- [x] Tests tests tests
- [x] No changelog needed
- [x] No docs needed
- [x] Master branch only
