### PR TITLE
Fix S011 lint

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -150,7 +150,7 @@ STYLE_CHECKS = {
         'index': 10
     },
     re.compile(r'(?<!{)#.*?{[{%]'): {
-        'short': 'Cylc will process commented Jinja2!',
+        'short': 'Cylc comments (#) do not prevent Jinja2 processing.',
         'url': '',
         'index': 11
     }

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -149,7 +149,7 @@ STYLE_CHECKS = {
         'url': 'https://github.com/cylc/cylc-flow/issues/3825',
         'index': 10
     },
-    re.compile(r'#.*?{[{%]'): {
+    re.compile(r'(?<!{)#.*?{[{%]'): {
         'short': 'Cylc will process commented Jinja2!',
         'url': '',
         'index': 11

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -239,7 +239,7 @@ def test_check_exclusions(create_testable_file, exclusion):
 
 def test_check_cylc_file_jinja2_comments(create_testable_file):
     # Repalce the '# {{' line to be '{# {{' which should not be a warning
-    result, _ = create_testable_file(LINT_TEST_FILE.replace('# {{', '{# {{'), ['style'])
+    result, _ = create_testable_file('{# {{ foo }} #}', ['style'])
     assert 'S011' not in result.out
 
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -237,6 +237,12 @@ def test_check_exclusions(create_testable_file, exclusion):
         assert item not in result.out
 
 
+def test_check_cylc_file_jinja2_comments(create_testable_file):
+    # Repalce the '# {{' line to be '{# {{' which should not be a warning
+    result, _ = create_testable_file(LINT_TEST_FILE.replace('# {{', '{# {{'), ['style'])
+    assert 'S011' not in result.out
+
+
 @pytest.fixture
 def create_testable_dir(tmp_path):
     test_file = (tmp_path / 'suite.rc')


### PR DESCRIPTION
The linter suggests that Cylc parses Jinja2 when it is commneted, which I agree with. However if it is a Jinja2 comment wrapping Jinja2 , then it will parse the comment and ignore the inside. It should not be a warning. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
