### PR TITLE
events: refactor key and make the event message available to handlers

### DIFF
--- a/changes.d/5769.feat.md
+++ b/changes.d/5769.feat.md
@@ -1,0 +1,1 @@
+Include task messages and workflow port as appropriate in emails configured by "mail events".

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -163,6 +163,12 @@ class Tokens(dict):
             for key in self._KEYS
         )
 
+    def __lt__(self, other):
+        return self.id < other.id
+
+    def __gt__(self, other):
+        return self.id > other.id
+
     def __ne__(self, other):
         if not isinstance(other, self.__class__):
             return True

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -294,7 +294,7 @@ async def parse_ids_async(
 
     # infer the run number if not specified the ID (and if possible)
     if infer_latest_runs:
-        _infer_latest_runs(*tokens_list, src_path=src_path)
+        _infer_latest_runs(tokens_list, src_path=src_path)
 
     _validate_number(
         *tokens_list,
@@ -409,12 +409,14 @@ def _validate_workflow_ids(*tokens_list, src_path):
         detect_both_flow_and_suite(src_path)
 
 
-def _infer_latest_runs(*tokens_list, src_path):
+def _infer_latest_runs(tokens_list, src_path):
     for ind, tokens in enumerate(tokens_list):
         if ind == 0 and src_path:
             # source workflow passed in as a path
             continue
-        tokens['workflow'] = infer_latest_run_from_id(tokens['workflow'])
+        tokens_list[ind] = tokens.duplicate(
+            workflow=infer_latest_run_from_id(tokens['workflow'])
+        )
         pass
 
 

--- a/cylc/flow/scripts/completion_server.py
+++ b/cylc/flow/scripts/completion_server.py
@@ -390,7 +390,6 @@ async def list_in_workflow(tokens: Tokens, infer_run=True) -> t.List[str]:
             # list possible IDs
             cli_detokenise(
                 tokens.duplicate(
-                    tokens=None,
                     # use the workflow ID provided on the CLI to allow
                     # run name inference
                     workflow=input_workflow,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -984,7 +984,11 @@ class TaskEventsManager():
         if self.mail_footer:
             stdin_str += process_mail_footer(
                 self.mail_footer,
-                get_workflow_template_variables(schd, id_keys[-1].event, ''),
+                get_workflow_template_variables(
+                    schd,
+                    id_keys[-1].event,
+                    id_keys[-1].message,
+                ),
             )
         self._send_mail(ctx, cmd, stdin_str, id_keys, schd)
 

--- a/cylc/flow/task_id.py
+++ b/cylc/flow/task_id.py
@@ -107,5 +107,6 @@ class TaskID:
     def get_standardised_taskid(cls, task_id):
         """Return task ID with standardised cycle point."""
         tokens = Tokens(task_id, relative=True)
-        tokens['cycle'] = cls.get_standardised_point_string(tokens['cycle'])
-        return tokens.relative_id
+        return tokens.duplicate(
+            cycle=cls.get_standardised_point_string(tokens['cycle'])
+        ).relative_id

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -43,8 +43,11 @@ from cylc.flow.id_match import filter_ids
 from cylc.flow.workflow_status import StopMode
 from cylc.flow.task_action_timer import TaskActionTimer, TimerFlags
 from cylc.flow.task_events_mgr import (
-    CustomTaskEventHandlerContext, TaskEventMailContext,
-    TaskJobLogsRetrieveContext)
+    CustomTaskEventHandlerContext,
+    EventKey,
+    TaskEventMailContext,
+    TaskJobLogsRetrieveContext,
+)
 from cylc.flow.task_id import TaskID
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import (
@@ -617,16 +620,17 @@ class TaskPool:
             self.compute_runahead()
             self.release_runahead_tasks()
 
-    def load_db_task_action_timers(self, row_idx, row):
+    def load_db_task_action_timers(self, row_idx, row) -> None:
         """Load a task action timer, e.g. event handlers, retry states."""
         if row_idx == 0:
             LOG.info("LOADING task action timers")
         (cycle, name, ctx_key_raw, ctx_raw, delays_raw, num, delay,
          timeout) = row
-        id_ = Tokens(
+        tokens = Tokens(
             cycle=cycle,
             task=name,
-        ).relative_id
+        )
+        id_ = tokens.relative_id
         try:
             # Extract type namedtuple variables from JSON strings
             ctx_key = json.loads(str(ctx_key_raw))
@@ -680,14 +684,13 @@ class TaskPool:
             itask.try_timers[ctx_key[1]] = TaskActionTimer(
                 ctx, delays, num, delay, timeout)
         elif ctx:
-            key1, submit_num = ctx_key
-            # Convert key1 to type tuple - JSON restores as type list
-            # and this will not previously have been converted back
-            if isinstance(key1, list):
-                key1 = tuple(key1)
-            key = (key1, cycle, name, submit_num)
+            (handler, event), submit_num = ctx_key
             self.task_events_mgr.add_event_timer(
-                key,
+                EventKey(
+                    handler,
+                    event,
+                    tokens.duplicate(job=submit_num),
+                ),
                 TaskActionTimer(
                     ctx, delays, num, delay, timeout
                 )
@@ -1091,7 +1094,7 @@ class TaskPool:
             for itask in self.get_tasks()
         )
 
-    def warn_stop_orphans(self):
+    def warn_stop_orphans(self) -> None:
         """Log (warning) orphaned tasks on workflow stop."""
         orphans = []
         orphans_kill_failed = []
@@ -1118,11 +1121,12 @@ class TaskPool:
                 )
             )
 
-        for key1, point, name, submit_num in (
-                self.task_events_mgr._event_timers
-        ):
-            LOG.warning("%s/%s/%s: incomplete task event handler %s" % (
-                point, name, submit_num, key1))
+        for id_key in self.task_events_mgr._event_timers:
+            LOG.warning(
+                f"{id_key.tokens.relative_id}:"
+                " incomplete task event handler"
+                f" {(id_key.handler, id_key.event)}"
+            )
 
     def log_incomplete_tasks(self) -> bool:
         """Log finished but incomplete tasks; return True if there any."""

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1917,7 +1917,7 @@ class TaskPool:
                 # Glob or task state was not matched by active tasks
                 if not tokens['task']:
                     # make task globs explicit to make warnings clearer
-                    tokens['task'] = '*'
+                    tokens = tokens.duplicate(task='*')
                 LOG.warning(
                     'No active tasks matching:'
                     # preserve :selectors when logging the id
@@ -1985,7 +1985,7 @@ class TaskPool:
             point_str = tokens['cycle']
             if not tokens['task']:
                 # make task globs explicit to make warnings clearer
-                tokens['task'] = '*'
+                tokens = tokens.duplicate(task='*')
             name_str = tokens['task']
             try:
                 point_str = standardise_point_string(point_str)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -689,6 +689,9 @@ class TaskPool:
                 EventKey(
                     handler,
                     event,
+                    # NOTE: the event "message" is not preserved in the DB so
+                    # we use the event as a placeholder
+                    event,
                     tokens.duplicate(job=submit_num),
                 ),
                 TaskActionTimer(

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -20,7 +20,15 @@ from collections import Counter
 from copy import copy
 from fnmatch import fnmatchcase
 from typing import (
-    Any, Callable, Dict, List, Set, Tuple, Optional, TYPE_CHECKING
+    Any,
+    Callable,
+    Counter as TypingCounter,
+    Dict,
+    List,
+    Optional,
+    Set,
+    TYPE_CHECKING,
+    Tuple,
 )
 
 from metomi.isodatetime.timezone import get_local_time_zone
@@ -242,7 +250,7 @@ class TaskProxy:
         self.poll_timer: Optional['TaskActionTimer'] = None
         self.timeout: Optional[float] = None
         self.try_timers: Dict[str, 'TaskActionTimer'] = {}
-        self.non_unique_events = Counter()  # type: ignore # TODO: figure out
+        self.non_unique_events: TypingCounter[str] = Counter()
 
         self.clock_trigger_times: Dict[str, int] = {}
         self.expire_time: Optional[float] = None

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.scheduler import Scheduler
     from cylc.flow.task_pool import TaskPool
+    from cylc.flow.task_events_mgr import EventKey
 
 Version = Any
 # TODO: narrow down Any (should be str | int) after implementing type
@@ -385,16 +386,17 @@ class WorkflowDatabaseManager:
             for key, value in template_vars.items()
         )
 
-    def put_task_event_timers(self, task_events_mgr):
+    def put_task_event_timers(self, task_events_mgr) -> None:
         """Put statements to update the task_action_timers table."""
         if task_events_mgr.event_timers_updated:
             self.db_deletes_map[self.TABLE_TASK_ACTION_TIMERS].append({})
-            for key, timer in task_events_mgr._event_timers.items():
-                key1, point, name, submit_num = key
+            id_key: 'EventKey'
+            for id_key, timer in task_events_mgr._event_timers.items():
+                key1 = (id_key.handler, id_key.event)
                 self.db_inserts_map[self.TABLE_TASK_ACTION_TIMERS].append({
-                    "name": name,
-                    "cycle": point,
-                    "ctx_key": json.dumps((key1, submit_num,)),
+                    "name": id_key.tokens['task'],
+                    "cycle": id_key.tokens['cycle'],
+                    "ctx_key": json.dumps((key1, id_key.tokens['job'],)),
                     "ctx": self._namedtuple2json(timer.ctx),
                     "delays": json.dumps(timer.delays),
                     "num": timer.num,

--- a/tests/functional/events/09-task-event-mail.t
+++ b/tests/functional/events/09-task-event-mail.t
@@ -20,7 +20,7 @@
 if ! command -v mail 2>'/dev/null'; then
     skip_all '"mail" command not available'
 fi
-set_test_number 5
+set_test_number 6
 mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
@@ -49,17 +49,15 @@ run_ok "${TEST_NAME_BASE}-validate" \
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --reference-test --debug --no-detach ${OPT_SET} "${WORKFLOW_NAME}"
 
-contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
-retry: 1/t1/01
-succeeded: 1/t1/02
-see: http://localhost/stuff/${USER}/${WORKFLOW_NAME}/
-__LOG__
+run_ok "${TEST_NAME_BASE}-grep-log-1" \
+    grep -Pizo 'job: 1/t1/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-grep-log-2" \
+    grep -Pizo 'job: 1/t1/02.*\n.*event: succeeded' "${TEST_SMTPD_LOG}"
 
-
-run_ok "${TEST_NAME_BASE}-grep-log" \
-    grep -qPizo "Subject: \[1/t1/01 retry\]\n? ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
-run_ok "${TEST_NAME_BASE}-grep-log" \
-    grep -qPizo "Subject: \[1/t1/02 succeeded\]\n? ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-grep-log-3" \
+    grep -Pizo "Subject: \[1/t1/01 retry\].*(\n)?.* ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-grep-log-4" \
+    grep -Pizo "Subject: \[1/t1/02 succeeded\].*(\n)?.* ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
 
 purge
 mock_smtpd_kill

--- a/tests/functional/events/29-task-event-mail-1.t
+++ b/tests/functional/events/29-task-event-mail-1.t
@@ -20,7 +20,7 @@
 if ! command -v mail 2>'/dev/null'; then
     skip_all '"mail" command not available'
 fi
-set_test_number 4
+set_test_number 5
 
 mock_smtpd_init
 create_test_global_config "
@@ -37,13 +37,15 @@ run_ok "${TEST_NAME_BASE}-validate" \
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --reference-test --debug --no-detach "$WORKFLOW_NAME"
 
-contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
-retry: 1/t1/01
-see: http://localhost/stuff/${USER}/${WORKFLOW_NAME}/
-__LOG__
+run_ok "${TEST_NAME_BASE}-grep-log-1" \
+    grep -Pizo "job: 1/t1/01.*\n.*event: retry.*\n.*" "${TEST_SMTPD_LOG}"
 
-run_ok "${TEST_NAME_BASE}-grep-log" \
-    grep -qPizo "Subject: \[1/t1/01 retry\]\n? ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-grep-log-2" grep  \
+    "see: http://localhost/stuff/${USER}/${WORKFLOW_NAME}/" \
+    "${TEST_SMTPD_LOG}"
+
+run_ok "${TEST_NAME_BASE}-grep-log-2" \
+    grep -Pizo "Subject: \\[1/t1/01 retry\\].*(\n)?.*${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
 
 purge
 mock_smtpd_kill

--- a/tests/functional/events/30-task-event-mail-2.t
+++ b/tests/functional/events/30-task-event-mail-2.t
@@ -20,7 +20,7 @@
 if ! command -v mail 2>'/dev/null'; then
     skip_all '"mail" command not available'
 fi
-set_test_number 5
+set_test_number 20
 mock_smtpd_init
 OPT_SET=
 if [[ "${TEST_NAME_BASE}" == *-globalcfg ]]; then
@@ -49,22 +49,29 @@ run_ok "${TEST_NAME_BASE}-validate" \
 workflow_run_fail "${TEST_NAME_BASE}-run" \
     cylc play --reference-test --debug --no-detach ${OPT_SET} "${WORKFLOW_NAME}"
 
+# 1 - retry
+run_ok "${TEST_NAME_BASE}-t1-01" grep -Pizo 'job: 1/t1/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t2-01" grep -Pizo 'job: 1/t2/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t3-01" grep -Pizo 'job: 1/t3/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t4-01" grep -Pizo 'job: 1/t4/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t5-01" grep -Pizo 'job: 1/t5/01.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+
+# 2 - retry
+run_ok "${TEST_NAME_BASE}-t1-02" grep -Pizo 'job: 1/t1/02.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t2-02" grep -Pizo 'job: 1/t2/02.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t3-02" grep -Pizo 'job: 1/t3/02.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t4-02" grep -Pizo 'job: 1/t4/02.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t5-02" grep -Pizo 'job: 1/t5/02.*\n.*event: retry' "${TEST_SMTPD_LOG}"
+
+# 3 - fail
+run_ok "${TEST_NAME_BASE}-t1-03" grep -Pizo 'job: 1/t1/03.*\n.*event: failed' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t2-03" grep -Pizo 'job: 1/t2/03.*\n.*event: failed' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t3-03" grep -Pizo 'job: 1/t3/03.*\n.*event: failed' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t4-03" grep -Pizo 'job: 1/t4/03.*\n.*event: failed' "${TEST_SMTPD_LOG}"
+run_ok "${TEST_NAME_BASE}-t5-03" grep -Pizo 'job: 1/t5/03.*\n.*event: failed' "${TEST_SMTPD_LOG}"
+
+
 contains_ok "${TEST_SMTPD_LOG}" <<__LOG__
-retry: 1/t1/01
-retry: 1/t2/01
-retry: 1/t3/01
-retry: 1/t4/01
-retry: 1/t5/01
-retry: 1/t1/02
-retry: 1/t2/02
-retry: 1/t3/02
-retry: 1/t4/02
-retry: 1/t5/02
-failed: 1/t1/03
-failed: 1/t2/03
-failed: 1/t3/03
-failed: 1/t4/03
-failed: 1/t5/03
 see: http://localhost/stuff/${USER}/${WORKFLOW_NAME}/
 __LOG__
 
@@ -73,6 +80,6 @@ run_ok "${TEST_NAME_BASE}-grep-log" \
 run_ok "${TEST_NAME_BASE}-grep-log" \
     grep -qPizo "Subject: \[. tasks failed\]\n? ${WORKFLOW_NAME}" "${TEST_SMTPD_LOG}"
 
-    purge
+purge
 mock_smtpd_kill
 exit

--- a/tests/functional/restart/44-reinvoke.t
+++ b/tests/functional/restart/44-reinvoke.t
@@ -53,7 +53,7 @@ run_ok "${TEST_NAME_BASE}-cmd" \
 sed -n -i 's/CYLC_WORKFLOW_COMMAND=.*cylc //p' "${TEST_NAME_BASE}-cmd.stdout"
 
 # ensure the whole workflow ID is present in the command (including the run number)
-CMD="^play --pause ${WORKFLOW_NAME}/run1 --host=localhost$"
+CMD="^play --pause ${WORKFLOW_NAME}/run1 --host=localhost --color=never$"
 if grep "${CMD}" "${TEST_NAME_BASE}-cmd.stdout"; then
     ok "${TEST_NAME_BASE}-re-invoked-id"
 else

--- a/tests/integration/events/test_task_events.py
+++ b/tests/integration/events/test_task_events.py
@@ -51,7 +51,7 @@ async def test_mail_footer_template(
 
     # start the workflow and get it to send an email
     ctx = SimpleNamespace(mail_to=None, mail_from=None)
-    id_keys = [EventKey('none', 'failed', Tokens('//1/a'))]
+    id_keys = [EventKey('none', 'failed', 'failed', Tokens('//1/a'))]
     async with start(mod_one) as one_log:
         mod_one.task_events_mgr._process_event_email(mod_one, ctx, id_keys)
 
@@ -71,6 +71,33 @@ async def test_mail_footer_template(
     # check that the mail is sent even if there are issues with the footer
     assert len(mail_calls) == 1
 
+
+async def test_event_email_body(
+    mod_one,
+    start,
+    capcall,
+):
+    """It should send an email with the event context."""
+    mail_calls = capcall(
+        'cylc.flow.task_events_mgr.TaskEventsManager._send_mail'
+    )
+
+    # start the workflow and get it to send an email
+    ctx = SimpleNamespace(mail_to=None, mail_from=None)
+    async with start(mod_one):
+        # send a custom task message with the warning severity level
+        id_keys = [EventKey('none', 'warning', 'warning message', Tokens('//1/a/01'))]
+        mod_one.task_events_mgr._process_event_email(mod_one, ctx, id_keys)
+
+    # test the email which would have been sent for this message
+    email_body = mail_calls[0][0][3]
+    assert 'event: warning'
+    assert 'job: 1/a/01' in email_body
+    assert 'message: warning message' in email_body
+    assert f'workflow: {mod_one.tokens["workflow"]}' in email_body
+    assert f'host: {mod_one.host}' in email_body
+    assert f'port: {mod_one.server.port}' in email_body
+    assert f'owner: {mod_one.owner}' in email_body
 
 # NOTE: we do not test custom event handlers here because these are tested
 # as a part of workflow validation (now also performed by cylc play)

--- a/tests/integration/events/test_task_events.py
+++ b/tests/integration/events/test_task_events.py
@@ -18,6 +18,9 @@ from types import SimpleNamespace
 
 from .test_workflow_events import TEMPLATES
 
+from cylc.flow.id import Tokens
+from cylc.flow.task_events_mgr import EventKey
+
 import pytest
 
 
@@ -48,7 +51,7 @@ async def test_mail_footer_template(
 
     # start the workflow and get it to send an email
     ctx = SimpleNamespace(mail_to=None, mail_from=None)
-    id_keys = [((None, 'failed'), '1', 'a', 1)]
+    id_keys = [EventKey('none', 'failed', Tokens('//1/a'))]
     async with start(mod_one) as one_log:
         mod_one.task_events_mgr._process_event_email(mod_one, ctx, id_keys)
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -216,7 +216,8 @@ async def test_filter_task_proxies(
     expected_bad_items: List[str],
     expected_warnings: List[str],
     mod_example_flow: Scheduler,
-    caplog: pytest.LogCaptureFixture
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch,
 ) -> None:
     """Test TaskPool.filter_task_proxies().
 
@@ -256,7 +257,8 @@ async def test_filter_task_proxies_hidden(
     expected_bad_items: List[str],
     expected_warnings: List[str],
     mod_example_flow: Scheduler,
-    caplog: pytest.LogCaptureFixture
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch,
 ) -> None:
     """Test TaskPool.filter_task_proxies().
 
@@ -277,6 +279,13 @@ async def test_filter_task_proxies_hidden(
         expected_bad_items: Expected to be returned.
         expected_warnings: Expected to be logged.
     """
+    monkeypatch.setattr(
+        # make Tokens objects mutable to allow deepcopy to work on TaskProxy
+        # objects
+        'cylc.flow.id.Tokens.__setitem__',
+        lambda self, key, value: dict.__setitem__(self, key, value),
+    )
+
     caplog.set_level(logging.WARNING, CYLC_LOG)
     task_pool = mod_example_flow.pool
 

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -316,9 +316,9 @@ def test_tokens():
     with pytest.raises(ValueError):
         Tokens(foo='a')
 
-    Tokens()['cycle'] = 'a'
+    Tokens().duplicate(cycle='a')
     with pytest.raises(ValueError):
-        Tokens()['foo'] = 'a'
+        Tokens(foo='a')
 
     # test equality
     assert Tokens('a') == Tokens('a')
@@ -335,10 +335,24 @@ def test_tokens():
     assert not Tokens('a') == 1
 
     tokens = Tokens('a//b')
-    tokens.update({'cycle': 'c', 'task': 'd'})
-    assert tokens == Tokens('a//c/d')
-    with pytest.raises(ValueError):
+    new_tokens = tokens.duplicate(cycle='c', task='d')
+    assert new_tokens == Tokens('a//c/d')
+    with pytest.raises(Exception):
         tokens.update({'foo': 'c'})
+    with pytest.raises(Exception):
+        tokens['cycle'] = 'a'
+
+    # test gt/lt
+    assert sorted(
+        tokens.id
+        for tokens in [
+            Tokens('~u/c'),
+            Tokens('~u/b//1'),
+            Tokens('~u/a'),
+            Tokens('~u/b'),
+            Tokens('~u/b//2'),
+        ]
+    ) == ['~u/a', '~u/b', '~u/b//1', '~u/b//2', '~u/c']
 
 
 def test_no_look_behind():

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -576,6 +576,6 @@ async def test_expand_workflow_tokens_impl_selector(no_scan):
     """It should reject filters it can't handle."""
     tokens = tokenise('~user/*')
     await _expand_workflow_tokens([tokens])
-    tokens['workflow_sel'] = 'stopped'
+    tokens = tokens.duplicate(workflow_sel='stopped')
     with pytest.raises(InputError):
         await _expand_workflow_tokens([tokens])


### PR DESCRIPTION
#5566 turned out to be remarkably awkward to solve, as a result there are two other changes on this PR.

* Tokens objects are now immutable.
  * Partially addresses #5183
  * This means we can use them as dict keys and in sets which is greatly advantageous.
  * It also opens the door to caching as needed.
* Task events now use a named tuple and the fields have been rationalised.
  * Closes https://github.com/cylc/cylc-flow/issues/5566
  * The separate cycle/task/job fields have been combined into tokens.
  * The `key1` field has been flattened out.
* The message field is now available to event handlers.
  * This means we can get access to task messages.
  * There is a caveat attached to this, I haven't added a message column to the DB. This would be awkward as the table is shared with task action timers, etc.
  * This means that if an event handler is actioned just before a workflow shuts down, the exact message will be lost when the workflow restarts.
  * In this situation, it defaults to the event name, which might be INFO or custom for a task message.
* Fix a remote test which doesn't get run on CI and became broken by another change.
* Fix an email field which was never present.
* Change the event email format a tad to allow multiple event messages per email.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
