### PR TITLE
Docs: fix hidden note

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -605,7 +605,7 @@ with Conf(
             The stop cycle point can be overridden on the command line using
             ``cylc play --stop-cycle-point=POINT``
 
-            .. note:
+            .. note::
 
                Not to be confused with :cylc:conf:`[..]final cycle point`:
                There can be more graph beyond this point, but you are


### PR DESCRIPTION
I did a grep for other possible unintentionally hidden admonitions and couldn't find any others.