### PR TITLE
cylc lint non zero code from warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@ for `cylc play` when called by `cylc vip` or `cylc vr`.
 -------------------------------------------------------------------------------
 ## __cylc-8.1.5 (<span actions:bind='release-date'>Awaiting Release</span>)__
 
+### Enhancements
+
+[#5546](https://github.com/cylc/cylc-flow/pull/5546) -
+`cylc lint` will provide a non-zero return code if any issues are identified.
+This can be overridden using the new `--exit-zero` flag.
+
 ### Fixes
 
 [#5228](https://github.com/cylc/cylc-flow/pull/5228) -

--- a/tests/functional/cylc-lint/00.lint.t
+++ b/tests/functional/cylc-lint/00.lint.t
@@ -18,7 +18,7 @@
 #------------------------------------------------------------------------------
 # Test workflow installation
 . "$(dirname "$0")/test_header"
-set_test_number 18
+set_test_number 20
 
 cat > flow.cylc <<__HERE__
 # This is definitely not an OK flow.cylc file.
@@ -29,15 +29,15 @@ __HERE__
 rm etc/global.cylc
 
 TEST_NAME="${TEST_NAME_BASE}.vanilla"
-run_ok "${TEST_NAME}" cylc lint .
+run_fail "${TEST_NAME}" cylc lint .
 named_grep_ok "check-for-error-code" "S004" "${TEST_NAME}.stdout"
 
 TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset"
-run_ok "${TEST_NAME}" cylc lint . -r 728
+run_fail "${TEST_NAME}" cylc lint . -r 728
 named_grep_ok "check-for-error-code" "U024" "${TEST_NAME}.stdout"
 
 TEST_NAME="${TEST_NAME_BASE}.inplace"
-run_ok "${TEST_NAME}" cylc lint . -i
+run_fail "${TEST_NAME}" cylc lint . -i
 named_grep_ok "check-for-error-code-in-file" "U024" flow.cylc
 
 rm flow.cylc
@@ -47,12 +47,18 @@ cat > suite.rc <<__HERE__
 {{FOO}}
 __HERE__
 
-TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset"
-run_ok "${TEST_NAME}" cylc lint . -r 728
+TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset-728"
+run_fail "${TEST_NAME}" cylc lint . -r 728
 named_grep_ok "do-not-upgrade-check-if-compat-mode" "Lint after renaming" "${TEST_NAME}.stderr"
 
-TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset2"
-run_ok "${TEST_NAME}" cylc lint . -r all
+TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset-728-exit-zero"
+run_ok "${TEST_NAME}" cylc lint . -r 728 --exit-zero
+
+TEST_NAME="${TEST_NAME_BASE}.pick-a-ruleset-all"
+run_fail "${TEST_NAME}" cylc lint . -r all
+
+TEST_NAME="${TEST_NAME_BASE}.exit-zero"
+run_ok "${TEST_NAME}" cylc lint --exit-zero .
 
 rm suite.rc
 

--- a/tests/functional/cylc-lint/01.lint-toml.t
+++ b/tests/functional/cylc-lint/01.lint-toml.t
@@ -47,7 +47,7 @@ __HERE__
 
 # Control tests
 TEST_NAME="it lints without toml file"
-run_ok "${TEST_NAME}" cylc lint
+run_fail "${TEST_NAME}" cylc lint
 TESTOUT="${TEST_NAME}.stdout"
 named_grep_ok "it returns error code" "S004" "${TESTOUT}"
 named_grep_ok "it returns error from subdirectory" "niwa.cylc" "${TESTOUT}"
@@ -75,7 +75,7 @@ __HERE__
 
 # Test that results are different:
 TEST_NAME="it_lints_with_toml_file"
-run_ok "${TEST_NAME}" cylc lint
+run_fail "${TEST_NAME}" cylc lint
 TESTOUT="${TEST_NAME}.stdout"
 grep_fail "S004" "${TESTOUT}"
 grep_fail "niwa.cylc" "${TESTOUT}"
@@ -93,7 +93,7 @@ cat > flow.cylc <<__HERE__
 __HERE__
 
 TEST_NAME="it_fails_if_max-line-length_set"
-run_ok "${TEST_NAME}" cylc lint
+run_fail "${TEST_NAME}" cylc lint
 named_grep_ok "${TEST_NAME}-line-too-long-message" \
     "\[S008\] flow.cylc:2: line > 4 characters." \
     "${TEST_NAME}.stdout"


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5545

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.

~No tests - I didn't think they were needed for this change.~

I have not updated docs as I didn't see where it would be appropriate to add anything about this.

Targetting the 8.1.x branch, but can change if required.