### PR TITLE
Tweak swarm configure. [skip ci]

### DIFF
--- a/etc/bin/swarm
+++ b/etc/bin/swarm
@@ -204,7 +204,7 @@ append_config () {
         if prompt "Write \"$LINE\" to \"$LOC\"?"; then
             if [[ "$POS" == top ]]; then
                 # ... at the top of the file
-                sed -i "1i$LINE" "$LOC"
+                echo -e "${LINE}\n$(cat ${LOC})" > "$LOC"
             elif [[ "$POS" == bottom ]]; then
                 # ... at the bottom of the file
                 echo -e "\n$LINE" >> "$LOC"


### PR DESCRIPTION
It silently fails to modify `.ssh/config` if the file doesn't already exist, or if it exists but is empty.

(One review will do; no need for tests or change log entry).