### PR TITLE
Fix data-store reloaded flag

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -568,6 +568,9 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                                     workflow_id=w_id)
                                 delta_store[DELTA_ADDED] = (
                                     self.data_store_mgr.data[w_id])
+                                delta_store[DELTA_ADDED][
+                                    WORKFLOW
+                                ].reloaded = True
                                 deltas_queue.put(
                                     (w_id, 'initial_burst', delta_store))
                     elif w_id in self.delta_store[sub_id]:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1160,7 +1160,7 @@ class Scheduler:
             self._update_workflow_state()
 
             # Re-initialise data model on reload
-            self.data_store_mgr.initiate_data_model(reloaded=True)
+            self.data_store_mgr.initiate_data_model(self.is_reloaded)
 
             # Reset the remote init map to trigger fresh file installation
             self.task_job_mgr.task_remote_mgr.remote_init_map.clear()
@@ -1548,7 +1548,7 @@ class Scheduler:
 
         # Is the workflow ready to shut down now?
         if self.pool.can_stop(self.stop_mode):
-            await self.update_data_structure(self.is_reloaded)
+            await self.update_data_structure()
             self.proc_pool.close()
             if self.stop_mode != StopMode.REQUEST_NOW_NOW:
                 # Wait for process pool to complete,
@@ -1767,7 +1767,7 @@ class Scheduler:
 
             if has_updated or self.data_store_mgr.updates_pending:
                 # Update the datastore.
-                await self.update_data_structure(self.is_reloaded)
+                await self.update_data_structure()
 
             if has_updated:
                 if not self.is_reloaded:
@@ -1838,28 +1838,24 @@ class Scheduler:
         A cut-down version of update_data_structure which only considers
         workflow state changes e.g. status, status message, state totals, etc.
         """
+        # Publish any existing before potentially creating more
+        self._publish_deltas()
         # update the workflow state in the data store
-        self.data_store_mgr.update_workflow()
-
-        # push out update deltas
-        self.data_store_mgr.batch_deltas()
-        self.data_store_mgr.apply_delta_batch()
-        self.data_store_mgr.apply_delta_checksum()
-        self.data_store_mgr.publish_deltas = (
-            self.data_store_mgr.get_publish_deltas()
-        )
-        self.server.publish_queue.put(
-            self.data_store_mgr.publish_deltas)
-
-        # Non-async sleep - yield to other threads rather
-        # than event loop
-        sleep(0)
+        self.data_store_mgr.update_workflow_states()
+        self._publish_deltas()
 
     async def update_data_structure(self, reloaded: bool = False):
         """Update DB, UIS, Summary data elements"""
+        # Publish any existing before potentially creating more
+        self._publish_deltas()
         # Collect/apply data store updates/deltas
-        self.data_store_mgr.update_data_structure(reloaded=reloaded)
-        # Publish updates:
+        self.data_store_mgr.update_data_structure()
+        self._publish_deltas()
+        # Database update
+        self.workflow_db_mgr.put_task_pool(self.pool)
+
+    def _publish_deltas(self):
+        """Publish pending deltas."""
         if self.data_store_mgr.publish_pending:
             self.data_store_mgr.publish_pending = False
             self.server.publish_queue.put(
@@ -1867,8 +1863,6 @@ class Scheduler:
             # Non-async sleep - yield to other threads rather
             # than event loop
             sleep(0)
-        # Database update
-        self.workflow_db_mgr.put_task_pool(self.pool)
 
     def check_workflow_timers(self):
         """Check timers, and abort or run event handlers as configured."""


### PR DESCRIPTION
Partially addresses https://github.com/cylc/cylc-uiserver/issues/485

The `reloaded` field wasn't being set/sent, this change fixes it:

![image](https://github.com/cylc/cylc-flow/assets/11400777/dd65f107-4a15-47ac-9515-6575dd048cd8)



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Covered by existing tests.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
