### PR TITLE
Fix upgrader for max active cylc points to runahead limit.

### DIFF
--- a/changes.d/5704.fix.md
+++ b/changes.d/5704.fix.md
@@ -1,0 +1,2 @@
+Fix bug where runahead limit was set to max active cycle points by
+the configuration converter.

--- a/changes.d/5704.fix.md
+++ b/changes.d/5704.fix.md
@@ -1,2 +1,1 @@
-Fix bug where runahead limit was set to max active cycle points by
-the configuration converter.
+Fix off-by-one error in automatic upgrade of Cylc 7 "max active cycle points" to Cylc 8 "runahead limit".

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1846,7 +1846,10 @@ def upg(cfg, descr):
         '8.0.0',
         ['scheduling', 'max active cycle points'],
         ['scheduling', 'runahead limit'],
-        cvtr=converter(lambda x: f'P{x}' if x != '' else '', '"n" -> "Pn"'),
+        cvtr=converter(
+            lambda x: f'P{int(x)-1}' if x != '' else '',
+            '"{old}" -> "{new}"'
+        ),
         silent=cylc.flow.flags.cylc7_back_compat,
     )
     u.deprecate(

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -212,7 +212,10 @@ class upgrader:
                         if upg['new']:
                             msg += ' -> ' + self.show_keys(upg['new'],
                                                            upg['is_section'])
-                        msg += " - " + upg['cvt'].describe()
+                        msg += " - " + upg['cvt'].describe().format(
+                            old=old,
+                            new=upg['cvt'].convert(old)
+                        )
                         if not upg['silent']:
                             warnings.setdefault(vn, [])
                             warnings[vn].append(msg)

--- a/tests/functional/deprecations/01-cylc8-basic/validation.stderr
+++ b/tests/functional/deprecations/01-cylc8-basic/validation.stderr
@@ -22,7 +22,7 @@ WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail to -> [runtime][foo, c
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail from -> [runtime][foo, cat, dog][mail]from - value unchanged
 WARNING -  * (8.0.0) [cylc][events]mail smtp - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][events]mail smtp - DELETED (OBSOLETE) - use "global.cylc[scheduler][mail]smtp" instead
-WARNING -  * (8.0.0) [scheduling]max active cycle points -> [scheduling]runahead limit - "n" -> "Pn"
+WARNING -  * (8.0.0) [scheduling]max active cycle points -> [scheduling]runahead limit - "2" -> "P1"
 WARNING -  * (8.0.0) [scheduling]hold after point -> [scheduling]hold after cycle point - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][suite state polling] -> [runtime][foo, cat, dog][workflow state polling] - value unchanged
 WARNING -  * (8.0.0) [runtime][foo, cat, dog][job]execution polling intervals -> [runtime][foo, cat, dog]execution polling intervals - value unchanged

--- a/tests/unit/cfgspec/test_workflow.py
+++ b/tests/unit/cfgspec/test_workflow.py
@@ -19,7 +19,7 @@ import pytest
 from typing import Any, Dict, Optional
 
 from cylc.flow import CYLC_LOG
-from cylc.flow.cfgspec.workflow import warn_about_depr_platform, upg
+from cylc.flow.cfgspec.workflow import warn_about_depr_platform
 from cylc.flow.exceptions import PlatformLookupError
 
 
@@ -87,9 +87,3 @@ def test_warn_about_depr_platform(
             assert expected_warning in caplog.text
         else:
             assert caplog.record_tuples == []
-
-
-def test_max_active_cycle_point_converter(caplog):
-    cfg = {'scheduling': {'max active cycle points': 5}}
-    upg(cfg, 'standalone run of upgrader.')
-    assert cfg['scheduling']['runahead limit'] == 'P4'

--- a/tests/unit/cfgspec/test_workflow.py
+++ b/tests/unit/cfgspec/test_workflow.py
@@ -19,7 +19,7 @@ import pytest
 from typing import Any, Dict, Optional
 
 from cylc.flow import CYLC_LOG
-from cylc.flow.cfgspec.workflow import warn_about_depr_platform
+from cylc.flow.cfgspec.workflow import warn_about_depr_platform, upg
 from cylc.flow.exceptions import PlatformLookupError
 
 
@@ -87,3 +87,9 @@ def test_warn_about_depr_platform(
             assert expected_warning in caplog.text
         else:
             assert caplog.record_tuples == []
+
+
+def test_max_active_cycle_point_converter(caplog):
+    cfg = {'scheduling': {'max active cycle points': 5}}
+    upg(cfg, 'standalone run of upgrader.')
+    assert cfg['scheduling']['runahead limit'] == 'P4'

--- a/tests/unit/parsec/test_upgrade.py
+++ b/tests/unit/parsec/test_upgrade.py
@@ -275,3 +275,17 @@ class TestUpgrade(unittest.TestCase):
         expanded = self.u.expand(upg)
         self.assertEqual(1, len(expanded))
         self.assertTrue(expanded[0]['new'] is None)
+
+
+def test_template_in_converter_description(caplog, capsys):
+    """Before and after values are available to the conversion descriptor"""
+    cfg = {'old': 42}
+    u = upgrader(cfg, 'Whateva')
+    u.deprecate(
+        '2.0.0', ['old'], ['new'],
+        cvtr=converter(lambda x: x + 20, '{old} -> {new}'),
+        silent=False,
+    )
+    u.upgrade()
+    assert cfg == {'new': 62}
+    assert '42 -> 62' in caplog.records[1].message

--- a/tests/unit/test_config_upgrader.py
+++ b/tests/unit/test_config_upgrader.py
@@ -108,7 +108,7 @@ def test_upgrade_param_env_templates(cfg, expected):
 
 @pytest.mark.parametrize(
     'macp, rlim',
-    [(16, 'P16'),
+    [(16, 'P15'),
      ('', '')]
 )
 def test_upgrade_max_active_cycle_points(macp, rlim):


### PR DESCRIPTION
Closes a bug noted locally by a customer.

Previously the converted was `x -> 'P{x}'`, but the runahead limit should be `'P{x-1}'`.

Additional feature - allow the converter description to include the templates for old and new values.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~Cylc doc update~ is not required.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
