### PR TITLE
Fix execution time limit polling intervals [cylc 8]

### DIFF
--- a/changes.d/5753.fix.md
+++ b/changes.d/5753.fix.md
@@ -1,1 +1,1 @@
-Execution time limit polling intervals should not have the last item modified
+Fixed bug where execution time limit polling intervals could end up incorrectly applied

--- a/changes.d/5753.fix.md
+++ b/changes.d/5753.fix.md
@@ -1,0 +1,1 @@
+Execution time limit polling intervals should not have the last item modified

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1653,12 +1653,11 @@ class TaskEventsManager():
             # execution time limit:
             while sum(delays) > time_limit:
                 del delays[-1]
-        else:
+        elif delays:
             # Repeat the last execution polling interval up to the execution
             # time limit:
-            if delays:
-                size = int((time_limit - sum(delays)) / delays[-1])
-                delays.extend([delays[-1]] * size)
+            size = int((time_limit - sum(delays)) / delays[-1])
+            delays.extend([delays[-1]] * size)
 
         # After the last delay before the execution time limit add the
         # delay to get to the execution_time_limit

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1662,11 +1662,11 @@ class TaskEventsManager():
 
         # After the last delay before the execution time limit add the
         # delay to get to the execution_time_limit
-        if len(time_limit_polling_intervals) > 1:
-            time_limit_polling_intervals[0] += time_limit - sum(delays)
-        else:
-            delays.append(
-                time_limit_polling_intervals[0] + time_limit - sum(delays))
+        if len(time_limit_polling_intervals) == 1:
+            time_limit_polling_intervals.append(
+                time_limit_polling_intervals[0]
+            )
+        time_limit_polling_intervals[0] += time_limit - sum(delays)
 
         # After the execution time limit poll at execution time limit polling
         # intervals.

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -42,3 +42,26 @@ async def test_process_job_logs_retrieval_warns_no_platform(
         warning = caplog.records[-1]
         assert warning.levelname == 'WARNING'
         assert 'Unable to retrieve' in warning.msg
+
+
+async def test__reset_job_timers(
+    one_conf: Fixture, flow: Fixture, scheduler: Fixture,
+    start: Fixture, caplog: Fixture, mock_glbl_cfg: Fixture,
+):
+    """Integration test of pathway leading to
+    process_execution_polling_intervals.
+    """
+    schd = scheduler(flow(one_conf))
+    async with start(schd):
+        itask = schd.pool.get_tasks()[0]
+        itask.state.status = 'running'
+        itask.platform['execution polling intervals'] = [25]
+        itask.platform['execution time limit polling intervals'] = [10]
+        itask.summary['execution_time_limit'] = 30
+        caplog.records.clear()
+        schd.task_events_mgr._reset_job_timers(itask)
+
+    assert (
+        'polling intervals=PT25S,PT15S,PT10S,...'
+        in caplog.records[0].msg
+    )


### PR DESCRIPTION
Response to a bug not otherwise recorded:

### Bug description

If the sum of `execution polling intervals` < `execution time limit` the remainder should be added to the first, but only the first `execution time limit polling interval`. Currently the remainder is always added to the first items in the list of `execution time limit polling intervals`.

The last item in the list of `execution time limit polling intervals` is repeated until the final itask timeout. At the moment if we set only one item in `execution time limit polling intervals` then every polling interval is `execution time limit polling intervals[0] + remainder`.

#### Example

```
execution_time_limit = 60
execution_polling_intervals = [50]
execution time limit polling intervals = [10]

list_of_polling_intervals_is = [50, 20] # polls onwards at intervals of 20s ...
list_of_polling_intervals_should_be = [50, 20, 10]   # polls onwards at intervals of 10s ...

```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
