### PR TITLE
misc

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1024,11 +1024,11 @@ with Conf('global.cylc', desc='''
                     Alternative location for the run dir.
 
                     If specified, the workflow run directory will
-                    be created in ``<this-path>/cylc-run/<workflow-name>``
+                    be created in ``<this-path>/cylc-run/<workflow-id>``
                     and a symbolic link will be created from
-                    ``$HOME/cylc-run/<workflow-name>``.
+                    ``$HOME/cylc-run/<workflow-id>``.
                     If not specified the workflow run directory will be created
-                    in ``$HOME/cylc-run/<workflow-name>``.
+                    in ``$HOME/cylc-run/<workflow-id>``.
                     All the workflow files and the ``.service`` directory get
                     installed into this directory.
 
@@ -1038,11 +1038,11 @@ with Conf('global.cylc', desc='''
                     Alternative location for the log dir.
 
                     If specified the workflow log directory will be created in
-                    ``<this-path>/cylc-run/<workflow-name>/log`` and a
+                    ``<this-path>/cylc-run/<workflow-id>/log`` and a
                     symbolic link will be created from
-                    ``$HOME/cylc-run/<workflow-name>/log``. If not specified
+                    ``$HOME/cylc-run/<workflow-id>/log``. If not specified
                     the workflow log directory will be created in
-                    ``$HOME/cylc-run/<workflow-name>/log``.
+                    ``$HOME/cylc-run/<workflow-id>/log``.
 
                     .. versionadded:: 8.0.0
                 """)
@@ -1050,11 +1050,11 @@ with Conf('global.cylc', desc='''
                     Alternative location for the share dir.
 
                     If specified the workflow share directory will be
-                    created in ``<this-path>/cylc-run/<workflow-name>/share``
+                    created in ``<this-path>/cylc-run/<workflow-id>/share``
                     and a symbolic link will be created from
-                    ``<$HOME/cylc-run/<workflow-name>/share``. If not specified
+                    ``<$HOME/cylc-run/<workflow-id>/share``. If not specified
                     the workflow share directory will be created in
-                    ``$HOME/cylc-run/<workflow-name>/share``.
+                    ``$HOME/cylc-run/<workflow-id>/share``.
 
                     .. versionadded:: 8.0.0
                 """)
@@ -1063,11 +1063,11 @@ with Conf('global.cylc', desc='''
 
                     If specified the workflow share/cycle directory
                     will be created in
-                    ``<this-path>/cylc-run/<workflow-name>/share/cycle``
+                    ``<this-path>/cylc-run/<workflow-id>/share/cycle``
                     and a symbolic link will be created from
-                    ``$HOME/cylc-run/<workflow-name>/share/cycle``. If not
+                    ``$HOME/cylc-run/<workflow-id>/share/cycle``. If not
                     specified the workflow share/cycle directory will be
-                    created in ``$HOME/cylc-run/<workflow-name>/share/cycle``.
+                    created in ``$HOME/cylc-run/<workflow-id>/share/cycle``.
 
                     .. versionadded:: 8.0.0
                 """)
@@ -1075,11 +1075,11 @@ with Conf('global.cylc', desc='''
                     Alternative directory for the work dir.
 
                     If specified the workflow work directory will be created in
-                    ``<this-path>/cylc-run/<workflow-name>/work`` and a
+                    ``<this-path>/cylc-run/<workflow-id>/work`` and a
                     symbolic link will be created from
-                    ``$HOME/cylc-run/<workflow-name>/work``. If not specified
+                    ``$HOME/cylc-run/<workflow-id>/work``. If not specified
                     the workflow work directory will be created in
-                    ``$HOME/cylc-run/<workflow-name>/work``.
+                    ``$HOME/cylc-run/<workflow-id>/work``.
 
                     .. versionadded:: 8.0.0
                 """)

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1530,7 +1530,7 @@ with Conf(
 
                 The items in this section reflect
                 options and defaults of the ``cylc workflow-state`` command,
-                except that the target workflow name and the
+                except that the target workflow ID and the
                 ``--task``, ``--cycle``, and ``--status`` options are
                 taken from the graph notation.
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -59,11 +59,11 @@ from cylc.flow.cycling.integer import IntegerInterval
 from cylc.flow.cycling.iso8601 import ingest_time, ISO8601Interval
 from cylc.flow.exceptions import (
     CylcError,
-    WorkflowConfigError,
+    InputError,
     IntervalParsingError,
-    TaskDefError,
     ParamExpandError,
-    InputError
+    TaskDefError,
+    WorkflowConfigError,
 )
 import cylc.flow.flags
 from cylc.flow.graph_parser import GraphParser
@@ -209,6 +209,8 @@ def dequote(string):
         'foo'
         >>> dequote('"f')
         '"f'
+        >>> dequote('f')
+        'f'
 
     """
     if len(string) < 2:

--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -583,7 +583,7 @@ def check_nested_dirs(
             install dirs.
 
     Raises:
-        WorkflowFilesError if reg dir is nested inside a run dir, or an
+        WorkflowFilesError if id_ dir is nested inside a run dir, or an
             install dirs are nested.
     """
     if install_dir is not None:

--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -547,8 +547,8 @@ def detect_flow_exists(
     """Returns True if installed flow already exists.
 
     Args:
-        run_path_base: Absolute path of workflow directory,
-            i.e ~/cylc-run/<workflow_id>
+        run_path_base: Absolute path of the parent of the workflow's run dir,
+            i.e ~/cylc-run/<workflow_name>
         numbered: If True, will detect if numbered runs exist. If False, will
             detect if non-numbered runs exist, i.e. runs installed
             by --run-name.
@@ -583,8 +583,8 @@ def check_nested_dirs(
             install dirs.
 
     Raises:
-        WorkflowFilesError if id_ dir is nested inside a run dir, or an
-            install dirs are nested.
+        WorkflowFilesError if run_dir is nested inside an existing run dir,
+            or install dirs are nested.
     """
     if install_dir is not None:
         install_dir = Path(os.path.normpath(install_dir))

--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -548,7 +548,7 @@ def detect_flow_exists(
 
     Args:
         run_path_base: Absolute path of workflow directory,
-            i.e ~/cylc-run/<workflow_name>
+            i.e ~/cylc-run/<workflow_id>
         numbered: If True, will detect if numbered runs exist. If False, will
             detect if non-numbered runs exist, i.e. runs installed
             by --run-name.

--- a/cylc/flow/network/__init__.py
+++ b/cylc/flow/network/__init__.py
@@ -67,7 +67,7 @@ def get_location(workflow: str) -> Tuple[str, int, int]:
     NB: if it fails to load the workflow contact file, it will exit.
 
     Args:
-        workflow: workflow name
+        workflow: workflow ID
     Returns:
         Tuple (host name, port number, publish port number)
     Raises:

--- a/cylc/flow/network/authentication.py
+++ b/cylc/flow/network/authentication.py
@@ -24,12 +24,12 @@ from cylc.flow.workflow_files import (
     remove_keys_on_server)
 
 
-def key_housekeeping(reg, platform=None, create=True):
+def key_housekeeping(id_, platform=None, create=True):
 
     """Clean any existing authentication keys and create new ones.
         If create is set to false, keys will only be cleaned from
         server."""
-    workflow_srv_dir = get_workflow_srv_dir(reg)
+    workflow_srv_dir = get_workflow_srv_dir(id_)
     keys = {
         "client_public_key": KeyInfo(
             KeyType.PUBLIC,

--- a/cylc/flow/network/client_factory.py
+++ b/cylc/flow/network/client_factory.py
@@ -46,7 +46,7 @@ def get_runtime_client(
 
         Args:
             comm_method: communication method
-            workflow: workflow name
+            workflow: workflow ID
     """
     if comms_method == CommsMeth.SSH:
         from cylc.flow.network.ssh_client import WorkflowRuntimeClient

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -56,19 +56,19 @@ def expand_path(*args: Union[Path, str]) -> str:
 
 
 def get_remote_workflow_run_dir(
-    workflow_name: Union[Path, str], *args: Union[Path, str]
+    workflow_id: Union[Path, str], *args: Union[Path, str]
 ) -> str:
     """Return remote workflow run directory, joining any extra args,
     NOT expanding vars or user."""
-    return os.path.join(_CYLC_RUN_DIR, workflow_name, *args)
+    return os.path.join(_CYLC_RUN_DIR, workflow_id, *args)
 
 
 def get_remote_workflow_run_job_dir(
-    workflow_name: Union[Path, str], *args: Union[Path, str]
+    workflow_id: Union[Path, str], *args: Union[Path, str]
 ) -> str:
     """Return remote workflow job log directory, joining any extra args,
     NOT expanding vars or user."""
-    return get_remote_workflow_run_dir(workflow_name, 'log', 'job', *args)
+    return get_remote_workflow_run_dir(workflow_id, 'log', 'job', *args)
 
 
 def get_cylc_run_dir() -> str:
@@ -77,14 +77,14 @@ def get_cylc_run_dir() -> str:
 
 
 def get_workflow_run_dir(
-    workflow_name: Union[Path, str], *args: Union[Path, str]
+    workflow_id: Union[Path, str], *args: Union[Path, str]
 ) -> str:
     """Return local workflow run directory, joining any extra args, and
     expanding vars and user.
 
     Does not check that the directory exists.
     """
-    return expand_path(_CYLC_RUN_DIR, workflow_name, *args)
+    return expand_path(_CYLC_RUN_DIR, workflow_id, *args)
 
 
 def get_workflow_run_job_dir(workflow, *args):
@@ -157,7 +157,7 @@ def make_localhost_symlinks(
     """Creates symlinks for any configured symlink dirs from glbl_cfg.
     Args:
         rund: the entire run directory path
-        named_sub_dir: e.g workflow_name/run1
+        named_sub_dir: e.g workflow_id/run1
         symlink_conf: Symlinks dirs configuration passed from cli
 
     Returns:
@@ -195,7 +195,7 @@ def make_localhost_symlinks(
 
 def get_dirs_to_symlink(
     install_target: str,
-    workflow_name: str,
+    workflow_id: str,
     symlink_conf: Optional[Dict[str, Dict[str, Any]]] = None
 ) -> Dict[str, str]:
     """Returns dictionary of directories to symlink.
@@ -204,7 +204,7 @@ def get_dirs_to_symlink(
 
     Args:
         install_target: Symlinks to be created on this install target
-        flow_name: full name of the run, e.g. myflow/run1
+        flow_id: full id of the run, e.g. myflow/run1
         symlink_conf: Symlink dirs, if sent on the cli.
             Defaults to None, in which case global config symlink dirs will
             be applied.
@@ -220,13 +220,13 @@ def get_dirs_to_symlink(
     base_dir = symlink_conf[install_target]['run']
     if base_dir:
         dirs_to_symlink['run'] = os.path.join(
-            base_dir, 'cylc-run', workflow_name)
+            base_dir, 'cylc-run', workflow_id)
     for dir_ in ['log', 'share', 'share/cycle', 'work']:
         link = symlink_conf[install_target].get(dir_, None)
         if (not link) or link == base_dir:
             continue
         dirs_to_symlink[dir_] = os.path.join(
-            link, 'cylc-run', workflow_name, dir_)
+            link, 'cylc-run', workflow_id, dir_)
     return dirs_to_symlink
 
 

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -157,7 +157,7 @@ def make_localhost_symlinks(
     """Creates symlinks for any configured symlink dirs from glbl_cfg.
     Args:
         rund: the entire run directory path
-        named_sub_dir: e.g workflow_id/run1
+        named_sub_dir: e.g workflow_name/run1
         symlink_conf: Symlinks dirs configuration passed from cli
 
     Returns:
@@ -204,7 +204,7 @@ def get_dirs_to_symlink(
 
     Args:
         install_target: Symlinks to be created on this install target
-        flow_id: full id of the run, e.g. myflow/run1
+        workflow_id: full id of the run, e.g. myflow/run1
         symlink_conf: Symlink dirs, if sent on the cli.
             Defaults to None, in which case global config symlink dirs will
             be applied.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -271,9 +271,9 @@ class Scheduler:
 
     time_next_kill: Optional[float] = None
 
-    def __init__(self, reg: str, options: Values) -> None:
+    def __init__(self, id_: str, options: Values) -> None:
         # flow information
-        self.workflow = reg
+        self.workflow = id_
         self.workflow_name = get_workflow_name_from_id(self.workflow)
         self.owner = get_user()
         self.host = get_host()

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -29,7 +29,7 @@ not backed up elsewhere, it will be lost.
 
 It will also remove any symlink directory targets.
 
-Workflow names can be hierarchical, corresponding to the path under ~/cylc-run.
+Workflow IDs can be hierarchical, corresponding to the path under ~/cylc-run.
 
 Examples:
   # Remove the workflow at ~/cylc-run/foo/bar

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -198,7 +198,7 @@ def _get_inheritance_nodes_and_edges(
 
 
 def get_config(workflow_id: str, opts: 'Values', flow_file) -> WorkflowConfig:
-    """Return a WorkflowConfig object for the provided reg / path."""
+    """Return a WorkflowConfig object for the provided id_ / path."""
     template_vars = get_template_vars(opts)
     return WorkflowConfig(
         workflow_id, flow_file, opts, template_vars=template_vars

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -27,14 +27,14 @@ Normal installation creates a numbered run directory
 
 If a SOURCE_NAME is supplied, Cylc will search for the workflow source in the
 list of directories given by "global.cylc[install]source dirs", and install
-the first match. The installed workflow ID will be the same as SOURCE_NAME,
+the first match. The installed workflow ID will start with SOURCE_NAME,
 unless --workflow-name is used.
 
 If a PATH is supplied, Cylc will install the workflow from the source directory
 given by the path. Relative paths must start with "./" to avoid ambiguity with
 SOURCE_NAME (i.e. "foo/bar" will be interpreted as a source name, whereas
 "./foo/bar" will be interpreted as a path). The installed workflow ID will
-be the basename of the path, unless --workflow-name is used.
+start with the basename of the path, unless --workflow-name is used.
 
 If no argument is supplied, Cylc will install the workflow from the source
 in the current working directory.

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -27,13 +27,13 @@ Normal installation creates a numbered run directory
 
 If a SOURCE_NAME is supplied, Cylc will search for the workflow source in the
 list of directories given by "global.cylc[install]source dirs", and install
-the first match. The installed workflow name will be the same as SOURCE_NAME,
+the first match. The installed workflow ID will be the same as SOURCE_NAME,
 unless --workflow-name is used.
 
 If a PATH is supplied, Cylc will install the workflow from the source directory
 given by the path. Relative paths must start with "./" to avoid ambiguity with
 SOURCE_NAME (i.e. "foo/bar" will be interpreted as a source name, whereas
-"./foo/bar" will be interpreted as a path). The installed workflow name will
+"./foo/bar" will be interpreted as a path). The installed workflow ID will
 be the basename of the path, unless --workflow-name is used.
 
 If no argument is supplied, Cylc will install the workflow from the source

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -265,18 +265,18 @@ InstallOptions = Options(get_option_parser())
 def main(
     _parser: COP,
     opts: 'Values',
-    reg: Optional[str] = None
+    id_: Optional[str] = None
 ) -> None:
     """CLI wrapper."""
-    install_cli(opts, reg)
+    install_cli(opts, id_)
 
 
 def install_cli(
     opts: 'Values',
-    reg: Optional[str] = None
+    id_: Optional[str] = None
 ) -> Tuple[str, str]:
     """Install workflow and scan for already-running instances."""
-    wf_name, wf_id = install(opts, reg)
+    wf_name, wf_id = install(opts, id_)
     asyncio.run(
         scan(wf_name, not opts.no_ping)
     )
@@ -284,14 +284,14 @@ def install_cli(
 
 
 def install(
-    opts: 'Values', reg: Optional[str] = None
+    opts: 'Values', id_: Optional[str] = None
 ) -> Tuple[str, str]:
     set_timestamps(LOG, opts.log_timestamp and opts.verbosity > 1)
     if opts.no_run_name and opts.run_name:
         raise InputError(
             "options --no-run-name and --run-name are mutually exclusive."
         )
-    source = get_source_location(reg)
+    source = get_source_location(id_)
 
     # Check deprecation to allow plugins to have access to correct flags
     # for compatibility mode:

--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -78,7 +78,7 @@ Note:
 
 For backward compatibility, if number of arguments is less than or equal to 2,
 the command assumes the classic interface, where all arguments are messages.
-Otherwise, the first 2 arguments are assumed to be workflow name and job
+Otherwise, the first 2 arguments are assumed to be workflow ID and job
 identifier.
 """
 

--- a/cylc/flow/scripts/remote_init.py
+++ b/cylc/flow/scripts/remote_init.py
@@ -21,7 +21,7 @@
 Initialise an install target.
 
 Initialisation creates a workflow run directory on the install target,
-"$HOME/cylc-run/<WORKFLOW_NAME>/". The .service directory is also created and
+"$HOME/cylc-run/<WORKFLOW_ID>/". The .service directory is also created and
 populated with the install target authentication files and the contact file.
 
 Symlinks are created for run, work, share, share/cycle, log directories,

--- a/cylc/flow/scripts/scan.py
+++ b/cylc/flow/scripts/scan.py
@@ -210,7 +210,7 @@ def get_option_parser() -> COP:
         '--format', '-t',
         help=(
             'Output data and format (default "plain").'
-            ' ("name": list the workflow names only)'
+            ' ("name": list the workflow IDs only)'
             ' ("plain": name,host:port,PID on one line)'
             ' ("tree": name,host:port,PID in tree format)'
             ' ("json": full contact data in JSON format)'

--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -77,7 +77,7 @@ def record_messages(workflow: str, job_id: str, messages: List[list]) -> None:
     Send the messages to the workflow, if possible.
 
     Arguments:
-        workflow: Workflow name.
+        workflow: Workflow ID.
         job_id: Job identifier "CYCLE/TASK_NAME/SUBMIT_NUM".
         messages: List of messages "[[severity, message], ...]".
     """

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -60,7 +60,7 @@ def remove_keys_on_client(srvd, install_target, full_clean=False):
 
 
 def create_client_keys(srvd, install_target):
-    """Create or renew authentication keys for workflow 'reg' in the .service
+    """Create or renew authentication keys for workflow 'id_' in the .service
      directory.
      Generate a pair of ZMQ authentication keys"""
 

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -201,7 +201,7 @@ class TuiApp:
     tab/selection panel.
 
     Arguments:
-        reg (str):
+        id_ (str):
             Workflow registration
 
     """
@@ -227,8 +227,8 @@ class TuiApp:
         for status, spec in WORKFLOW_COLOURS.items()
     ]
 
-    def __init__(self, reg, screen=None):
-        self.reg = reg
+    def __init__(self, id_, screen=None):
+        self.id_ = id_
         self.client = None
         self.loop = None
         self.screen = None
@@ -297,7 +297,7 @@ class TuiApp:
         """
         try:
             if not self.client:
-                self.client = get_client(self.reg, timeout=self.CLIENT_TIMEOUT)
+                self.client = get_client(self.id_, timeout=self.CLIENT_TIMEOUT)
             data = self.client(
                 'graphql',
                 {
@@ -315,7 +315,7 @@ class TuiApp:
         except WorkflowStopped:
             # Distinguish stopped flow from non-existent flow.
             self.client = None
-            full_path = Path(get_workflow_run_dir(self.reg))
+            full_path = Path(get_workflow_run_dir(self.id_))
             if (
                 (full_path / WorkflowFiles.SUITE_RC).is_file()
                 or (full_path / WorkflowFiles.FLOW_FILE).is_file()
@@ -324,12 +324,12 @@ class TuiApp:
             else:
                 message = (
                     f"No {WorkflowFiles.SUITE_RC} or {WorkflowFiles.FLOW_FILE}"
-                    f"found in {self.reg}."
+                    f"found in {self.id_}."
                 )
 
             return dummy_flow({
-                'name': self.reg,
-                'id': self.reg,
+                'name': self.id_,
+                'id': self.id_,
                 'status': message,
                 'stateTotals': {}
             })

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -100,7 +100,7 @@ def run_dir():
 
 @pytest.fixture(scope='session')
 def ses_test_dir(request, run_dir):
-    """The root reg dir for test flows in this test session."""
+    """The root run dir for test flows in this test session."""
     timestamp = get_current_time_string(use_basic_format=True)
     uuid = f'cit-{timestamp}'
     path = Path(run_dir, uuid)
@@ -111,7 +111,7 @@ def ses_test_dir(request, run_dir):
 
 @pytest.fixture(scope='module')
 def mod_test_dir(request, ses_test_dir):
-    """The root reg dir for test flows in this test module."""
+    """The root run dir for test flows in this test module."""
     path = Path(ses_test_dir, request.module.__name__)
     path.mkdir(exist_ok=True)
     yield path
@@ -125,7 +125,7 @@ def mod_test_dir(request, ses_test_dir):
 
 @pytest.fixture
 def test_dir(request, mod_test_dir):
-    """The root reg dir for test flows in this test function."""
+    """The root run dir for test flows in this test function."""
     path = Path(mod_test_dir, request.function.__name__)
     path.mkdir(parents=True, exist_ok=True)
     yield path
@@ -164,7 +164,7 @@ def scheduler():
     """Return a Scheduler object for a flow.
 
     Args:
-        reg (str): Workflow name.
+        id_ (str): Workflow name.
         **opts (Any): Options to be passed to the Scheduler.
     """
     with _make_scheduler() as _scheduler:
@@ -226,15 +226,15 @@ def mod_one_conf():
 @pytest.fixture
 def one(one_conf, flow, scheduler):
     """Return a Scheduler for the simple "R1 = one" graph."""
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     return schd
 
 
 @pytest.fixture(scope='module')
 def mod_one(mod_one_conf, mod_flow, mod_scheduler):
-    reg = mod_flow(mod_one_conf)
-    schd = mod_scheduler(reg)
+    id_ = mod_flow(mod_one_conf)
+    schd = mod_scheduler(id_)
     return schd
 
 
@@ -342,14 +342,14 @@ def validate(run_dir):
     errors.
 
     Args:
-        reg - The flow to validate
+        id_ - The flow to validate
         kwargs - Arguments to pass to ValidateOptions
     """
-    def _validate(reg: Union[str, Path], **kwargs) -> WorkflowConfig:
-        reg = str(reg)
+    def _validate(id_: Union[str, Path], **kwargs) -> WorkflowConfig:
+        id_ = str(id_)
         return WorkflowConfig(
-            reg,
-            str(Path(run_dir, reg, 'flow.cylc')),
+            id_,
+            str(Path(run_dir, id_, 'flow.cylc')),
             ValidateOptions(**kwargs)
         )
 

--- a/tests/integration/events/test_workflow_events.py
+++ b/tests/integration/events/test_workflow_events.py
@@ -57,7 +57,9 @@ async def test_mail_footer_template(
 
     # start the workflow and get it to send an email
     async with start(mod_one) as one_log:
-        mod_one.run_event_handlers(
+        one_log.clear()  # clear previous log messages
+        mod_one.workflow_event_handler.handle(
+            mod_one,
             WorkflowEventHandler.EVENT_STARTUP,
             'event message'
         )
@@ -100,7 +102,9 @@ async def test_custom_event_handler_template(
 
     # start the workflow and get it to send an email
     async with start(mod_one) as one_log:
-        mod_one.run_event_handlers(
+        one_log.clear()  # clear previous log messages
+        mod_one.workflow_event_handler.handle(
+            mod_one,
             WorkflowEventHandler.EVENT_STARTUP,
             'event message'
         )

--- a/tests/integration/graphql/test_root.py
+++ b/tests/integration/graphql/test_root.py
@@ -21,7 +21,7 @@ from cylc.flow.network.client import WorkflowRuntimeClient
 
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run):
-    reg = mod_flow({
+    id_ = mod_flow({
         'scheduling': {
             'graph': {
                 'R1': '''
@@ -42,9 +42,9 @@ async def harness(mod_flow, mod_scheduler, mod_run):
             'b': {},
         },
     })
-    schd = mod_scheduler(reg)
+    schd = mod_scheduler(id_)
     async with mod_run(schd):
-        client = WorkflowRuntimeClient(reg)
+        client = WorkflowRuntimeClient(id_)
 
         async def _query(query_string):
             nonlocal client

--- a/tests/integration/main_loop/test_auto_restart.py
+++ b/tests/integration/main_loop/test_auto_restart.py
@@ -42,8 +42,8 @@ async def test_no_detach(
         'cylc.flow.main_loop.auto_restart._should_auto_restart',
         Mock(return_value=AutoRestartMode.RESTART_NORMAL)
     )
-    reg: str = flow(one_conf)
-    schd: Scheduler = scheduler(reg, paused_start=True, no_detach=True)
+    id_: str = flow(one_conf)
+    schd: Scheduler = scheduler(id_, paused_start=True, no_detach=True)
     with pytest.raises(MainLoopPluginException) as exc:
         async with run(schd) as log:
             await asyncio.sleep(2)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -23,10 +23,10 @@ from cylc.flow.network.server import PB_METHOD_MAP
 
 @pytest.fixture(scope='module')
 async def harness(mod_flow, mod_scheduler, mod_run, mod_one_conf):
-    reg = mod_flow(mod_one_conf)
-    schd = mod_scheduler(reg)
+    id_ = mod_flow(mod_one_conf)
+    schd = mod_scheduler(id_)
     async with mod_run(schd):
-        client = WorkflowRuntimeClient(reg)
+        client = WorkflowRuntimeClient(id_)
         yield schd, client
 
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -48,7 +48,7 @@ def test_validate_task_name(
     valid: bool
 ):
     """It should raise errors for invalid task names in the runtime section."""
-    reg = flow({
+    id_ = flow({
         **one_conf,
         'runtime': {
             task_name: {}
@@ -56,10 +56,10 @@ def test_validate_task_name(
     })
 
     if valid:
-        validate(reg)
+        validate(id_)
     else:
         with pytest.raises(WorkflowConfigError) as exc_ctx:
-            validate(reg)
+            validate(id_)
         assert task_name in str(exc_ctx.value)
 
 
@@ -82,7 +82,7 @@ def test_validate_implicit_task_name(
     Here we ensure that names which look like valid graph node names but which
     are blacklisted get caught and raise errors.
     """
-    reg = flow({
+    id_ = flow({
         'scheduler': {
             'allow implicit tasks': 'True'
         },
@@ -99,7 +99,7 @@ def test_validate_implicit_task_name(
     })
 
     with pytest.raises(WorkflowConfigError) as exc_ctx:
-        validate(reg)
+        validate(id_)
     assert str(exc_ctx.value).splitlines()[0] == (
         f'invalid task name "{task_name}"'
     )
@@ -114,7 +114,7 @@ def test_validate_implicit_task_name(
 )
 def test_validate_env_vars(flow, one_conf, validate, env_var, valid):
     """It should validate environment variable names."""
-    reg = flow({
+    id_ = flow({
         **one_conf,
         'runtime': {
             'foo': {
@@ -125,10 +125,10 @@ def test_validate_env_vars(flow, one_conf, validate, env_var, valid):
         }
     })
     if valid:
-        validate(reg)
+        validate(id_)
     else:
         with pytest.raises(WorkflowConfigError) as exc_ctx:
-            validate(reg)
+            validate(id_)
         assert env_var in str(exc_ctx.value)
 
 
@@ -147,7 +147,7 @@ def test_validate_param_env_templ(
     log_filter,
 ):
     """It should validate parameter environment templates."""
-    reg = flow({
+    id_ = flow({
         **one_conf,
         'runtime': {
             'foo': {
@@ -157,18 +157,18 @@ def test_validate_param_env_templ(
             }
         }
     })
-    validate(reg)
+    validate(id_)
     assert log_filter(caplog, contains='bad parameter environment template')
     assert log_filter(caplog, contains=env_val)
 
 
 def test_no_graph(flow, validate):
     """It should fail for missing graph sections."""
-    reg = flow({
+    id_ = flow({
         'scheduling': {},
     })
     with pytest.raises(WorkflowConfigError) as exc_ctx:
-        validate(reg)
+        validate(id_)
     assert 'missing [scheduling][[graph]] section.' in str(exc_ctx.value)
 
 
@@ -181,7 +181,7 @@ def test_no_graph(flow, validate):
 )
 def test_parse_special_tasks_invalid(flow, validate, section):
     """It should fail for invalid "special tasks"."""
-    reg = flow({
+    id_ = flow({
         'scheduler': {
             'allow implicit tasks': 'True',
         },
@@ -196,14 +196,14 @@ def test_parse_special_tasks_invalid(flow, validate, section):
         }
     })
     with pytest.raises(WorkflowConfigError) as exc_ctx:
-        validate(reg)
+        validate(id_)
     assert f'Illegal {section} spec' in str(exc_ctx.value)
     assert 'foo' in str(exc_ctx.value)
 
 
 def test_parse_special_tasks_interval(flow, validate):
     """It should fail for invalid durations in clock-triggers."""
-    reg = flow({
+    id_ = flow({
         'scheduler': {
             'allow implicit tasks': 'True',
         },
@@ -218,7 +218,7 @@ def test_parse_special_tasks_interval(flow, validate):
         }
     })
     with pytest.raises(WorkflowConfigError) as exc_ctx:
-        validate(reg)
+        validate(id_)
     assert 'Illegal clock-trigger spec' in str(exc_ctx.value)
     assert 'PT1Y' in str(exc_ctx.value)
 
@@ -232,7 +232,7 @@ def test_parse_special_tasks_interval(flow, validate):
 )
 def test_parse_special_tasks_families(flow, scheduler, validate, section):
     """It should expand families in special tasks."""
-    reg = flow({
+    id_ = flow({
         'scheduling': {
             'initial cycle point': 'now',
             'special tasks': {
@@ -261,10 +261,10 @@ def test_parse_special_tasks_families(flow, scheduler, validate, section):
         # external triggers cannot be used for multiple tasks so if family
         # expansion is completed correctly, validation should fail
         with pytest.raises(WorkflowConfigError) as exc_ctx:
-            config = validate(reg)
+            config = validate(id_)
         assert 'external triggers must be used only once' in str(exc_ctx.value)
     else:
-        config = validate(reg)
+        config = validate(id_)
         assert set(config.cfg['scheduling']['special tasks'][section]) == {
             # the family FOO has been expanded to the tasks foo, foot
             'foo(P1D)',
@@ -277,7 +277,7 @@ def test_queue_treated_as_implicit(flow, validate, caplog):
 
     https://github.com/cylc/cylc-flow/issues/5260
     """
-    reg = flow(
+    id_ = flow(
         {
             "scheduling": {
                 "queues": {"my_queue": {"members": "task1, task2"}},
@@ -286,7 +286,7 @@ def test_queue_treated_as_implicit(flow, validate, caplog):
             "runtime": {"task2": {}},
         }
     )
-    validate(reg)
+    validate(id_)
     assert (
         'Queues contain tasks not defined in runtime'
         in caplog.records[0].message
@@ -298,7 +298,7 @@ def test_queue_treated_as_comma_separated(flow, validate):
 
     https://github.com/cylc/cylc-flow/issues/5260
     """
-    reg = flow(
+    id_ = flow(
         {
             "scheduling": {
                 "queues": {"my_queue": {"members": "task1 task2"}},
@@ -308,7 +308,7 @@ def test_queue_treated_as_comma_separated(flow, validate):
         }
     )
     with pytest.raises(ListValueError, match="cannot contain a space"):
-        validate(reg)
+        validate(id_)
 
 
 def test_validate_incompatible_db(one_conf, flow, validate):

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -100,8 +100,8 @@ async def harness(mod_flow, mod_scheduler, mod_start):
             }
         }
     }
-    reg: str = mod_flow(flow_def)
-    schd: 'Scheduler' = mod_scheduler(reg)
+    id_: str = mod_flow(flow_def)
+    schd: 'Scheduler' = mod_scheduler(id_)
     async with mod_start(schd):
         await schd.update_data_structure()
         data = schd.data_store_mgr.data[schd.data_store_mgr.workflow_id]

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -31,7 +31,7 @@ from cylc.flow import __version__
 async def test_create_flow(flow, run_dir):
     """Use the flow fixture to create workflows on the file system."""
     # Ensure a flow.cylc file gets written out
-    reg = flow({
+    id_ = flow({
         'scheduler': {
             'allow implicit tasks': True
         },
@@ -41,7 +41,7 @@ async def test_create_flow(flow, run_dir):
             }
         }
     })
-    workflow_dir = run_dir / reg
+    workflow_dir = run_dir / id_
     flow_file = workflow_dir / 'flow.cylc'
 
     assert workflow_dir.exists()
@@ -51,8 +51,8 @@ async def test_create_flow(flow, run_dir):
 async def test_run(flow, scheduler, run, one_conf):
     """Create a workflow, initialise the scheduler and run it."""
     # Ensure the scheduler can survive for at least one second without crashing
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     async with run(schd):
         await asyncio.sleep(1)  # this yields control to the main loop
 
@@ -60,8 +60,8 @@ async def test_run(flow, scheduler, run, one_conf):
 async def test_logging(flow, scheduler, start, one_conf, log_filter):
     """We can capture log records when we run a scheduler."""
     # Ensure that the cylc version is logged on startup.
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     async with start(schd) as log:
         # this returns a list of log records containing __version__
         assert log_filter(log, contains=__version__)
@@ -76,12 +76,12 @@ async def test_scheduler_arguments(flow, scheduler, start, one_conf):
 
     """
     # Ensure the paused_start option is obeyed by the scheduler.
-    reg = flow(one_conf)
-    schd = scheduler(reg, paused_start=True)
+    id_ = flow(one_conf)
+    schd = scheduler(id_, paused_start=True)
     async with start(schd):
         assert schd.is_paused
-    reg = flow(one_conf)
-    schd = scheduler(reg, paused_start=False)
+    id_ = flow(one_conf)
+    schd = scheduler(id_, paused_start=False)
     async with start(schd):
         assert not schd.is_paused
 
@@ -95,8 +95,8 @@ async def test_shutdown(flow, scheduler, start, one_conf):
 
     """
     # Ensure the TCP server shuts down with the scheduler.
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     async with start(schd):
         pass
     assert schd.server.replier.socket.closed
@@ -110,8 +110,8 @@ async def test_install(flow, scheduler, one_conf, run_dir):
 
     """
     # Ensure the installation of the job script is completed.
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     await schd.install()
     assert Path(
         run_dir, schd.workflow, '.service', 'etc', 'job.sh'
@@ -193,8 +193,8 @@ async def myflow(mod_flow, mod_scheduler, mod_one_conf):
     object you are testing in the tests.
 
     """
-    reg = mod_flow(mod_one_conf)
-    schd = mod_scheduler(reg)
+    id_ = mod_flow(mod_one_conf)
+    schd = mod_scheduler(id_)
     return schd
 
 

--- a/tests/integration/test_graphql.py
+++ b/tests/integration/test_graphql.py
@@ -91,10 +91,10 @@ async def harness(mod_flow, mod_scheduler, mod_run):
             },
         },
     }
-    reg: str = mod_flow(flow_def)
-    schd: 'Scheduler' = mod_scheduler(reg)
+    id_: str = mod_flow(flow_def)
+    schd: 'Scheduler' = mod_scheduler(id_)
     async with mod_run(schd):
-        client = WorkflowRuntimeClient(reg)
+        client = WorkflowRuntimeClient(id_)
         schd.pool.hold_tasks('*')
         schd.resume_workflow()
         # Think this is needed to save the data state at first start (?)

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -110,14 +110,14 @@ def test_install_scan_no_ping(
     opts = InstallOptions()
     opts.no_ping = True
 
-    install_cli(opts, reg='w1')
+    install_cli(opts, id_='w1')
     out = capsys.readouterr().out
     assert INSTALLED_MSG.format(wfrun='w1/run2') in out
     assert WF_ACTIVE_MSG.format(wf='w1') in out
     # Empty contact file faked with "touch":
     assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
 
-    install_cli(opts, reg='w2')
+    install_cli(opts, id_='w2')
     out = capsys.readouterr().out
     assert WF_ACTIVE_MSG.format(wf='w2') not in out
     assert INSTALLED_MSG.format(wfrun='w2/run1') in out
@@ -136,7 +136,7 @@ def test_install_scan_ping(
     opts = InstallOptions()
     opts.no_ping = False
 
-    install_cli(opts, reg='w1')
+    install_cli(opts, id_='w1')
     out = capsys.readouterr().out
     assert INSTALLED_MSG.format(wfrun='w1/run2') in out
     assert WF_ACTIVE_MSG.format(wf='w1') in out
@@ -144,7 +144,7 @@ def test_install_scan_ping(
     # Empty contact file faked with "touch":
     assert f"{BAD_CONTACT_MSG} w1/run1" in caplog.text
 
-    install_cli(opts, reg='w2')
+    install_cli(opts, id_='w2')
     out = capsys.readouterr().out
     assert INSTALLED_MSG.format(wfrun='w2/run1') in out
     assert WF_ACTIVE_MSG.format(wf='w2') not in out
@@ -182,9 +182,9 @@ def test_install_gets_back_compat_mode_for_plugins(
     opts = InstallOptions()
 
     monkeypatch.setattr('cylc.flow.flags.cylc7_back_compat', False)
-    install_cli(opts, reg='w1')
+    install_cli(opts, id_='w1')
     assert capsys.readouterr()[0].split('\n')[0] == 'Plugin:False'
 
     monkeypatch.setattr('cylc.flow.flags.cylc7_back_compat', True)
-    install_cli(opts, reg='w1')
+    install_cli(opts, id_='w1')
     assert capsys.readouterr()[0].split('\n')[0] == 'Plugin:True'

--- a/tests/integration/test_publisher.py
+++ b/tests/integration/test_publisher.py
@@ -24,8 +24,8 @@ from cylc.flow.network.subscriber import (
 
 async def test_publisher(flow, scheduler, run, one_conf, port_range):
     """It should publish deltas when the flow starts."""
-    reg = flow(one_conf)
-    schd = scheduler(reg, paused_start=False)
+    id_ = flow(one_conf)
+    schd = scheduler(id_, paused_start=False)
     async with run(schd):
         # create a subscriber
         subscriber = WorkflowSubscriber(

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -56,7 +56,7 @@ async def mock_flow(
     mod_start,
 ) -> AsyncGenerator[Scheduler, None]:
     ret = Mock()
-    ret.reg = mod_flow({
+    ret.id_ = mod_flow({
         'scheduler': {
             'allow implicit tasks': True
         },
@@ -69,7 +69,7 @@ async def mock_flow(
         }
     })
 
-    ret.schd = mod_scheduler(ret.reg, paused_start=True)
+    ret.schd = mod_scheduler(ret.id_, paused_start=True)
     async with mod_start(ret.schd):
         ret.schd.pool.release_runahead_tasks()
         ret.schd.data_store_mgr.initiate_data_model()

--- a/tests/integration/test_scan.py
+++ b/tests/integration/test_scan.py
@@ -408,8 +408,8 @@ async def test_scan_sigstop(
 
     """
     # run a workflow
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     async with start(schd):
         # stop the server to make the flow un-responsive
         await schd.server.stop('make-unresponsive')
@@ -419,7 +419,7 @@ async def test_scan_sigstop(
         async for flow in pipe:
             raise Exception("There shouldn't be any scan results")
         # there should, however, be a warning
-        name = Path(reg).name
+        name = Path(id_).name
         assert (
             (30, f'Workflow not running: {name}')
             in [(level, msg) for _, level, msg in caplog.record_tuples]

--- a/tests/integration/test_scan_api.py
+++ b/tests/integration/test_scan_api.py
@@ -251,9 +251,9 @@ async def test_scan_cleans_stuck_contact_files(
 ):
     """Ensure scan tidies up contact files from crashed flows."""
     # create a flow
-    reg = flow(one_conf, name='-crashed-')
-    schd = scheduler(reg)
-    srv_dir = Path(run_dir, reg, WorkflowFiles.Service.DIRNAME)
+    id_ = flow(one_conf, name='-crashed-')
+    schd = scheduler(id_)
+    srv_dir = Path(run_dir, id_, WorkflowFiles.Service.DIRNAME)
     tmp_dir = test_dir / 'srv'
     cont = srv_dir / WorkflowFiles.Service.CONTACT
 
@@ -269,9 +269,9 @@ async def test_scan_cleans_stuck_contact_files(
     # integration test the process is the pytest process and it is still
     # running so we need to change the command so that Cylc sees the flow as
     # having crashed
-    contact_info = load_contact_file(reg)
+    contact_info = load_contact_file(id_)
     contact_info[ContactFileFields.COMMAND] += 'xyz'
-    dump_contact_file(reg, contact_info)
+    dump_contact_file(id_, contact_info)
 
     # make sure this flow shows for a regular filesystem-only scan
     opts = ScanOptions(states='running,paused', format='name')
@@ -306,9 +306,9 @@ async def test_scan_fail_well_when_client_unreachable(
     elegently.
     """
     # create a flow
-    reg = flow(one_conf, name='-crashed-')
-    schd = scheduler(reg)
-    srv_dir = Path(run_dir, reg, WorkflowFiles.Service.DIRNAME)
+    id_ = flow(one_conf, name='-crashed-')
+    schd = scheduler(id_)
+    srv_dir = Path(run_dir, id_, WorkflowFiles.Service.DIRNAME)
     tmp_dir = test_dir / 'srv'
 
     # run the flow, copy the contact, stop the flow, copy back the contact
@@ -323,9 +323,9 @@ async def test_scan_fail_well_when_client_unreachable(
     # integration test the process is the pytest process and it is still
     # running so we need to change the command so that Cylc sees the flow as
     # having crashed
-    contact_info = load_contact_file(reg)
+    contact_info = load_contact_file(id_)
     contact_info[ContactFileFields.COMMAND] += 'xyz'
-    dump_contact_file(reg, contact_info)
+    dump_contact_file(id_, contact_info)
 
     # Run Cylc Scan
     opts = ScanOptions(states='all', format='rich', ping=True)

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -43,8 +43,8 @@ async def test_is_paused_after_stop(
         one_conf: Fixture, flow: Fixture, scheduler: Fixture, run: Fixture,
         db_select: Fixture):
     """Test the paused status is unset on normal shutdown."""
-    reg: str = flow(one_conf)
-    schd: 'Scheduler' = scheduler(reg, paused_start=True)
+    id_: str = flow(one_conf)
+    schd: 'Scheduler' = scheduler(id_, paused_start=True)
     # Run
     async with run(schd):
         assert not schd.is_restart
@@ -52,7 +52,7 @@ async def test_is_paused_after_stop(
     # Stopped
     assert ('is_paused', '1') not in db_select(schd, False, 'workflow_params')
     # Restart
-    schd = scheduler(reg, paused_start=None)
+    schd = scheduler(id_, paused_start=None)
     async with run(schd):
         assert schd.is_restart
         assert not schd.is_paused
@@ -62,8 +62,8 @@ async def test_is_paused_after_crash(
         one_conf: Fixture, flow: Fixture, scheduler: Fixture, run: Fixture,
         db_select: Fixture):
     """Test the paused status is not unset for an interrupted workflow."""
-    reg: str = flow(one_conf)
-    schd: 'Scheduler' = scheduler(reg, paused_start=True)
+    id_: str = flow(one_conf)
+    schd: 'Scheduler' = scheduler(id_, paused_start=True)
 
     def ctrl_c():
         raise asyncio.CancelledError("Mock keyboard interrupt")
@@ -81,7 +81,7 @@ async def test_is_paused_after_crash(
     # Reset patched method
     setattr(schd, 'workflow_shutdown', _schd_workflow_shutdown)
     # Restart
-    schd = scheduler(reg, paused_start=None)
+    schd = scheduler(id_, paused_start=None)
     async with run(schd):
         assert schd.is_restart
         assert schd.is_paused
@@ -154,8 +154,8 @@ async def test_holding_tasks_whilst_scheduler_paused(
 
     See https://github.com/cylc/cylc-flow/issues/4278
     """
-    reg = flow(one_conf)
-    one = scheduler(reg, paused_start=True)
+    id_ = flow(one_conf)
+    one = scheduler(id_, paused_start=True)
 
     # run the workflow
     async with start(one):
@@ -201,10 +201,10 @@ async def test_no_poll_waiting_tasks(
 
     See https://github.com/cylc/cylc-flow/issues/4658
     """
-    reg: str = flow(one_conf)
+    id_: str = flow(one_conf)
     # start the scheduler in live mode in order to activate regular polling
     # logic
-    one: Scheduler = scheduler(reg, run_mode='live')
+    one: Scheduler = scheduler(id_, run_mode='live')
 
     log: pytest.LogCaptureFixture
     async with start(one) as log:

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -202,11 +202,12 @@ async def test_no_poll_waiting_tasks(
     See https://github.com/cylc/cylc-flow/issues/4658
     """
     reg: str = flow(one_conf)
-    one: Scheduler = scheduler(reg, paused_start=True)
+    # start the scheduler in live mode in order to activate regular polling
+    # logic
+    one: Scheduler = scheduler(reg, run_mode='live')
 
     log: pytest.LogCaptureFixture
     async with start(one) as log:
-
         # Test assumes start up with a waiting task.
         task = (one.pool.get_all_tasks())[0]
         assert task.state.status == TASK_STATUS_WAITING

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -26,8 +26,8 @@ from cylc.flow.scheduler import Scheduler
 
 @pytest.fixture(scope='module')
 async def myflow(mod_flow, mod_scheduler, mod_run, mod_one_conf):
-    reg = mod_flow(mod_one_conf)
-    schd = mod_scheduler(reg)
+    id_ = mod_flow(mod_one_conf)
+    schd = mod_scheduler(id_)
     async with mod_run(schd):
         yield schd
 

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -32,8 +32,8 @@ async def test_process_job_logs_retrieval_warns_no_platform(
         max_size=256,
         key='skarloey'
     )
-    reg: str = flow(one_conf)
-    schd: 'Scheduler' = scheduler(reg, paused_start=True)
+    id_: str = flow(one_conf)
+    schd: 'Scheduler' = scheduler(id_, paused_start=True)
     # Run
     async with run(schd):
         schd.task_events_mgr._process_job_logs_retrieval(

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -114,8 +114,8 @@ async def test__run_job_cmd_logs_platform_lookup_fail(
     db_select: Fixture, caplog: Fixture
 ) -> None:
     """TaskJobMg._run_job_cmd handles failure to get platform."""
-    reg: str = flow(one_conf)
-    schd: 'Scheduler' = scheduler(reg, paused_start=True)
+    id_: str = flow(one_conf)
+    schd: 'Scheduler' = scheduler(id_, paused_start=True)
     # Run
     async with run(schd):
         from types import SimpleNamespace

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -100,8 +100,8 @@ async def mod_example_flow(
     This is module-scoped so faster than example_flow, but should only be used
     where the test does not mutate the state of the scheduler or task pool.
     """
-    reg = mod_flow(EXAMPLE_FLOW_CFG)
-    schd: Scheduler = mod_scheduler(reg, paused_start=True)
+    id_ = mod_flow(EXAMPLE_FLOW_CFG)
+    schd: Scheduler = mod_scheduler(id_, paused_start=True)
     async with mod_run(schd):
         pass
     return schd
@@ -122,8 +122,8 @@ async def example_flow(
     # The run(schd) fixture doesn't work for modifying the DB, so have to
     # set up caplog and do schd.install()/.initialise()/.configure() instead
     caplog.set_level(logging.INFO, CYLC_LOG)
-    reg = flow(EXAMPLE_FLOW_CFG)
-    schd: Scheduler = scheduler(reg)
+    id_ = flow(EXAMPLE_FLOW_CFG)
+    schd: Scheduler = scheduler(id_)
     async with start(schd):
         yield schd
 

--- a/tests/integration/test_workflow_db_mgr.py
+++ b/tests/integration/test_workflow_db_mgr.py
@@ -26,12 +26,12 @@ async def test_restart_number(
     flow, one_conf, start, scheduler, log_filter, db_select
 ):
     """The restart number should increment correctly."""
-    reg = flow(one_conf)
+    id_ = flow(one_conf)
 
     async def test(expected_restart_num: int, do_reload: bool = False):
         """(Re)start the workflow and check the restart number is as expected.
         """
-        schd: Scheduler = scheduler(reg, paused_start=True)
+        schd: Scheduler = scheduler(id_, paused_start=True)
         async with start(schd) as log:
             if do_reload:
                 schd.command_reload_workflow()
@@ -81,10 +81,10 @@ async def test_db_upgrade_pre_803(
     flow, one_conf, start, scheduler, log_filter, db_select
 ):
     """Test scheduler restart with upgrade of pre-8.0.3 DB."""
-    reg = flow(one_conf)
+    id_ = flow(one_conf)
 
     # Run a scheduler to create a DB.
-    schd: Scheduler = scheduler(reg, paused_start=True)
+    schd: Scheduler = scheduler(id_, paused_start=True)
     async with start(schd):
         assert ('n_restart', '0') in db_select(schd, False, 'workflow_params')
 
@@ -92,7 +92,7 @@ async def test_db_upgrade_pre_803(
     db_remove_column(schd, "task_states", "is_manual_submit")
     db_remove_column(schd, "task_jobs", "flow_nums")
 
-    schd: Scheduler = scheduler(reg, paused_start=True)
+    schd: Scheduler = scheduler(id_, paused_start=True)
 
     # Restart should fail due to the missing column.
     with pytest.raises(sqlite3.OperationalError):
@@ -100,7 +100,7 @@ async def test_db_upgrade_pre_803(
             pass
     assert ('n_restart', '1') in db_select(schd, False, 'workflow_params')
 
-    schd: Scheduler = scheduler(reg, paused_start=True)
+    schd: Scheduler = scheduler(id_, paused_start=True)
 
     # Run the DB upgrader for version 8.0.2
     # (8.0.2 requires upgrade)

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -40,8 +40,8 @@ from cylc.flow.workflow_files import (
 
 @pytest.fixture(scope='module')
 async def myflow(mod_flow, mod_scheduler, mod_run, mod_one_conf):
-    reg = mod_flow(mod_one_conf)
-    schd = mod_scheduler(reg)
+    id_ = mod_flow(mod_one_conf)
+    schd = mod_scheduler(id_)
     async with mod_run(schd):
         yield schd
 
@@ -62,8 +62,8 @@ async def test_load_contact_file_async(myflow):
 
 @pytest.fixture
 async def workflow(flow, scheduler, one_conf, run_dir):
-    reg = flow(one_conf)
-    schd = scheduler(reg)
+    id_ = flow(one_conf)
+    schd = scheduler(id_)
     await schd.install()
 
     from collections import namedtuple
@@ -73,15 +73,15 @@ async def workflow(flow, scheduler, one_conf, run_dir):
     contact_data = schd.get_contact_data()
     contact_file = Path(
         run_dir,
-        reg,
+        id_,
         WorkflowFiles.Service.DIRNAME,
         WorkflowFiles.Service.CONTACT
     )
 
     def dump_contact(**kwargs):
-        nonlocal contact_data, reg
+        nonlocal contact_data, id_
         dump_contact_file(
-            reg,
+            id_,
             {
                 **contact_data,
                 **kwargs
@@ -94,20 +94,20 @@ async def workflow(flow, scheduler, one_conf, run_dir):
     Fixture = namedtuple(
         'TextFixture',
         [
-            'reg',
+            'id_',
             'contact_file',
             'contact_data',
             'dump_contact',
         ]
     )
-    return Fixture(reg, contact_file, contact_data, dump_contact)
+    return Fixture(id_, contact_file, contact_data, dump_contact)
 
 
 def test_detect_old_contact_file_running(workflow):
     """It should raise an error if the workflow is running."""
     # the workflow is running so we should get a ServiceFileError
     with pytest.raises(ContactFileExists):
-        detect_old_contact_file(workflow.reg)
+        detect_old_contact_file(workflow.id_)
     # the contact file is valid so should be left alone
     assert workflow.contact_file.exists()
 
@@ -124,7 +124,7 @@ def test_detect_old_contact_file_network_issue(workflow):
     # detect_old_contact_file should report that it can't tell if the workflow
     # is running or not
     with pytest.raises(CylcError) as exc_ctx:
-        detect_old_contact_file(workflow.reg)
+        detect_old_contact_file(workflow.id_)
     assert (
         'Cannot determine whether workflow is running'
         in str(exc_ctx.value)
@@ -145,7 +145,7 @@ def test_detect_old_contact_file_old_run(workflow, caplog, log_filter):
 
     # the workflow should not appear to be running (according to the contact
     # data) so detect_old_contact_file should not raise any errors
-    detect_old_contact_file(workflow.reg)
+    detect_old_contact_file(workflow.id_)
 
     # as a side effect the contact file should have been removed
     assert not workflow.contact_file.exists()
@@ -159,7 +159,7 @@ def test_detect_old_contact_file_none(workflow):
     assert not workflow.contact_file.exists()
     # detect_old_contact_file should return
 
-    detect_old_contact_file(workflow.reg)
+    detect_old_contact_file(workflow.id_)
 
     # it should not recreate the contact file
     assert not workflow.contact_file.exists()
@@ -236,9 +236,9 @@ def test_detect_old_contact_file_removal_errors(
     if process_running:
         # this should error if the process is running
         with pytest.raises(ContactFileExists):
-            detect_old_contact_file(workflow.reg)
+            detect_old_contact_file(workflow.id_)
     else:
-        detect_old_contact_file(workflow.reg)
+        detect_old_contact_file(workflow.id_)
 
     # decide which log messages we should expect to see
     if process_running:
@@ -264,7 +264,7 @@ def test_detect_old_contact_file_removal_errors(
     assert bool(log_filter(
         caplog,
         contains=(
-            f'Failed to remove contact file for {workflow.reg}:'
+            f'Failed to remove contact file for {workflow.id_}:'
             '\nmocked-os-error'
         ),
     )) is remove_failed

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -79,8 +79,12 @@ def _make_scheduler():
     schd: Scheduler = None  # type: ignore[assignment]
 
     def __make_scheduler(reg: str, **opts: Any) -> Scheduler:
-        # This allows paused_start to be overridden:
-        opts = {'paused_start': True, **opts}
+        opts = {
+            # safe n sane defaults for integration tests
+            'paused_start': True,
+            'run_mode': 'simulation',
+            **opts,
+        }
         options = RunOptions(**opts)
         # create workflow
         nonlocal schd

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -65,12 +65,12 @@ def _make_flow(
             name = str(uuid1())
         flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
-    reg = str(flow_run_dir.relative_to(cylc_run_dir))
+    id_ = str(flow_run_dir.relative_to(cylc_run_dir))
     if isinstance(conf, dict):
         conf = flow_config_str(conf)
     with open((flow_run_dir / WorkflowFiles.FLOW_FILE), 'w+') as flow_file:
         flow_file.write(conf)
-    return reg
+    return id_
 
 
 @contextmanager
@@ -78,7 +78,7 @@ def _make_scheduler():
     """Return a scheduler object for a flow registration."""
     schd: Scheduler = None  # type: ignore[assignment]
 
-    def __make_scheduler(reg: str, **opts: Any) -> Scheduler:
+    def __make_scheduler(id_: str, **opts: Any) -> Scheduler:
         opts = {
             # safe n sane defaults for integration tests
             'paused_start': True,
@@ -88,7 +88,7 @@ def _make_scheduler():
         options = RunOptions(**opts)
         # create workflow
         nonlocal schd
-        schd = Scheduler(reg, options)
+        schd = Scheduler(id_, options)
         return schd
 
     yield __make_scheduler

--- a/tests/integration/utils/test_flow_tools.py
+++ b/tests/integration/utils/test_flow_tools.py
@@ -25,8 +25,8 @@ from pathlib import Path
 # test _make_flow via the conftest fixture
 def test_flow(run_dir, flow, one_conf):
     """It should create a flow in the run directory."""
-    reg = flow(one_conf)
-    assert Path(run_dir / reg).exists()
-    assert Path(run_dir / reg / 'flow.cylc').exists()
-    with open(Path(run_dir / reg / 'flow.cylc'), 'r') as flow_file:
+    id_ = flow(one_conf)
+    assert Path(run_dir / id_).exists()
+    assert Path(run_dir / id_ / 'flow.cylc').exists()
+    with open(Path(run_dir / id_ / 'flow.cylc'), 'r') as flow_file:
         assert 'scheduling' in flow_file.read()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,7 +70,7 @@ def _tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     Adds the runN symlink automatically if the workflow ID ends with /run__.
 
     Args:
-        reg: Workflow name.
+        id_: Workflow name.
         installed: If True, make it look like the workflow was installed
             using cylc install (creates _cylc-install dir).
         named: If True and installed is True, the _cylc-install dir will
@@ -83,7 +83,7 @@ def _tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         cylc_run_dir = tmp_run_dir()
     """
     def __tmp_run_dir(
-        reg: Optional[str] = None,
+        id_: Optional[str] = None,
         installed: bool = False,
         named: bool = False
     ) -> Path:
@@ -92,8 +92,8 @@ def _tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         cylc_run_dir = tmp_path / 'cylc-run'
         cylc_run_dir.mkdir(exist_ok=True)
         monkeypatch.setattr('cylc.flow.pathutil._CYLC_RUN_DIR', cylc_run_dir)
-        if reg:
-            run_dir = cylc_run_dir.joinpath(reg)
+        if id_:
+            run_dir = cylc_run_dir.joinpath(id_)
             run_dir.mkdir(parents=True, exist_ok=True)
             (run_dir / WorkflowFiles.FLOW_FILE).touch(exist_ok=True)
             (run_dir / WorkflowFiles.Service.DIRNAME).mkdir(exist_ok=True)
@@ -102,8 +102,8 @@ def _tmp_run_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
                 link_runN(run_dir)
             if installed:
                 if named:
-                    if len(Path(reg).parts) < 2:
-                        raise ValueError("Named run requires two-level reg")
+                    if len(Path(id_).parts) < 2:
+                        raise ValueError("Named run requires two-level id_")
                     (run_dir.parent / WorkflowFiles.Install.DIRNAME).mkdir(
                         exist_ok=True)
                 else:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -341,6 +341,16 @@ def test_family_inheritance_and_quotes(
             (WorkflowConfigError, "does not meet the constraints"),
             id="Violated constraints"
         ),
+        pytest.param(
+            ISO8601_CYCLING_TYPE,
+            {
+                'initial cycle point': 'a',
+            },
+            None,
+            None,
+            (WorkflowConfigError, 'Invalid ISO 8601 date representation: a'),
+            id="invalid"
+        ),
     ]
 )
 def test_process_icp(

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -136,8 +136,8 @@ def test_install_workflow__symlink_target_exists(
 ):
     """Test that you can't install workflow when run dir symlink dir target
     already exists."""
-    reg = 'smeagol'
-    src_dir: Path = tmp_src_dir(reg)
+    id_ = 'smeagol'
+    src_dir: Path = tmp_src_dir(id_)
     tmp_run_dir()
     sym_run = tmp_path / 'sym-run'
     sym_log = tmp_path / 'sym-log'
@@ -153,13 +153,13 @@ def test_install_workflow__symlink_target_exists(
     )
     msg = "Symlink dir target already exists: .*{}"
     # Test:
-    (sym_run / 'cylc-run' / reg / 'run1').mkdir(parents=True)
+    (sym_run / 'cylc-run' / id_ / 'run1').mkdir(parents=True)
     with pytest.raises(WorkflowFilesError, match=msg.format(sym_run)):
         install_workflow(src_dir)
 
     shutil.rmtree(sym_run)
     (
-        sym_log / 'cylc-run' / reg / 'run1' / WorkflowFiles.LogDir.DIRNAME
+        sym_log / 'cylc-run' / id_ / 'run1' / WorkflowFiles.LogDir.DIRNAME
     ).mkdir(parents=True)
     with pytest.raises(WorkflowFilesError, match=msg.format(sym_log)):
         install_workflow(src_dir)

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -438,21 +438,21 @@ def test_remove_empty_parents(tmp_path: Path):
     """Test that _remove_empty_parents() doesn't remove parents containing a
     sibling."""
     # -- Setup --
-    reg = 'foo/bar/baz/qux'
-    path = tmp_path.joinpath(reg)
+    id_ = 'foo/bar/baz/qux'
+    path = tmp_path.joinpath(id_)
     tmp_path.joinpath('foo/bar/baz').mkdir(parents=True)
     # Note qux does not exist, but that shouldn't matter
     sibling_reg = 'foo/darmok'
     sibling_path = tmp_path.joinpath(sibling_reg)
     sibling_path.mkdir()
     # -- Test --
-    remove_empty_parents(path, reg)
+    remove_empty_parents(path, id_)
     assert tmp_path.joinpath('foo/bar').exists() is False
     assert tmp_path.joinpath('foo').exists() is True
     # Check it skips non-existent dirs, and stops at the right place too
     tmp_path.joinpath('foo/bar').mkdir()
     sibling_path.rmdir()
-    remove_empty_parents(path, reg)
+    remove_empty_parents(path, id_)
     assert tmp_path.joinpath('foo').exists() is False
     assert tmp_path.exists() is True
 

--- a/tests/unit/test_task_remote_mgr.py
+++ b/tests/unit/test_task_remote_mgr.py
@@ -43,9 +43,9 @@ def test__remote_init_items(comms_meth: CommsMeth, expected: bool):
 
     Should only includes files under .service/
     """
-    reg = 'barclay'
-    mock_mgr = Mock(workflow=reg)
-    srv_dir = get_workflow_srv_dir(reg)
+    id_ = 'barclay'
+    mock_mgr = Mock(workflow=id_)
+    srv_dir = get_workflow_srv_dir(id_)
     items = TaskRemoteMgr._remote_init_items(mock_mgr, comms_meth)
     if expected:
         assert items

--- a/tests/unit/test_taskdef.py
+++ b/tests/unit/test_taskdef.py
@@ -24,9 +24,9 @@ from .test_config import tmp_flow_config
 
 def test_generate_graph_parents_1(tmp_flow_config):
     """Test that parents are only generated from valid recurrences."""
-    reg = 'pan-galactic'
+    id_ = 'pan-galactic'
     flow_file = tmp_flow_config(
-        reg,
+        id_,
         f"""
             [scheduler]
                 UTC mode = True
@@ -41,7 +41,7 @@ def test_generate_graph_parents_1(tmp_flow_config):
                 [[every_cycle, run_once_at_midnight]]
         """
     )
-    cfg = WorkflowConfig(workflow=reg, fpath=flow_file, options=None)
+    cfg = WorkflowConfig(workflow=id_, fpath=flow_file, options=None)
 
     # Each instance of every_cycle should have a parent only at T00.
     for point in [
@@ -65,9 +65,9 @@ def test_generate_graph_parents_1(tmp_flow_config):
 
 def test_generate_graph_parents_2(tmp_flow_config):
     """Test inferred parents are valid w.r.t to their own recurrences."""
-    reg = 'gargle-blaster'
+    id_ = 'gargle-blaster'
     flow_file = tmp_flow_config(
-        reg,
+        id_,
         f"""
             [scheduling]
                 cycling mode = integer
@@ -77,7 +77,7 @@ def test_generate_graph_parents_2(tmp_flow_config):
                 [[foo]]
         """
     )
-    cfg = WorkflowConfig(workflow=reg, fpath=flow_file, options=None)
+    cfg = WorkflowConfig(workflow=id_, fpath=flow_file, options=None)
 
     # Each instance of every_cycle should have a parent only at T00.
     parents = generate_graph_parents(

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -93,7 +93,7 @@ def test_is_valid_run_dir(is_abs_path: bool, tmp_run_dir: Callable):
 
 
 @pytest.mark.parametrize(
-    'reg, expected_err, expected_msg',
+    'id_, expected_err, expected_msg',
     [('foo/bar/', None, None),
      ('/foo/bar', WorkflowFilesError, "cannot be an absolute path"),
      ('$HOME/alone', WorkflowFilesError, "invalid workflow name"),
@@ -101,14 +101,14 @@ def test_is_valid_run_dir(is_abs_path: bool, tmp_run_dir: Callable):
      ('meow/..', WorkflowFilesError,
       "cannot be a path that points to the cylc-run directory or above")]
 )
-def test_validate_workflow_name(reg, expected_err, expected_msg):
+def test_validate_workflow_name(id_, expected_err, expected_msg):
     if expected_err:
         with pytest.raises(expected_err) as exc:
-            validate_workflow_name(reg)
+            validate_workflow_name(id_)
         if expected_msg:
             assert expected_msg in str(exc.value)
     else:
-        validate_workflow_name(reg)
+        validate_workflow_name(id_)
 
 
 @pytest.mark.parametrize(
@@ -169,7 +169,7 @@ def test_infer_latest_run(
     Params:
         path: Input arg.
         implicit_runN: Input arg.
-        expected_reg: The reg part of the expected returned tuple.
+        expected_reg: The id_ part of the expected returned tuple.
     """
     # Setup
     cylc_run_dir: Path = tmp_run_dir()
@@ -307,11 +307,11 @@ def test_get_symlink_dirs(
     # Setup
     cylc_run_dir = tmp_run_dir()
     create_filetree(filetree, tmp_path, tmp_path)
-    reg = 'foo/bar'
+    id_ = 'foo/bar'
     for k, v in expected.items():
         expected[k] = Path(tmp_path / v)
     # Test
-    assert get_symlink_dirs(reg, cylc_run_dir / reg) == expected
+    assert get_symlink_dirs(id_, cylc_run_dir / id_) == expected
 
 
 
@@ -484,14 +484,14 @@ def test_check_flow_file_symlink(
 
 
 @pytest.mark.parametrize(
-    'reg, installed, named,  expected',
+    'id_, installed, named,  expected',
     [('reg1/run1', True, True, True),
      ('reg2', True, False, True),
      ('reg3', False, False, False)]
 )
-def test_is_installed(tmp_run_dir: Callable, reg, installed, named, expected):
+def test_is_installed(tmp_run_dir: Callable, id_, installed, named, expected):
     """Test is_installed correctly identifies presence of _cylc-install dir"""
-    cylc_run_dir: Path = tmp_run_dir(reg, installed=installed, named=named)
+    cylc_run_dir: Path = tmp_run_dir(id_, installed=installed, named=named)
     actual = is_installed(cylc_run_dir)
     assert actual == expected
 

--- a/tests/unit/xtriggers/test_workflow_state.py
+++ b/tests/unit/xtriggers/test_workflow_state.py
@@ -24,8 +24,8 @@ from ..conftest import MonkeyMock
 
 def test_inferred_run(tmp_run_dir: Callable, monkeymock: MonkeyMock):
     """Test that the workflow_state xtrigger infers the run number"""
-    reg = 'isildur'
-    expected_workflow_id = f'{reg}/run1'
+    id_ = 'isildur'
+    expected_workflow_id = f'{id_}/run1'
     cylc_run_dir = str(tmp_run_dir())
     tmp_run_dir(expected_workflow_id, installed=True, named=True)
     mock_db_checker = monkeymock(
@@ -35,6 +35,6 @@ def test_inferred_run(tmp_run_dir: Callable, monkeymock: MonkeyMock):
         )
     )
 
-    _, results = workflow_state(reg, task='precious', point='3000')
+    _, results = workflow_state(id_, task='precious', point='3000')
     mock_db_checker.assert_called_once_with(cylc_run_dir, expected_workflow_id)
     assert results['workflow'] == expected_workflow_id


### PR DESCRIPTION
Misceallaneous stuff from recent reviews...

terminology: workflow-name => workflow-id                                                                                          
    
* Workflow name still exists as an install concept in relation to the source    
  directory, and in the run directory where it is the workflow ID with    
  the run name removed.    
    
terminology: reg->id                               
                                                            
* Reg was a Cylc <= 6 concept relating to the registration DB.    
* Beyond Cylc 6 we didn't have a better name for this.    
* With the universal ID, workflow reg became workflow ID.    
    
tests/integration: set run_mode=simulation as the default    
    
* Integration tests shouldn't go running workflows for real.    
* Set the simulation run mode as the default, this avoids shell    
  interaction and reduces the number of moving parts.  

config: fill small coverage gap

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.