### PR TITLE
Added a :noindex: to an autodoc command

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1689,6 +1689,7 @@ with Conf(
                     Task messages must satisfy these rules:
 
                     .. autoclass:: cylc.flow.unicode_rules.TaskMessageValidator
+                       :noindex:
                 ''')
 
             with Conf('parameter environment templates', desc='''


### PR DESCRIPTION
The addition of `.. autoclass:: cylc.flow.unicode_rules.TaskMessageValidator` in https://github.com/cylc/cylc-flow/pull/5606/files broke Cylc Doc because `TaskMessageValidator` referenced in autodocs twice. I've undone this, which should allow the nightly build against `master` to succeed. The problem with the 8.1.x branch is different.

Reviewer should build docs locally to check.


**Check List**
- [x] This is a small PR enabling the documentation build to work. As such I believe that it's reasonable to replace the normal checklist.