### PR TITLE
prerequisite: remove set_not_satisfied

### DIFF
--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -264,21 +264,6 @@ class Prerequisite:
         else:
             self._all_satisfied = self._conditional_is_satisfied()
 
-    def set_not_satisfied(self):
-        """Force this prerequisite into the un-satisfied state.
-
-        State can be overridden by calling `self.satisfy_me`.
-
-        """
-        for message in self.satisfied:
-            self.satisfied[message] = self.DEP_STATE_UNSATISFIED
-        if not self.satisfied:
-            self._all_satisfied = True
-        elif self.conditional_expression is None:
-            self._all_satisfied = False
-        else:
-            self._all_satisfied = self._conditional_is_satisfied()
-
     def iter_target_point_strings(self):
         yield from {
             message[0]

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -364,12 +364,6 @@ class TaskState:
             prereq.set_satisfied()
         self._is_satisfied = None
 
-    def set_prerequisites_not_satisfied(self):
-        """Reset prerequisites."""
-        for prereq in self.prerequisites:
-            prereq.set_not_satisfied()
-        self._is_satisfied = None
-
     def get_resolved_dependencies(self):
         """Return a list of dependencies which have been met for this task.
 

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -298,7 +298,10 @@ def test_delta_task_prerequisite(harness):
         for t in schd.data_store_mgr.updated[TASK_PROXIES].values()
         for p in t.prerequisites})
     for itask in schd.pool.get_all_tasks():
-        itask.state.set_prerequisites_not_satisfied()
+        # set prereqs as not-satisfied
+        for prereq in itask.state.prerequisites:
+            prereq._all_satisfied = False
+            prereq.satisfied = {key: False for key in prereq.satisfied}
         schd.data_store_mgr.delta_task_prerequisite(itask)
     assert not any({
         p.satisfied

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -636,7 +636,8 @@ def list_tasks(schd):
                 {('1', 'a', 'succeeded'): 'satisfied naturally'},
                 {('1', 'b', 'succeeded'): False},
                 {('1', 'c', 'succeeded'): False},
-            ]
+            ],
+            id='added'
         ),
         param(  # Restart after removing a prerequisite from task z
             '''a => z
@@ -662,7 +663,8 @@ def list_tasks(schd):
             [
                 {('1', 'a', 'succeeded'): 'satisfied naturally'},
                 {('1', 'b', 'succeeded'): False},
-            ]
+            ],
+            id='removed'
         )
     ]
 )
@@ -755,7 +757,8 @@ async def test_restart_prereqs(
                 {('1', 'a', 'succeeded'): 'satisfied naturally'},
                 {('1', 'b', 'succeeded'): False},
                 {('1', 'c', 'succeeded'): False},
-            ]
+            ],
+            id='added'
         ),
         param(  # Reload after removing a prerequisite from task z
             '''a => z
@@ -781,7 +784,8 @@ async def test_restart_prereqs(
             [
                 {('1', 'a', 'succeeded'): 'satisfied naturally'},
                 {('1', 'b', 'succeeded'): False},
-            ]
+            ],
+            id='removed'
         )
     ]
 )

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -85,16 +85,6 @@ def test_satisfied(prereq):
         # the remaining dependency should be marked as forse-satisfied
         ('2001', 'd', 'custom'): 'force satisfied',
     }
-    # mark all prereqs as unsatisfied
-    prereq.set_not_satisfied()
-    assert prereq.satisfied == {
-        # all prereqs INCLUDING the pre-initial should be marked as nnot
-        # satisfied
-        ('1999', 'a', 'succeeded'): False,
-        ('2000', 'b', 'succeeded'): False,
-        ('2000', 'c', 'succeeded'): False,
-        ('2001', 'd', 'custom'): False,
-    }
 
 
 def test_iter_target_point_strings(prereq):


### PR DESCRIPTION
Closes #5508

* Remove an unused code interface.
* Also add some parameter IDs for tests to make them CLI friendly.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.