### PR TITLE
Support expanding `<param1><param2>` in inherited family names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ ones in. -->
 
 ### Enhancements
 
+[#5537](https://github.com/cylc/cylc-flow/pull/5537) - Allow parameters
+in family names to be split, e.g. `<foo>FAM<bar>`.
+
 [#5405](https://github.com/cylc/cylc-flow/pull/5405) - Improve scan command
 help, and add scheduler PID to the output.
 

--- a/cylc/flow/param_expand.py
+++ b/cylc/flow/param_expand.py
@@ -240,8 +240,7 @@ class NameExpander:
         """
         param_list = []
 
-        def _parse_replacement(match: re.Match) -> str:
-            nonlocal param_list
+        for match in REC_P_GROUP.finditer(task_str):
             param = match.group(1)
             if ',' in param:
                 # parameter syntax `<foo, bar>`
@@ -259,11 +258,10 @@ class NameExpander:
                     replacement = '{' + param.split('=')[0] + '}'
                 else:
                     replacement = '{' + param + '}'
-            return replacement
 
-        replacement = REC_P_GROUP.sub(_parse_replacement, task_str)
+            task_str = task_str.replace(match.group(0), replacement, 1)
 
-        return param_list, replacement
+        return param_list, task_str
 
     def expand_parent_params(self, parent, param_values, origin):
         """Replace parameters with specific values in inherited parent names.


### PR DESCRIPTION
Closes #5118 

The form `FAM<foo,bar>` is already supported in graph strings and `[runtime][task]inherit`, while the functionally equivalent `FAM<foo><bar>` is only supported in graph strings. This PR adds full support for the latter

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/611.
- [x] ~If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.~ N/A
