### PR TITLE
pool: ensure the DB is updated when tasks are removed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,9 @@ Various enhancements to `cylc lint`:
 
 ### Fixes
 
+[#5619](https://github.com/cylc/cylc-flow/pull/5619) -
+Fix an issue where the `task_pool` table in the database wasn't being updated
+in a timely fashion when tasks completed.
 
 [#5606](https://github.com/cylc/cylc-flow/pull/5606) -
 Task outputs and messages are now validated to avoid conflicts with built-in

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1691,7 +1691,11 @@ class Scheduler:
         """Update DB, UIS, Summary data elements"""
         updated_tasks = [
             t for t in self.pool.get_tasks() if t.state.is_updated]
-        has_updated = self.is_updated or updated_tasks
+        has_updated = (
+            self.is_updated
+            or updated_tasks
+            or self.pool.tasks_removed
+        )
         reloaded = self.is_reloaded
         # Add tasks that have moved moved from runahead to live pool.
         if has_updated or self.data_store_mgr.updates_pending:
@@ -1716,6 +1720,7 @@ class Scheduler:
             for itask in updated_tasks:
                 itask.state.is_updated = False
             self.update_data_store()
+            self.pool.tasks_removed = False
         return has_updated
 
     def check_workflow_timers(self):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -123,6 +123,7 @@ class TaskPool:
         self._hidden_pool_list: List[TaskProxy] = []
         self.main_pool_changed = False
         self.hidden_pool_changed = False
+        self.tasks_removed = False
 
         self.hold_point: Optional['PointBase'] = None
         self.abs_outputs_done: Set[Tuple[str, str, str]] = set()
@@ -736,6 +737,7 @@ class TaskPool:
 
     def remove(self, itask, reason=""):
         """Remove a task from the pool (e.g. after a reload)."""
+        self.tasks_removed = True
         msg = "task proxy removed"
         if reason:
             msg += f" ({reason})"


### PR DESCRIPTION
* Before this change, the `task_pool` table was only being updated when tasks were added, or changed state, but not when they were removed.
* Closes #5598

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.