### PR TITLE
Fix missing line break in docs

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -141,6 +141,7 @@ def check_if_jinja2(
 
         >>> check_if_jinja2('foofoo', jinja_shebang=True, function=func)
         ['foo', 'foo']
+
     """
     if jinja_shebang:
         return function(line)
@@ -971,7 +972,7 @@ def get_reference_rst(checks):
                 output += (
                     '\n.. note::\n'
                     '\n   U998 and U999 represent automatically generated '
-                    'sets of deprecations and upgrades.'
+                    'sets of deprecations and upgrades.\n'
                 )
 
         if current_checkset == 'A':


### PR DESCRIPTION
A failure to add a line-break after an indented chunk of rst was causing the docs build to fail.

To test: Make the Cylc docs with this checked out.

**Check List**

- [x] This is a very small bug which does not require the full checklist.