### PR TITLE
Fix.cycle task states query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,10 +24,13 @@ management and does not bundle Jinja2.
 
 ## __cylc-7.8.14 (Upcoming)__
 
+[#5747](https://github.com/cylc/cylc-flow/pull/5747) - Fix a bug where Cylc
+Review was not returning the correct number of entries in the Cycles page.
+
 
 ## __cylc-7.8.13 (2023-06-13)__
 
-[#5309](https://github.com/cylc/cylc-flow/pull/5309) - Cylc 8 compat for Cylc Review: 
+[#5309](https://github.com/cylc/cylc-flow/pull/5309) - Cylc 8 compat for Cylc Review:
   - Allow Cylc Review to see all jobs with different flow nums for Cylc 8.1 workflows
   - Warn that not all jobs for different flows will be visible for Cylc 8.0 workflows
 

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -559,9 +559,9 @@ class CylcReviewDAO(object):
             " sum(" + states_stmt["fail"] + ") AS n_fail"
             " FROM task_states" +
             " GROUP BY cycle" +
-            " HAVING sum(" + states_stmt["active"] + ")>0" +
-            " OR sum(" + states_stmt["success"] + ")>0" +
-            " OR sum(" + states_stmt["fail"] + ")>0"
+            " HAVING n_active > 0" +
+            " OR n_success > 0" +
+            " OR n_fail >0"
         )
         if integer_mode:
             stmt += " ORDER BY cast(cycle as number)"


### PR DESCRIPTION
Fixes a bug reported by a user.

Pagination in Cylc Review works on number of cycles in database up to the limit per page, whether or not those cycles will be displayed!

### Bug description and reproduction

```ini
# Suite.rc
[scheduling]
    cycling mode = integer
    initial cycle point = 0
    runahead limit = P20
    spawn to max active cycle points = true
    [[dependencies]]
        [[[P1]]]
            graph = foo[-P1] => foo
[runtime]
    [[foo]]
        script = sleep 600
```

1. Run this workflow, wait until all the tasks have spawned out to the runahead limit.
2. Open a copy of Cylc Review and click on the link to the Cycles List of this workflow.
3. Try changing the number of entries per page for i in range(21,23). 

### Possible secondary bug (Cylc 8 workflows)

`ready` state has become `preparing`. States `queued`, `runahead`, `retrying` and `submit-retrying` can no longer be identified from the database.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are not included because this is legacy software. Reviewers should test the main bug as described. n.b. to test explicitly run `/path/to/cylc-7-worktree/bin/cylc review start` to start your own server.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
