### PR TITLE
parentless sequential clock trigger spawns

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -467,6 +467,7 @@ class Scheduler:
             self.config,
             self.workflow_db_mgr,
             self.task_events_mgr,
+            self.xtrigger_mgr,
             self.data_store_mgr,
             self.flow_mgr
         )
@@ -1734,6 +1735,8 @@ class Scheduler:
                     self.pool.queue_task(itask)
 
             if housekeep_xtriggers:
+                # Spawn parentless clock-triggered
+                self.pool.spawn_parentless_clock_triggered()
                 # (Could do this periodically?)
                 self.xtrigger_mgr.housekeep(self.pool.get_tasks())
 


### PR DESCRIPTION
superseded by #5738 

Spawning parentless clock triggered tasks out to the run ahead limit is unnecessary, and creates a lot of UI clutter.

Naturally clock trigger tasks are sequential in time, so it makes sense to only spawn the next parentless clock-trigger task when the current clock trigger is satisfied.

This PR attempts this.. In the simplest case;
```
[scheduling]
    initial cycle point = 20230915T0140Z
    [[xtriggers]]
        clock_1 = wall_clock()
    [[graph]]
        PT1M = """
@clock_1 => a
a => b
"""
[runtime]
    [[root]]
        script = sleep 5
    [[a,b]]
```
cutting down this;
![image](https://github.com/cylc/cylc-flow/assets/11400777/e114e8e2-3d86-4e9e-ba0c-0ae8b7ef0607)

to this:
![image](https://github.com/cylc/cylc-flow/assets/11400777/253aabd9-4ddb-4b6b-98c2-3a912b6c143e)

(would only show one cycle, but obviously the trigger is satisfied)

Real workflows often have a much greater chain than `a => b` (and possibly much greater run-ahead limits), so you can imagine the clutter. (such as those at NIWA)

One thing to note; if your task has multiple xtriggers including a clock trigger, i.e.;
```
    [[xtriggers]]
        clock_1 = wall_clock()
        up_1 = workflow_state(workflow=clockspawn, task=b, point=%(point)s, offset=-P1Y):PT10S
    [[graph]]
        PT1M = """
@clock_1 => a
a => b
"""
        +PT1M/PT1M = """
@up_1 => b
"""
```
Then the task will still be clock blocked from spawning out to the RH (will instead spawn sequentially on trigger satisfaction, as described).
And if for some fringe reason a user wants the non-clock xtrigger to be checked/run out into the future/RH-limit **and** associated task clock bound to when it actually runs, then they can simply split them up:
```
    [[xtriggers]]
        clock_1 = wall_clock()
        up_1 = workflow_state(workflow=clockspawn, task=b, point=%(point)s, offset=-P1Y):PT10S
    [[graph]]
        PT1M = """
@clock_1 => a
a => b
"""
        +PT1M/PT1M = """
@up_1 => up_xtrig
up_xtrig => a
"""
```
(or w/e they desire.. alternatively turning their bespoke xtrigger into a task if that works)

In this way, I believe the behavior introduced here should be the default/natural restriction..


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Appears to be covered by existing Tests.
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.

