### PR TITLE
schema: enable selected mutations for the stopping workflow state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,14 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
+## __cylc-8.1.4 (<span actions:bind='release-date'>Awaiting Release</span>)__
+
+### Fixes
+
+[#5228](https://github.com/cylc/cylc-flow/pull/5228) -
+Enabled the "stop", "poll", "kill" and "message" commands to be issued from
+the UI whilst the workflow is in the process of shutting down.
+
 ## __cylc-8.1.4 (<span actions:bind='release-date'>Released 2023-05-04</span>)__
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 -------------------------------------------------------------------------------
-## __cylc-8.1.4 (<span actions:bind='release-date'>Awaiting Release</span>)__
+## __cylc-8.1.5 (<span actions:bind='release-date'>Awaiting Release</span>)__
 
 ### Fixes
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1597,7 +1597,7 @@ class Message(Mutation):
             this command to report messages and to report registered task
             outputs.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = partial(mutator, command='put_messages')
 
@@ -1728,7 +1728,7 @@ class Stop(Mutation):
             be executed prior to shutdown, unless
             the stop mode is `{WorkflowStopMode.Now.name}`.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = mutator
 
@@ -1881,7 +1881,7 @@ class Kill(Mutation, TaskMutation):
         description = sstrip('''
             Kill running or submitted jobs.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = partial(mutator, command='kill_tasks')
 
@@ -1898,7 +1898,7 @@ class Poll(Mutation, TaskMutation):
             an associated job ID, including incomplete finished
             tasks.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = partial(mutator, command='poll_tasks')
 


### PR DESCRIPTION
* Some mutations e.g. "stop" remain applicable even when a workflow is shutting down. E.G. you could tell a workflow to shut down, then upgrade that to "--now" with a subsequent mutation.
* The UI now uses metadata stored in mutations "description" field to filter out mutations which are not applicable, causing these to be disabled at present.

To test, try starting a workflow like this:

```
[scheduling]
  [[graph]]
    R1 = a

[runtime]
  [[a]]
    script = sleep 1000
```

* Then, opening this workflow in the GUI and pressing the stop button.
* The workflow should now show as stopping, but not actually stop due to the running task.
* Then open the mutations menu for the workflow and edit the stop mutation. (stop was disabled in the menu before)
* Change the mode to NOW_NOW and press submit.
* The workflow should now shut down immediately.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.