### PR TITLE
Fix doc build error in lint

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -878,7 +878,7 @@ def get_reference_rst(checks):
                 output += (
                     '\n.. note::\n'
                     '\n   U998 and U999 represent automatically generated '
-                    'sets of deprecations and upgrades.'
+                    'sets of deprecations and upgrades.\n\n'
                 )
 
         if current_checkset == 'A':


### PR DESCRIPTION
Should enable nightly docs builds to pass.
