### PR TITLE
log_vc_info: catch info command errors and present them as warnings

### DIFF
--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -35,6 +35,13 @@ LOG_LEVELS = {
 }
 
 
+class LoggerAdaptor(logging.LoggerAdapter):
+    """Adds a prefix to log messages."""
+    def process(self, msg, kwargs):
+        ret = f"[{self.extra['prefix']}] {msg}" if self.extra else msg
+        return ret, kwargs
+
+
 def environ_init():
     """Initialise cylc environment."""
     # Python output buffering delays appearance of stdout and stderr

--- a/cylc/flow/install_plugins/log_vc_info.py
+++ b/cylc/flow/install_plugins/log_vc_info.py
@@ -169,7 +169,7 @@ def get_vc_info(path: Union[Path, str]) -> Optional[Dict[str, Any]]:
             ):
                 LOG.debug(f"Source dir {path} is not a {vcs} repository")
             elif cylc.flow.flags.verbosity > -1:
-                LOG.warning(exc)
+                LOG.warning(f"$ {vcs} {' '.join(args)}\n{exc}")
             continue
 
         info['version control system'] = vcs

--- a/cylc/flow/install_plugins/log_vc_info.py
+++ b/cylc/flow/install_plugins/log_vc_info.py
@@ -66,13 +66,15 @@ from typing import (
     Any, Dict, Iterable, List, Optional, TYPE_CHECKING, TextIO, Union, overload
 )
 
-from cylc.flow import LOG
+from cylc.flow import LOG as _LOG, LoggerAdaptor
 from cylc.flow.exceptions import CylcError
 import cylc.flow.flags
 from cylc.flow.workflow_files import WorkflowFiles
 
 if TYPE_CHECKING:
     from optparse import Values
+
+LOG = LoggerAdaptor(_LOG, {'prefix': __name__})
 
 
 SVN = 'svn'

--- a/cylc/flow/install_plugins/log_vc_info.py
+++ b/cylc/flow/install_plugins/log_vc_info.py
@@ -68,6 +68,7 @@ from typing import (
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import CylcError
+import cylc.flow.flags
 from cylc.flow.workflow_files import WorkflowFiles
 
 if TYPE_CHECKING:
@@ -162,14 +163,14 @@ def get_vc_info(path: Union[Path, str]) -> Optional[Dict[str, Any]]:
             missing_base = True
             LOG.debug(exc)
         except OSError as exc:
-            if not any(
+            if any(
                 exc.strerror.lower().startswith(err)
                 for err in NOT_REPO_ERRS[vcs]
             ):
-                raise exc
-            else:
                 LOG.debug(f"Source dir {path} is not a {vcs} repository")
-                continue
+            elif cylc.flow.flags.verbosity > -1:
+                LOG.warning(exc)
+            continue
 
         info['version control system'] = vcs
         if vcs == SVN:

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -92,9 +92,9 @@ from cylc.flow.scripts.scan import (
     FLOW_STATE_SYMBOLS,
     FLOW_STATE_CMAP
 )
-from cylc.flow import iter_entry_points
+from cylc.flow import LOG, iter_entry_points
 from cylc.flow.exceptions import PluginError, InputError
-from cylc.flow.loggingutil import CylcLogFormatter
+from cylc.flow.loggingutil import CylcLogFormatter, set_timestamps
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     OptionSettings,
@@ -285,6 +285,7 @@ def install_cli(
 def install(
     opts: 'Values', reg: Optional[str] = None
 ) -> Tuple[str, str]:
+    set_timestamps(LOG, opts.verbosity > 1)
     if opts.no_run_name and opts.run_name:
         raise InputError(
             "options --no-run-name and --run-name are mutually exclusive."

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -285,7 +285,7 @@ def install_cli(
 def install(
     opts: 'Values', reg: Optional[str] = None
 ) -> Tuple[str, str]:
-    set_timestamps(LOG, opts.verbosity > 1)
+    set_timestamps(LOG, opts.log_timestamp and opts.verbosity > 1)
     if opts.no_run_name and opts.run_name:
         raise InputError(
             "options --no-run-name and --run-name are mutually exclusive."

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -337,4 +337,6 @@ def install(
                 exc
             ) from None
 
+    print(f'INSTALLED {workflow_id} from {source_dir}')
+
     return workflow_name, workflow_id

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1753,7 +1753,6 @@ def install_workflow(
         install_log.info(
             f'Symlink from "{source_link}" to "{source}" in place.')
     install_log.info(f'INSTALLED {named_run} from {source}')
-    print(f'INSTALLED {named_run} from {source}')
     close_log(install_log)
     return source, rundir, workflow_name, named_run
 

--- a/tests/unit/post_install/test_log_vc_info.py
+++ b/tests/unit/post_install/test_log_vc_info.py
@@ -283,4 +283,4 @@ def test_untracked_svn_subdir(
     source_dir = Path(repo_dir, 'jar_jar_binks')
     source_dir.mkdir()
     assert get_vc_info(source_dir) is None
-    assert log_filter(caplog, level=logging.WARNING, contains="E200009")
+    assert log_filter(caplog, level=logging.WARNING, contains="$ svn info")

--- a/tests/unit/post_install/test_log_vc_info.py
+++ b/tests/unit/post_install/test_log_vc_info.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import logging
 from pathlib import Path
 import pytest
 from pytest import MonkeyPatch, TempPathFactory
@@ -272,3 +273,14 @@ def test_no_base_commit_git(tmp_path: Path):
     diff_file = write_diff('git', source_dir, run_dir)
     for line in diff_file.read_text().splitlines():
         assert line.startswith('#')
+
+
+@require_svn
+def test_untracked_svn_subdir(
+    svn_source_repo: Tuple[str, str, str], caplog, log_filter
+):
+    repo_dir, *_ = svn_source_repo
+    source_dir = Path(repo_dir, 'jar_jar_binks')
+    source_dir.mkdir()
+    assert get_vc_info(source_dir) is None
+    assert log_filter(caplog, level=logging.WARNING, contains="E200009")


### PR DESCRIPTION
This fixes a scary traceback when installing a workflow from an untracked subdirectory of an SVN repo. In general, it presents any non-zero exit from a VCS command as a warning rather than an error.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] No `CHANGES.md` entry included as this is minor
- [x] No docs update needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
