### PR TITLE
clarify SLURM job handler docs

### DIFF
--- a/cylc/flow/job_runner_handlers/slurm.py
+++ b/cylc/flow/job_runner_handlers/slurm.py
@@ -42,7 +42,6 @@ file:
 
    * Cylc requires long form directives (e.g. ``--begin`` not ``-b``).
    * Cylc requires an ``=`` even if the directive does not have a value
-   * Cylc requires an ``=`` even if the directive does not have a value
      (e.g. ``--hold=`` not ``--hold``).
    * If a directive does not have a value you may use the short form
      (e.g. ``-H=``). But the directive must still be suffixed with an ``=``.

--- a/cylc/flow/job_runner_handlers/slurm.py
+++ b/cylc/flow/job_runner_handlers/slurm.py
@@ -40,8 +40,12 @@ file:
 
 .. note::
 
-   Since not all SLURM commands have a short form, cylc requires
-   the long form directives.
+   * Cylc requires long form directives (e.g. ``--begin`` not ``-b``).
+   * Cylc requires an ``=`` even if the directive does not have a value
+   * Cylc requires an ``=`` even if the directive does not have a value
+     (e.g. ``--hold=`` not ``--hold``).
+   * If a directive does not have a value you may use the short form
+     (e.g. ``-H=``). But the directive must still be suffixed with an ``=``.
 
 These are written to the top of the job script like this:
 


### PR DESCRIPTION
Clarify the formats permitted for directives to SLURM.

Record investigations:

```ini
# part of a flow.cylc file
[[[directives]]]
  -H               # Fails Cylc validation
  -H=              # Works
  --hold           # Fails Cylc validation
  --hold=          # Holds your SLURM job as you'd hope
  -b now+60        # Fails Cylc validation
  -b=now+60        # Sbatch fails with invalid options
  -b now+60=       # Sbatch ... just no
  --begin=now+60   # Works

```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] This is a documentation change only: I have built the documentation locally.