### PR TITLE
Add CYLC_ variables to template engine globals.

### DIFF
--- a/changes.d/5571.feat.md
+++ b/changes.d/5571.feat.md
@@ -1,0 +1,1 @@
+Make workflow `CYLC_` variables available to the template processor during parsing.

--- a/cylc/flow/parsec/empysupport.py
+++ b/cylc/flow/parsec/empysupport.py
@@ -24,6 +24,7 @@ import os
 import typing as t
 
 from cylc.flow.parsec.exceptions import EmPyError
+from cylc.flow.parsec.fileparse import get_cylc_env_vars
 
 
 def empyprocess(
@@ -52,6 +53,12 @@ def empyprocess(
     ftempl = StringIO('\n'.join(flines))
     xtempl = StringIO()
     interpreter = em.Interpreter(output=em.UncloseableFile(xtempl))
+
+    # Add `CYLC_` environment variables to the global namespace.
+    interpreter.updateGlobals(
+        get_cylc_env_vars()
+    )
+
     try:
         interpreter.file(ftempl, '<template>', template_vars)
     except Exception as exc:

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -105,6 +105,27 @@ _UNCLOSED_MULTILINE = re.compile(
 )
 
 
+def get_cylc_env_vars() -> t.Dict[str, str]:
+    """Return a restricted dict of CYLC_ environment variables for templating.
+
+    The following variables are ignored because the do not necessarily reflect
+    the running code version (I might not use the "cylc" wrapper, or it might
+    select a different version):
+
+    CYLC_VERSION
+        Set as a template variable elsewhere, from the hardwired code version.
+
+    CYLC_ENV_NAME
+        Providing it as a template variable would just be misleading.
+    """
+    return {
+        key: val
+        for key, val in os.environ.items()
+        if key.startswith('CYLC_')
+        if key not in ["CYLC_VERSION", "CYLC_ENV_NAME"]
+    }
+
+
 def _concatenate(lines):
     """concatenate continuation lines"""
     index = 0
@@ -446,10 +467,9 @@ def read_and_proc(
         flines = inline(
             flines, fdir, fpath, viewcfg=viewcfg)
 
+    # Add the hardwired code version to template vars as CYLC_VERSION
     template_vars['CYLC_VERSION'] = __version__
-
     template_vars = merge_template_vars(template_vars, extra_vars)
-
     template_vars['CYLC_TEMPLATE_VARS'] = template_vars
 
     # Fail if templating_detected ≠ hashbang

--- a/tests/functional/cylc-cat-log/01-remote.t
+++ b/tests/functional/cylc-cat-log/01-remote.t
@@ -30,7 +30,9 @@ TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME="${TEST_NAME_BASE}-run"
-workflow_run_ok "${TEST_NAME}" cylc play --debug --no-detach "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME}" \
+    cylc play --debug --no-detach \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${WORKFLOW_NAME}"
 #-------------------------------------------------------------------------------
 TEST_NAME=${TEST_NAME_BASE}-task-out
 cylc cat-log -f o "${WORKFLOW_NAME}//1/a-task" >"${TEST_NAME}.out"
@@ -56,7 +58,7 @@ grep_ok "jumped over the lazy dog" "${TEST_NAME}.out"
 # remote
 TEST_NAME=${TEST_NAME_BASE}-task-status
 cylc cat-log -f s "${WORKFLOW_NAME}//1/a-task" >"${TEST_NAME}.out"
-grep_ok "CYLC_JOB_RUNNER_NAME=background" "${TEST_NAME}.out"
+grep_ok "CYLC_JOB_RUNNER_NAME=at" "${TEST_NAME}.out"
 #-------------------------------------------------------------------------------
 # local
 TEST_NAME=${TEST_NAME_BASE}-task-activity

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -34,6 +34,7 @@ from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.fileparse import (
     _prepend_old_templatevars,
     _get_fpath_for_source,
+    get_cylc_env_vars,
     addict,
     addsect,
     multiline,
@@ -736,3 +737,23 @@ def test_get_fpath_for_source(tmp_path):
     opts.against_source = True
     assert _get_fpath_for_source(
         rundir / 'flow.cylc', opts) == str(srcdir / 'flow.cylc')
+
+
+def test_get_cylc_env_vars(monkeypatch):
+    """It should return CYLC env vars but not CYLC_VERSION or CYLC_ENV_NAME."""
+    monkeypatch.setattr(
+        'os.environ',
+        {
+            "CYLC_VERSION": "betwixt",
+            "CYLC_ENV_NAME": "between",
+            "CYLC_QUESTION": "que?", 
+            "CYLC_ANSWER": "42", 
+            "FOO": "foo"
+        }
+    )
+    assert (
+        get_cylc_env_vars() == {
+            "CYLC_QUESTION": "que?", 
+            "CYLC_ANSWER": "42", 
+        }
+    )


### PR DESCRIPTION
What it says.  Make this sort of thing work during `flow.cylc` parsing:
```
{{ CYLC_WORKFLOW_RUN_DIR | default("not defined") }}
``` 

See explanation in https://github.com/cylc/cylc-flow/pull/5570#issue-1744687086

If agreed, I'll document this, and do the same for Empy.

Will need to document that this should not be used in place of the associated environment variables in task definitions (they get evaluated at job run time and will therefore always be defined).

[UPDATE: for the linked use case, #5589 makes this PR redundant. But this might be useful for other reasons]

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/631.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
