### PR TITLE
Kill tasks during job prep.

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -920,6 +920,7 @@ class Scheduler:
                 name, args, kwargs = command
             except Empty:
                 break
+
             args_string = ', '.join(str(a) for a in args)
             kwargs_string = ', '.join(
                 f"{key}={value}" for key, value in kwargs.items()

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -140,7 +140,7 @@ class TaskProxy:
             True whilst task is awaiting job prep, reset to False once the
             preparation has completed.
         .killed_in_job_prep:
-            killed during job preparation. set to submit-failed once prep finished
+            killed during job preparation; set to submit-failed once prepped
 
     Args:
         tdef: The definition object of this task.

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -134,11 +134,13 @@ class TaskProxy:
             graph children: {msg: [(name, point), ...]}
         .flow_nums:
             flows I belong to
-         flow_wait:
+         .flow_wait:
             wait for flow merge before spawning children
         .waiting_on_job_prep:
             True whilst task is awaiting job prep, reset to False once the
             preparation has completed.
+        .killed_in_job_prep:
+            killed during job preparation. set to submit-failed once prep finished
 
     Args:
         tdef: The definition object of this task.
@@ -180,6 +182,7 @@ class TaskProxy:
         'tokens',
         'try_timers',
         'waiting_on_job_prep',
+        'killed_in_job_prep'
     ]
 
     def __init__(
@@ -252,6 +255,7 @@ class TaskProxy:
         self.late_time: Optional[float] = None
         self.is_late = is_late
         self.waiting_on_job_prep = False
+        self.killed_in_job_prep = False
 
         self.state = TaskState(tdef, self.point, status, is_held)
 


### PR DESCRIPTION
Close #5746 

This PR allows `cylc kill` to abort jobs that are in the job preparation pipeline, resulting in the submit-failed state.

To avoid dealing with the complexities of partial job preparation, I've take the following approach:
- the kill command sets a flag in preparing task proxies
- the job submission process aborts at the last minute, after preparation has completed 
- (so retriggering the task will result in a new submit number).

Tested by deliberately extending job preparation like this (and kill tasks whilst still in the preparing state)

```
platform = $(sleep 10; echo localhost)
```


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
