### PR TITLE
Use towncrier for changelog generation

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -43,14 +43,13 @@ jobs:
           init-file: 'cylc/flow/__init__.py'
           pypi-package-name: 'cylc-flow'
 
-      - name: Update "released on" date in changelog
-        continue-on-error: true
-        uses: cylc/release-actions/stage-1/update-changelog-release-date@v1
-        with:
-          changelog-file: 'CHANGES.md'
-
       - name: Test build
         uses: cylc/release-actions/build-python-package@v1
+
+      - name: Generate changelog
+        run: |
+          python3 -m pip install -q towncrier
+          towncrier build --yes
 
       - name: Create pull request
         uses: cylc/release-actions/stage-1/create-release-pr@v1

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Configure git  # Needed by the odd test
         uses: cylc/release-actions/configure-git@v1
 
+      - name: Check changelog
+        if: startsWith(matrix.os, 'ubuntu')
+        run: towncrier build --draft
+
       - name: Style
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,12 @@ List of notable changes, for a complete list of changes see the
 [closed milestones](https://github.com/cylc/cylc-flow/milestones?state=closed)
 for each release.
 
-<!-- The topmost release date is automatically updated by GitHub Actions. When
-creating a new release entry be sure to copy & paste the span tag with the
-`actions:bind` attribute, which is used by a regex to find the text to be
-updated. Only the first match gets replaced, so it's fine to leave the old
-ones in. -->
+<!--
+NOTE: Do not add entries here, use towncrier fragments instead:
+$ towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
+-->
+
+<!-- towncrier release notes start -->
 
 ## __cylc-8.2.0 (<span actions:bind='release-date'>Upcoming</span>)__
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,11 @@ Feel free to ask questions on the issue or
 [developers chat](https://matrix.to/#/#cylc-general:matrix.org) if unsure about
 anything.
 
+We use [towncrier](https://towncrier.readthedocs.io/en/stable/index.html) for
+generating the changelog. Changelog entries are added by running
+```
+towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
+```
 
 ## Code Contributors
 

--- a/changes.d/changelog-template.jinja
+++ b/changes.d/changelog-template.jinja
@@ -1,0 +1,13 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+### {{ definitions[category]['name'] }}
+
+{% for text, pulls in sections[""][category].items() %}
+{{ pulls|join(', ') }} - {{ text }}
+
+{% endfor %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.towncrier]
+directory = "changes.d"
+name = "Cylc"
+package = "cylc.flow"
+filename = "CHANGES.md"
+template = "changes.d/changelog-template.jinja"
+underlines = ["", "", ""]
+title_format = "## __cylc-{version} (Released {project_date})__"
+issue_format = "[#{issue}](https://github.com/cylc/cylc-flow/pull/{issue})"
+
+# These changelog sections will be shown in the defined order:
+[[tool.towncrier.type]]
+directory = "break" # NB this is just the filename not directory e.g. 123.break.md
+name = "Breaking Changes"
+showcontent = true
+[[tool.towncrier.type]]
+directory = "feat"
+name = "Enhancements"
+showcontent = true
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Fixes"
+showcontent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ issue_format = "[#{issue}](https://github.com/cylc/cylc-flow/pull/{issue})"
 # These changelog sections will be shown in the defined order:
 [[tool.towncrier.type]]
 directory = "break" # NB this is just the filename not directory e.g. 123.break.md
-name = "Breaking Changes"
+name = "⚠ Breaking Changes"
 showcontent = true
 [[tool.towncrier.type]]
 directory = "feat"
-name = "Enhancements"
+name = "🚀 Enhancements"
 showcontent = true
 [[tool.towncrier.type]]
 directory = "fix"
-name = "Fixes"
+name = "🔧 Fixes"
 showcontent = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,7 @@ tests =
     pytest-mock>=3.6.1
     pytest>=6
     testfixtures>=6.11.0
+    towncrier>=23
     # Type annotation stubs
     # http://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
     types-Jinja2>=0.1.3


### PR DESCRIPTION
https://towncrier.readthedocs.io/en/stable/index.html

If we go for this it means no more changelog conflicts 🎉 Instead you either
- write your changelog entries to a file at `changes.d/<PR-number>.<break|feat|fix>.md`
- or run `towncrier create <PR-number>.<break|feat|fix>.md --content "<insert content here>"`
 
and before the release they get collated into `CHANGES.md`.

Also it guarantees changelog entries go under the right release section despite any milestone bump-backs or cherry-picks that happen.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Dependency changes do not apply to `conda-environment.yml`
- [x] Tests N/A
- [x] No changelog entry needed
- [x] No cylc-doc change needed
