### PR TITLE
Include severity in delta for task message

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -591,11 +591,10 @@ class TaskEventsManager():
                 itask, severity, message, event_time, flag, submit_num):
             return None
 
+        new_msg = f'{severity}:{message}'
         # always update the workflow state summary for latest message
         if flag == self.FLAG_POLLED:
-            new_msg = f'{message} {self.FLAG_POLLED}'
-        else:
-            new_msg = message
+            new_msg = f'{new_msg} {self.FLAG_POLLED}'
         self.data_store_mgr.delta_job_msg(
             itask.tokens.duplicate(job=str(submit_num)),
             new_msg


### PR DESCRIPTION
Closes #5713 

This will allow the UI to know the severity level of task messages, which will be used to colour the message chips in the tree view - https://github.com/cylc/cylc-ui/pull/1436

By not changing the GraphQL schema this is the simplest way to address #5713

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests are included
- [x] No changelog entry as minor
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
