### PR TITLE
Fix execution time limit polling intervals [Cylc 7]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,10 +24,13 @@ management and does not bundle Jinja2.
 
 ## __cylc-7.8.14 (Upcoming)__
 
+[#5751](https://github.com/cylc/cylc-flow/pull/5309) - prevent first
+execution time limit polling delay incrementing for every task where it is
+used.
 
 ## __cylc-7.8.13 (2023-06-13)__
 
-[#5309](https://github.com/cylc/cylc-flow/pull/5309) - Cylc 8 compat for Cylc Review: 
+[#5309](https://github.com/cylc/cylc-flow/pull/5309) - Cylc 8 compat for Cylc Review:
   - Allow Cylc Review to see all jobs with different flow nums for Cylc 8.1 workflows
   - Warn that not all jobs for different flows will be visible for Cylc 8.0 workflows
 

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -1068,12 +1068,12 @@ class TaskEventsManager(object):
 
         Returns: List of delays from start of task.
         """
-        # Remove excessive polling before time limit
-        while sum(delays) > time_limit:
-            del delays[-1]
-
-        # But fill up the gap before time limit
-        if delays:
+        if sum(delays) > time_limit:
+            # Remove excessive polling before time limit
+            while sum(delays) > time_limit:
+                del delays[-1]
+        elif delays:
+            # But fill up the gap before time limit
             size = int((time_limit - sum(delays)) / delays[-1])
             delays.extend([delays[-1]] * size)
 

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -28,6 +28,7 @@ This module provides logic to:
 """
 
 from collections import namedtuple
+import copy
 from logging import getLevelName, CRITICAL, ERROR, WARNING, INFO, DEBUG
 import os
 from pipes import quote
@@ -1013,7 +1014,7 @@ class TaskEventsManager(object):
                 # Total timeout after adding execution time limit polling
                 # intervals:
                 timeout = (time_limit + sum(time_limit_delays))
-
+                import pdb; pdb.set_trace()
                 delays = self.process_execution_polling_delays(
                     delays, time_limit, time_limit_delays
                 )
@@ -1093,7 +1094,17 @@ class TaskEventsManager(object):
             # We have a list of execution time limit polling intervals,
             >>> this([10], 25, [5, 6, 7, 8])
             [10, 10, 10, 6, 7, 8]
+
+            >>> time_limit_delays = [10]
+            >>> this([40, 40], 60, time_limit_delays)
+            [40, 30, 10]
+
+            >>> time_limit_delays
+            [10]
+
         """
+        # We do not want to modify time limit delays config in memory:
+        time_limit_delays = copy.copy(time_limit_delays)
         if sum(delays) > time_limit:
             # Remove excessive polling before time limit
             while sum(delays) > time_limit:

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -1105,11 +1105,9 @@ class TaskEventsManager(object):
 
         # After the last delay before the execution time limit add the
         # delay to get to the execution_time_limit
-        if len(time_limit_delays) > 1:
-            time_limit_delays[0] += time_limit - sum(delays)
-        else:
-            delays.append(
-                time_limit_delays[0] + time_limit - sum(delays))
+        if len(time_limit_delays) == 1:
+            time_limit_delays.append(time_limit_delays[0])
+        time_limit_delays[0] += time_limit - sum(delays)
 
         delays += time_limit_delays
         return delays

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -1015,7 +1015,7 @@ class TaskEventsManager(object):
                 timeout = (time_limit + sum(time_limit_delays))
 
                 delays = self.process_execution_polling_delays(
-                    delays, time_limit_delays, time_limit
+                    delays, time_limit, time_limit_delays
                 )
 
         else:  # if itask.state.status == TASK_STATUS_SUBMITTED:
@@ -1057,7 +1057,7 @@ class TaskEventsManager(object):
 
     @staticmethod
     def process_execution_polling_delays(
-        delays, time_limit_delays, time_limit
+        delays, time_limit, time_limit_delays
     ):
         """Create list of intervals after starting at which to poll a task.
 
@@ -1067,6 +1067,33 @@ class TaskEventsManager(object):
             time_limit: Execution Time Limit.
 
         Returns: List of delays from start of task.
+
+        Examples:
+
+            >>> this = TaskEventsManager.process_execution_polling_delays
+
+            # Basic example:
+            >>> this([40, 35], 100, [10])
+            [40, 35, 35, 10]
+
+            # Second 40 second delay gets lopped off the list because it's
+            # after the execution time limit:
+            >>> this([40, 40], 60, [10])
+            [40, 30, 10]
+
+            # Expand last item in exection polling intervals to fill the
+            # execution time limit:
+            >>> this([5, 20], 100, [10])
+            [5, 20, 20, 20, 20, 25, 10]
+
+            # There are no execution polling intervals set - polling starts
+            # at execution time limit:
+            >>> this([], 10, [5])
+            [15, 5]
+
+            # We have a list of execution time limit polling intervals,
+            >>> this([10], 25, [5, 6, 7, 8])
+            [10, 10, 10, 6, 7, 8]
         """
         if sum(delays) > time_limit:
             # Remove excessive polling before time limit

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -1035,8 +1035,7 @@ class TaskEventsManager(object):
         itask.poll_timer = TaskActionTimer(ctx=ctx, delays=delays)
 
         # Log timeout and polling schedule
-        message = 'health check settings: %s=%s' % (
-            timeout_key, time_limit_str)
+        message = 'health check settings: %s=%s' % (timeout_key, time_limit_str)
         # Attempt to group identical consecutive delays as N*DELAY,...
         if itask.poll_timer.delays:
             items = []  # [(number of item - 1, item), ...]

--- a/lib/cylc/task_events_mgr.py
+++ b/lib/cylc/task_events_mgr.py
@@ -1014,7 +1014,6 @@ class TaskEventsManager(object):
                 # Total timeout after adding execution time limit polling
                 # intervals:
                 timeout = (time_limit + sum(time_limit_delays))
-                import pdb; pdb.set_trace()
                 delays = self.process_execution_polling_delays(
                     delays, time_limit, time_limit_delays
                 )
@@ -1028,15 +1027,15 @@ class TaskEventsManager(object):
                 default=[900]))  # Default 15 minute intervals
         try:
             itask.timeout = timeref + float(timeout)
-            time_limit_str = intvl_as_str(time_limit)
+            timeout_str = intvl_as_str(timeout)
         except (TypeError, ValueError):
             itask.timeout = None
-            time_limit_str = None
+            timeout_str = None
 
         itask.poll_timer = TaskActionTimer(ctx=ctx, delays=delays)
 
         # Log timeout and polling schedule
-        message = 'health check settings: %s=%s' % (timeout_key, time_limit_str)
+        message = 'health check settings: %s=%s' % (timeout_key, timeout_str)
         # Attempt to group identical consecutive delays as N*DELAY,...
         if itask.poll_timer.delays:
             items = []  # [(number of item - 1, item), ...]

--- a/lib/cylc/tests/test_task_events_mgr.py
+++ b/lib/cylc/tests/test_task_events_mgr.py
@@ -54,6 +54,17 @@ class TestTaskEventsManager(unittest.TestCase):
         self.assertEqual(1, cylc_log.debug.call_count)
         self.assertTrue(cylc_log.debug.call_args.contains("ls /tmp/123"))
 
+    def test_execution_polling_delays(self):
+        delays = []
+        time_limit_delays = [20, 30]
+        time_limit = 30
+        result = TaskEventsManager(
+            None, None, None, None
+        ).process_execution_polling_delays(
+            delays, time_limit_delays, time_limit
+        )
+        assert result == [50, 60]
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lib/parsec/fileparse.py
+++ b/lib/parsec/fileparse.py
@@ -262,7 +262,7 @@ def read_and_proc(fpath, template_vars=None, viewcfg=None, asedit=False):
         try:
             flines = inline(
                 flines, fdir, fpath, False, viewcfg=viewcfg, for_edit=asedit)
-        except IncludeFileNotFoundError, x:
+        except IncludeFileNotFoundError as x:
             raise FileParseError(str(x))
 
     # process with EmPy


### PR DESCRIPTION
Fixes 2 bugs without issues reports.

1. Backport of [this fix](https://github.com/cylc/cylc-flow/pull/5753) - ticket contains a fuller explanation.
2. Prevent task events manager modifying the list of `execution time limit polling intervals` in `glbl_cfg`, which was causing the first polling interval after the execution time limit to increment every time this code was run.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included - I've tested that this now produces more sensible output, but have not formally tested it.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
