### PR TITLE
Allow pre configure plugin to access compat mode info in cylc install.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,6 @@ enhancements to ``cylc lint``:
   * __Only__ check for missing Jinja2 shebangs in ``flow.cylc`` and
     ``suite.rc`` files.
 
-### Fixes
 ### Breaking Changes
 
 [#5600](https://github.com/cylc/cylc-flow/pull/5600) -
@@ -52,6 +51,9 @@ for `cylc play` when called by `cylc vip` or `cylc vr`.
 [#5228](https://github.com/cylc/cylc-flow/pull/5228) -
 Enabled the "stop", "poll", "kill" and "message" commands to be issued from
 the UI whilst the workflow is in the process of shutting down.
+
+[#5582](https://github.com/cylc/cylc-flow/pull/5582) - Set Cylc 7 compatibility
+mode before running pre-configure plugins.
 
 ## __cylc-8.1.4 (<span actions:bind='release-date'>Released 2023-05-04</span>)__
 

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -108,7 +108,8 @@ from cylc.flow.pathutil import (
 from cylc.flow.workflow_files import (
     install_workflow,
     parse_cli_sym_dirs,
-    search_install_source_dirs
+    search_install_source_dirs,
+    check_deprecation,
 )
 from cylc.flow.terminal import cli_function
 
@@ -290,6 +291,11 @@ def install(
             "options --no-run-name and --run-name are mutually exclusive."
         )
     source = get_source_location(reg)
+
+    # Check deprecation to allow plugins to have access to correct flags
+    # for compatibility mode:
+    check_deprecation(source)
+
     for entry_point in iter_entry_points(
         'cylc.pre_configure'
     ):

--- a/cylc/flow/scripts/validate_install_play.py
+++ b/cylc/flow/scripts/validate_install_play.py
@@ -28,6 +28,8 @@ This script is equivalent to:
 
 """
 
+import sys
+
 from cylc.flow.scripts.validate import (
     VALIDATE_OPTIONS,
     _main as validate_main
@@ -111,5 +113,5 @@ def main(parser: COP, options: 'Values', workflow_id: Optional[str] = None):
     )
 
     set_timestamps(LOG, options.log_timestamp)
-    log_subcommand('play', workflow_id)
+    log_subcommand(*sys.argv[1:])
     _play(parser, options, workflow_id)

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1237,12 +1237,12 @@ def check_deprecation(path, warn=True):
     Path can point to config file or parent directory (i.e. workflow name).
     """
     if (
-        (
+        # Don't want to log if it's already been set True.
+        not cylc.flow.flags.cylc7_back_compat
+        and (
             path.resolve().name == WorkflowFiles.SUITE_RC
             or (path / WorkflowFiles.SUITE_RC).is_file()
         )
-        # Don't want to log if it's already been set True.
-        and not cylc.flow.flags.cylc7_back_compat
     ):
         cylc.flow.flags.cylc7_back_compat = True
         if warn:

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -1237,8 +1237,12 @@ def check_deprecation(path, warn=True):
     Path can point to config file or parent directory (i.e. workflow name).
     """
     if (
-        path.resolve().name == WorkflowFiles.SUITE_RC
-        or (path / WorkflowFiles.SUITE_RC).is_file()
+        (
+            path.resolve().name == WorkflowFiles.SUITE_RC
+            or (path / WorkflowFiles.SUITE_RC).is_file()
+        )
+        # Don't want to log if it's already been set True.
+        and not cylc.flow.flags.cylc7_back_compat
     ):
         cylc.flow.flags.cylc7_back_compat = True
         if warn:

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -167,8 +167,8 @@ def test_install_gets_back_compat_mode_for_plugins(
 
         @staticmethod
         def raiser(*_, **__):
-            import cylc
-            if cylc.flow.flags.cylc7_back_compat is True:
+            import cylc.flow.flags
+            if cylc.flow.flags.cylc7_back_compat:
                 print('Plugin:True')
                 return True
             print('Plugin:False')


### PR DESCRIPTION
(Show "real" args used by Cylc Play in VIP)

Part fixes a bug spotted by a user and not documented as a separate ticket: Cylc install behaviour was inconsistent between `cylc install` and `cylc vip` in the example described in https://github.com/cylc/cylc-rose/issues/230 because `cylc install` did not set the `cylc7_compat_mode` until after the pre_configure plugin ran.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
