### PR TITLE
Fix initial runahead limit, for offset recurrence start

### DIFF
--- a/changes.d/5708.fix.md
+++ b/changes.d/5708.fix.md
@@ -1,0 +1,1 @@
+Fix runahead limit at start-up, with recurrences that start beyond the limit.

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -320,8 +320,8 @@ class SequenceBase(metaclass=ABCMeta):
     They should also provide get_async_expr, get_interval,
     get_offset & set_offset (deprecated), is_on_sequence,
     get_nearest_prev_point, get_next_point,
-    get_next_point_on_sequence, get_first_point, and
-    get_stop_point.
+    get_next_point_on_sequence, get_first_point
+    get_start_point, and get_stop_point.
 
     They should also provide a self.__eq__ implementation
     which should return whether a SequenceBase-derived object
@@ -406,9 +406,30 @@ class SequenceBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_stop_point(self):
-        """Return the last point in this sequence, or None if unbounded."""
+    def get_start_point(self):
+        """Return the first point of this sequence."""
         pass
+
+    @abstractmethod
+    def get_stop_point(self):
+        """Return the last point of this sequence, or None if unbounded."""
+        pass
+
+    def get_first_n_points(self, n, point=None):
+        """Return a list of first n points of this sequence."""
+        if point is None:
+            p1 = self.get_start_point()
+        else:
+            p1 = self.get_first_point(point)
+        if p1 is None:
+            return []
+        result = [p1]
+        for _ in range(1, n):
+            p1 = self.get_next_point_on_sequence(p1)
+            if p1 is None:
+                break
+            result.append(p1)
+        return result
 
     @abstractmethod
     def __eq__(self, other) -> bool:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -314,7 +314,7 @@ class TaskPool:
         count_cycles = False
         with suppress(TypeError):
             # Count cycles (integer cycling, and optional for datetime too).
-            climit = int(limit)  # type: ignore
+            ilimit = int(limit)  # type: ignore
             count_cycles = True
 
         base_point: 'PointBase'
@@ -323,21 +323,19 @@ class TaskPool:
         if not self.main_pool:
             # No tasks yet, just consider sequence points.
             if count_cycles:
-                # Get the first climit points in each sequence.
+                # Get the first ilimit points in each sequence.
                 # (After workflow start point - sequence may begin earlier).
                 points = [
                     point
                     for plist in [
                         seq.get_first_n_points(
-                            climit, self.config.start_point)
+                            ilimit, self.config.start_point)
                         for seq in self.config.sequences
                     ]
                     for point in plist
                 ]
                 # Drop points beyond the limit.
-                if not points:
-                    return False
-                points = sorted(points)[:climit + 1]
+                points = sorted(points)[:ilimit + 1]
                 base_point = min(points)
 
             else:
@@ -351,8 +349,6 @@ class TaskPool:
                     }
                     if point is not None
                 ]
-                if not points:
-                    return False
                 base_point = min(points)
                 # Drop points beyond the limit.
                 points = [
@@ -422,7 +418,7 @@ class TaskPool:
                 while seq_point is not None:
                     if count_cycles:
                         # P0 allows only the base cycle point to run.
-                        if count > 1 + climit:
+                        if count > 1 + ilimit:
                             break
                     else:
                         # PT0H allows only the base cycle point to run.
@@ -438,7 +434,7 @@ class TaskPool:
 
         if count_cycles:
             # Some sequences may have different intervals.
-            limit_point = sorted(points)[:(climit + 1)][-1]
+            limit_point = sorted(points)[:(ilimit + 1)][-1]
         else:
             # We already stopped at the runahead limit.
             limit_point = sorted(points)[-1]

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -309,18 +309,58 @@ class TaskPool:
         With force=True we recompute the limit even if the base point has not
         changed (needed if max_future_offset changed, or on reload).
         """
+
+        limit = self.config.runahead_limit  # e.g. P2 or P2D
+        count_cycles = False
+        with suppress(TypeError):
+            # Count cycles (integer cycling, and optional for datetime too).
+            climit = int(limit)  # type: ignore
+            count_cycles = True
+
+        base_point: 'PointBase'
         points: List['PointBase'] = []
-        sequence_points: Set['PointBase']
+
         if not self.main_pool:
-            # Start at first point in each sequence, after the initial point.
-            points = [
-                point
-                for point in {
-                    seq.get_first_point(self.config.start_point)
-                    for seq in self.config.sequences
-                }
-                if point is not None
-            ]
+            # No tasks yet, just consider sequence points.
+            if count_cycles:
+                # Get the first climit points in each sequence.
+                # (After workflow start point - sequence may begin earlier).
+                points = [
+                    point
+                    for plist in [
+                        seq.get_first_n_points(
+                            climit, self.config.start_point)
+                        for seq in self.config.sequences
+                    ]
+                    for point in plist
+                ]
+                # Drop points beyond the limit.
+                if not points:
+                    return False
+                points = sorted(points)[:climit + 1]
+                base_point = min(points)
+
+            else:
+                # Start at first point in each sequence.
+                # (After workflow start point - sequence may begin earlier).
+                points = [
+                    point
+                    for point in {
+                        seq.get_first_point(self.config.start_point)
+                        for seq in self.config.sequences
+                    }
+                    if point is not None
+                ]
+                if not points:
+                    return False
+                base_point = min(points)
+                # Drop points beyond the limit.
+                points = [
+                    point
+                    for point in points
+                    if point <= base_point + limit
+                ]
+
         else:
             # Find the earliest point with unfinished tasks.
             for point, itasks in sorted(self.get_tasks_by_point().items()):
@@ -344,9 +384,10 @@ class TaskPool:
                     )
                 ):
                     points.append(point)
-        if not points:
-            return False
-        base_point = min(points)
+
+            if not points:
+                return False
+            base_point = min(points)
 
         if self._prev_runahead_base_point is None:
             self._prev_runahead_base_point = base_point
@@ -363,15 +404,8 @@ class TaskPool:
             # change or the runahead limit is already at stop point.
             return False
 
-        try:
-            limit = int(self.config.runahead_limit)  # type: ignore
-        except TypeError:
-            count_cycles = False
-            limit = self.config.runahead_limit
-        else:
-            count_cycles = True
-
-        # Get all cycle points possible after the runahead base point.
+        # Get all cycle points possible after the base point.
+        sequence_points: Set['PointBase']
         if (
             not force
             and self._prev_runahead_sequence_points
@@ -388,7 +422,7 @@ class TaskPool:
                 while seq_point is not None:
                     if count_cycles:
                         # P0 allows only the base cycle point to run.
-                        if count > 1 + limit:
+                        if count > 1 + climit:
                             break
                     else:
                         # PT0H allows only the base cycle point to run.
@@ -404,7 +438,7 @@ class TaskPool:
 
         if count_cycles:
             # Some sequences may have different intervals.
-            limit_point = sorted(points)[:(limit + 1)][-1]
+            limit_point = sorted(points)[:(climit + 1)][-1]
         else:
             # We already stopped at the runahead limit.
             limit_point = sorted(points)[-1]

--- a/tests/unit/cycling/test_cycling.py
+++ b/tests/unit/cycling/test_cycling.py
@@ -23,6 +23,21 @@ from cylc.flow.cycling import (
     parse_exclusion,
 )
 
+from cylc.flow.cycling.integer import (
+    IntegerPoint,
+    IntegerSequence,
+)
+
+from cylc.flow.cycling.iso8601 import (
+    ISO8601Point,
+    ISO8601Sequence,
+)
+
+from cylc.flow.cycling.loader import (
+    INTEGER_CYCLING_TYPE,
+    ISO8601_CYCLING_TYPE,
+)
+
 
 def test_simple_abstract_class_test():
     """Cannot instantiate abstract classes, they must be defined in
@@ -73,3 +88,86 @@ def test_parse_bad_exclusion(expression):
     """Tests incorrectly formatted exclusions"""
     with pytest.raises(Exception):
         parse_exclusion(expression)
+
+
+@pytest.mark.parametrize(
+    'sequence, wf_start_point, expected',
+    (
+        (
+            ('R/2/P2', 1),
+            None,
+            [2,4,6,8,10]
+        ),
+        (
+            ('R/2/P2', 1),
+            3,
+            [4,6,8,10,12]
+        ),
+    ),
+)
+def test_get_first_n_points_integer(
+    set_cycling_type,
+    sequence, wf_start_point, expected
+):
+    """Test sequence get_first_n_points method.
+
+    (The method is implemented in the base class).
+    """
+    set_cycling_type(INTEGER_CYCLING_TYPE)
+    sequence = IntegerSequence(*sequence)
+    if wf_start_point is not None:
+        wf_start_point = IntegerPoint(wf_start_point)
+    expected = [
+        IntegerPoint(p)
+        for p in expected
+    ]
+    assert (
+        expected == (
+            sequence.get_first_n_points(
+                len(expected),
+                wf_start_point
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    'sequence, wf_start_point, expected',
+    (
+        (
+            ('R/2008/P2Y', '2001'),
+            None,
+            ['2008', '2010', '2012', '2014', '2016']
+        ),
+        (
+            ('R/2008/P2Y', '2001'),
+            '2009',
+            ['2010', '2012', '2014', '2016', '2018']
+        ),
+    ),
+)
+def test_get_first_n_points_iso8601(
+    set_cycling_type,
+    sequence, wf_start_point, expected
+):
+    """Test sequence get_first_n_points method.
+
+    (The method is implemented in the base class).
+    """
+    set_cycling_type(ISO8601_CYCLING_TYPE, 'Z')
+    sequence = ISO8601Sequence(*sequence)
+    if wf_start_point is not None:
+        wf_start_point = ISO8601Point(wf_start_point)
+    expected = [
+        ISO8601Point(p)
+        for p in expected
+    ]
+
+    assert (
+        expected == (
+            sequence.get_first_n_points(
+                len(expected),
+                wf_start_point
+            )
+        )
+    )


### PR DESCRIPTION
Close #5705 

When computing the runahead limit at start-up (before the task pool is loaded), recurrence start points beyond the limit have to be ignored. 

Getting this right for "max cycles" limits (e.g. `P3` in integer or datetime cycling, as opposed to `PT3H` in datetime cycling) requires counting sequence points for all sequences.

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
