### PR TITLE
data_store: reduce the cost of creating prerequisite objects

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1197,7 +1197,8 @@ class DataStoreMgr:
                 cycle=cycle,
                 task=name,
             )
-            itask, is_parent = self.db_load_task_proxies[tokens.relative_id]
+            relative_id = tokens.relative_id
+            itask, is_parent = self.db_load_task_proxies[relative_id]
             itask.submit_num = submit_num
             flow_nums = deserialise(flow_nums_str)
             # Do not set states and outputs for future tasks in flow.
@@ -1222,7 +1223,7 @@ class DataStoreMgr:
                 for message in json.loads(outputs_str):
                     itask.state.outputs.set_completion(message, True)
             # Gather tasks with flow id.
-            prereq_ids.add(f'{tokens.relative_id}/{flow_nums_str}')
+            prereq_ids.add(f'{relative_id}/{flow_nums_str}')
 
         # Batch load prerequisites of tasks according to flow.
         prereqs_map = {}
@@ -1304,7 +1305,7 @@ class DataStoreMgr:
             self.xtrigger_tasks.setdefault(sig, set()).add(tproxy.id)
 
         if tproxy.state in self.latest_state_tasks:
-            tp_ref = Tokens(tproxy.id).relative_id
+            tp_ref = itask.identity
             tp_queue = self.latest_state_tasks[tproxy.state]
             if tp_ref in tp_queue:
                 tp_queue.remove(tp_ref)
@@ -1927,7 +1928,7 @@ class DataStoreMgr:
         tp_delta.state = itask.state.status
         self.state_update_families.add(tproxy.first_parent)
         if tp_delta.state in self.latest_state_tasks:
-            tp_ref = Tokens(tproxy.id).relative_id
+            tp_ref = itask.identity
             tp_queue = self.latest_state_tasks[tp_delta.state]
             if tp_ref in tp_queue:
                 tp_queue.remove(tp_ref)

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -545,6 +545,21 @@ LEGACY_CYCLE_SLASH_TASK = re.compile(
 )
 
 
+def quick_relative_detokenise(cycle, task):
+    """Generate a relative ID for a task.
+
+    This is a more efficient solution to `Tokens` for cases where
+    you only want the ID string and don't have any use for a Tokens object.
+
+    Example:
+        >>> q = quick_relative_detokenise
+        >>> q('1', 'a') == Tokens(cycle='1', task='a').relative_id
+        True
+
+    """
+    return f'{cycle}/{task}'
+
+
 def _dict_strip(dictionary):
     """Run str.strip against dictionary values.
 


### PR DESCRIPTION
Attempt to reduce the overheads of creating prerequisite objects in the data store.

At Cylc7 we only created prerequisite objects for tasks in the pool. At Cylc 8 we create pbPrerequsite objects for each task in the n=1 window by default, expandable out to large n numbers by request.

These prereq objects are costly to generate. The bulk of that is due to a high number of `detokenise` calls. Since there is no real function to having the tokens objects around for data store prerequsites which don't technically exist yet, we may as well go back to string formatting here.

Also make some minor optimisations on route and fix what looks like a bug in the expression for non-conditional prerequisites.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] There are other changelog entries about similar efficiency improvements.
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.