### PR TITLE
Stop Unit tests symlinking on workflow installation

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -204,3 +204,11 @@ def xtrigger_mgr() -> XtriggerManager:
             create_autospec(Scheduler, workflow=workflow_name, owner=user)
         )
     )
+
+
+@pytest.fixture()
+def prevent_symlinking(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        'cylc.flow.pathutil.make_symlink_dir',
+        lambda *_, **__: {}
+    )

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import os
 import shutil
 from pathlib import Path
@@ -30,7 +29,6 @@ from typing import (
 
 import pytest
 
-from cylc.flow import workflow_files
 from cylc.flow.exceptions import (
     InputError,
     WorkflowFilesError,
@@ -82,7 +80,8 @@ def test_install_workflow__max_depth(
     err_expected: bool,
     tmp_run_dir: Callable,
     tmp_src_dir: Callable,
-    glbl_cfg_max_scan_depth: NonCallableFixture
+    glbl_cfg_max_scan_depth: NonCallableFixture,
+    prevent_symlinking,
 ):
     """Test that trying to install beyond max depth fails."""
     tmp_run_dir()
@@ -109,7 +108,8 @@ def test_install_workflow__next_to_flow_file(
     flow_file: Optional[str],
     expected_exc: Optional[Type[Exception]],
     tmp_run_dir: Callable,
-    tmp_src_dir: Callable
+    tmp_src_dir: Callable,
+    prevent_symlinking,
 ):
     """Test that you can't install into a dir that contains a workflow file."""
     # Setup


### PR DESCRIPTION
Closes #5172

Fixes Test `tests/integration/cylc_install`, which previously installed workflows in Cylc Src.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] ~Tests are included~ Fixes a broken test
- [x] ~`CHANGES.md` entry included~ Test fix only
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
