### PR TITLE
S007 now does not match inherit = None

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -125,8 +125,11 @@ STYLE_CHECKS = {
         'url': STYLE_GUIDE + 'trailing-whitespace',
         'index': 6
     },
-    # Look for families both from inherit=FAMILY and FAMILY:trigger-all/any
-    re.compile(r'(inherit\s*=\s*.*[a-z].*)|(\w[a-z]\w:\w+?-a(ll|ny))'): {
+    # Look for families both from inherit=FAMILY and FAMILY:trigger-all/any.
+    # Do not match inherit lines with `None` at the start.
+    re.compile(
+        r'(inherit\s*=(?!\s*None\s*(?!.*[a-z])))|(\w[a-z]\w:\w+?-a(ll|ny))'
+    ): {
         'short': 'Family name contains lowercase characters.',
         'url': STYLE_GUIDE + 'task-naming-conventions',
         'index': 7

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -206,6 +206,34 @@ def test_check_cylc_file_line_no(create_testable_file, capsys):
 
 
 @pytest.mark.parametrize(
+    'inherit_line',
+    (
+        'inherit = foo, b, a, r',
+        'inherit = FOO, bar',
+        'inherit = None, bar',
+        'inherit = g',
+        'inherit = B, None',
+    )
+)
+def test_inherit_lowercase_matches(create_testable_file, inherit_line):
+    result, _ = create_testable_file(inherit_line, ['style'])
+    assert 'S007' in result.out
+
+
+@pytest.mark.parametrize(
+    'inherit_line',
+    (
+        'inherit = None',
+        'inherit = None,',
+        'inherit = None, FOO',
+    )
+)
+def test_inherit_lowercase_not_match_none(create_testable_file, inherit_line):
+    result, _ = create_testable_file(inherit_line, ['style'])
+    assert 'S007' not in result.out
+
+
+@pytest.mark.parametrize(
     'number', range(len(STYLE_CHECKS))
 )
 def test_check_cylc_file_lint(create_testable_file, number):


### PR DESCRIPTION
**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.

Currently, `inherit = None` fails the linter as None contains lowercase characters. But, [None is acceptable according to the docs](https://cylc.github.io/cylc-doc/8.1.4/html/workflow-design-guide/efficiency.html#task-families-and-visualization). This fixes the bug.