### PR TITLE
validate-reinstall: don't print reload message [skip ci]

### DIFF
--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -146,6 +146,7 @@ def main(
 def reinstall_cli(
     opts: 'Values',
     args: Optional[str] = None,
+    print_reload_tip: bool = True,
 ) -> bool:
     """Implement cylc reinstall.
 
@@ -212,7 +213,8 @@ def reinstall_cli(
         # reinstall for real
         reinstall(opts, workflow_id, source, run_dir, dry_run=False)
         print(cparse('<green>Successfully reinstalled.</green>'))
-        display_cylc_reload_tip(workflow_id)
+        if print_reload_tip:
+            display_cylc_reload_tip(workflow_id)
         return True
 
     else:

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -162,7 +162,7 @@ def vro_cli(parser: COP, options: 'Values', workflow_id: str):
     cylc_validate(parser, options, workflow_id)
 
     log_subcommand('reinstall', workflow_id)
-    reinstall_ok = cylc_reinstall(options, workflow_id)
+    reinstall_ok = cylc_reinstall(options, workflow_id, print_reload_tip=False)
     if not reinstall_ok:
         LOG.warning(
             'No changes to source: No reinstall or'


### PR DESCRIPTION
Cherry-picked #5460 to 8.1.x to get it released sooner (this small bug is already causing some confusion out in the wild). 

One review will do.

* The reload message is not applicable when using `cylc vr` because it does it for you.

