### PR TITLE
blacklist setuptools v67

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,9 @@ xtrigger function signatures.
 Fix a bug when rapidly issuing the same/opposite commands e.g. pausing &
 resuming a workflow.
 
+[#5625](https://github.com/cylc/cylc-flow/pull/5625) - Exclude `setuptools`
+version (v67) which results in dependency check failure with editable installs.
+
 ## __cylc-8.1.4 (<span actions:bind='release-date'>Released 2023-05-04</span>)__
 
 ### Fixes

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - psutil >=5.6.0
   - python
   - pyzmq >=22
-  - setuptools >=49
+  - setuptools >=49,!=67.*
   - importlib_metadata # [py<3.8]
   - urwid >=2,<3
   - tomli >=2 # [py<3.11]

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     psutil>=5.6.0
     pyzmq>=22
     # https://github.com/pypa/setuptools/issues/3802
-    setuptools>=49
+    setuptools>=49,!=67.*
     importlib_metadata; python_version < "3.8"
     urwid==2.*
     # unpinned transient dependencies used for type checking


### PR DESCRIPTION
relates to https://github.com/pypa/setuptools/issues/3802

`setuptools` at v67 results in failure running cylc
```
(flow) sutherlander@cortex:cylc-flow$ cylc --version

Traceback (most recent call last):

  File "/home/sutherlander/.envs/flow/lib/python3.10/site-packages/pkg_resources/__init__.py", line 629, in _build_master

    ws.require(__requires__)
.
.
.
pkg_resources.DistributionNotFound: The 'metomi-isodatetime==1!3.0.*' distribution was not found and is required by cylc-flow
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
