### PR TITLE
Dump timeout

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -303,7 +303,9 @@ class WorkflowRuntimeClient(  # type: ignore[misc]
             raise ClientTimeout(
                 'Timeout waiting for server response.'
                 ' This could be due to network or server issues.'
-                ' Check the workflow log.'
+                '\n* You might want to increase the timeout using the'
+                ' --comms-timeout option;'
+                '\n* or check the workflow log.'
             )
 
         if msg['command'] in PB_METHOD_MAP:

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -184,7 +184,12 @@ def main(_, options: 'Values', workflow_id: str) -> None:
         workflow_id,
         constraint='workflows',
     )
-    pclient = get_client(workflow_id, timeout=options.comms_timeout)
+    pclient = get_client(
+        workflow_id,
+        # set the default timeout a bit higher for "cylc dump" as it can
+        # take a little while for Cylc to formulate the response
+        timeout=options.comms_timeout or 15,
+    )
 
     if options.sort_by_cycle:
         sort_args = {'keys': ['cyclePoint', 'name']}


### PR DESCRIPTION
Issue from a Discourse thread: https://cylc.discourse.group/t/cylc8-migration-issues/733/37

The `cylc dump` command requires a bit of scheduler-side processing and sometimes isn't complete before the 5 second default comms-timeout. I tried testing this with the complex workflow (simulation mode) and got responses of ~3 seconds which is flying a bit close to the limit.

This PR ups the default comms timeout for the `cylc dump` command to 15 seconds and better explains the `ClientTimeout` error.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.