### PR TITLE
Forward arbitrary environment variables over SSH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ requests_).
  - Prasanna Challuri
  - David Matthews
  - Tim Whitcomb
- - (Scott Wales)
+ - Scott Wales
  - Tomek Trzeciak
  - Thomas Coleman
  - Bruno Kinoshita

--- a/changes.d/5709.feat.md
+++ b/changes.d/5709.feat.md
@@ -1,0 +1,1 @@
+Forward arbitrary environment variables over SSH connections

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1416,6 +1416,13 @@ with Conf('global.cylc', desc='''
                    {REPLACES}``global.rc[hosts][<host>]copyable
                    environment variables``.
             ''')
+            Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
+                 desc=f'''
+                A list containing the names of the environment variables to
+                forward with SSH connections to the server and run hosts
+
+                .. versionchanged:: 8.3.0
+            ''')
             Conf('retrieve job logs', VDR.V_BOOLEAN,
                  desc=f'''
                 {LOG_RETR_SETTINGS['retrieve job logs']}

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -790,7 +790,7 @@ with Conf('global.cylc', desc='''
                 forward with SSH connections to the workflow host from
                 the host running 'cylc play'
 
-                .. versionchanged:: 8.3.0
+                .. versionadded:: 8.3.0
             ''')
 
         with Conf('host self-identification', desc=f'''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -787,7 +787,7 @@ with Conf('global.cylc', desc='''
             Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
                  desc='''
                 A list containing the names of the environment variables to
-                forward with SSH connections to the run and job hosts from
+                forward with SSH connections to the workflow host from
                 the host running 'cylc play'
 
                 .. versionchanged:: 8.3.0

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1417,7 +1417,7 @@ with Conf('global.cylc', desc='''
                    environment variables``.
             ''')
             Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
-                 desc=f'''
+                 desc='''
                 A list containing the names of the environment variables to
                 forward with SSH connections to the server and run hosts
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -784,14 +784,6 @@ with Conf('global.cylc', desc='''
 
                    {REPLACES}``[suite servers][run host select]rank``.
             ''')
-            Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
-                 desc='''
-                A list containing the names of the environment variables to
-                forward with SSH connections to the workflow host from
-                the host running 'cylc play'
-
-                .. versionadded:: 8.3.0
-            ''')
 
         with Conf('host self-identification', desc=f'''
             How Cylc determines and shares the identity of the workflow host.
@@ -1639,6 +1631,14 @@ with Conf('global.cylc', desc='''
                 of job submissions which can be batched together.
 
                 .. versionadded:: 8.0.0
+            ''')
+            Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
+                 desc='''
+                A list containing the names of the environment variables to
+                forward with SSH connections to the workflow host from
+                the host running 'cylc play'
+
+                .. versionadded:: 8.3.0
             ''')
             with Conf('selection', desc='''
                 How to select a host from the list of platform hosts.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -784,6 +784,14 @@ with Conf('global.cylc', desc='''
 
                    {REPLACES}``[suite servers][run host select]rank``.
             ''')
+            Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
+                 desc='''
+                A list containing the names of the environment variables to
+                forward with SSH connections to the run and job hosts from
+                the host running 'cylc play'
+
+                .. versionchanged:: 8.3.0
+            ''')
 
         with Conf('host self-identification', desc=f'''
             How Cylc determines and shares the identity of the workflow host.
@@ -1415,13 +1423,6 @@ with Conf('global.cylc', desc='''
 
                    {REPLACES}``global.rc[hosts][<host>]copyable
                    environment variables``.
-            ''')
-            Conf('ssh forward environment variables', VDR.V_STRING_LIST, '',
-                 desc='''
-                A list containing the names of the environment variables to
-                forward with SSH connections to the server and run hosts
-
-                .. versionchanged:: 8.3.0
             ''')
             Conf('retrieve job logs', VDR.V_BOOLEAN,
                  desc=f'''

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -35,6 +35,7 @@ from cylc.flow import __version__ as CYLC_VERSION, LOG
 from cylc.flow.option_parsers import verbosity_to_opts
 from cylc.flow.platforms import get_platform, get_host_from_platform
 from cylc.flow.util import format_cmd
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
 
 def get_proc_ancestors():
@@ -299,7 +300,9 @@ def construct_ssh_cmd(
         'CYLC_COVERAGE',
         'CLIENT_COMMS_METH',
         'CYLC_ENV_NAME',
-        *platform['ssh forward environment variables'],
+        *(glbl_cfg().get(['scheduler'])
+            ['run hosts']
+            ['ssh forward environment variables']),
     ]:
         if envvar in os.environ:
             command.append(

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -35,7 +35,6 @@ from cylc.flow import __version__ as CYLC_VERSION, LOG
 from cylc.flow.option_parsers import verbosity_to_opts
 from cylc.flow.platforms import get_platform, get_host_from_platform
 from cylc.flow.util import format_cmd
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
 
 def get_proc_ancestors():
@@ -300,9 +299,7 @@ def construct_ssh_cmd(
         'CYLC_COVERAGE',
         'CLIENT_COMMS_METH',
         'CYLC_ENV_NAME',
-        *(glbl_cfg().get(['scheduler'])
-            ['run hosts']
-            ['ssh forward environment variables']),
+        *platform['ssh forward environment variables'],
     ]:
         if envvar in os.environ:
             command.append(

--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -298,7 +298,8 @@ def construct_ssh_cmd(
         'CYLC_CONF_PATH',
         'CYLC_COVERAGE',
         'CLIENT_COMMS_METH',
-        'CYLC_ENV_NAME'
+        'CYLC_ENV_NAME',
+        *platform['ssh forward environment variables'],
     ]:
         if envvar in os.environ:
             command.append(

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -148,3 +148,13 @@ def test_source_dir_validation(
         assert "must be an absolute path" in str(excinfo.value)
     else:
         glblcfg.load()
+
+def test_platform_ssh_forward_variables(mock_global_config):
+
+    glblcfg: GlobalConfig = mock_global_config('''
+    [platforms]
+        [[foo]]
+            ssh forward environment variables = "FOO", "BAR"
+    ''')
+
+    assert glblcfg.get(['platforms','foo','ssh forward environment variables']) == ["FOO", "BAR"]

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -90,25 +90,17 @@ def test_construct_rsync_over_ssh_cmd():
     ]
 
 
-def test_construct_ssh_cmd_forward_env(mock_glbl_cfg):
+def test_construct_ssh_cmd_forward_env():
     """ Test for 'ssh forward environment variables'
     """
     import os
-
-    mock_glbl_cfg(
-        'cylc.flow.remote.glbl_cfg',
-        '''
-        [scheduler]
-            [[run hosts]]
-                ssh forward environment variables = FOO, BAR
-        '''
-    )
 
     host = 'example.com'
     config = {
         'ssh command': 'ssh',
         'use login shell': None,
         'cylc path': None,
+        'ssh forward environment variables': ['FOO', 'BAZ'],
         }
 
     # Variable isn't set, no change to command

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -90,17 +90,25 @@ def test_construct_rsync_over_ssh_cmd():
     ]
 
 
-def test_construct_ssh_cmd_forward_env():
+def test_construct_ssh_cmd_forward_env(mock_glbl_cfg):
     """ Test for 'ssh forward environment variables'
     """
     import os
+
+    mock_glbl_cfg(
+        'cylc.flow.remote.glbl_cfg',
+        '''
+        [scheduler]
+            [[run hosts]]
+                ssh forward environment variables = FOO, BAR
+        '''
+    )
 
     host = 'example.com'
     config = {
         'ssh command': 'ssh',
         'use login shell': None,
         'cylc path': None,
-        'ssh forward environment variables': ['FOO'],
         }
 
     # Variable isn't set, no change to command

--- a/tests/unit/test_remote.py
+++ b/tests/unit/test_remote.py
@@ -15,7 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test the cylc.flow.remote module."""
 
-from cylc.flow.remote import run_cmd, construct_rsync_over_ssh_cmd
+from cylc.flow.remote import run_cmd, construct_rsync_over_ssh_cmd, construct_ssh_cmd
+from unittest import mock
+import cylc.flow
 
 
 def test_run_cmd_stdin_str():
@@ -86,3 +88,28 @@ def test_construct_rsync_over_ssh_cmd():
         '/foo/',
         'miklegard:/bar/',
     ]
+
+
+def test_construct_ssh_cmd_forward_env():
+    """ Test for 'ssh forward environment variables'
+    """
+    import os
+
+    host = 'example.com'
+    config = {
+        'ssh command': 'ssh',
+        'use login shell': None,
+        'cylc path': None,
+        'ssh forward environment variables': ['FOO'],
+        }
+
+    # Variable isn't set, no change to command
+    expect = ['ssh', host, 'env', f'CYLC_VERSION={cylc.flow.__version__}', 'cylc', 'play']
+    cmd = construct_ssh_cmd(['play'], config, host)
+    assert cmd == expect
+
+    # Variable is set, appears in `env` list
+    with mock.patch.dict(os.environ, {'FOO': 'BAR'}):
+        expect = ['ssh', host, 'env', f'CYLC_VERSION={cylc.flow.__version__}', 'FOO=BAR', 'cylc', 'play']
+        cmd = construct_ssh_cmd(['play'], config, host)
+        assert cmd == expect


### PR DESCRIPTION
Allow users to specify environment variables that get forwarded from the submit host to the workflow host.

Define variables to forward in `global.cylc` like:
```
[scheduler]
    [[run hosts]]
        ssh forward environment variables = PROJECT, LUSTRE_DISK
```

This will add `PROJECT` and `LUSTRE_DISK` to the list of variables exported in SSH commands to launch the scheduler on remote hosts (if they have been set in the current environment).

Once they are available on the scheduler they can be used in the `global.cylc` templating, e.g:
```
[scheduler]
    [[run hosts]]
        ssh forward environment variables = PROJECT, LUSTRE_DISK

[install]
    [[symlink dirs]]
        [[[hpc]]]
           run = {{ environ['LUSTRE_DISK'] }}
[platforms]
    [[hpc]]
        submit method = pbs
        [[[directives]]]
            -P = {{ environ['PROJECT'] }}
```

See #5418 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/650.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
