### PR TITLE
setup: pin matplotlib for python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,16 +92,20 @@ graph =
 main_loop-log_data_store =
     pympler
     matplotlib
+    matplotlib < 3.8.0; python_version < "3.8"
 main_loop-log_main_loop =
     matplotlib
+    matplotlib < 3.8.0; python_version < "3.8"
 main_loop-log_memory =
     pympler
     matplotlib
+    matplotlib < 3.8.0; python_version < "3.8"
 main_loop-log_db =
     sqlparse
 report-timings =
     pandas==1.*
     matplotlib
+    matplotlib < 3.8.0; python_version < "3.8"
 tests =
     async_generator
     bandit>=1.7.0


### PR DESCRIPTION
* Matplotlib has dropped Python 3.7 support in version 3.8.0.
* This causes `mypy` to fail.
* Exclude the new, incompatible matplotlib version for Python 3.7 installations.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
