### PR TITLE
Fix runtime environment (scheduler, validation, etc.)

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -241,10 +241,10 @@ class WorkflowConfig:
         """
         Initialize the workflow config object.
 
-        Positional args:
+        Args:
             workflow: workflow ID
             fpath: workflow config file path
-             options: CLI options
+            options: CLI options
         """
         check_deprecation(Path(fpath))
         self.mem_log = mem_log_func

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -895,9 +895,7 @@ class WorkflowConfig:
             )
         # Allow implicit tasks in back-compat mode unless rose-suite.conf
         # present (to maintain compat with Rose 2019)
-        elif (
-            not (self.fpath.parent / Path('rose-suite.conf')).is_file()
-        ):
+        elif not (self.fpath.parent / "rose-suite.conf").is_file():
             LOG.debug(msg)
             return
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1632,9 +1632,10 @@ def test_cylc_env_at_parsing(
 
     flow_file.write_text(flow_config)
 
-    monkeypatch.setattr(
-        'cylc.flow.config.is_installed',
-        lambda _: installed
+    # Make it looks as if path is relative to cylc-run (i.e. installed).
+    monkeypatch.setattrt (
+        'cylc.flow.config.is_relative_to',
+        lambda _a, _b: installed
     )
 
     # Parse the workflow config then check the environment.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1581,7 +1581,7 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_SHARE_DIR': False,
                 'CYLC_WORKFLOW_LOG_DIR': False,
             },
-        id="source-dir"
+            id="source-dir"
         ),
         pytest.param(
             True,
@@ -1594,7 +1594,7 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_SHARE_DIR': False,
                 'CYLC_WORKFLOW_LOG_DIR': False,
             },
-        id="run-dir"
+            id="run-dir"
         ),
         pytest.param(
             True,
@@ -1607,7 +1607,7 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_SHARE_DIR': True,
                 'CYLC_WORKFLOW_LOG_DIR': True,
             },
-        id="run-dir-from-scheduler"
+            id="run-dir-from-scheduler"
         ),
     ]
 )
@@ -1633,7 +1633,7 @@ def test_cylc_env_at_parsing(
     flow_file.write_text(flow_config)
 
     # Make it looks as if path is relative to cylc-run (i.e. installed).
-    monkeypatch.setattrt (
+    monkeypatch.setattr(
         'cylc.flow.config.is_relative_to',
         lambda _a, _b: installed
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from optparse import Values
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 from pathlib import Path
@@ -1565,3 +1566,84 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
     assert "'baz'" not in result
     assert f"showing first {max_warning_lines}" in result
 
+
+@pytest.mark.parametrize(
+    'installed, run_dir, cylc_vars',
+    [
+        pytest.param(
+            False,  # not installed (parsing a source dir)
+            None,  # no run directory passed to config object by scheduler
+            {
+                'CYLC_WORKFLOW_NAME': True,  # expected environment variables
+                'CYLC_WORKFLOW_ID': False,
+                'CYLC_WORKFLOW_RUN_DIR': False,
+                'CYLC_WORKFLOW_WORK_DIR': False,
+                'CYLC_WORKFLOW_SHARE_DIR': False,
+                'CYLC_WORKFLOW_LOG_DIR': False,
+            }
+        ),
+        pytest.param(
+            True,
+            None,
+            {
+                'CYLC_WORKFLOW_NAME': True,
+                'CYLC_WORKFLOW_ID': True,
+                'CYLC_WORKFLOW_RUN_DIR': True,
+                'CYLC_WORKFLOW_WORK_DIR': False,
+                'CYLC_WORKFLOW_SHARE_DIR': False,
+                'CYLC_WORKFLOW_LOG_DIR': False,
+            }
+        ),
+        pytest.param(
+            True,
+            "/some/path",
+            {
+                'CYLC_WORKFLOW_NAME': True,
+                'CYLC_WORKFLOW_ID': True,
+                'CYLC_WORKFLOW_RUN_DIR': True,
+                'CYLC_WORKFLOW_WORK_DIR': True,
+                'CYLC_WORKFLOW_SHARE_DIR': True,
+                'CYLC_WORKFLOW_LOG_DIR': True,
+            }
+        ),
+    ]
+)
+def test_cylc_env_at_parsing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    installed,
+    run_dir,
+    cylc_vars
+):
+    """Check that CYLC_ environment vars exported during config file parsing
+       are appropriate to the workflow context (source, installed, or running).
+    """
+    flow_file = tmp_path / WorkflowFiles.FLOW_FILE
+    flow_config = """
+    [scheduler]
+        allow implicit tasks = True
+    [scheduling]
+        [[graph]]
+            R1 = 'foo'
+    """
+
+    flow_file.write_text(flow_config)
+
+    monkeypatch.setattr(
+        'cylc.flow.config.is_installed',
+        lambda _: installed
+    )
+
+    # Parse the workflow config then check the environment.
+    WorkflowConfig(
+        workflow="name", fpath=flow_file, options=Mock(spec=[]),
+        run_dir=run_dir
+    )
+
+    cylc_env = [k for k in os.environ.keys() if k.startswith('CYLC_')]
+
+    for var, expected in cylc_vars.items():
+        if expected:
+            assert var in cylc_env
+        else:
+            assert var not in cylc_env

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,7 @@ import pytest
 import logging
 from types import SimpleNamespace
 from unittest.mock import Mock
+from contextlib import suppress
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.config import WorkflowConfig
@@ -1621,6 +1622,12 @@ def test_cylc_env_at_parsing(
     """Check that CYLC_ environment vars exported during config file parsing
        are appropriate to the workflow context (source, installed, or running).
     """
+
+    # Purge environment from previous tests.
+    for key in cylc_vars.keys():
+        with suppress(KeyError):
+            del os.environ[key]
+
     flow_file = tmp_path / WorkflowFiles.FLOW_FILE
     flow_config = """
     [scheduler]
@@ -1632,7 +1639,7 @@ def test_cylc_env_at_parsing(
 
     flow_file.write_text(flow_config)
 
-    # Make it looks as if path is relative to cylc-run (i.e. installed).
+    # Make it look as if path is relative to cylc-run (i.e. installed).
     monkeypatch.setattr(
         'cylc.flow.config.is_relative_to',
         lambda _a, _b: installed

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1580,7 +1580,8 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_WORK_DIR': False,
                 'CYLC_WORKFLOW_SHARE_DIR': False,
                 'CYLC_WORKFLOW_LOG_DIR': False,
-            }
+            },
+        id="source-dir"
         ),
         pytest.param(
             True,
@@ -1592,7 +1593,8 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_WORK_DIR': False,
                 'CYLC_WORKFLOW_SHARE_DIR': False,
                 'CYLC_WORKFLOW_LOG_DIR': False,
-            }
+            },
+        id="run-dir"
         ),
         pytest.param(
             True,
@@ -1604,7 +1606,8 @@ def test__warn_if_queues_have_implicit_tasks(caplog):
                 'CYLC_WORKFLOW_WORK_DIR': True,
                 'CYLC_WORKFLOW_SHARE_DIR': True,
                 'CYLC_WORKFLOW_LOG_DIR': True,
-            }
+            },
+        id="run-dir-from-scheduler"
         ),
     ]
 )


### PR DESCRIPTION
Currently in `config.py` we infer a run directory, and work and share sub-directories, and export associated environment variables, even when parsing a source workflow (which may not be installed) or when parsing an installed workflow but not running the scheduler (in which case work etc. may not exist).

The original motivation for this PR was:
 *There are use cases where src-dir needs to be distinguished from run-dir at config parsing time.  Example: dependency graph constructed on the fly according to the content of some workflow sub-dir.  For validation of the source workflow, the location of this content is relative to the source dir; for validation of the installed workflow (or at scheduler start-up) it must be relative to the run directory.*

#5589 now provides a better solution to that problem, but in any case the exported environment should be consistent with the workflow location (as it is accessible to the template processor during parsing).

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] ~Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).~
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] ~If this is a bug fix, PR should be raised against the relevant `?.?.x` branch~. (we're currently aiming all changes at 8.2.0)
