### PR TITLE
job: redact the CYLC_TASK_DEPENDENCIES variable if too long

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ ones in. -->
 -------------------------------------------------------------------------------
 ## __cylc-8.1.5 (<span actions:bind='release-date'>Upcoming</span>)__
 
+### Breaking Changes
+
+[#5600](https://github.com/cylc/cylc-flow/pull/5600) -
+The `CYLC_TASK_DEPENDENCIES` environment variable will no longer be exported
+in job environments if there are more than 50 dependencies. This avoids an
+issue which could cause jobs to fail if this variable became too long.
+
 ### Fixes
 
 [#5524](https://github.com/cylc/cylc-flow/pull/5524) - Logging includes timestamps

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -31,6 +31,8 @@ from cylc.flow.config import interpolate_template, ParamExpandError
 # the maximum number of task dependencies which Cylc will list before
 # omitting the CYLC_TASK_DEPENDENCIES environment variable
 # see: https://github.com/cylc/cylc-flow/issues/5551
+# NOTE: please update `src/reference/job-script-vars/var-list.txt`
+#       in cylc-doc if changing this value
 MAX_CYLC_TASK_DEPENDENCIES_LEN = 50
 
 


### PR DESCRIPTION
* Long environment variables can eat into the shell's address space causing subsequent commands to fail.
* Redact the `CYLC_TASK_DEPENDENCIES` variable when there are more than 50 upstream tasks.
* If a task cycle point is ~25 chars and the name up to ~75 chars then that's 100 chars per task x 50 tasks => 50'000 chars which should be within the limit (~126'000 on my system).
* Closes https://github.com/cylc/cylc-flow/issues/5551

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc/pull/613) pull request opened if required at [cylc/cylc-doc/pull/613](https://github.com/cylc/cylc-doc/pull/613).
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.