### PR TITLE
Graduated force-triggering (prereqs, xtriggers, queues).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ ones in. -->
 
 ### Enhancements
 
+[#5585](https://github.com/cylc/cylc-flow/pull/5585) - Make `cylc trigger` 
+act incrementally with each call: first runahead release and satisfy
+prerequisites, then xtriggers, then queue release.
+
 [#5405](https://github.com/cylc/cylc-flow/pull/5405) - Improve scan command
 help, and add scheduler PID to the output.
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1604,8 +1604,7 @@ class Scheduler:
                     if self.xtrigger_mgr.check_xtriggers(
                             itask, self.workflow_db_mgr.put_xtriggers):
                         housekeep_xtriggers = True
-                        if all(itask.is_ready_to_run()):
-                            self.pool.queue_task(itask)
+                        self.pool.queue_if_ready(itask)
 
                 # Check for satisfied ext_triggers, and queue if ready.
                 if (
@@ -1613,9 +1612,8 @@ class Scheduler:
                     and not itask.state.external_triggers_all_satisfied()
                     and self.broadcast_mgr.check_ext_triggers(
                         itask, self.ext_trigger_queue)
-                    and all(itask.is_ready_to_run())
                 ):
-                    self.pool.queue_task(itask)
+                    self.pool.queue_if_ready(itask)
 
             if housekeep_xtriggers:
                 # (Could do this periodically?)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -466,7 +466,8 @@ class Scheduler:
             self.workflow_db_mgr,
             self.task_events_mgr,
             self.data_store_mgr,
-            self.flow_mgr
+            self.flow_mgr,
+            self.xtrigger_mgr
         )
 
         self.data_store_mgr.initiate_data_model()

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,18 +17,22 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-Force tasks to run despite unsatisfied prerequisites.
+Force tasks to run despite the runahead limit, unsatisfied prerequisites,
+xtriggers, and queue limiting.
 
-* Triggering an unqueued waiting task queues it, regardless of prerequisites.
-* Triggering a queued task submits it, regardless of queue limiting.
-* Triggering an active task has no effect (it already triggered).
+- If a task has unsatisfied prerequisites, triggering will satisfy them
+- Otherwise, it will satisfy any unsatisfied xtriggers
+- Otherwise, it will submit the task to run despite queue limiting
 
-Incomplete and active-waiting tasks in the n=0 window already belong to a flow.
-Triggering them queues them to run (or rerun) in the same flow.
+If a task has unsatisfied prerequisites and xtriggers, and belongs to a limited
+queue, you may need to trigger it three times to make it run immediately.
 
-Beyond n=0, triggered tasks get all current active flow numbers by default, or
-specified flow numbers via the --flow option. Those flows - if/when they catch
-up - will see tasks that ran after triggering event as having run already.
+The runahead limit is ignored (i.e., you can trigger tasks beyond the limit).
+
+Tasks in the n=0 window already belong to a flow. Others will be assigned all
+current active flows by default (see --flow for other options).
+
+Triggering an active task has no effect (it is already triggered).
 
 Examples:
   # trigger task foo in cycle 1234 in test
@@ -98,10 +102,11 @@ def get_option_parser() -> COP:
 
     parser.add_option(
         "--flow", action="append", dest="flow", metavar="FLOW",
-        help=f"Assign the triggered task to all active flows ({FLOW_ALL});"
-             f" no flow ({FLOW_NONE}); a new flow ({FLOW_NEW});"
-             f" or a specific flow (e.g. 2). The default is {FLOW_ALL}."
-             " Reuse the option to assign multiple specific flows."
+        help=f"If the target task does not already belong to a flow,"
+             f" assign it to all active flows ({FLOW_ALL});"
+             f" or to no flow ({FLOW_NONE}); or to a new flow ({FLOW_NEW});"
+             f" or to a specific flow (e.g. 2). The default is {FLOW_ALL}."
+             " Reuse the option to assign to multiple specific flows."
     )
 
     parser.add_option(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -286,7 +286,6 @@ class TaskPool:
 
         for itask in release_me:
             self.runahead_release(itask)
-            self.queue_if_ready(itask)
             released = True
 
         return released
@@ -580,7 +579,6 @@ class TaskPool:
                 or itask.is_manual_submit  # TODO check abuse of (graduated)
             ):
                 self.runahead_release(itask)
-                self.queue_if_ready(itask)
 
             self.compute_runahead()
             self.release_runahead_tasks()
@@ -1339,7 +1337,6 @@ class TaskPool:
 
                     if t.point <= self.runahead_limit_point:
                         self.runahead_release(t)
-                        self.queue_if_ready(itask)
 
                     # Event-driven suicide.
                     if (
@@ -1456,7 +1453,6 @@ class TaskPool:
                     and c_task.point <= self.runahead_limit_point
                 ):
                     self.runahead_release(c_task)
-                    self.queue_if_ready(c_task)
 
     def can_spawn(self, name: str, point: 'PointBase') -> bool:
         """Return True if the task with the given name & point is within
@@ -1727,7 +1723,6 @@ class TaskPool:
             itask.state.set_prerequisites_all_satisfied()
             self.add_to_pool(itask)
             self.runahead_release(itask)
-            self.queue_if_ready(itask)
 
         for itask in itasks:
             # Trigger existing n=0 tasks.
@@ -1751,7 +1746,6 @@ class TaskPool:
                 )
                 itask.state.set_prerequisites_all_satisfied()
                 self.runahead_release(itask)
-                self.queue_if_ready(itask)
                 continue
 
             if (

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1728,6 +1728,7 @@ class TaskPool:
             itask.state.set_prerequisites_all_satisfied()
             self.add_to_pool(itask)
             self.runahead_release(itask)
+
         for itask in itasks:
             # Trigger existing n=0 tasks.
             # These might not be runahead limited.
@@ -1777,6 +1778,8 @@ class TaskPool:
             if itask.state.is_queued:
                 LOG.warning(f"[{itask}] - Forcing queue release.")
                 self.task_queue_mgr.force_release_task(itask)
+            else:
+                self.queue_if_ready(itask)
 
         return len(unmatched)
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1658,17 +1658,20 @@ class TaskPool:
     ) -> int:
         """Forced (manual) task triggering.
 
-        Force-triggering a future (n>0) task:
-          - spawns it into n=0 with prerequisites satisfied
-            (and with the given or default flow numbers)
+        - If a task has unsatisfied prerequisites, triggering will satisfy them
+        - Otherwise, it will satisfy any unsatisfied xtriggers
+        - Otherwise, it will submit the task to run despite queue limiting
 
-        Force-triggering an n=0 task:
-          - satisfies its prerequisites, if any are unsatisfied;
-          - else satisfies its xtriggers, if any are unsatisfied;
-          - else queues it, if not already queued;
-          - else releases it to run, if queued.
+        If a task has unsatisfied prerequisites and xtriggers, and belongs to a
+        limited queue, you may need to trigger it three times to make it run
+        immediately.
 
-        This always releases tasks from runahead limiting.
+        The runahead limit is ignored (i.e., you can trigger tasks beyond it).
+
+        Tasks in the active window already belong to a flow. Others belong to
+        all active flows by default. See --flow for other options.
+
+        Triggering an active task has no effect (it is already triggered).
 
         TODO - extend to push ext-triggers.
 

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -390,12 +390,9 @@ class TaskProxy:
         """Is this task ready to run?
 
         Takes account of all dependence: on other tasks, xtriggers, and
-        old-style ext-triggers. Or, manual triggering.
+        old-style ext-triggers.
 
         """
-        if self.is_manual_submit:
-            # Manually triggered, ignore unsatisfied prerequisites.
-            return (True,)
         if self.state.is_held:
             # A held task is not ready to run.
             return (False,)

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -321,7 +321,10 @@ class TaskState:
         return all(self.xtriggers.values())
 
     def xtriggers_set_all_satisfied(self):
-        """Set all xtriggers to satisfied."""
+        """Set all xtriggers to satisfied.
+
+        WARNING: you must invoke xtrigger manager housekeeping after this.
+        """
         for xtrig in self.xtriggers.keys():
             self.xtriggers[xtrig] = True
 

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -321,7 +321,7 @@ class TaskState:
         return all(self.xtriggers.values())
 
     def xtriggers_set_all_satisfied(self):
-        """Set all xtriggers to satisfied.
+        """Force-satisfy all xtriggers.
 
         WARNING: you must invoke xtrigger manager housekeeping after this.
         """
@@ -331,6 +331,11 @@ class TaskState:
     def external_triggers_all_satisfied(self):
         """Return True if all external triggers are satisfied."""
         return all(self.external_triggers.values())
+
+    def external_triggers_set_all_satisfied(self):
+        """Force-satisfy all external triggers."""
+        for key in self.external_triggers.keys():
+            self.external_triggers[key] = True
 
     def prerequisites_all_satisfied(self):
         """Return True if (non-suicide) prerequisites are fully satisfied."""

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -320,6 +320,11 @@ class TaskState:
         """Return True if all xtriggers are satisfied."""
         return all(self.xtriggers.values())
 
+    def xtriggers_set_all_satisfied(self):
+        """Set all xtriggers to satisfied."""
+        for xtrig in self.xtriggers.keys():
+            self.xtriggers[xtrig] = True
+
     def external_triggers_all_satisfied(self):
         """Return True if all external triggers are satisfied."""
         return all(self.external_triggers.values())

--- a/tests/functional/triggering/21-graduated-triggering.t
+++ b/tests/functional/triggering/21-graduated-triggering.t
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+
+# A task with prerequisites, xtriggers, and queue limiting needs manual
+# triggering three times to make it run.
+. "$(dirname "$0")/test_header"
+set_test_number 2
+reftest
+exit

--- a/tests/functional/triggering/21-graduated-triggering/flow.cylc
+++ b/tests/functional/triggering/21-graduated-triggering/flow.cylc
@@ -12,6 +12,8 @@
             limit = 1
     [[xtriggers]]
         never = xrandom("0","0")
+    [[special tasks]]
+        external-trigger = foo("Ain't never gonna happen.")
     [[graph]]
         R1 = """
             triggerer
@@ -29,7 +31,7 @@
             cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
             cylc__job__poll_grep_workflow_log -E "1/foo .* Force-satisfying prerequisites"
             cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
-            cylc__job__poll_grep_workflow_log -E "1/foo .* Force-satisfying xtriggers"
+            cylc__job__poll_grep_workflow_log -E "1/foo .* Force-satisfying external triggers"
             cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
             cylc__job__poll_grep_workflow_log -E "1/foo .* Forcing queue release"
             cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"

--- a/tests/functional/triggering/21-graduated-triggering/flow.cylc
+++ b/tests/functional/triggering/21-graduated-triggering/flow.cylc
@@ -1,0 +1,36 @@
+[scheduler]
+    [[events]]
+        abort on inactivity timeout = True
+        abort on stall timeout = True
+        stall timeout = PT0S
+        inactivity timeout = PT2M
+        expected task failures = 1/failer
+[scheduling]
+    [[queues]]
+        [[[cheese]]]
+            members = triggerer, foo
+            limit = 1
+    [[xtriggers]]
+        never = xrandom("0","0")
+    [[graph]]
+        R1 = """
+            triggerer
+            @never => foo
+            failer => foo
+        """
+[runtime]
+    [[foo]]
+        script = "cylc remove $CYLC_WORKFLOW_ID//1/failer"
+    [[failer]]
+        script = false
+    [[triggerer]]
+        script = """
+            cylc__job__poll_grep_workflow_log "1/failer failed"
+            cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
+            cylc__job__poll_grep_workflow_log -E "1/foo .* Force-satisfying prerequisites"
+            cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
+            cylc__job__poll_grep_workflow_log -E "1/foo .* Force-satisfying xtriggers"
+            cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
+            cylc__job__poll_grep_workflow_log -E "1/foo .* Forcing queue release"
+            cylc trigger "${CYLC_WORKFLOW_ID}//1/foo"
+        """

--- a/tests/functional/triggering/21-graduated-triggering/reference.log
+++ b/tests/functional/triggering/21-graduated-triggering/reference.log
@@ -1,0 +1,3 @@
+1/triggerer -triggered off [] in flow 1
+1/failer -triggered off [] in flow 1
+1/foo -triggered off [] in flow 1


### PR DESCRIPTION
Close #5572 (and extends it to push ext-triggers as well)

- If a task has unsatisfied prerequisites, `cylc trigger` will satisfy them
- Otherwise, it will satisfy any unsatisfied xtriggers
- Otherwise, it will submit the task to run despite queue limiting

The runahead limit is ignored (i.e., you can trigger tasks beyond the limit).

Reviewers - this is an important part of required intervention capability. E.g. if starting a flow in the middle of a cycle point, we need to be able to set up clock-triggered tasks in subsequent cycles to start checking their clock-triggers now, but not to run immediately.

@dpmatthews - pinging you for a quick look, as the brains behind the xtrigger tweak on this branch.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] ~Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).~
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [ ] ~Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~
- [ ] ~If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.~
