### PR TITLE
data store: catch possible traceback

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -337,7 +337,8 @@ def apply_delta(key, delta, data):
             # elements and their relationships missing on reload.
             if key == TASK_PROXIES:
                 # remove relationship from task
-                data[TASKS][data[key][del_id].task].proxies.remove(del_id)
+                with suppress(KeyError, ValueError):
+                    data[TASKS][data[key][del_id].task].proxies.remove(del_id)
                 # remove relationship from parent/family
                 with suppress(KeyError, ValueError):
                     data[FAMILY_PROXIES][
@@ -347,7 +348,10 @@ def apply_delta(key, delta, data):
                 with suppress(KeyError, ValueError):
                     getattr(data[WORKFLOW], key).remove(del_id)
             elif key == FAMILY_PROXIES:
-                data[FAMILIES][data[key][del_id].family].proxies.remove(del_id)
+                with suppress(KeyError, ValueError):
+                    data[FAMILIES][
+                        data[key][del_id].family
+                    ].proxies.remove(del_id)
                 with suppress(KeyError, ValueError):
                     data[FAMILY_PROXIES][
                         data[key][del_id].first_parent


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-uiserver/issues/473

I'm not sure what circumstances can cause this, seems sensible to ignore `KeyError` i.e. the thing you were trying to remove wasn't there, @dwsutherland any thoughts?

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
