### PR TITLE
actions: exclude mypy with more recent python version

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -58,8 +58,10 @@ jobs:
           flake8
           etc/bin/shellchecker
 
+      # note: exclude python 3.10+ from mypy checks as these produce false
+      # positives in installed libraries for python 3.7
       - name: Typing
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python-version, 3.9)
         run: mypy
 
       - name: Doctests


### PR DESCRIPTION
* matplotlib has not dropped Python 3.7 support.
* mypy produces a false positive error when scanning the installed matplotlib code (even though no_silence_site_packages=false).
* cylc is still compatible with the more recent matplotlib releases, it's down to the installer (pip/conda/whatever) to install a version that's compatible with the python interpretter so there's no reason to put an upper pin in the metadata.