### PR TITLE
ensure output from xtrigger scripts are logged

### DIFF
--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -1063,13 +1063,12 @@ class CylcConfigValidator(ParsecValidator):
         Checks for legal string templates in arg values too.
 
         Examples:
-            >>> xtrig = CylcConfigValidator.coerce_xtrigger
-
-            # parse xtrig function signatures
-            >>> xtrig('a(b, c):PT1M', [None])
-            a(b, c):60.0
-            >>> xtrig('a(x, "1,2,3", y):PT1S', [None])
-            a(x, 1,2,3, y):1.0
+            >>> ctx = CylcConfigValidator.coerce_xtrigger(
+            ... 'a(b, c):PT1M', [None])
+            >>> ctx.get_signature()
+            'a(b, c)'
+            >>> ctx.intvl
+            60.0
 
             # cast types
             >>> x = xtrig('a(1, 1.1, True, abc, x=True, y=1.1)', [None])

--- a/cylc/flow/subprocctx.py
+++ b/cylc/flow/subprocctx.py
@@ -158,12 +158,3 @@ class SubFuncContext(SubProcContext):
         args = self.func_args + [
             "%s=%s" % (i, self.func_kwargs[i]) for i in skeys]
         return "%s(%s)" % (self.func_name, ", ".join([str(a) for a in args]))
-
-    def __str__(self):
-        return (
-            f'{self.func_name}('
-            f'{", ".join(map(str, self.func_args + list(self.func_kwargs)))}'
-            f'):{self.intvl}'
-        )
-
-    __repr__ = __str__

--- a/tests/integration/test_subprocctx.py
+++ b/tests/integration/test_subprocctx.py
@@ -16,8 +16,7 @@
 """Tests involving the Cylc Subprocess Context Object
 """
 
-import asyncio
-from cylc.flow import logging
+from logging import DEBUG
 
 
 async def test_log_xtrigger_stdout(
@@ -46,7 +45,7 @@ async def test_log_xtrigger_stdout(
         "    return True, {}"
     )
     schd = scheduler(id_)
-    async with start(schd, level=logging.DEBUG) as log:
+    async with start(schd, level=DEBUG) as log:
         # Set off check for x-trigger:
         task = schd.pool.get_tasks()[0]
         schd.xtrigger_mgr.call_xtriggers_async(task)
@@ -58,4 +57,4 @@ async def test_log_xtrigger_stdout(
         # Assert that both stderr and out from the print statement
         # in our xtrigger appear in the log.
         for expected in ['Hello World', 'Hello Hades']:
-            assert log_filter(log, contains=expected)
+            assert log_filter(log, contains=expected, level=DEBUG)

--- a/tests/integration/test_subprocctx.py
+++ b/tests/integration/test_subprocctx.py
@@ -1,0 +1,62 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests involving the Cylc Subprocess Context Object
+"""
+
+import asyncio
+from cylc.flow import logging
+
+
+async def test_log_xtrigger_stdout(flow, scheduler, run_dir, run):
+    """Output from xtriggers should appear in the scheduler log:
+
+    (As per the toy example in the Cylc Docs)
+    """
+    # Setup a workflow:
+    reg = flow({
+        'scheduler': {'allow implicit tasks': True},
+        'scheduling': {
+            'graph': {'R1': '@myxtrigger => foo'},
+            'xtriggers': {'myxtrigger': 'myxtrigger()'}
+        }
+    })
+    # Create an xtrigger:
+    xt_lib = run_dir / reg / 'lib/python/myxtrigger.py'
+    xt_lib.parent.mkdir(parents=True, exist_ok=True)
+    xt_lib.write_text(
+        "from sys import stderr\n\n\n"
+        "def myxtrigger():\n"
+        "    print('Hello World')\n"
+        "    print('Hello Hades', file=stderr)\n"
+        "    return True, {}"
+    )
+    schd = scheduler(reg)
+    async with run(schd, level=logging.DEBUG) as log:
+        # Set off check for x-trigger:
+        schd.xtrigger_mgr.call_xtriggers_async(
+            schd.pool.get_tasks()[0])
+
+        # Wait on the main-loop until the xtrigger has finished:
+        xt_complete = False
+        while not xt_complete:
+            xt_complete = schd.xtrigger_mgr._get_xtrigs(
+                schd.pool.get_tasks()[0])[0][3]
+            await asyncio.sleep(1)
+
+        # Assert that both stderr and out from the print statement
+        # in our xtrigger appear in the log.
+        for expected in ['Hello World', 'Hello Hades']:
+            assert any(expected in i.message for i in log.records)


### PR DESCRIPTION
This closes a small issue not logged elsewhere:

Due to a change in the `__str__` method of the subprocess context object the results of printing to stdout/err in extrigger scripts was no longer logged.

To replicate  the problem on master try the [first Toy example of an xtrigger from the docs](https://cylc.github.io/cylc-doc/stable/html/user-guide/writing-workflows/external-triggers.html#echo)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] ~`CHANGES.md`~ This is a really, really small change.
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc)~ Brings code back into line with docs.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
