### PR TITLE
completion_server: minor fixes

### DIFF
--- a/cylc/flow/scripts/completion_server.py
+++ b/cylc/flow/scripts/completion_server.py
@@ -60,7 +60,7 @@ from cylc.flow.resources import (
     list_resources as list_resources_,
     RESOURCE_DIR,
 )
-from cylc.flow.scripts.cylc import COMMANDS
+from cylc.flow.scripts.cylc import ALIASES, COMMANDS
 from cylc.flow.scripts.scan import FLOW_STATES, get_pipe, ScanOptions
 from cylc.flow.terminal import cli_function
 from cylc.flow.workflow_files import infer_latest_run_from_id
@@ -181,7 +181,7 @@ async def complete_cylc(_root: str, *items: str) -> t.List[str]:
         return await complete_command()
     if length == 1:
         return await complete_command(partial)
-    command: str = items[0]
+    command: str = ALIASES.get(items[0], items[0])  # resolve command aliases
 
     # special logic for the pseudo "help" and "version" commands
     if command == 'help':
@@ -314,6 +314,8 @@ def list_options(command: str) -> t.List[str]:
 
     Note: This provides the long formats of options e.g. `--help` not `-h`.
     """
+    if command in COMMAND_OPTION_MAP:
+        return COMMAND_OPTION_MAP[command]
     try:
         entry_point = COMMANDS[command].resolve()
     except KeyError:
@@ -478,12 +480,29 @@ async def list_colours(
 # non-exhaustive list of Cylc commands which take non-workflow arguments
 COMMAND_MAP: t.Dict[str, t.Optional[t.Callable]] = {
     # register commands which have special positional arguments
-    'install': list_src_workflows,
     'get-resources': list_resources,
+    'install': list_src_workflows,
+    'vip': list_src_workflows,
     # commands for which we should not attempt to complete arguments
-    'scan': None,
     'cycle-point': None,
+    'hub': None,
     'message': None,
+    'scan': None,
+}
+
+
+# commands we can't list options for in the standard way
+COMMAND_OPTION_MAP = {
+    'gui': [
+        '--debug',
+        '--help',
+        '--new',
+        '--no-browser',
+    ],
+    'hub': [
+        '--debug',
+        '--help',
+    ],
 }
 
 # non-exhaustive list of Cylc CLI options

--- a/tests/unit/scripts/test_completion_server.py
+++ b/tests/unit/scripts/test_completion_server.py
@@ -246,6 +246,12 @@ async def test_complete_cylc(dummy_workflow):
         'cylc', '62656566', '--77656C6C696E67746F6E='
     ) == set()
 
+    # $ cylc cat-log f<tab><tab>
+    assert await _complete_cylc('cylc', 'cat-log', 'f') == {'foo/run2//'}
+
+    # $ cylc log f<tab><tab>  # NOTE: "log" is an alias for "cat-log"
+    assert await _complete_cylc('cylc', 'log', 'f') == {'foo/run2//'}
+
     # $ cylc help <tab><tab>
     assert 'all' in await _complete_cylc('cylc', 'help', '')
 


### PR DESCRIPTION
* Options and arguments are now correctly listed for command aliases.
  * No options or arguments were listed for aliases before.
* Arguments are now correctly listed for `vip`.
  * It was listing installed workflows before, it now lists source workflows.
* Some default options are now correctly listed for `gui` and `hub`.
  * No options were listed for `gui` or `hub` before.

To test:
* Install the [auto completion](https://cylc.github.io/cylc-doc/stable/html/installation.html#shell-auto-completion).
* Check out this branch and activate your Cylc environment.
* Then use the shell completion as normal.
* Check the three bullet points above are correct.

Note: To stop your completion server `ps -faux | grep cylc` then `kill <pid>`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.