### PR TITLE
Flow-specific hold/release

### DIFF
--- a/changes.d/5698.feat.md
+++ b/changes.d/5698.feat.md
@@ -1,0 +1,1 @@
+Task hold and release can now be flow-specific.

--- a/changes.d/5698.feat.md
+++ b/changes.d/5698.feat.md
@@ -1,1 +1,1 @@
-Task hold and release can now be flow-specific.
+Flow-specific task hold and release.

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1012,10 +1012,7 @@ class DataStoreMgr:
             id=tp_id,
             task=t_id,
             cycle_point=point_string,
-            is_held=(
-                (name, point)
-                in self.schd.pool.tasks_to_hold
-            ),
+            is_held=self.schd.pool.hold_mgr.is_held(name, point),
             depth=task_def.depth,
             name=name,
         )

--- a/cylc/flow/flow_mgr.py
+++ b/cylc/flow/flow_mgr.py
@@ -38,7 +38,7 @@ def validate_flow_opt(val):
             int(val)
         except ValueError:
             raise InputError(f"--flow={val}: value must be integer.")
- 
+
 
 class FlowMgr:
     """Logic to manage flow counter and flow metadata."""

--- a/cylc/flow/flow_mgr.py
+++ b/cylc/flow/flow_mgr.py
@@ -20,6 +20,7 @@ from typing import Dict, Set, Optional
 import datetime
 
 from cylc.flow import LOG
+from cylc.flow.exceptions import InputError
 from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
 
 
@@ -29,6 +30,15 @@ FLOW_ALL = "all"
 FLOW_NEW = "new"
 FLOW_NONE = "none"
 
+
+def validate_flow_opt(val):
+    """Validate command line --flow opions."""
+    if val is not None:
+        try:
+            int(val)
+        except ValueError:
+            raise InputError(f"--flow={val}: value must be integer.")
+ 
 
 class FlowMgr:
     """Logic to manage flow counter and flow metadata."""

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2052,6 +2052,11 @@ class Release(Mutation, TaskMutation):
         ''')
         resolver = mutator
 
+    class Arguments(TaskMutation.Arguments):
+        flow_num = Int(
+            description='Number of flow to release.'
+        )
+
 
 class Kill(Mutation, TaskMutation):
     # TODO: This should be a job mutation?

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2035,6 +2035,11 @@ class Hold(Mutation, TaskMutation):
         ''')
         resolver = mutator
 
+    class Arguments(TaskMutation.Arguments):
+        flow_num = Int(
+            description='Number of flow to hold.'
+        )
+
 
 class Release(Mutation, TaskMutation):
     class Meta:

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1735,7 +1735,9 @@ class SetHoldPoint(Mutation):
             description='Hold all tasks after the specified cycle point.',
             required=True
         )
-
+        flow_num = Int(
+            description='Number of flow to hold.'
+        )
     result = GenericScalar()
 
 

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -319,6 +319,7 @@ class CylcWorkflowDAO:
         TABLE_TASKS_TO_HOLD: [
             ["name"],
             ["cycle"],
+            ["flow"],
         ],
     }
 
@@ -939,11 +940,11 @@ class CylcWorkflowDAO:
         stmt_args = [cycle, name, flow_nums]
         return list(self.connect().execute(stmt, stmt_args))
 
-    def select_tasks_to_hold(self) -> List[Tuple[str, str]]:
+    def select_tasks_to_hold(self) -> List[Tuple[str, str, str]]:
         """Return all tasks to hold stored in the DB."""
         stmt = rf'''
             SELECT
-                name, cycle
+                name, cycle, flow
             FROM
                 {self.TABLE_TASKS_TO_HOLD}
         '''  # nosec (table name is code constant)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1070,14 +1070,14 @@ class Scheduler:
         self.pause_workflow()
 
     @staticmethod
-    def command_set_verbosity(lvl: Union[int, str]) -> None:
+    def command_set_verbosity(level: Union[int, str]) -> None:
         """Set workflow verbosity."""
         try:
-            lvl = int(lvl)
-            LOG.setLevel(lvl)
+            level = int(level)
+            LOG.setLevel(level)
         except (TypeError, ValueError) as exc:
             raise CommandFailedError(exc)
-        cylc.flow.flags.verbosity = log_level_to_verbosity(lvl)
+        cylc.flow.flags.verbosity = log_level_to_verbosity(level)
 
     def command_remove_tasks(self, tasks) -> int:
         """Remove tasks."""

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1044,6 +1044,11 @@ class Scheduler:
                     self.data_store_mgr.delta_task_state(itask)
             return len(bad_items)
         self.task_job_mgr.kill_task_jobs(self.workflow, itasks)
+        # killed tasks get held
+        # TODO TAKE TASK HOLD OUT OF JOB MGR?
+        for itask in itasks:
+            if itask.state.is_held:
+                self.pool.hold_mgr.hold_active_task(itask, check=False)
         return len(bad_items)
 
     def command_hold(self, tasks: Iterable[str], flow_num=None) -> int:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1043,12 +1043,10 @@ class Scheduler:
                     itask.state_reset(TASK_STATUS_FAILED)
                     self.data_store_mgr.delta_task_state(itask)
             return len(bad_items)
-        self.task_job_mgr.kill_task_jobs(self.workflow, itasks)
-        # killed tasks get held
-        # TODO TAKE TASK HOLD OUT OF JOB MGR?
-        for itask in itasks:
-            if itask.state.is_held:
-                self.pool.hold_mgr.hold_active_task(itask, check=False)
+        to_kill = self.task_job_mgr.kill_task_jobs(self.workflow, itasks)
+        # Hold killed tasks to prevent automatic retry.
+        for itask in to_kill:
+            self.pool.hold_mgr.hold_active_task(itask)
         return len(bad_items)
 
     def command_hold(self, tasks: Iterable[str], flow_num=None) -> int:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1012,9 +1012,9 @@ class Scheduler:
         self.stop_mode = stop_mode
         self.update_data_store()
 
-    def command_release(self, tasks: Iterable[str]) -> int:
+    def command_release(self, tasks: Iterable[str], flow_num=None) -> int:
         """Release held tasks."""
-        return self.pool.release_held_tasks(tasks)
+        return self.pool.release_held_tasks(tasks, flow_num)
 
     def command_release_hold_point(self) -> None:
         """Release all held tasks and unset workflow hold after cycle point,

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -905,7 +905,7 @@ class Scheduler:
     def queue_command(self, command: str, kwargs: dict) -> None:
         self.command_queue.put((
             command,
-            [],
+            (),
             kwargs,
         ))
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -532,7 +532,7 @@ class Scheduler:
         elif self.config.cfg['scheduling']['hold after cycle point']:
             holdcp = self.config.cfg['scheduling']['hold after cycle point']
         if holdcp is not None:
-            self.command_set_hold_point(holdcp, self.options.holdcp_flow)
+            self.command_set_hold_point(holdcp)
 
         if self.options.paused_start:
             self.pause_workflow('Paused on start up')

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -74,13 +74,13 @@ if TYPE_CHECKING:
 HOLD_MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!,
-  $tasks: [NamespaceIDGlob]!
-  $flowNum: Int,
+  $tasks: [NamespaceIDGlob]!,
+  $flowNum: Int
 ) {
   hold (
     workflows: $wFlows,
     tasks: $tasks,
-    flowNum: $flowNum,
+    flowNum: $flowNum
   ) {
     result
   }

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -59,6 +59,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import InputError
+from cylc.flow.flow_mgr import validate_flow_opt
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.option_parsers import (
     FULL_ID_MULTI_ARG_DOC,
@@ -66,6 +67,7 @@ from cylc.flow.option_parsers import (
 )
 from cylc.flow.terminal import cli_function
 from cylc.flow.network.multi import call_multi
+
 
 if TYPE_CHECKING:
     from optparse import Values
@@ -135,6 +137,8 @@ def _validate(options: 'Values', *task_globs: str) -> None:
     elif not task_globs:
         raise InputError(
             "Must define Cycles/Tasks. See `cylc hold --help`.")
+
+    validate_flow_opt(options.flow_num)
 
 
 async def run(options, workflow_id, *tokens_list):

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -75,10 +75,12 @@ HOLD_MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!,
   $tasks: [NamespaceIDGlob]!
+  $flowNum: Int,
 ) {
   hold (
     workflows: $wFlows,
-    tasks: $tasks
+    tasks: $tasks,
+    flowNum: $flowNum,
   ) {
     result
   }
@@ -114,6 +116,11 @@ def get_option_parser() -> COP:
         help="Hold all tasks after this cycle point.",
         metavar="CYCLE_POINT", action="store", dest="hold_point_string")
 
+    parser.add_option(
+        "--flow",
+        help="Hold tasks that belong to a specific flow.",
+        metavar="INT", action="store", dest="flow_num")
+
     return parser
 
 
@@ -144,7 +151,8 @@ async def run(options, workflow_id, *tokens_list):
             'tasks': [
                 id_.relative_id_with_selectors
                 for id_ in tokens_list
-            ]
+            ],
+            'flowNum': options.flow_num
         }
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -92,11 +92,13 @@ mutation (
 SET_HOLD_POINT_MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!,
-  $point: CyclePoint!
+  $point: CyclePoint!,
+  $flowNum: Int
 ) {
   setHoldPoint (
     workflows: $wFlows,
-    point: $point
+    point: $point,
+    flowNum: $flowNum
   ) {
     result
   }
@@ -132,8 +134,8 @@ def _validate(options: 'Values', *task_globs: str) -> None:
         if task_globs:
             raise InputError(
                 "Cannot combine --after with Cylc/Task IDs.\n"
-                "`cylc hold --after` holds all tasks after the given "
-                "cycle point.")
+                "`cylc hold --after` holds ALL tasks after the given "
+                "cycle point. Can be used with `--flow`.")
     elif not task_globs:
         raise InputError(
             "Must define Cycles/Tasks. See `cylc hold --help`.")
@@ -148,7 +150,10 @@ async def run(options, workflow_id, *tokens_list):
 
     if options.hold_point_string:
         mutation = SET_HOLD_POINT_MUTATION
-        args = {'point': options.hold_point_string}
+        args = {
+            'point': options.hold_point_string,
+            'flowNum': options.flow_num
+        }
     else:
         mutation = HOLD_MUTATION
         args = {

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -57,11 +57,13 @@ if TYPE_CHECKING:
 RELEASE_MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!,
-  $tasks: [NamespaceIDGlob]!
+  $tasks: [NamespaceIDGlob]!,
+  $flowNum: Int
 ) {
   release (
     workflows: $wFlows,
     tasks: $tasks,
+    flowNum: $flowNum
   ) {
     result
   }
@@ -97,6 +99,11 @@ def get_option_parser() -> COP:
             "if set."),
         action="store_true", dest="release_all")
 
+    parser.add_option(
+        "--flow",
+        help="Release tasks that belong to a specific flow.",
+        metavar="INT", action="store", dest="flow_num")
+
     return parser
 
 
@@ -126,7 +133,8 @@ async def run(options: 'Values', workflow_id, *tokens_list):
             'tasks': [
                 tokens.relative_id_with_selectors
                 for tokens in tokens_list
-            ]
+            ],
+            'flowNum': options.flow_num
         }
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -42,6 +42,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 from cylc.flow.exceptions import InputError
+from cylc.flow.flow_mgr import validate_flow_opt
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import (
@@ -118,6 +119,8 @@ def _validate(options: 'Values', *tokens_list: str) -> None:
                 "Must define Cycles/Tasks. See `cylc release --help`."
             )
 
+    validate_flow_opt(options.flow_num)
+ 
 
 async def run(options: 'Values', workflow_id, *tokens_list):
     _validate(options, *tokens_list)

--- a/cylc/flow/scripts/release.py
+++ b/cylc/flow/scripts/release.py
@@ -120,7 +120,7 @@ def _validate(options: 'Values', *tokens_list: str) -> None:
             )
 
     validate_flow_opt(options.flow_num)
- 
+
 
 async def run(options: 'Values', workflow_id, *tokens_list):
     _validate(options, *tokens_list)

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -92,7 +92,7 @@ def get_option_parser() -> COP:
         action="append", default=None, dest="outputs")
 
     parser.add_option(
-        "-f", "--flow", metavar="FLOW",
+        "-f", "--flow", metavar="INT",
         help="Number of the flow to attribute the outputs.",
         action="store", default=None, dest="flow_num")
 

--- a/cylc/flow/scripts/set_outputs.py
+++ b/cylc/flow/scripts/set_outputs.py
@@ -50,6 +50,7 @@ Use --output multiple times to spawn off of several outputs at once.
 from functools import partial
 from optparse import Values
 
+from cylc.flow.flow_mgr import validate_flow_opt
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import (
@@ -57,6 +58,7 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
 )
 from cylc.flow.terminal import cli_function
+
 
 MUTATION = '''
 mutation (
@@ -99,7 +101,14 @@ def get_option_parser() -> COP:
     return parser
 
 
+def _validate(options: 'Values', *task_globs: str) -> None:
+    """Check combination of options and task globs is valid."""
+    validate_flow_opt(options.flow_num)
+
+
 async def run(options: 'Values', workflow_id: str, *tokens_list) -> None:
+
+    _validate(options, *tokens_list)
     pclient = get_client(workflow_id, timeout=options.comms_timeout)
 
     mutation_kwargs = {

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -100,7 +100,8 @@ def get_option_parser() -> COP:
         "--flow", action="append", dest="flow", metavar="FLOW",
         help=f"Assign the triggered task to all active flows ({FLOW_ALL});"
              f" no flow ({FLOW_NONE}); a new flow ({FLOW_NEW});"
-             f" or a specific flow (e.g. 2). The default is {FLOW_ALL}."
+             " or a specific integer flow (e.g. 2). The default is"
+             f" {FLOW_ALL}."
              " Reuse the option to assign multiple specific flows."
     )
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -176,7 +176,7 @@ class TaskJobManager:
             self.poll_task_jobs(workflow, poll_tasks)
 
     def kill_task_jobs(self, workflow, itasks):
-        """Kill jobs of active tasks, and hold the tasks.
+        """Kill jobs of active tasks.
 
         If items is specified, kill active tasks matching given IDs.
 
@@ -184,8 +184,6 @@ class TaskJobManager:
         to_kill_tasks = []
         for itask in itasks:
             if itask.state(*TASK_STATUSES_ACTIVE):
-                itask.state_reset(is_held=True)
-                self.data_store_mgr.delta_task_held(itask)
                 to_kill_tasks.append(itask)
             else:
                 LOG.warning(f"[{itask}] not killable")
@@ -194,6 +192,7 @@ class TaskJobManager:
             self._kill_task_jobs_callback,
             self._kill_task_jobs_callback_255
         )
+        return to_kill_tasks
 
     def poll_task_jobs(self, workflow, itasks, msg=None):
         """Poll jobs of specified tasks.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -177,7 +177,7 @@ class TaskHoldMgr:
             flow_num is None
             or flow_num == self.hold[(name, point)]
         ):
-            self.hold[(name, point)]
+            del self.hold[(name, point)]
 
         self._update_stores((name, point, True))
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1191,7 +1191,7 @@ class TaskPool:
                 self.hold_active_task(itask)
         self.workflow_db_mgr.put_workflow_hold_cycle_point(point)
 
-    def hold_tasks(self, items: Iterable[str]) -> int:
+    def hold_tasks(self, items: Iterable[str], flow_num=None) -> int:
         """Hold tasks with IDs matching the specified items."""
         # Hold active tasks:
         itasks, future_tasks, unmatched = self.filter_task_proxies(
@@ -1200,6 +1200,8 @@ class TaskPool:
             future=True,
         )
         for itask in itasks:
+            if flow_num is not None and flow_num not in itask.flow_nums:
+                continue
             self.hold_active_task(itask)
         # Set future tasks to be held:
         for name, cycle in future_tasks:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -134,15 +134,19 @@ class TaskHoldMgr:
             self.hold[(name, get_point(cycle))] = flow_num
 
     def hold_active_task(
-        self, itask: TaskProxy, flow_num: Optional[int] = None
+        self,
+        itask: TaskProxy,
+        flow_num: Optional[int] = None,
+        check: bool = True
     ) -> bool:
         """Hold itask if the specified flow_num matches or is None."""
-        if flow_num is not None and flow_num not in itask.flow_nums:
-            # specified flow does not match this task
-            return False
-        if not itask.state_reset(is_held=True):
-            # this task is already held
-            return False
+        if check:
+            if flow_num is not None and flow_num not in itask.flow_nums:
+                # specified flow does not match this task
+                return False
+            if not itask.state_reset(is_held=True):
+                # this task is already held
+                return False
 
         self.hold[(itask.tdef.name, itask.point)] = flow_num
         self._update_stores(itask)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -173,11 +173,12 @@ class TaskHoldMgr:
             return
         if (
             flow_num is None
+            or self.hold[(name, point)] is None
             or flow_num == self.hold[(name, point)]
         ):
             del self.hold[(name, point)]
 
-        self._update_stores((name, point, True))
+        self._update_stores((name, point, False))
 
     def release_active_task(
         self, itask: TaskProxy, queue_func: Callable, flow_num=None,

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -519,7 +519,7 @@ class WorkflowDatabaseManager:
                 itask.state.time_updated = None
 
     def put_tasks_to_hold(
-        self, tasks: Set[Tuple[str, 'PointBase']]
+        self, tasks: Set[Tuple[str, 'PointBase', Optional[int]]]
     ) -> None:
         """Replace the tasks in the tasks_to_hold table."""
         # There isn't that much cost in calling this multiple times between
@@ -528,8 +528,8 @@ class WorkflowDatabaseManager:
         # whole table each time the queue is processed is a bit inefficient.
         self.db_deletes_map[self.TABLE_TASKS_TO_HOLD] = [{}]
         self.db_inserts_map[self.TABLE_TASKS_TO_HOLD] = [
-            {"name": name, "cycle": str(point)}
-            for name, point in tasks
+            {"name": name, "cycle": str(point), "flow": flow_num}
+            for name, point, flow_num in tasks
         ]
 
     def put_insert_task_events(self, itask, args):

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -77,6 +77,7 @@ class WorkflowDatabaseManager:
     KEY_UTC_MODE = 'UTC_mode'
     KEY_PAUSED = 'is_paused'
     KEY_HOLD_CYCLE_POINT = 'holdcp'
+    KEY_HOLD_CYCLE_POINT_FLOW = 'holdcp_flow'
     KEY_RUN_MODE = 'run_mode'
     KEY_STOP_CLOCK_TIME = 'stop_clock_time'
     KEY_STOP_TASK = 'stop_task'
@@ -352,12 +353,17 @@ class WorkflowDatabaseManager:
         self.put_workflow_params_1(self.KEY_PAUSED, int(value))
 
     def put_workflow_hold_cycle_point(
-        self, value: Optional['PointBase']
+        self,
+        value: Optional['PointBase'],
+        flow_num: Optional[int] = None
     ) -> None:
         """Put workflow hold cycle point to workflow_params table."""
         self.put_workflow_params_1(
             self.KEY_HOLD_CYCLE_POINT,
             str(value) if value is not None else None
+        )
+        self.put_workflow_params_1(
+            self.KEY_HOLD_CYCLE_POINT_FLOW, flow_num
         )
 
     def put_workflow_stop_clock_time(self, value: Optional[str]) -> None:

--- a/tests/flakyfunctional/database/00-simple/schema.out
+++ b/tests/flakyfunctional/database/00-simple/schema.out
@@ -12,7 +12,7 @@ CREATE TABLE task_pool(cycle TEXT, name TEXT, flow_nums TEXT, status TEXT, is_he
 CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_name TEXT, prereq_cycle TEXT, prereq_output TEXT, satisfied TEXT, PRIMARY KEY(cycle, name, flow_nums, prereq_name, prereq_cycle, prereq_output));
 CREATE TABLE task_states(name TEXT, cycle TEXT, flow_nums TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, flow_wait INTEGER, is_manual_submit INTEGER, PRIMARY KEY(name, cycle, flow_nums));
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));
-CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT);
+CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT, flow TEXT);
 CREATE TABLE workflow_flows(flow_num INTEGER, start_time TEXT, description TEXT, PRIMARY KEY(flow_num));
 CREATE TABLE xtriggers(signature TEXT, results TEXT, PRIMARY KEY(signature));
 CREATE TABLE absolute_outputs(cycle TEXT, name TEXT, output TEXT);

--- a/tests/functional/database/08-broadcast-upgrade/db.sqlite3
+++ b/tests/functional/database/08-broadcast-upgrade/db.sqlite3
@@ -20,7 +20,7 @@ CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_na
 CREATE TABLE task_states(name TEXT, cycle TEXT, flow_nums TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, flow_wait INTEGER, is_manual_submit INTEGER, PRIMARY KEY(name, cycle, flow_nums));
 INSERT INTO task_states VALUES('foo','1','[1]','2022-11-11T11:17:54Z','2022-11-11T11:17:54Z',0,'waiting',0,0);
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));
-CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT);
+CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT, flow TEXT);
 CREATE TABLE workflow_flows(flow_num INTEGER, start_time TEXT, description TEXT, PRIMARY KEY(flow_num));
 INSERT INTO workflow_flows VALUES(1,'2022-11-11 11:17:54','original flow from 1');
 CREATE TABLE workflow_params(key TEXT, value TEXT, PRIMARY KEY(key));

--- a/tests/functional/restart/57-ghost-job/db.sqlite3
+++ b/tests/functional/restart/57-ghost-job/db.sqlite3
@@ -22,7 +22,7 @@ CREATE TABLE task_prerequisites(cycle TEXT, name TEXT, flow_nums TEXT, prereq_na
 CREATE TABLE task_states(name TEXT, cycle TEXT, flow_nums TEXT, time_created TEXT, time_updated TEXT, submit_num INTEGER, status TEXT, flow_wait INTEGER, is_manual_submit INTEGER, PRIMARY KEY(name, cycle, flow_nums));
 INSERT INTO task_states VALUES('foo','1','[1]','2022-07-25T16:18:23+01:00','2022-07-25T16:18:23+01:00',1,'preparing',NULL, '0');
 CREATE TABLE task_timeout_timers(cycle TEXT, name TEXT, timeout REAL, PRIMARY KEY(cycle, name));
-CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT);
+CREATE TABLE tasks_to_hold(name TEXT, cycle TEXT, flow TEXT);
 CREATE TABLE workflow_flows(flow_num INTEGER, start_time TEXT, description TEXT, PRIMARY KEY(flow_num));
 INSERT INTO workflow_flows VALUES(1,'2022-07-25 16:18:23','original flow from 1');
 CREATE TABLE workflow_params(key TEXT, value TEXT, PRIMARY KEY(key));

--- a/tests/unit/scripts/test_hold.py
+++ b/tests/unit/scripts/test_hold.py
@@ -32,6 +32,13 @@ Opts = Options(get_option_parser())
     'opts, task_globs, expected_err',
     [
         (Opts(), ['*'], None),
+        (Opts(flow_num=None), ['*'], None),
+        (Opts(flow_num=2), ['*'], None),
+        (
+            Opts(flow_num='cat'),
+            ['*'],
+            (InputError, "--flow=cat: value must be integer")
+        ),
         (Opts(hold_point_string='2'), [], None),
         (
             Opts(hold_point_string='2'),

--- a/tests/unit/scripts/test_release.py
+++ b/tests/unit/scripts/test_release.py
@@ -33,6 +33,13 @@ Opts = Options(get_option_parser())
     [
         (Opts(), ['*'], None),
         (Opts(release_all=True), [], None),
+        (Opts(flow_num=None), ['*'], None),
+        (Opts(flow_num=2), ['*'], None),
+        (
+            Opts(flow_num='cat'),
+            ['*'],
+            (InputError, "--flow=cat: value must be integer")
+        ),
         (
             Opts(release_all=True),
             ['*'],


### PR DESCRIPTION
Close #4277 

Hold/release tasks in a specific flow (or any flow, by default)

- [x] Implement `cylc hold --flow=n`
- [x] Same for `cylc release --flow=n`

If `--flow` is not used, matching tasks will be held or released regardless of flow number.
  - (most of the time there will only be one flow)

If `--flow=n` is specified, matching tasks will be held or released if their flow numbers include `n`
  - (if a merged task `foo` has flow numbers `{2,3}` it belongs to flow `2` (and `3`), so if I ask to hold `foo` in flow `2` (or `3`) it should be held. Ditto for release).

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/646
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch. (not a bug fix)
