### PR TITLE
Allow isodatetime 3.1

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - graphviz  # for static graphing
   # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
   - jinja2 >=3.0,<3.1
-  - metomi-isodatetime >=1!3.0.0, <1!3.1.0
+  - metomi-isodatetime >=1!3.0.0, <1!3.2.0
   # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
   - protobuf >=4.21.2,<4.22.0
   - psutil >=5.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ install_requires =
     graphene>=2.1,<3
     # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
     jinja2==3.0.*
-    metomi-isodatetime==1!3.0.*
+    metomi-isodatetime>=1!3.0.0,<1!3.2.0
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
     protobuf>=4.21.2,<4.22.0
     psutil>=5.6.0


### PR DESCRIPTION
We released isodatetime 3.1.0 which was basically a bugfix release apart from dropping support for Python 3.6. The only real change in it was fixing mistake in the `isodatetime` command CLI help text.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] No tests needed
- [x] No `CHANGES.md` entry needed
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
