### PR TITLE
Cylc pause help fix

### DIFF
--- a/changes.d/5685.fix.md
+++ b/changes.d/5685.fix.md
@@ -1,0 +1,2 @@
+Fix "cylc pause" command help (it targets workflows, not tasks, but was
+printing task-matching documentation as well).

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -64,7 +64,7 @@ def get_option_parser() -> COP:
     parser = COP(
         __doc__,
         comms=True,
-        multitask=True,
+        multitask=False,
         multiworkflow=True,
         argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -20,7 +20,7 @@
 
 Pause a workflow.
 
-This suspends submission of tasks.
+This suspends submission of all tasks in a workflow.
 
 Examples:
   # pause my_flow
@@ -29,7 +29,8 @@ Examples:
   # resume my_flow
   $ cylc play my_flow
 
-Not to be confused with `cylc hold`.
+(Not to be confused with `cylc hold` which suspends submission of individual
+tasks within a workflow).
 """
 
 from functools import partial


### PR DESCRIPTION
`cylc pause` targets workflows, not tasks, but the command help is printing the task-matching documentation as well.

Small fix, not much point in tests for this.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why **tests are not needed**).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
