### PR TITLE
Fix command logging

### DIFF
--- a/changes.d/5693.fix.md
+++ b/changes.d/5693.fix.md
@@ -1,0 +1,1 @@
+Log command issuer, if not the workflow owner, for all commands.


### PR DESCRIPTION
Close #5691 

Log issuer name, if not owner, for all commands.

Question: this now logs `[command] <command-name>` for all commands, with or without `issuer != owner`. Arguably that is duplication (with the later "command actioned" message) but it is more consistent than before. Any objections?

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
