### PR TITLE
cat-log: exit when file is deleted

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1437,12 +1437,15 @@ with Conf('global.cylc', desc='''
                        "[remote]retrieve job logs retry delays")}
             ''')
             Conf('tail command template',
-                 VDR.V_STRING, 'tail -n +1 --follow=name -F %(filename)s',
+                 VDR.V_STRING, 'tail -n +1 --follow=name %(filename)s',
                  desc=f'''
                 A command template (with ``%(filename)s`` substitution) to
                 tail-follow job logs this platform, by ``cylc cat-log``.
 
-                You are are unlikely to need to override this.
+                .. warning::
+
+                   You are are unlikely to need to override this. Doing so may
+                   adversely affect the UI log view.
 
                 .. versionchanged:: 8.0.0
 

--- a/tests/functional/cylc-cat-log/12-delete-kill.t
+++ b/tests/functional/cylc-cat-log/12-delete-kill.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc cat-log" exits when the log file is deleted
+# or when tail is killed.
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+init_workflow "${TEST_NAME_BASE}" << __EOF__
+# whatever
+__EOF__
+
+log_file="${WORKFLOW_RUN_DIR}/log/foo.log"
+echo "Hello, Mr. Thompson" > "$log_file"
+
+TEST_NAME="${TEST_NAME_BASE}-delete"
+cylc cat-log --mode=tail "$WORKFLOW_NAME" -f foo.log 2>&1 &
+cat_log_pid="$!"
+# Wait for tail to start
+sleep 3
+# We should be able to delete the log file
+run_ok "$TEST_NAME" rm "$log_file"
+# cat-log should exit 0
+poll_pid_done "$cat_log_pid"
+run_ok "${TEST_NAME}_ret" wait "$cat_log_pid"
+
+echo "Hello, Mr. Thompson" > "$log_file"
+
+TEST_NAME="${TEST_NAME_BASE}-kill"
+cylc cat-log --mode=tail "$WORKFLOW_NAME" -f foo.log 2>&1 &
+cat_log_pid="$!"
+# Wait for tail to start
+sleep 3
+tail_pid="$(ps --no-headers -C tail --ppid "$cat_log_pid" -o pid)"
+kill "$tail_pid"
+# cat-log should exit non-zero
+poll_pid_done "$cat_log_pid"
+run_fail "${TEST_NAME}_ret" wait "$cat_log_pid"
+
+purge


### PR DESCRIPTION
Remove `-F` (which implied `--retry`) from tail command template.

Used by https://github.com/cylc/cylc-uiserver/pull/457 & https://github.com/cylc/cylc-ui/pull/1306

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs update needed
- [x] Master is correct branch I think
