### PR TITLE
cd to workflow dir during file parsing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@ After successful reload the scheduler will unpause the workflow.
 [#5537](https://github.com/cylc/cylc-flow/pull/5537) - Allow parameters
 in family names to be split, e.g. `<foo>FAM<bar>`.
 
+[#5589](https://github.com/cylc/cylc-flow/pull/5589) - Move to workflow
+directory during file parsing, to give the template processor access to
+workflow files.
+
 [#5405](https://github.com/cylc/cylc-flow/pull/5405) - Improve scan command
 help, and add scheduler PID to the output.
 

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -401,6 +401,12 @@ def read_and_proc(
     fpath = _get_fpath_for_source(fpath, opts)
     fdir = os.path.dirname(fpath)
 
+    odir = os.getcwd()
+
+    # Move to the file location to give the template processor easy access to
+    # other files in the workflow directory (whether source or installed).
+    os.chdir(fdir)
+
     # Allow Python modules in lib/python/ (e.g. for use by Jinja2 filters).
     workflow_lib_python = os.path.join(fdir, "lib", "python")
     if (
@@ -493,6 +499,8 @@ def read_and_proc(
     # concatenate continuation lines
     if do_contin:
         flines = _concatenate(flines)
+
+    os.chdir(odir)
 
     # return rstripped lines
     return [fl.rstrip() for fl in flines]

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import tempfile
+from tempfile import NamedTemporaryFile
+from contextlib import suppress
 
 import os
 import pytest
@@ -278,7 +279,7 @@ def test_multiline():
 
 
 def test_read_and_proc_no_template_engine():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = None
         viewcfg = {
@@ -305,7 +306,7 @@ def test_read_and_proc_no_template_engine():
 
 
 def test_inline():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = None
         viewcfg = {
@@ -313,7 +314,7 @@ def test_inline():
             'contin': False, 'inline': True,
             'mark': None, 'single': None, 'label': None
         }
-        with tempfile.NamedTemporaryFile() as include_file:
+        with NamedTemporaryFile() as include_file:
             include_file.write("c=d".encode())
             include_file.flush()
             tf.write(("a=b\n%include \"{0}\""
@@ -325,7 +326,7 @@ def test_inline():
 
 
 def test_inline_error():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = None
         viewcfg = {
@@ -342,7 +343,7 @@ def test_inline_error():
 
 
 def test_read_and_proc_jinja2():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = {
             'name': 'Cylc'
@@ -395,7 +396,7 @@ def test_read_and_proc_cwd(tmp_path):
 
 
 def test_read_and_proc_jinja2_error():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = {
             'name': 'Cylc'
@@ -416,7 +417,7 @@ def test_read_and_proc_jinja2_error():
 
 
 def test_read_and_proc_jinja2_error_missing_shebang():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = {
             'name': 'Cylc'
@@ -436,112 +437,107 @@ def test_read_and_proc_jinja2_error_missing_shebang():
 # --- originally we had a test for empy here, moved to test_empysupport
 
 def test_parse_keys_only_singleline():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write("#!jinja2\na={{ name }}\n".encode())
-            tf.flush()
-            r = parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            expected = OrderedDictWithDefaults()
-            expected['a'] = 'Cylc'
-            assert r == expected
-            of.flush()
-            output_file_contents = of.read().decode()
-            assert output_file_contents == 'a=Cylc\n'
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write("#!jinja2\na={{ name }}\n".encode())
+        tf.flush()
+        r = parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        expected = OrderedDictWithDefaults()
+        expected['a'] = 'Cylc'
+        assert r == expected
+        of.flush()
+        output_file_contents = of.read().decode()
+        assert output_file_contents == 'a=Cylc\n'
 
 
 def test_parse_keys_only_multiline():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write(
-                "#!jinja2\na='''value is \\\n{{ name }}'''\n".encode())
-            tf.flush()
-            r = parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            expected = OrderedDictWithDefaults()
-            expected['a'] = "'''value is Cylc'''"
-            assert r == expected
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write(
+            "#!jinja2\na='''value is \\\n{{ name }}'''\n".encode())
+        tf.flush()
+        r = parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        expected = OrderedDictWithDefaults()
+        expected['a'] = "'''value is Cylc'''"
+        assert r == expected
 
 
 def test_parse_invalid_line():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write("#!jinja2\n{{ name }}\n".encode())
-            tf.flush()
-            with pytest.raises(FileParseError) as cm:
-                parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            exc = cm.value
-            assert exc.reason == 'Invalid line'
-            assert exc.line_num == 1
-            assert exc.line == 'Cylc'
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write("#!jinja2\n{{ name }}\n".encode())
+        tf.flush()
+        with pytest.raises(FileParseError) as cm:
+            parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        exc = cm.value
+        assert exc.reason == 'Invalid line'
+        assert exc.line_num == 1
+        assert exc.line == 'Cylc'
 
 
 def test_parse_comments():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write("#!jinja2\na={{ name }}\n# comment!".encode())
-            tf.flush()
-            r = parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            expected = OrderedDictWithDefaults()
-            expected['a'] = 'Cylc'
-            assert r == expected
-            of.flush()
-            output_file_contents = of.read().decode()
-            assert output_file_contents == 'a=Cylc\n# comment!\n'
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write("#!jinja2\na={{ name }}\n# comment!".encode())
+        tf.flush()
+        r = parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        expected = OrderedDictWithDefaults()
+        expected['a'] = 'Cylc'
+        assert r == expected
+        of.flush()
+        output_file_contents = of.read().decode()
+        assert output_file_contents == 'a=Cylc\n# comment!\n'
 
 
 def test_parse_with_sections():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write(("#!jinja2\n[section1]\n"
-                      "a={{ name }}\n# comment!\n"
-                      "[[subsection1]]\n"
-                      "[[subsection2]]\n"
-                      "[section2]").encode())
-            tf.flush()
-            r = parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            expected = OrderedDictWithDefaults()
-            expected['section1'] = OrderedDictWithDefaults()
-            expected['section1']['a'] = 'Cylc'
-            expected['section1']['subsection1'] = OrderedDictWithDefaults()
-            expected['section1']['subsection2'] = OrderedDictWithDefaults()
-            expected['section2'] = OrderedDictWithDefaults()
-            assert r == expected
-            of.flush()
-            output_file_contents = of.read().decode()
-            assert output_file_contents == (
-                '[section1]\na=Cylc\n# comment!\n'
-                '[[subsection1]]\n'
-                '[[subsection2]]\n'
-                '[section2]\n'
-            )
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write(("#!jinja2\n[section1]\n"
+                  "a={{ name }}\n# comment!\n"
+                  "[[subsection1]]\n"
+                  "[[subsection2]]\n"
+                  "[section2]").encode())
+        tf.flush()
+        r = parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        expected = OrderedDictWithDefaults()
+        expected['section1'] = OrderedDictWithDefaults()
+        expected['section1']['a'] = 'Cylc'
+        expected['section1']['subsection1'] = OrderedDictWithDefaults()
+        expected['section1']['subsection2'] = OrderedDictWithDefaults()
+        expected['section2'] = OrderedDictWithDefaults()
+        assert r == expected
+        of.flush()
+        output_file_contents = of.read().decode()
+        assert output_file_contents == (
+            '[section1]\na=Cylc\n# comment!\n'
+            '[[subsection1]]\n'
+            '[[subsection2]]\n'
+            '[section2]\n'
+        )
 
 
 def test_parse_with_sections_missing_bracket():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = {
             'name': 'Cylc'
@@ -558,27 +554,26 @@ def test_parse_with_sections_missing_bracket():
 
 
 def test_parse_with_sections_error_wrong_level():
-    with tempfile.NamedTemporaryFile() as of:
-        with tempfile.NamedTemporaryFile() as tf:
-            fpath = tf.name
-            template_vars = {
-                'name': 'Cylc'
-            }
-            tf.write(("#!jinja2\n[section1]\n"
-                      "a={{ name }}\n# comment!\n"
-                      "[[[subsection1]]]\n")  # expected [[]] instead!
-                     .encode())
-            tf.flush()
-            with pytest.raises(FileParseError) as cm:
-                parse(fpath=fpath, output_fname=of.name,
-                      template_vars=template_vars)
-            exc = cm.value
-            assert exc.line_num == 4
-            assert exc.line == '[[[subsection1]]]'
+    with NamedTemporaryFile() as of, NamedTemporaryFile() as tf:
+        fpath = tf.name
+        template_vars = {
+            'name': 'Cylc'
+        }
+        tf.write(("#!jinja2\n[section1]\n"
+                  "a={{ name }}\n# comment!\n"
+                  "[[[subsection1]]]\n")  # expected [[]] instead!
+                 .encode())
+        tf.flush()
+        with pytest.raises(FileParseError) as cm:
+            parse(fpath=fpath, output_fname=of.name,
+                  template_vars=template_vars)
+        exc = cm.value
+        assert exc.line_num == 4
+        assert exc.line == '[[[subsection1]]]'
 
 
 def test_unclosed_multiline():
-    with tempfile.NamedTemporaryFile() as tf:
+    with NamedTemporaryFile() as tf:
         fpath = tf.name
         template_vars = {
             'name': 'Cylc'
@@ -681,11 +676,9 @@ def _mock_old_template_vars_db(tmp_path):
             src.mkdir(exist_ok=True)
             link = tmp_path.parent / '_cylc-install/source'
             link.parent.mkdir(exist_ok=True)
-            try:
-                os.symlink(src, link)
-            except FileExistsError:
+            with suppress(FileExistsError):
                 # We don't mind the link persisting.
-                pass
+                os.symlink(src, link)
         return tmp_path / 'flow.cylc'
     yield _inner
 

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -382,7 +382,7 @@ def test_read_and_proc_cwd():
 """)
             tf.flush()
             r = read_and_proc(fpath=tf.name, viewcfg=viewcfg)
-            assert r == ['a', 'b', 'c']
+            assert sorted(r) == ['a', 'b', 'c']
 
 def test_read_and_proc_jinja2_error():
     with tempfile.NamedTemporaryFile() as tf:


### PR DESCRIPTION
Allow the template processor to access workflow files - in the source dir for a source workflow, or the run dir for installed workflows.

This is the most straightforward way to cater to [this kind of use case](https://github.com/cylc/cylc-flow/pull/5570#issue-1744687086)

(I can't think of any downside...)

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) issue opened if required at cylc/cylc-doc/issues/622
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
