### PR TITLE
Logging: say command actioned instead of succeeded

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -898,10 +898,11 @@ class Scheduler:
             else:
                 if n_warnings:
                     LOG.info(
-                        'Command succeeded with %s warning(s): %s' %
-                        (n_warnings, cmdstr))
+                        f"Command actioned with {n_warnings} warning(s): "
+                        f"{cmdstr}"
+                    )
                 else:
-                    LOG.info(f"Command succeeded: {cmdstr}")
+                    LOG.info(f"Command actioned: {cmdstr}")
                 self.is_updated = True
             self.command_queue.task_done()
 

--- a/tests/functional/cli/03-set-verbosity.t
+++ b/tests/functional/cli/03-set-verbosity.t
@@ -39,7 +39,7 @@ workflow_run_ok "${TEST_NAME}-run" cylc play --pause "$WORKFLOW_NAME"
 
 run_ok "$TEST_NAME" cylc set-verbosity DEBUG "$WORKFLOW_NAME"
 log_scan "${TEST_NAME}-grep" "${WORKFLOW_RUN_DIR}/log/scheduler/log" 5 1 \
-    'Command succeeded: set_verbosity'
+    'Command actioned: set_verbosity'
 
 cylc stop "$WORKFLOW_NAME"
 purge

--- a/tests/functional/hold-release/00-workflow/flow.cylc
+++ b/tests/functional/hold-release/00-workflow/flow.cylc
@@ -23,7 +23,7 @@
         script = """
             cylc__job__wait_cylc_message_started
             cylc hold --after=1900 "${CYLC_WORKFLOW_ID}"
-            cylc__job__poll_grep_workflow_log -F 'INFO - Command succeeded: set_hold_point'
+            cylc__job__poll_grep_workflow_log -F 'INFO - Command actioned: set_hold_point'
             cylc release --all "${CYLC_WORKFLOW_ID}"
         """
     [[foo,bar]]

--- a/tests/functional/hold-release/05-release.t
+++ b/tests/functional/hold-release/05-release.t
@@ -34,7 +34,7 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
         script = """
             cylc__job__wait_cylc_message_started
             cylc hold --after=0 ${CYLC_WORKFLOW_ID}
-            cylc__job__poll_grep_workflow_log 'Command succeeded: set_hold_point'
+            cylc__job__poll_grep_workflow_log 'Command actioned: set_hold_point'
             cylc release "${CYLC_WORKFLOW_ID}//1/*FF"  # inexact fam
             cylc release "${CYLC_WORKFLOW_ID}//1/TOAST"  # exact fam
             cylc release "${CYLC_WORKFLOW_ID}//1/cat*"  # inexact tasks

--- a/tests/functional/pause-resume/00-workflow/flow.cylc
+++ b/tests/functional/pause-resume/00-workflow/flow.cylc
@@ -19,7 +19,7 @@
         script = """
             wait
             cylc pause "${CYLC_WORKFLOW_ID}"
-            cylc__job__poll_grep_workflow_log -F 'INFO - Command succeeded: pause()'
+            cylc__job__poll_grep_workflow_log -F 'INFO - Command actioned: pause()'
             cylc play "${CYLC_WORKFLOW_ID}"
         """
     [[foo,bar]]

--- a/tests/functional/pause-resume/12-pause-then-retry/flow.cylc
+++ b/tests/functional/pause-resume/12-pause-then-retry/flow.cylc
@@ -19,7 +19,7 @@
     [[t-pause]]
         script = """
             cylc pause "${CYLC_WORKFLOW_ID}"
-            cylc__job__poll_grep_workflow_log -F 'Command succeeded: pause'
+            cylc__job__poll_grep_workflow_log -F 'Command actioned: pause'
 
             # Poll t-submit-retry-able, should return submit-fail
             cylc poll "${CYLC_WORKFLOW_ID}//*/t-submit-retry-able"

--- a/tests/functional/reload/25-xtriggers.t
+++ b/tests/functional/reload/25-xtriggers.t
@@ -64,7 +64,7 @@ log_scan "${TEST_NAME_BASE}-scan" \
     "$(cylc cat-log -m p "${WORKFLOW_NAME}")" \
     1 1 \
     '1/broken .* (received)failed/ERR' \
-    'Command succeeded: reload_workflow()' \
+    'Command actioned: reload_workflow()' \
     'xtrigger satisfied: _cylc_retry_1/broken' \
     '\[1/broken .* => succeeded'
 

--- a/tests/functional/spawn-on-demand/05-stop-flow/flow.cylc
+++ b/tests/functional/spawn-on-demand/05-stop-flow/flow.cylc
@@ -10,5 +10,5 @@
     [[bar]]
          script = """
              cylc stop --flow=1 ${CYLC_WORKFLOW_ID}
-             cylc__job__poll_grep_workflow_log 'Command succeeded: stop'
+             cylc__job__poll_grep_workflow_log 'Command actioned: stop'
          """

--- a/tests/functional/spawn-on-demand/06-stop-flow-2/flow.cylc
+++ b/tests/functional/spawn-on-demand/06-stop-flow-2/flow.cylc
@@ -14,7 +14,7 @@
          script = """
 if (( CYLC_TASK_SUBMIT_NUMBER == 2 )); then
    cylc stop --flow=1 ${CYLC_WORKFLOW_ID}
-   cylc__job__poll_grep_workflow_log "Command succeeded: stop"
+   cylc__job__poll_grep_workflow_log "Command actioned: stop"
 fi
          """
     [[baz]]

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -234,6 +234,6 @@ async def test_stop(
         resolvers.stop(StopMode.REQUEST_CLEAN)
         one.process_command_queue()
         assert log_filter(
-            log, level=logging.INFO, contains="Command succeeded: stop"
+            log, level=logging.INFO, contains="Command actioned: stop"
         )
         assert one.stop_mode == StopMode.REQUEST_CLEAN


### PR DESCRIPTION
```
INFO - Command succeeded: poll_tasks(['1/foo'])
```

"Succeeded" is perhaps too strong a word. What's happened is the command finished without any uncaught exceptions but it doesn't mean that it necessarily did what the user expected (e.g. in this case there were no available hosts which is logged in a separate debug message).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests updated
- [x] No changelog entry as tiny change
- [x] No docs update needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
