### PR TITLE
parentless sequential xtrigger spawning

### DIFF
--- a/changes.d/5738.feat.md
+++ b/changes.d/5738.feat.md
@@ -1,0 +1,1 @@
+Optionally spawn parentless xtriggered tasks sequentially - i.e., one at a time, after the previous xtrigger is satisfied, instead of all at once out to the runahead limit. The `wall_clock` xtrigger is now sequential by default.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -814,8 +814,26 @@ with Conf(
 
                 Example::
 
-                ``my_trigger(arg1, arg2, kwarg1, kwarg2):PT10S``
+            .. code-block:: cylc
+
+                [[xtriggers]]
+                    my_trig = my_trigger(arg1, arg2, kwarg1, kwarg2):PT10S
+                    [[[settings]]]
+                        non-sequential xtriggers = my_trig
+
             ''')
+            with Conf('settings', desc='''
+                Section heading for xtrigger behavior settings.
+            ''') as Queue:
+                Conf('non-sequential xtriggers', VDR.V_STRING_LIST, desc='''
+                    A list of xtrigger labels whose xtrigger, of associated
+                    parentless task, be checked out to the runahead limit.
+
+                    This allows for non-sequential xtrigger checking.
+
+                    A task with multiple xtriggers requires all labels
+                    be specified to behave in this way.
+                ''')
 
         with Conf('graph', desc=f'''
             The workflow graph is defined under this section.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -802,9 +802,21 @@ with Conf(
                     :ref:`SequentialTasks`.
             ''')
 
+        Conf('sequential xtriggers default', VDR.V_BOOLEAN, False, desc='''
+            Set to ``True``, this allows for sequential spawning of associated
+            parentless tasks on xtrigger satisfaction.
+            Instead of out to the runahead limit (default: ``False``).
+
+            This workflow wide default can be overridden by a reserved
+            keyword argument in the xtrigger function declaration
+            (``sequential=True/False``).
+
+            The presence of one sequential xtrigger on a parentless task with
+            multiple xtriggers will cause sequential behavior.
+        ''')
         with Conf('xtriggers', desc='''
-                This section is for *External Trigger* function declarations -
-                see :ref:`Section External Triggers`.
+            This section is for *External Trigger* function declarations -
+            see :ref:`Section External Triggers`.
         '''):
             Conf('<xtrigger name>', VDR.V_XTRIGGER, desc='''
                 Any user-defined event trigger function declarations and
@@ -814,26 +826,8 @@ with Conf(
 
                 Example::
 
-            .. code-block:: cylc
-
-                [[xtriggers]]
-                    my_trig = my_trigger(arg1, arg2, kwarg1, kwarg2):PT10S
-                    [[[settings]]]
-                        non-sequential xtriggers = my_trig
-
+                ``my_trigger(arg1, arg2, kwarg1, kwarg2):PT10S``
             ''')
-            with Conf('settings', desc='''
-                Section heading for xtrigger behavior settings.
-            ''') as Queue:
-                Conf('non-sequential xtriggers', VDR.V_STRING_LIST, desc='''
-                    A list of xtrigger labels whose xtrigger, of associated
-                    parentless task, be checked out to the runahead limit.
-
-                    This allows for non-sequential xtrigger checking.
-
-                    A task with multiple xtriggers requires all labels
-                    be specified to behave in this way.
-                ''')
 
         with Conf('graph', desc=f'''
             The workflow graph is defined under this section.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -808,8 +808,8 @@ with Conf(
             Instead of out to the runahead limit (default: ``False``).
 
             This workflow wide default can be overridden by a reserved
-            keyword argument in the xtrigger function declaration
-            (``sequential=True/False``).
+            keyword argument in the xtrigger function declaration and/or
+            function (``sequential=True/False``).
 
             The presence of one sequential xtrigger on a parentless task with
             multiple xtriggers will cause sequential behavior.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -808,9 +808,8 @@ with Conf(
             until their previous (cycle point) instance is satisfied.
             Otherwise, they will all spawn at once out to the runahead limit.
 
-            This setting can be overridden by a reserved keyword argument in
-            individual xtrigger declarations, or in xtrigger function
-            definitions.
+            This setting can be overridden by the reserved keyword argument
+            ``sequential`` in individual xtrigger declarations.
 
             One sequential xtrigger on a parentless task with multiple
             xtriggers will cause sequential behavior.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -802,18 +802,18 @@ with Conf(
                     :ref:`SequentialTasks`.
             ''')
 
-        Conf('sequential xtriggers default', VDR.V_BOOLEAN, False, desc='''
-            When set to ``True``, parentless tasks that trigger off xtriggers
-            will only spawn sequentially, i.e. on the satisfaction of the
-            xtriggers in order. Otherwise, these tasks will all spawn at the
-            same time up to the runahead limit.
+        Conf('spawn from xtriggers sequentially', VDR.V_BOOLEAN, False,
+             desc='''
+            If ``True``, tasks that only depend on xtriggers will not spawn
+            until their previous (cycle point) instance is satisfied.
+            Otherwise, they will all spawn at once out to the runahead limit.
 
-            This workflow-wide default can be overridden by a reserved
-            keyword argument in the xtrigger function declaration and/or
-            function (``sequential=True/False``).
+            This setting can be overridden by a reserved keyword argument in
+            individual xtrigger declarations, or in xtrigger function
+            definitions.
 
-            The presence of one sequential xtrigger on a parentless task with
-            multiple xtriggers will cause sequential behavior.
+            One sequential xtrigger on a parentless task with multiple
+            xtriggers will cause sequential behavior.
         ''')
         with Conf('xtriggers', desc='''
             This section is for *External Trigger* function declarations -

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -802,17 +802,17 @@ with Conf(
                     :ref:`SequentialTasks`.
             ''')
 
-        Conf('spawn from xtriggers sequentially', VDR.V_BOOLEAN, False,
+        Conf('sequential xtriggers', VDR.V_BOOLEAN, False,
              desc='''
             If ``True``, tasks that only depend on xtriggers will not spawn
-            until their previous (cycle point) instance is satisfied.
+            until the xtrigger of previous (cycle point) instance is satisfied.
             Otherwise, they will all spawn at once out to the runahead limit.
 
             This setting can be overridden by the reserved keyword argument
             ``sequential`` in individual xtrigger declarations.
 
             One sequential xtrigger on a parentless task with multiple
-            xtriggers will cause sequential behavior.
+            xtriggers will cause sequential spawning.
         ''')
         with Conf('xtriggers', desc='''
             This section is for *External Trigger* function declarations -

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -803,11 +803,12 @@ with Conf(
             ''')
 
         Conf('sequential xtriggers default', VDR.V_BOOLEAN, False, desc='''
-            Set to ``True``, this allows for sequential spawning of associated
-            parentless tasks on xtrigger satisfaction.
-            Instead of out to the runahead limit (default: ``False``).
+            When set to ``True``, parentless tasks that trigger off xtriggers
+            will only spawn sequentially, i.e. on the satisfaction of the
+            xtriggers in order. Otherwise, these tasks will all spawn at the
+            same time up to the runahead limit.
 
-            This workflow wide default can be overridden by a reserved
+            This workflow-wide default can be overridden by a reserved
             keyword argument in the xtrigger function declaration and/or
             function (``sequential=True/False``).
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1715,7 +1715,7 @@ class WorkflowConfig:
 
         if self.xtrigger_mgr is not None:
             self.xtrigger_mgr.sequential_xtriggers_default = (
-                self.cfg['scheduling']['spawn from xtriggers sequentially']
+                self.cfg['scheduling']['sequential xtriggers']
             )
         for label in xtrig_labels:
             try:

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1707,17 +1707,16 @@ class WorkflowConfig:
         validator = XtriggerNameValidator.validate
         xtrigs = self.cfg['scheduling']['xtriggers']
         for label in xtrigs:
-            if (
-                label == 'settings'
-                and not isinstance(xtrigs[label], SubFuncContext)
-            ):
-                continue
             valid, msg = validator(label)
             if not valid:
                 raise WorkflowConfigError(
                     f'Invalid xtrigger name "{label}" - {msg}'
                 )
 
+        if self.xtrigger_mgr is not None:
+            self.xtrigger_mgr.sequential_xtriggers_default = (
+                self.cfg['scheduling']['sequential xtriggers default']
+            )
         for label in xtrig_labels:
             try:
                 xtrig = xtrigs[label]
@@ -1745,12 +1744,6 @@ class WorkflowConfig:
                 self.xtrigger_mgr.add_trig(label, xtrig, self.fdir)
 
             self.taskdefs[right].add_xtrig_label(label, seq)
-
-        if self.xtrigger_mgr is not None:
-            with suppress(KeyError):
-                self.xtrigger_mgr.non_sequential_labels.update(
-                    set(xtrigs['settings']['non-sequential xtriggers'])
-                )
 
     def get_actual_first_point(self, start_point):
         """Get actual first cycle point for the workflow

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1715,7 +1715,7 @@ class WorkflowConfig:
 
         if self.xtrigger_mgr is not None:
             self.xtrigger_mgr.sequential_xtriggers_default = (
-                self.cfg['scheduling']['sequential xtriggers default']
+                self.cfg['scheduling']['spawn from xtriggers sequentially']
             )
         for label in xtrig_labels:
             try:

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1192,7 +1192,10 @@ class DataStoreMgr:
                 point,
                 flow_nums,
                 submit_num=0,
-                data_mode=True
+                data_mode=True,
+                sequential_xtrigger_labels=(
+                    self.schd.xtrigger_mgr.sequential_xtrigger_labels
+                ),
             )
 
         is_orphan = False

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1750,7 +1750,6 @@ class Scheduler:
                     self.pool.queue_task(itask)
 
             if self.xtrigger_mgr.sequential_spawn_next:
-                # Spawn parentless tasks with sequentially checked xtrigger(s).
                 self.pool.spawn_parentless_sequential_xtriggers()
 
             if self.xtrigger_mgr.do_housekeeping:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -2151,7 +2151,7 @@ class Scheduler:
     def command_force_trigger_tasks(
         self,
         tasks: Iterable[str],
-        flow: List[str],
+        flow: List[Union[str, int]],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):
@@ -2162,7 +2162,7 @@ class Scheduler:
     def command_set(
         self,
         tasks: List[str],
-        flow: List[str],
+        flow: List[Union[str, int]],
         outputs: Optional[List[str]] = None,
         prerequisites: Optional[List[str]] = None,
         flow_wait: bool = False,

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -2151,7 +2151,7 @@ class Scheduler:
     def command_force_trigger_tasks(
         self,
         tasks: Iterable[str],
-        flow: List[Union[str, int]],
+        flow: List[str],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):
@@ -2162,7 +2162,7 @@ class Scheduler:
     def command_set(
         self,
         tasks: List[str],
-        flow: List[Union[str, int]],
+        flow: List[str],
         outputs: Optional[List[str]] = None,
         prerequisites: Optional[List[str]] = None,
         flow_wait: bool = False,

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -481,6 +481,7 @@ class Scheduler:
             self.config,
             self.workflow_db_mgr,
             self.task_events_mgr,
+            self.xtrigger_mgr,
             self.data_store_mgr,
             self.flow_mgr
         )
@@ -1747,6 +1748,10 @@ class Scheduler:
 
                 if all(itask.is_ready_to_run()):
                     self.pool.queue_task(itask)
+
+            if self.xtrigger_mgr.sequential_spawn_next:
+                # Spawn parentless tasks with sequentially checked xtrigger(s).
+                self.pool.spawn_parentless_sequential_xtriggers()
 
             if self.xtrigger_mgr.do_housekeeping:
                 self.xtrigger_mgr.housekeep(self.pool.get_tasks())

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1803,7 +1803,7 @@ class TaskPool:
         items: Iterable[str],
         outputs: List[str],
         prereqs: List[str],
-        flow: List[Union[str, int]],
+        flow: List[str],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):
@@ -2001,7 +2001,7 @@ class TaskPool:
 
     def _get_flow_nums(
             self,
-            flow: List[Union[str, int]],
+            flow: List[str],
             meta: Optional[str] = None,
     ) -> Optional[Set[int]]:
         """Get correct flow numbers given user command options."""
@@ -2073,7 +2073,7 @@ class TaskPool:
 
     def force_trigger_tasks(
         self, items: Iterable[str],
-        flow: List[Union[str, int]],
+        flow: List[str],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
     from cylc.flow.data_store_mgr import DataStoreMgr
     from cylc.flow.taskdef import TaskDef
     from cylc.flow.task_events_mgr import TaskEventsManager
+    from cylc.flow.xtrigger_mgr import XtriggerManager
     from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
     from cylc.flow.flow_mgr import FlowMgr, FlowNums
 
@@ -110,6 +111,7 @@ class TaskPool:
         config: 'WorkflowConfig',
         workflow_db_mgr: 'WorkflowDatabaseManager',
         task_events_mgr: 'TaskEventsManager',
+        xtrigger_mgr: 'XtriggerManager',
         data_store_mgr: 'DataStoreMgr',
         flow_mgr: 'FlowMgr'
     ) -> None:
@@ -119,6 +121,7 @@ class TaskPool:
         self.workflow_db_mgr: 'WorkflowDatabaseManager' = workflow_db_mgr
         self.task_events_mgr: 'TaskEventsManager' = task_events_mgr
         self.task_events_mgr.spawn_func = self.spawn_on_output
+        self.xtrigger_mgr: 'XtriggerManager' = xtrigger_mgr
         self.data_store_mgr: 'DataStoreMgr' = data_store_mgr
         self.flow_mgr: 'FlowMgr' = flow_mgr
 
@@ -267,7 +270,7 @@ class TaskPool:
 
         for itask in release_me:
             self.rh_release_and_queue(itask)
-            if itask.flow_nums:
+            if itask.flow_nums and not itask.is_xtrigger_sequential:
                 self.spawn_to_rh_limit(
                     itask.tdef,
                     itask.tdef.next_point(itask.point),
@@ -560,6 +563,15 @@ class TaskPool:
                             )
                         )
 
+            # Set xtrigger checking type, which effects parentless spawning.
+            if (
+                itask.tdef.is_parentless(itask.point)
+                and set(itask.state.xtriggers.keys()).difference(
+                    self.xtrigger_mgr.non_sequential_labels
+                )
+            ):
+                itask.is_xtrigger_sequential = True
+
             if itask.state_reset(status, is_runahead=True):
                 self.data_store_mgr.delta_task_runahead(itask)
             self.add_to_pool(itask)
@@ -705,42 +717,65 @@ class TaskPool:
         ntask = self._get_task_by_id(
             Tokens(cycle=str(point), task=name).relative_id
         )
+        is_in_pool = False
         if ntask is None:
             # ntask does not exist: spawn it in the flow.
             ntask = self.spawn_task(name, point, flow_nums, flow_wait)
+            # if the task was found set xtrigger checking type.
+            if (
+                ntask is not None
+                and set(ntask.state.xtriggers.keys()).difference(
+                    self.xtrigger_mgr.non_sequential_labels
+                )
+            ):
+                ntask.is_xtrigger_sequential = True
         else:
             # ntask already exists (n=0): merge flows.
+            is_in_pool = True
             self.merge_flows(ntask, flow_nums)
-        return ntask  # may be None
+        return ntask, is_in_pool  # may be None
 
     def spawn_to_rh_limit(self, tdef, point, flow_nums) -> None:
-        """Spawn parentless task instances from point to runahead limit."""
+        """Spawn parentless task instances from point to runahead limit.
+
+        Sequentially checked xtriggers with spawn corresponding task out to the
+        next task with any xtrigger with the same behaviour, or to the runahead
+        limit (whichever occurs first).
+
+        """
         if not flow_nums or point is None:
             # Force-triggered no-flow task.
             # Or called with an invalid next_point.
             return
         if self.runahead_limit_point is None:
             self.compute_runahead()
+
+        is_sequential = False
         while point is not None and (point <= self.runahead_limit_point):
             if tdef.is_parentless(point):
-                ntask = self.get_or_spawn_task(
+                ntask, is_in_pool = self.get_or_spawn_task(
                     point, tdef.name, flow_nums
                 )
                 if ntask is not None:
-                    self.add_to_pool(ntask)
+                    if not is_in_pool:
+                        self.add_to_pool(ntask)
                     self.rh_release_and_queue(ntask)
+                    if ntask.is_xtrigger_sequential:
+                        is_sequential = True
+                        break
             point = tdef.next_point(point)
 
         # Once more for the runahead-limited task (don't release it).
-        self.spawn_if_parentless(tdef, point, flow_nums)
+        if not is_sequential:
+            self.spawn_if_parentless(tdef, point, flow_nums)
 
     def spawn_if_parentless(self, tdef, point, flow_nums):
         """Spawn a task if parentless, regardless of runahead limit."""
         if flow_nums and point is not None and tdef.is_parentless(point):
-            ntask = self.get_or_spawn_task(
+            ntask, is_in_pool = self.get_or_spawn_task(
                 point, tdef.name, flow_nums
             )
-            if ntask is not None:
+            if ntask is not None and not is_in_pool:
                 self.add_to_pool(ntask)
 
     def remove(self, itask, reason=None):
@@ -2042,6 +2077,19 @@ class TaskPool:
             # run it (or run it again for incomplete flow-wait)
             self.add_to_pool(itask)
             self._force_trigger(itask)
+
+    def spawn_parentless_sequential_xtriggers(self):
+        """Spawn successor(s) of parentless wall clock satisfied tasks."""
+        while self.xtrigger_mgr.sequential_spawn_next:
+            taskid = self.xtrigger_mgr.sequential_spawn_next.pop()
+            itask = self._get_task_by_id(taskid)
+            # Will spawn out to RH limit or next parentless clock trigger
+            # or non-parentless.
+            self.spawn_to_rh_limit(
+                itask.tdef,
+                itask.tdef.next_point(itask.point),
+                itask.flow_nums
+            )
 
     def clock_expire_tasks(self):
         """Expire any tasks past their clock-expiry time."""

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -715,8 +715,8 @@ class TaskPool:
             is_in_pool:
                 Was the task found in a pool.
             is_xtrig_sequential:
-                Is the next task occurance spawned on xtrigger satisfaction,
-                or do all occurances spawn out to the runahead limit.
+                Is the next task occurrence spawned on xtrigger satisfaction,
+                or do all occurrence spawn out to the runahead limit.
 
         It does not add a spawned task proxy to the pool.
         """

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -566,8 +566,8 @@ class TaskPool:
             # Set xtrigger checking type, which effects parentless spawning.
             if (
                 itask.tdef.is_parentless(itask.point)
-                and set(itask.state.xtriggers.keys()).difference(
-                    self.xtrigger_mgr.non_sequential_labels
+                and set(itask.state.xtriggers.keys()).intersection(
+                    self.xtrigger_mgr.sequential_xtrigger_labels
                 )
             ):
                 itask.is_xtrigger_sequential = True
@@ -724,8 +724,8 @@ class TaskPool:
             # if the task was found set xtrigger checking type.
             if (
                 ntask is not None
-                and set(ntask.state.xtriggers.keys()).difference(
-                    self.xtrigger_mgr.non_sequential_labels
+                and set(ntask.state.xtriggers.keys()).intersection(
+                    self.xtrigger_mgr.sequential_xtrigger_labels
                 )
             ):
                 ntask.is_xtrigger_sequential = True

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -858,7 +858,7 @@ class TaskPool:
             point_itasks[point] = list(itask_id_map.values())
         return point_itasks
 
-    def get_task(self, point, name) -> Optional[TaskProxy]:
+    def get_task(self, point: 'PointBase', name: str) -> Optional[TaskProxy]:
         """Retrieve a task from the pool."""
         rel_id = f'{point}/{name}'
         tasks = self.active_tasks.get(point)
@@ -1803,7 +1803,7 @@ class TaskPool:
         items: Iterable[str],
         outputs: List[str],
         prereqs: List[str],
-        flow: List[str],
+        flow: List[Union[str, int]],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):
@@ -2001,7 +2001,7 @@ class TaskPool:
 
     def _get_flow_nums(
             self,
-            flow: List[str],
+            flow: List[Union[str, int]],
             meta: Optional[str] = None,
     ) -> Optional[Set[int]]:
         """Get correct flow numbers given user command options."""
@@ -2073,7 +2073,7 @@ class TaskPool:
 
     def force_trigger_tasks(
         self, items: Iterable[str],
-        flow: List[str],
+        flow: List[Union[str, int]],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None
     ):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -751,9 +751,10 @@ class TaskPool:
     def spawn_to_rh_limit(self, tdef, point, flow_nums) -> None:
         """Spawn parentless task instances from point to runahead limit.
 
-        Sequentially checked xtriggers with spawn corresponding task out to the
-        next task with any xtrigger with the same behaviour, or to the runahead
-        limit (whichever occurs first).
+        Sequentially checked xtriggers will spawn the next occurrence of their
+        corresponding tasks. These tasks will keep spawning until they depend
+        on any unsatisfied xtrigger of the same sequential behavior, are no
+        longer parentless, and/or hit the runahead limit.
 
         """
         if not flow_nums or point is None:
@@ -812,10 +813,7 @@ class TaskPool:
             msg = f"removed ({reason})"
 
         if itask.is_xtrigger_sequential:
-            with suppress(ValueError):
-                self.xtrigger_mgr.sequential_spawn_next.remove(
-                    itask.identity
-                )
+            self.xtrigger_mgr.sequential_spawn_next.discard(itask.identity)
 
         try:
             del self.active_tasks[itask.point][itask.identity]
@@ -1977,7 +1975,7 @@ class TaskPool:
         """Remove tasks from the pool (forced by command)."""
         itasks, _, bad_items = self.filter_task_proxies(items)
         for itask in itasks:
-            # Spawn next occurance of xtrigger sequential task.
+            # Spawn next occurrence of xtrigger sequential task.
             if itask.is_xtrigger_sequential:
                 self.spawn_to_rh_limit(
                     itask.tdef,

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -164,6 +164,9 @@ class TaskProxy:
         .transient:
             This is a transient proxy - not to be added to the task pool, but
             used e.g. to spawn children, or to get task-specific information.
+        .is_xtrigger_sequential:
+            A flag used to determine whether this task needs to wait for
+            xtrigger satisfaction to spawn.
 
     Args:
         tdef: The definition object of this task.
@@ -206,7 +209,8 @@ class TaskProxy:
         'try_timers',
         'waiting_on_job_prep',
         'mode_settings',
-        'transient'
+        'transient',
+        'is_xtrigger_sequential',
     ]
 
     def __init__(
@@ -242,6 +246,7 @@ class TaskProxy:
             task=self.tdef.name,
         )
         self.identity = self.tokens.relative_id
+        self.is_xtrigger_sequential = False
         self.reload_successor: Optional['TaskProxy'] = None
         self.point_as_seconds: Optional[int] = None
 

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -226,7 +226,8 @@ class TaskProxy:
         is_manual_submit: bool = False,
         flow_wait: bool = False,
         data_mode: bool = False,
-        transient: bool = False
+        transient: bool = False,
+        sequential_xtrigger_labels: Optional[Set[str]] = None,
     ) -> None:
 
         self.tdef = tdef
@@ -246,7 +247,6 @@ class TaskProxy:
             task=self.tdef.name,
         )
         self.identity = self.tokens.relative_id
-        self.is_xtrigger_sequential = False
         self.reload_successor: Optional['TaskProxy'] = None
         self.point_as_seconds: Optional[int] = None
 
@@ -288,6 +288,18 @@ class TaskProxy:
         self.waiting_on_job_prep = False
 
         self.state = TaskState(tdef, self.point, status, is_held)
+
+        # Set xtrigger checking type, which effects parentless spawning.
+        if (
+            sequential_xtrigger_labels
+            and self.tdef.is_parentless(start_point)
+            and set(self.state.xtriggers.keys()).intersection(
+                sequential_xtrigger_labels
+            )
+        ):
+            self.is_xtrigger_sequential = True
+        else:
+            self.is_xtrigger_sequential = False
 
         # Determine graph children of this task (for spawning).
         if data_mode:

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -290,16 +290,11 @@ class TaskProxy:
         self.state = TaskState(tdef, self.point, status, is_held)
 
         # Set xtrigger checking type, which effects parentless spawning.
-        if (
+        self.is_xtrigger_sequential = bool(
             sequential_xtrigger_labels
             and self.tdef.is_parentless(start_point)
-            and set(self.state.xtriggers.keys()).intersection(
-                sequential_xtrigger_labels
-            )
-        ):
-            self.is_xtrigger_sequential = True
-        else:
-            self.is_xtrigger_sequential = False
+            and sequential_xtrigger_labels.intersection(self.state.xtriggers)
+        )
 
         # Determine graph children of this task (for spawning).
         if data_mode:

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -324,7 +324,6 @@ class XtriggerNameValidator(UnicodeRuleChecker):
     RULES = [
         allowed_characters(r'a-zA-Z0-9', '_'),
         not_starts_with('_cylc'),
-        not_equals('settings'),
     ]
 
 

--- a/cylc/flow/unicode_rules.py
+++ b/cylc/flow/unicode_rules.py
@@ -324,6 +324,7 @@ class XtriggerNameValidator(UnicodeRuleChecker):
     RULES = [
         allowed_characters(r'a-zA-Z0-9', '_'),
         not_starts_with('_cylc'),
+        not_equals('settings'),
     ]
 
 

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -204,20 +204,18 @@ class XtriggerManager:
 
     # Example:
     [scheduling]
-        sequential xtrigger default = True
+        sequential xtriggers = True
         [[xtriggers]]
-            clock_0 = wall_clock()  # offset PT0H
-            clock_1 = wall_clock(offset=PT1H)
-                 # or wall_clock(PT1H)
+            # "sequential=False" here overrides workflow and function default.
+            clock_0 = wall_clock(sequential=False)
             workflow_x = workflow_state(
                 workflow=other,
                 point=%(task_cycle_point)s,
-                sequential=False
             ):PT30S
         [[graph]]
             PT1H = '''
-                @clock_1 & @workflow_x => foo & bar
-                @wall_clock = baz  # pre-defined zero-offset clock
+                @workflow_x => foo & bar  # spawned on workflow_x satisfaction
+                @clock_0 => baz  # baz spawned out to RH
             '''
 
     Args:
@@ -259,7 +257,7 @@ class XtriggerManager:
         # Labels whose xtriggers are sequentially checked.
         self.sequential_xtrigger_labels: Set[str] = set()
         # Gather parentless tasks whose xtrigger(s) have been satisfied
-        # (these will be used to spawn the next occurance).
+        # (these will be used to spawn the next occurrence).
         self.sequential_spawn_next: Set[str] = set()
         self.sequential_has_spawned_next: Set[str] = set()
 

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -16,7 +16,7 @@
 
 from contextlib import suppress
 from enum import Enum
-from inspect import getfullargspec, signature
+from inspect import signature
 import json
 import re
 from copy import deepcopy
@@ -34,6 +34,7 @@ from cylc.flow import LOG
 from cylc.flow.exceptions import XtriggerConfigError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import get_user
+from cylc.flow.subprocctx import add_kwarg_to_sig
 from cylc.flow.subprocpool import get_xtrig_func
 from cylc.flow.xtriggers.wall_clock import _wall_clock
 
@@ -330,32 +331,33 @@ class XtriggerManager:
             raise XtriggerConfigError(
                 label, f"'{fname}' not callable in xtrigger module '{fname}'",
             )
-        x_argspec = getfullargspec(func)
-        if 'sequential' in x_argspec.args:
-            if (
-                x_argspec.defaults is None
-                or not isinstance(
-                    x_argspec.defaults[x_argspec.args.index('sequential')],
-                    bool
-                )
-            ):
+
+        sig = signature(func)
+        sig_str = fctx.get_signature()
+
+        # Handle reserved 'sequential' kwarg:
+        sequential_param = sig.parameters.get('sequential', None)
+        if sequential_param:
+            if not isinstance(sequential_param.default, bool):
                 raise XtriggerConfigError(
                     label,
-                    fname,
                     (
-                        f"xtrigger module '{fname}' contains reserved argument"
-                        " name 'sequential' that has no boolean default"
-                    ),
+                        f"xtrigger '{fname}' function definition contains "
+                        "reserved argument 'sequential' that has no "
+                        "boolean default"
+                    )
                 )
-            elif 'sequential' not in fctx.func_kwargs:
-                fctx.func_kwargs['sequential'] = x_argspec.defaults[
-                    x_argspec.args.index('sequential')
-                ]
+            fctx.func_kwargs.setdefault('sequential', sequential_param.default)
+        elif 'sequential' in fctx.func_kwargs:
+            # xtrig call marked as sequential; add 'sequential' arg to
+            # signature for validation
+            sig = add_kwarg_to_sig(
+                sig, 'sequential', fctx.func_kwargs['sequential']
+            )
 
         # Validate args and kwargs against the function signature
-        sig_str = fctx.get_signature()
         try:
-            bound_args = signature(func).bind(
+            bound_args = sig.bind(
                 *fctx.func_args, **fctx.func_kwargs
             )
         except TypeError as exc:

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -260,6 +260,7 @@ class XtriggerManager:
         # Gather parentless tasks whose xtrigger(s) have been satisfied
         # (these will be used to spawn the next occurance).
         self.sequential_spawn_next: Set[str] = set()
+        self.sequential_has_spawned_next: Set[str] = set()
 
         self.workflow_run_dir = workflow_run_dir
 

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -323,15 +323,27 @@ class XtriggerManager:
             raise XtriggerConfigError(
                 label, f"'{fname}' not callable in xtrigger module '{fname}'",
             )
-        if 'sequential' in getfullargspec(func).args:
-            raise XtriggerConfigError(
-                label,
-                fname,
-                (
-                    f"xtrigger module '{fname}' contains reserved"
-                    " argument name 'sequential'"
-                ),
-            )
+        x_argspec = getfullargspec(func)
+        if 'sequential' in x_argspec.args:
+            if (
+                x_argspec.defaults is None
+                or not isinstance(
+                    x_argspec.defaults[x_argspec.args.index('sequential')],
+                    bool
+                )
+            ):
+                raise XtriggerConfigError(
+                    label,
+                    fname,
+                    (
+                        f"xtrigger module '{fname}' contains reserved argument"
+                        " name 'sequential' that has no boolean default"
+                    ),
+                )
+            elif 'sequential' not in fctx.func_kwargs:
+                fctx.func_kwargs['sequential'] = x_argspec.defaults[
+                    x_argspec.args.index('sequential')
+                ]
 
         # Validate args and kwargs against the function signature
         sig_str = fctx.get_signature()

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -21,7 +21,14 @@ import json
 import re
 from copy import deepcopy
 from time import time
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Set,
+    Tuple,
+    TYPE_CHECKING
+)
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import XtriggerConfigError
@@ -244,15 +251,15 @@ class XtriggerManager:
         self.active: list = []
 
         # Clock labels, to avoid repeated string comparisons
-        self.wall_clock_labels: set = set()
+        self.wall_clock_labels: Set[str] = set()
 
         # Workflow wide default, used when not specified in xtrigger kwargs.
         self.sequential_xtriggers_default = False
         # Labels whose xtriggers are sequentially checked.
-        self.sequential_xtrigger_labels: set = set()
+        self.sequential_xtrigger_labels: Set[str] = set()
         # Gather parentless tasks whose xtrigger(s) have been satisfied
         # (these will be used to spawn the next occurance).
-        self.sequential_spawn_next: set = set()
+        self.sequential_spawn_next: Set[str] = set()
 
         self.workflow_run_dir = workflow_run_dir
 
@@ -299,7 +306,6 @@ class XtriggerManager:
             XtriggerConfigError:
                 * If the function module was not found.
                 * If the function was not found in the xtrigger module.
-                * If the function is not callable.
                 * If the function is not callable.
                 * If any string template in the function context
                   arguments are not present in the expected template values.

--- a/cylc/flow/xtriggers/wall_clock.py
+++ b/cylc/flow/xtriggers/wall_clock.py
@@ -22,7 +22,7 @@ from cylc.flow.cycling.iso8601 import interval_parse
 from cylc.flow.exceptions import WorkflowConfigError
 
 
-def wall_clock(offset: str = 'PT0S'):
+def wall_clock(offset: str = 'PT0S', sequential: bool = True):
     """Trigger at a specific real "wall clock" time relative to the cycle point
     in the graph.
 
@@ -48,6 +48,8 @@ def _wall_clock(trigger_time: int) -> bool:
     Args:
         trigger_time:
             Trigger time as seconds since Unix epoch.
+        sequential (bool):
+            Used by the workflow to flag corresponding xtriggers as sequential.
     """
     return time() > trigger_time
 

--- a/tests/functional/cylc-config/00-simple/section1.stdout
+++ b/tests/functional/cylc-config/00-simple/section1.stdout
@@ -6,6 +6,7 @@ hold after cycle point =
 stop after cycle point = 
 cycling mode = integer
 runahead limit = P4
+sequential xtriggers default = False
 [[queues]]
     [[[default]]]
         limit = 100
@@ -16,7 +17,5 @@ runahead limit = P4
     clock-expire = 
     sequential = 
 [[xtriggers]]
-    [[[settings]]]
-        non-sequential xtriggers = 
 [[graph]]
     R1 = OPS:finish-all => VAR

--- a/tests/functional/cylc-config/00-simple/section1.stdout
+++ b/tests/functional/cylc-config/00-simple/section1.stdout
@@ -16,5 +16,7 @@ runahead limit = P4
     clock-expire = 
     sequential = 
 [[xtriggers]]
+    [[[settings]]]
+        non-sequential xtriggers = 
 [[graph]]
     R1 = OPS:finish-all => VAR

--- a/tests/functional/cylc-config/00-simple/section1.stdout
+++ b/tests/functional/cylc-config/00-simple/section1.stdout
@@ -6,7 +6,7 @@ hold after cycle point =
 stop after cycle point = 
 cycling mode = integer
 runahead limit = P4
-sequential xtriggers default = False
+spawn from xtriggers sequentially = False
 [[queues]]
     [[[default]]]
         limit = 100

--- a/tests/functional/cylc-config/00-simple/section1.stdout
+++ b/tests/functional/cylc-config/00-simple/section1.stdout
@@ -6,7 +6,7 @@ hold after cycle point =
 stop after cycle point = 
 cycling mode = integer
 runahead limit = P4
-spawn from xtriggers sequentially = False
+sequential xtriggers = False
 [[queues]]
     [[[default]]]
         limit = 100

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -43,14 +43,14 @@ init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
         ):PT1S
     [[graph]]
         R1 = """
-@clock_1 => a
-b
-"""
+            @clock_1 => a
+            b
+        """
         +P1Y/P1Y = """
-@clock_2 => a
-@clock_2 => b
-@up_1 => c
-"""
+            @clock_2 => a
+            @clock_2 => b
+            @up_1 => c
+        """
 __FLOW_CONFIG__
 
 run_ok "${TEST_NAME_BASE}-val" cylc validate "${WORKFLOW_NAME}"

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -30,7 +30,7 @@ init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
 [scheduling]
     initial cycle point = 3000
     runahead limit = P5
-    sequential xtriggers default = True
+    spawn from xtriggers sequentially = True
     [[xtriggers]]
         clock_1 = wall_clock(offset=P2Y, sequential=False)
         clock_2 = wall_clock()

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test xtrigger sequential spawning -
+#   
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 7
+
+# Test workflow uses built-in 'echo' xtrigger.
+init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
+[scheduler]
+    cycle point format = %Y
+    allow implicit tasks = True
+[scheduling]
+    initial cycle point = 3000
+    runahead limit = P5
+    sequential xtriggers default = True
+    [[xtriggers]]
+        clock_1 = wall_clock(offset=P2Y, sequential=False)
+        clock_2 = wall_clock()
+        up_1 = workflow_state(\
+            workflow=%(workflow)s, \
+            task=b, \
+            point=%(point)s, \
+            offset=-P1Y, \
+            sequential=False \
+        ):PT1S
+    [[graph]]
+        R1 = """
+@clock_1 => a
+b
+"""
+        +P1Y/P1Y = """
+@clock_2 => a
+@clock_2 => b
+@up_1 => c
+"""
+__FLOW_CONFIG__
+
+run_ok "${TEST_NAME_BASE}-val" cylc validate "${WORKFLOW_NAME}"
+
+# Run workflow; it will stall waiting on the never-satisfied xtriggers.
+cylc play "${WORKFLOW_NAME}"
+
+poll_grep_workflow_log -E '3001/c/.* => succeeded'
+
+cylc stop --max-polls=10 --interval=2 "${WORKFLOW_NAME}"
+
+cylc play "${WORKFLOW_NAME}"
+
+cylc show "${WORKFLOW_NAME}//3001/a" | grep -E 'state: ' > 3001.a.log
+cylc show "${WORKFLOW_NAME}//3002/a" 2>&1 >/dev/null \
+    | grep -E 'No matching' > 3002.a.log
+
+# 3001/a should be spawned at both 3000/3001.
+cmp_ok 3001.a.log - <<__END__
+state: waiting
+__END__
+# 3002/a should not exist.
+cmp_ok 3002.a.log - <<__END__
+No matching active tasks found: 3002/a
+__END__
+
+cylc reload "${WORKFLOW_NAME}"
+
+cylc remove "${WORKFLOW_NAME}//3001/b"
+
+cylc show "${WORKFLOW_NAME}//3002/b" | grep -E 'state: ' > 3002.b.log
+cylc show "${WORKFLOW_NAME}//3003/b" 2>&1 >/dev/null \
+    | grep -E 'No matching' > 3003.b.log
+
+# 3002/b should be only at 3002.
+cmp_ok 3002.b.log - <<__END__
+state: waiting
+__END__
+cmp_ok 3003.b.log - <<__END__
+No matching active tasks found: 3003/b
+__END__
+
+cylc show "${WORKFLOW_NAME}//3002/c" | grep -E 'state: ' > 3002.c.log
+cylc show "${WORKFLOW_NAME}//3005/c" | grep -E 'state: ' > 3005.c.log
+
+# c should be from 3002-3005.
+cmp_ok 3002.c.log - <<__END__
+state: waiting
+__END__
+cmp_ok 3005.c.log - <<__END__
+state: waiting
+__END__
+
+
+cylc stop --now --max-polls=10 --interval=2 "${WORKFLOW_NAME}"
+purge
+exit

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -30,7 +30,7 @@ init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
 [scheduling]
     initial cycle point = 3000
     runahead limit = P5
-    spawn from xtriggers sequentially = True
+    sequential xtriggers = True
     [[xtriggers]]
         clock_1 = wall_clock(offset=P2Y, sequential=False)
         clock_2 = wall_clock()

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -90,9 +90,6 @@ def test_validate_implicit_task_name(
     are blacklisted get caught and raise errors.
     """
     id_ = flow({
-        'scheduler': {
-            'allow implicit tasks': 'True'
-        },
         'scheduling': {
             'graph': {
                 'R1': task_name
@@ -189,9 +186,6 @@ def test_no_graph(flow, validate):
 def test_parse_special_tasks_invalid(flow, validate, section):
     """It should fail for invalid "special tasks"."""
     id_ = flow({
-        'scheduler': {
-            'allow implicit tasks': 'True',
-        },
         'scheduling': {
             'initial cycle point': 'now',
             'special tasks': {
@@ -211,9 +205,6 @@ def test_parse_special_tasks_invalid(flow, validate, section):
 def test_parse_special_tasks_interval(flow, validate):
     """It should fail for invalid durations in clock-triggers."""
     id_ = flow({
-        'scheduler': {
-            'allow implicit tasks': 'True',
-        },
         'scheduling': {
             'initial cycle point': 'now',
             'special tasks': {
@@ -359,7 +350,6 @@ def test_xtrig_validation_wall_clock(
     https://github.com/cylc/cylc-flow/issues/5448
     """
     id_ = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'initial cycle point': '1012',
             'xtriggers': {'myxt': 'wall_clock(offset=PT7MH)'},
@@ -378,7 +368,6 @@ def test_xtrig_implicit_wall_clock(flow: Fixture, validate: Fixture):
     xtrigger definition.
     """
     wid = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'initial cycle point': '2024',
             'graph': {'R1': '@wall_clock => foo'},
@@ -396,7 +385,6 @@ def test_xtrig_validation_echo(
     https://github.com/cylc/cylc-flow/issues/5448
     """
     id_ = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'xtriggers': {'myxt': 'echo()'},
             'graph': {'R1': '@myxt => foo'},
@@ -418,7 +406,6 @@ def test_xtrig_validation_xrandom(
     https://github.com/cylc/cylc-flow/issues/5448
     """
     id_ = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'xtriggers': {'myxt': 'xrandom(200)'},
             'graph': {'R1': '@myxt => foo'},
@@ -459,7 +446,6 @@ def test_xtrig_validation_custom(
     )
 
     id_ = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'initial cycle point': '1012',
             'xtriggers': {'myxt': 'kustom_xt(feature=42)'},
@@ -490,7 +476,6 @@ def test_xtrig_signature_validation(
 ):
     """Test automatic xtrigger function signature validation."""
     id_ = flow({
-        'scheduler': {'allow implicit tasks': True},
         'scheduling': {
             'initial cycle point': '2024',
             'xtriggers': {'myxt': xtrig_call},

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -132,7 +132,7 @@ async def test_reload(sequential, start):
 # TODO: test setting the sequential argument in [scheduling][xtrigger] items
 # changes the behaviour
 
-# TODO: test the interaction between "sequential xtriggers default" and the
+# TODO: test the interaction between "spawn from xtriggers sequentially" and the
 # sequential argument to [scheduling][xtrigger]
 # * Should we be able to override the default by setting sequential=False?
 # * Or should that result in a validation error?

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -224,7 +224,7 @@ async def test_override(flow, scheduler, start):
     """Test that the 'sequential=False' arg can override a default of True."""
     wid = flow({
         'scheduling': {
-            'spawn from xtriggers sequentially': True,
+            'sequential xtriggers': True,
             'xtriggers': {
                 'xt1': 'custom_xt()',
                 'xt2': 'custom_xt(sequential=False)',

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -1,0 +1,138 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test interactions with sequential xtriggers."""
+
+import pytest
+
+from cylc.flow.cycling.iso8601 import ISO8601Point
+
+
+@pytest.fixture()
+def sequential(flow, scheduler):
+    id_ = flow({
+        'scheduler': {
+            'allow implicit tasks': 'True',
+            'cycle point format': 'CCYY',
+        },
+        'scheduling': {
+            'runahead limit': 'P2',
+            'initial cycle point': '2000',
+            'graph': {
+                'P1Y': '@wall_clock => foo',
+            }
+        }
+    })
+
+    sequential = scheduler(id_)
+
+    def list_tasks():
+        """List the task instance cycle points present in the pool."""
+        nonlocal sequential
+        return sorted(itask.tokens['cycle'] for itask in sequential.pool.get_all_tasks())
+
+    sequential.list_tasks = list_tasks
+
+    return sequential
+
+
+async def test_remove(sequential, start):
+    """It should spawn the next instance when a task is removed.
+
+    Ensure that removing a task with a sequential xtrigger does not break the
+    chain causing future instances to be removed from the workflow.
+    """
+    async with start(sequential):
+        # the scheduler starts with one task in the pool
+        assert sequential.list_tasks() == ['2000']
+
+        # it sequentially spawns out to the runahead limit
+        for year in range(2000, 2010):
+            foo = sequential.pool.get_task(ISO8601Point(f'{year}'), 'foo')
+            if foo.state(is_runahead=True):
+                break
+            sequential.xtrigger_mgr.call_xtriggers_async(foo)
+            sequential.pool.spawn_parentless_sequential_xtriggers()
+        assert sequential.list_tasks() == [
+            '2000',
+            '2001',
+            '2002',
+            '2003',
+        ]
+
+        # remove all tasks in the pool
+        sequential.pool.remove_tasks(['*'])
+
+        # the next cycle should be automatically spawned
+        assert sequential.list_tasks() == ['2004']
+
+        # NOTE: You won't spot this issue in a functional test because the
+        # re-spawned tasks are detected as completed and automatically removed.
+        # So ATM not dangerous, but potentially inefficient.
+
+
+async def test_trigger(sequential, start):
+    """It should spawn its next instance if triggered ahead of time.
+
+    If you manually trigger a sequentially spawned task before its xtriggers
+    have become satisfied, then the sequential spawning chain is broken.
+
+    The task pool should defend against this to ensure that triggering a task
+    doesn't cancel it's future instances.
+    """
+    async with start(sequential):
+        assert sequential.list_tasks() == ['2000']
+
+        foo = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
+        sequential.pool.force_trigger_tasks([foo.identity], {1})
+        foo.state_reset('succeeded')
+        sequential.pool.spawn_on_output(foo, 'succeeded')
+
+        assert sequential.list_tasks() == ['2001']
+
+
+async def test_reload(sequential, start):
+    """It should set the is_xtrigger_sequential flag on reload.
+
+    TODO: test that changes to the sequential status in the config get picked
+          up on reload
+    """
+    async with start(sequential):
+        # the task should be marked as sequential
+        pre_reload = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
+        assert pre_reload.is_xtrigger_sequential is True
+
+        # reload the workflow
+        sequential.pool.reload_taskdefs(sequential.config)
+
+        # the original task proxy should have been replaced
+        post_reload = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
+        assert id(pre_reload) != id(post_reload)
+
+        # the new task should be marked as sequential
+        assert post_reload.is_xtrigger_sequential is True
+
+
+# TODO: test that a task is marked as sequential if any of its xtriggers are
+# sequential (as opposed to all)?
+
+# TODO: test setting the sequential argument in [scheduling][xtrigger] items
+# changes the behaviour
+
+# TODO: test the interaction between "sequential xtriggers default" and the
+# sequential argument to [scheduling][xtrigger]
+# * Should we be able to override the default by setting sequential=False?
+# * Or should that result in a validation error?

--- a/tests/unit/test_xtrigger_mgr.py
+++ b/tests/unit/test_xtrigger_mgr.py
@@ -24,7 +24,7 @@ from cylc.flow.id import Tokens
 from cylc.flow.subprocctx import SubFuncContext
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.taskdef import TaskDef
-from cylc.flow.xtrigger_mgr import RE_STR_TMPL
+from cylc.flow.xtrigger_mgr import RE_STR_TMPL, XtriggerManager
 
 
 def test_constructor(xtrigger_mgr):
@@ -68,7 +68,7 @@ def test_add_xtrigger_with_params(xtrigger_mgr):
     assert xtrig == xtrigger_mgr.functx_map["xtrig"]
 
 
-def test_check_xtrigger_with_unknown_params(xtrigger_mgr):
+def test_check_xtrigger_with_unknown_params():
     """Test for adding an xtrigger with an unknown parameter.
 
     The XTriggerManager contains a list of specific parameters that are
@@ -90,10 +90,12 @@ def test_check_xtrigger_with_unknown_params(xtrigger_mgr):
         XtriggerConfigError,
         match="Illegal template in xtrigger: what_is_this"
     ):
-        xtrigger_mgr.check_xtrigger("xtrig", xtrig, 'fdir')
+        XtriggerManager.check_xtrigger("xtrig", xtrig, 'fdir')
 
 
-def test_check_xtrigger_with_deprecated_params(xtrigger_mgr, caplog):
+def test_check_xtrigger_with_deprecated_params(
+    caplog: pytest.LogCaptureFixture
+):
     """It should flag deprecated template variables."""
     xtrig = SubFuncContext(
         label="echo",
@@ -102,7 +104,7 @@ def test_check_xtrigger_with_deprecated_params(xtrigger_mgr, caplog):
         func_kwargs={"succeed": True}
     )
     caplog.set_level(logging.WARNING, CYLC_LOG)
-    xtrigger_mgr.check_xtrigger("xtrig", xtrig, 'fdir')
+    XtriggerManager.check_xtrigger("xtrig", xtrig, 'fdir')
     assert caplog.messages == [
         'Xtrigger "xtrig" uses deprecated template variables: suite_name'
     ]


### PR DESCRIPTION
supersedes #5732 

Spawning parentless xtrigger tasks out to the run ahead limit is unnecessary in the majority of cases, and creates a lot of UI clutter.

This PR makes sequential spawning on xtrigger satisfaction for parentless tasks optional, with non-sequential the default (no change). And the default for clock triggers.

Justification:
- Naturally clock trigger tasks are sequential in time, so it makes sense to only spawn the next parentless clock-triggered task when the current clock trigger is satisfied.
- Most workflows are sequential, and so workflows/downstream-workflows usually don't need to check xtriggers out to the runahead limit (i.e. `workflow_state`).
- It makes little difference (split seconds) in "catch-up" mode, where all xtriggers will be satisfied on first check.
- It puts less load on the Scheduler and UI, with `~1/runahead-limit` times less xtriggers to check and tasks to show.
- If the user wants non-sequential xtrigger checking, that xtrigger can be specified as such.

At NIWA we have a modular approach to running our workflows, both in operations  (around ~50 workflows, most interconnected) and in research (commonly downstream of operational workflows). So `wall_clock` and `workflow_state` are by far the most common xtriggers. We do have some requirement for non-sequential `workflow_state` xtriggers (i.e. satellite checking, where data may or may not come in for a cycle), however, nearly all workflows and downstream workflows are sequential.. And many of these require very large runahead limits.


Take the following simple example;
```
[scheduling]
    initial cycle point = 20230920T0530Z
    runahead limit = P5
    [[xtriggers]]
        clock_1 = wall_clock()
        up_1 = workflow_state(workflow=clockspawn, task=b, point=%(point)s):PT7S
    [[graph]]
        PT1M = """
@clock_1 => a
a => b
@up_1 => c
"""

[runtime]
    [[root]]
        script = sleep 2
    [[a,b,c]]
```
Currently that produces:
![image](https://github.com/cylc/cylc-flow/assets/11400777/3f287db8-3025-4818-91f4-9533a335f96f)

With this default behavior changed;
```
[scheduling]
    initial cycle point = 20230920T0530Z
    runahead limit = P5
    sequential xtriggers = True
    [[xtriggers]]
        clock_1 = wall_clock()
        up_1 = workflow_state(workflow=clockspawn, task=b, point=%(point)s):PT7S
.
.
.
```
it is reduced to:
![image](https://github.com/cylc/cylc-flow/assets/11400777/b2c8739e-6a7f-4139-bbd2-57c38608d443)

Real workflows commonly have **way more** tasks (branches length and/or parallel) and **way larger** runahead limits, so the efficiency and clutter-less gains are massive.

And if for some reason users want some xtriggers to be checked/run out into the future/RH-limit in a non-sequential manner, then they can override the default with an argument (i.e. `sequential=True/False`):
```
    sequential xtriggers = True
    [[xtriggers]]
        clock_1 = wall_clock()
        up_1 = workflow_state(workflow=clockspawn, task=b, point=%(point)s, sequential=False):PT7S
.
.
.
```
![image](https://github.com/cylc/cylc-flow/assets/11400777/e1a9d5cc-13ea-4464-a7c3-ed53afee02ee)
(if there's multiple xtriggers on a single task it upholds the sequential setting if any)

This `sequential` argument name is reserved, and not passed onto the xtrigger module/function.
It can be defined in the xtrigger module/function (as in workflow declaration), but must have a Boolean default:
![image](https://github.com/cylc/cylc-flow/assets/11400777/3acdfd4b-03c0-4aa1-bf0a-891206e54367)
(i.e. from modifying `cylc.flow.xtriggers.workflow_state` to include settings arg in function definition)
`cylc.flow.xtriggers.wall_clock.wall_clock` has `sequential=True` set

On xtrigger satisfaction the corresponding parentless sequential xtriggered task (PSXT) will spawn out to the RH limit, or next occurrence of a PSXT, or non-parentless task occurrence.


**Note:**
Tui sometimes shows no tasks before a corresponding xtrigger is satisfied. This problem is not reflected in the data-store or WUI.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.

