### PR TITLE
added hub url config to globalcfg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,6 @@ $ towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
 -->
 
 <!-- towncrier release notes start -->
-## __cylc-8.2.2
-
-### Enhancements
-
-[#5733](https://github.com/cylc/cylc-flow/pull/5733) - Added Hub url to global config
-
 
 ## __cylc-8.2.1 (Released 2023-08-14)__
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ $ towncrier create <PR-number>.<break|feat|fix>.md --content "Short description"
 -->
 
 <!-- towncrier release notes start -->
+## __cylc-8.2.2
+
+### Enhancements
+
+[#5733](https://github.com/cylc/cylc-flow/pull/5733) - Added Hub url to global config
+
 
 ## __cylc-8.2.1 (Released 2023-08-14)__
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ requests_).
  - John Haiducek
  - (Andrew Huang)
  - Cheng Da
+ - Mark Dawson
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -624,7 +624,7 @@ with Conf('global.cylc', desc='''
 
     '''):
         Conf('url', VDR.V_STRING, '', desc='''
-            ..versionadded:: 8.3.0
+            .. versionadded:: 8.3.0
 
             Where Jupyter Hub is used a url can be provided for routing on
             execution of ``cylc gui`` command.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -612,7 +612,7 @@ with Conf('global.cylc', desc='''
 ''') as SPEC:
     with Conf('hub', desc='''
         Configure the public URL of Jupyter Hub.
-        
+
         If configured, the ``cylc gui`` command will open a web browser at this
         location rather than starting a standalone server when called.
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -620,13 +620,11 @@ with Conf('global.cylc', desc='''
 
            The cylc hub is mostly documented here:
 
-           * :ref:`architecture-reference`.
-           * .. _architecture-reference:
+           :ref:`architecture-reference`.
 
         .. seealso::
 
-           * :ref:`UI_Server_config`.
-           * .. _UI_Server_config:
+           :ref:`UI_Server_config`.
 
     '''):
         Conf('url', VDR.V_STRING, '', desc='''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -611,16 +611,22 @@ with Conf('global.cylc', desc='''
        is no longer supported.
 ''') as SPEC:
     with Conf('hub', desc='''
+        Configure the public URL of Jupyter Hub.
+        
+        If configured, the ``cylc gui`` command will open a web browser at this
+        location rather than starting a standalone server when called.
 
-        The cylc hub is mostly documented here:
-              :ref:`architecture-reference`.
-              .. _architecture-reference:
+        .. note::
 
+           The cylc hub is mostly documented here:
+
+           * :ref:`architecture-reference`.
+           * .. _architecture-reference:
 
         .. seealso::
 
-            :ref:`UI_Server_config`.
-            .. _UI_Server_config:
+           * :ref:`UI_Server_config`.
+           * .. _UI_Server_config:
 
     '''):
         Conf('url', VDR.V_STRING, '', desc='''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -610,6 +610,26 @@ with Conf('global.cylc', desc='''
        Prior to Cylc 8, ``global.cylc`` was named ``global.rc``, but that name
        is no longer supported.
 ''') as SPEC:
+    with Conf('hub', desc='''
+
+        The cylc hub is mostly documented here:
+              :ref:`architecture-reference`.
+              .. _architecture-reference:
+
+
+        .. seealso::
+
+            :ref:`UI_Server_config`.
+            .. _UI_Server_config:
+
+    '''):
+        Conf('url', VDR.V_STRING, '', desc='''
+            ..versionadded:: 8.3.0
+
+            Where Jupyter Hub is used a url can be provided for routing on
+            execution of ``cylc gui`` command.
+        ''')
+
     with Conf('scheduler', desc=(
         default_for(SCHEDULER_DESCR, "[scheduler]", section=True)
     )):

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -616,15 +616,11 @@ with Conf('global.cylc', desc='''
         If configured, the ``cylc gui`` command will open a web browser at this
         location rather than starting a standalone server when called.
 
-        .. note::
-
-           The cylc hub is mostly documented here:
-
-           :ref:`architecture-reference`.
 
         .. seealso::
 
-           :ref:`UI_Server_config`.
+           * The cylc hub :ref:`architecture-reference` for fuller details.
+           * :ref:`UI_Server_config` for practical details.
 
     '''):
         Conf('url', VDR.V_STRING, '', desc='''


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-uiserver/issues/238

Added hub url to global config.
This is used by cylc-ui-server (see https://github.com/cylc/cylc-uiserver/pull/507) for routing users to the hub on execution of 
`cylc gui`
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes). 
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present). **NA**
- [x] Tests are included (or explain why tests are not needed). **NA - nothing that can be tested** 
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.**NA**
