### PR TITLE
doc: explain whitespace in env vars

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1594,7 +1594,7 @@ with Conf(
                 You can also specify job environment templates here for
                 :ref:`parameterized tasks <User Guide Param>`.
             '''):
-                Conf('<variable>', VDR.V_STRING, desc='''
+                Conf('<variable>', VDR.V_STRING, desc=r'''
                     A custom user defined variable for a task execution
                     environment.
 
@@ -1634,6 +1634,32 @@ with Conf(
                        MYNUM = %(i)d
                        MYITEM = %(item)s
                        MYFILE = /path/to/%(i)03d/%(item)s
+
+                    .. note::
+
+                       As with other Cylc configurations, leading or trailing
+                       whitespace will be stripped, so the following two examples
+                       are equivalent:
+
+                       .. list-table::
+                          :class: grid-table
+
+                          * - .. code-block:: cylc
+
+                                 [environment]
+                                     FOO = " a "
+                                     BAR = """
+                                       $(foo bar baz)
+                                   """
+                            - .. code-block:: cylc
+
+                                 [environment]
+                                     FOO = "a"
+                                     BAR = "$(foo bar baz)"
+
+                       If leading or trailing whitespace is required, consider
+                       using the ``\0`` escape character, or set the variable
+                       in :cylc:conf:`[..][..]env-script`.
 
                     .. versionchanged:: 7.8.7/7.9.2
 

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1638,8 +1638,8 @@ with Conf(
                     .. note::
 
                        As with other Cylc configurations, leading or trailing
-                       whitespace will be stripped, so the following two examples
-                       are equivalent:
+                       whitespace will be stripped, so the following two
+                       examples are equivalent:
 
                        .. list-table::
                           :class: grid-table


### PR DESCRIPTION
Document whitespace in env vars:

![Screenshot from 2023-07-17 12-02-21](https://github.com/cylc/cylc-flow/assets/16705946/3616ee96-0e8c-4614-aa71-77a6766230e0)

See https://github.com/cylc/cylc-flow/issues/5080#issuecomment-1637842468

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.