### PR TITLE
Upper pin coverage at 7.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -105,7 +105,7 @@ report-timings =
 tests =
     async_generator
     bandit>=1.7.0
-    coverage>=5.0.0
+    coverage>=5.0.0,<7.3.1
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0


### PR DESCRIPTION
[Prevent this error](https://github.com/cylc/cylc-flow/actions/runs/6099619962/job/16552197418)

MyPy appears to be objecting to a walrus operator added to coverage at 7.3.1. This is odd, because it only objects to it at python 3.10 & 3.11 where the Walrus operator is valid (Probably the python version set in `mypy.ini`). 

I'm not at all happy that this appears to be happening, but a quick investigation wasn't able to sort out the problem, and upper-pinning fixes the CI.