### PR TITLE
scheduler: separate "expected" and "unexpected" errrors

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -656,7 +656,12 @@ class Scheduler:
         except (KeyboardInterrupt, asyncio.CancelledError) as exc:
             await self.handle_exception(exc)
 
-        except Exception as exc:  # Includes SchedulerError
+        except CylcError as exc:  # Includes SchedulerError
+            # catch "expected" errors
+            await self.handle_exception(exc)
+
+        except Exception as exc:
+            # catch "unexpected" errors
             with suppress(Exception):
                 LOG.critical(
                     'An uncaught error caused Cylc to shut down.'


### PR DESCRIPTION
* Closes #5530
* Timeouts should no longer trigger the "unexpected error" message.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.