### PR TITLE
client: don't attempt to clean up old contact files in task messages

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -143,6 +143,10 @@ class WorkflowRuntimeClientBase(metaclass=ABCMeta):
                 f'It has moved to {contact_host}:{contact_port}'
             )
 
+        if os.getenv('CYLC_TASK_COMMS_METHOD'):
+            # don't attempt to clean up old contact files in task messages
+            return
+
         # Cannot connect, perhaps workflow is no longer running and is leaving
         # behind a contact file?
         try:


### PR DESCRIPTION
Closes #5013

* The `detect_old_contact_file` check serves two purposes:
  1. It removes the contact files of crashed workflows.
  2. It helps the client to differentiate between a communication timeout (e.g. network error or blocked port) and a stopped workflow.
* Remote platforms don't necessarily have SSH access back to the scheduler host which can cause confusing errors.
* Due to the potentially large number of jobs, this check can cause a flurry of SSH'es which isn't great.
* The consequence of this change is that WorkflowStopped errors will be replaced by ClientTimeout errors in job stderr.

Note this applies to the `cylc message` commands built into the job script, but also to any command run within a user's job e.g. `cylc message -- <msg or custom output> `, `cylc broadcast`, etc.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.