### PR TITLE
8.2.x: hide autoclass objects from `flow.cylc` reference

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1715,10 +1715,12 @@ with Conf(
                     Custom outputs must satisfy these rules:
 
                     .. autoclass:: cylc.flow.unicode_rules.TaskOutputValidator
+                       :noindex:
 
                     Task messages must satisfy these rules:
 
                     .. autoclass:: cylc.flow.unicode_rules.TaskMessageValidator
+                       :noindex:
                 ''')
 
             with Conf('parameter environment templates', desc='''


### PR DESCRIPTION
https://github.com/cylc/cylc-flow/pull/5710#issuecomment-1714152645 went into master but also wanted on 8.2.x

>Sibling to https://github.com/cylc/cylc-doc/pull/637
>
>We don't want to show these in the TOC tree
>
>![image](https://github.com/cylc/cylc-flow/assets/61982285/98dfeefb-7e62-4f2a-980e-6924d981580d)
