### PR TITLE
Improve CLI 'Done' stdout.

### DIFF
--- a/cylc/flow/network/multi.py
+++ b/cylc/flow/network/multi.py
@@ -107,4 +107,4 @@ def _report_single(report, workflow, result):
 
 
 def _report(_):
-    print('Done')
+    print('Command submitted; the scheduler will log any problems.')


### PR DESCRIPTION
The word "Done" after a CLI command is issued is less than helpful.

This changes it to something more descriptive of what's actually happening.

Before:
```
$ cylc trigger blah
Done.
```

After:
```
$ cylc trigger blah
Command submitted; the scheduler will log any problems.
```

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed). [not needed]
- [x] `CHANGES.md` entry included if this is a change that can affect users [not needed]
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX. [not needed]
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch. [not needed]
