### PR TITLE
lint: fix spurious lowercase family style warnings

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -129,10 +129,50 @@ STYLE_CHECKS = {
         'url': STYLE_GUIDE + 'trailing-whitespace',
         'index': 6
     },
-    # Look for families both from inherit=FAMILY and FAMILY:trigger-all/any.
-    # Do not match inherit lines with `None` at the start.
+    # Look for families in inherit= configurations.
     re.compile(
-        r'(inherit\s*=(?!\s*None\s*(?!.*[a-z])))|(\w[a-z]\w:\w+?-a(ll|ny))'
+        r'''
+          # match all inherit statements
+          ^\s*inherit\s*=
+          # filtering out those which match only valid family names
+          (?!
+            \s*
+            # none, None and root are valid family names
+            (none|None|root|
+              (
+                # as are families named with capital letters
+                [A-Z0-9_-]+
+                # which may include Cylc parameters
+                | (<[^>]+>)
+                # or Jinja2
+                | ({[{%].*[%}]})
+                # or EmPy
+                | (@[\[{\(]).*([\]\}\)])
+              )+
+            )
+            # this can be a comma separated list
+            (
+              \s*,\s*
+              # none, None and root are valid family names
+              (none|None|root|
+                (
+                  # as are families named with capital letters
+                  [A-Z0-9_-]+
+                  # which may include Cylc parameters
+                  | (<[^>]+>)
+                  # or Jinja2
+                  | ({[{%].*[%}]})
+                  # or EmPy
+                  | (@[\[{\(]).*([\]\}\)])
+                )+
+              )
+            )*
+            # allow trailing commas and whitespace
+            \s*,?\s*
+            $
+          )
+        ''',
+        re.X
     ): {
         'short': 'Family name contains lowercase characters.',
         'url': STYLE_GUIDE + 'task-naming-conventions',

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -138,10 +138,13 @@ STYLE_CHECKS = {
           (?!
             \s*
             # none, None and root are valid family names
-            (none|None|root|
+            # and `inherit =` or `inherit = # x` are valid too
+            (['"]?(none|None|root|\#.*|$)['"]?|
               (
                 # as are families named with capital letters
                 [A-Z0-9_-]+
+                # and optional quotes
+                | [\'\"]
                 # which may include Cylc parameters
                 | (<[^>]+>)
                 # or Jinja2
@@ -154,10 +157,12 @@ STYLE_CHECKS = {
             (
               \s*,\s*
               # none, None and root are valid family names
-              (none|None|root|
+              (['"]?(none|None|root)['"]?|
                 (
                   # as are families named with capital letters
                   [A-Z0-9_-]+
+                  # and optional quotes
+                  | [\'\"]
                   # which may include Cylc parameters
                   | (<[^>]+>)
                   # or Jinja2
@@ -169,6 +174,8 @@ STYLE_CHECKS = {
             )*
             # allow trailing commas and whitespace
             \s*,?\s*
+            # allow trailing comments
+            (\#.*)?
             $
           )
         ''',

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -216,6 +216,8 @@ def test_check_cylc_file_line_no(create_testable_file, capsys):
             'inherit = FOO, bar',
             'inherit = None, bar',
             'inherit = A, b, C',
+            'inherit = "A", "b"',
+            "inherit = 'A', 'b'",
             # parameters, jinja2 and empy should be ignored
             # but any lowercase chars before or after should not
             'inherit = a<x>z',
@@ -234,7 +236,10 @@ def test_inherit_lowercase_matches(create_testable_file, inherit_line):
     (
         param(item, id=str(ind))
         for ind, item in enumerate([
-            # none, None and root are valid family names
+            # undefined values are ok
+            'inherit =',
+            'inherit =  ',
+            # none, None and root are ok
             'inherit = none',
             'inherit = None',
             'inherit = root',
@@ -250,14 +255,22 @@ def test_inherit_lowercase_matches(create_testable_file, inherit_line):
             'inherit = FOO_BAR_0',
             # parameters should be ignored
             'inherit = A<a>Z',
-            'inherit = <a=1>',
+            'inherit = <a=1, b-1, c+1>',
             # jinja2 should be ignored
             'inherit = A{{ a }}Z, {% for x in range(5) %}'
             'A{{ x }}, {% endfor %}',
             # empy should be ignored
             'inherit = A@( a )Z',
+            # trailing comments should be ignored
+            'inherit = A, B # no, comment',
+            'inherit = # a',
+            # quotes are ok
+            'inherit = "A", "B"',
+            "inherit = 'A', 'B'",
+            'inherit = "None", B',
+            'inherit = <a = 1, b - 1>',
             # one really awkward, but valid example
-            'inherit = none, root, FOO_BAR_0, <a>, A<a>Z, A{{a}}Z, A@(a)Z',
+            'inherit = none, FOO_BAR_0, "<a - 1>", A<a>Z, A{{a}}Z, A@(a)Z',
         ])
     )
 )

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -208,11 +208,20 @@ def test_check_cylc_file_line_no(create_testable_file, capsys):
 @pytest.mark.parametrize(
     'inherit_line',
     (
-        'inherit = foo, b, a, r',
-        'inherit = FOO, bar',
-        'inherit = None, bar',
-        'inherit = g',
-        'inherit = B, None',
+        param(item, id=str(ind))
+        for ind, item in enumerate([
+            # lowercase family names are not permitted
+            'inherit = g',
+            'inherit = foo, b, a, r',
+            'inherit = FOO, bar',
+            'inherit = None, bar',
+            'inherit = A, b, C',
+            # parameters, jinja2 and empy should be ignored
+            # but any lowercase chars before or after should not
+            'inherit = a<x>z',
+            'inherit = a{{ x }}z',
+            'inherit = a@( x )z',
+        ])
     )
 )
 def test_inherit_lowercase_matches(create_testable_file, inherit_line):
@@ -223,9 +232,33 @@ def test_inherit_lowercase_matches(create_testable_file, inherit_line):
 @pytest.mark.parametrize(
     'inherit_line',
     (
-        'inherit = None',
-        'inherit = None,',
-        'inherit = None, FOO',
+        param(item, id=str(ind))
+        for ind, item in enumerate([
+            # none, None and root are valid family names
+            'inherit = none',
+            'inherit = None',
+            'inherit = root',
+            # trailing commas and whitespace are ok
+            'inherit = None,',
+            'inherit = None, ',
+            'inherit = None , ',
+            # uppercase family names are ok
+            'inherit = None, FOO, BAR',
+            'inherit = FOO',
+            'inherit = BAZ',
+            'inherit = root',
+            'inherit = FOO_BAR_0',
+            # parameters should be ignored
+            'inherit = A<a>Z',
+            'inherit = <a=1>',
+            # jinja2 should be ignored
+            'inherit = A{{ a }}Z, {% for x in range(5) %}'
+            'A{{ x }}, {% endfor %}',
+            # empy should be ignored
+            'inherit = A@( a )Z',
+            # one really awkward, but valid example
+            'inherit = none, root, FOO_BAR_0, <a>, A<a>Z, A{{a}}Z, A@(a)Z',
+        ])
     )
 )
 def test_inherit_lowercase_not_match_none(create_testable_file, inherit_line):


### PR DESCRIPTION
Closes #5558

This rule should now permit:
* Parameters.
* Jinja2.
* Empy.
* `none`, `None`, `root`.

~Regex playground: https://regex101.com/r/gyRD8h/1~ outdated

Worth trying this out with some real workflows to see if there are any other surprises.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.