### PR TITLE
pool-process-queued-ops

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1283,7 +1283,6 @@ class TaskPool:
                     (str(itask.point), itask.tdef.name, output))
                 self.workflow_db_mgr.put_insert_abs_output(
                     str(itask.point), itask.tdef.name, output)
-                self.workflow_db_mgr.process_queued_ops()
 
             c_taskid = Tokens(
                 cycle=str(c_point),
@@ -1351,6 +1350,8 @@ class TaskPool:
             TASK_OUTPUT_FAILED
         ]:
             self.remove_if_complete(itask)
+
+        self.workflow_db_mgr.process_queued_ops()
 
     def remove_if_complete(self, itask):
         """Remove finished itask if required outputs are complete.


### PR DESCRIPTION
This `process_queued_ops` is called inside a `for` loop, it should probably be called afterwards.

But more importantly, `remove_if_complete`, which is called at the end of the function, calls `remove` which queues a DB operation which wasn't getting processed until later.

The main loop calls `process_queued_ops`:

https://github.com/cylc/cylc-flow/blob/4d787f445d5d9cfa950fbd5568e03af9f630e486/cylc/flow/scheduler.py#L1646

So this could cause the task to stick around in the pool table longer than intended, but with the correct task state so probably isn't related to #5598.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.