### PR TITLE
Cylc to ignore PYTHONPATH: Use CYLC_PYTHONPATH for custom Python for Cylc

### DIFF
--- a/changes.d/5727.break.md
+++ b/changes.d/5727.break.md
@@ -1,2 +1,1 @@
-Cylc now ignores `PYTHONPATH` to make it more robust to task environments which set this value.
-If you want to add to the Cylc environment itself, e.g. to install a Cylc extension, use `CYLC_PYTHONPATH`.
+Cylc now ignores `PYTHONPATH` to make it more robust to task environments which set this value. If you want to add to the Cylc environment itself, e.g. to install a Cylc extension, use `CYLC_PYTHONPATH`.

--- a/changes.d/5727.break.md
+++ b/changes.d/5727.break.md
@@ -1,0 +1,2 @@
+Cylc now ignores `PYTHONPATH` to make it more robust to task environments which set this value.
+If you want to add to the Cylc environment itself, e.g. to install a Cylc extension, use `CYLC_PYTHONPATH`.

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/etc/python-job.settings
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/etc/python-job.settings
@@ -8,5 +8,4 @@
             # These environment variables ensure that tasks can
             # run in the same environment as the workflow:
             {% from "sys" import executable %}
-            PYTHONPATH = {{executable}}/../lib/python:$PYTHONPATH
             PATH = $(dirname {{executable}}):$PATH

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/etc/python-job.settings
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/etc/python-job.settings
@@ -7,6 +7,6 @@
         [[[environment]]]
             # These environment variables ensure that tasks can
             # run in the same environment as the workflow:
-            {% from "sys" import path, executable %}
-            PYTHONPATH = {{':'.join(path)}}
+            {% from "sys" import executable %}
+            PYTHONPATH = {{executable}}/../lib/python:$PYTHONPATH
             PATH = $(dirname {{executable}}):$PATH

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -16,10 +16,35 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """cylc main entry point"""
 
-import argparse
-from contextlib import contextmanager
 import os
 import sys
+
+
+def pythonpath_manip():
+    """Stop PYTHONPATH contaminating the Cylc Environment
+
+    * Remove PYTHONPATH items from sys.path to prevent PYTHONPATH
+      contaminating the Cylc Environment.
+    * Re-add items from CYLC_PYTHONPATH to sys.path.
+
+    See Also:
+        https://github.com/cylc/cylc-flow/issues/5124
+    """
+    if 'CYLC_PYTHONPATH' in os.environ:
+        for item in os.environ['CYLC_PYTHONPATH'].split(os.pathsep):
+            abspath = os.path.abspath(item)
+            sys.path.insert(0, abspath)
+    elif 'PYTHONPATH' in os.environ:
+        for item in os.environ['PYTHONPATH'].split(os.pathsep):
+            abspath = os.path.abspath(item)
+            if abspath in sys.path:
+                sys.path.remove(abspath)
+
+
+pythonpath_manip()
+
+import argparse
+from contextlib import contextmanager
 from typing import Iterator, NoReturn, Optional, Tuple
 
 from ansimarkup import parse as cparse

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -25,7 +25,7 @@ def pythonpath_manip():
 
     * Remove PYTHONPATH items from sys.path to prevent PYTHONPATH
       contaminating the Cylc Environment.
-    * Re-add items from CYLC_PYTHONPATH to sys.path.
+    * Add items from CYLC_PYTHONPATH to sys.path.
 
     See Also:
         https://github.com/cylc/cylc-flow/issues/5124
@@ -34,7 +34,7 @@ def pythonpath_manip():
         for item in os.environ['CYLC_PYTHONPATH'].split(os.pathsep):
             abspath = os.path.abspath(item)
             sys.path.insert(0, abspath)
-    elif 'PYTHONPATH' in os.environ:
+    if 'PYTHONPATH' in os.environ:
         for item in os.environ['PYTHONPATH'].split(os.pathsep):
             abspath = os.path.abspath(item)
             if abspath in sys.path:


### PR DESCRIPTION
Closes #5124 

> * Remove from `sys.path` anything in `PYTHONPATH`.
>   
>   * This prevents `PYTHONPATH` from breaking Cylc.
> * Add to `sys.path` anything in `CYLC_PYTHONPATH`.
>   
>   * This allows us to continue to install Cylc plugins via environment variable.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests this change needs to be manually tested alongside https://github.com/metomi/rose/pull/2725 . I've tested it with this workflow: [tmp.pythonpath.tar.gz](https://github.com/cylc/cylc-flow/files/12575203/tmp.pythonpath.tar.gz)
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/665.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
