### PR TITLE
show: display wall_clock xtrigger times in ISO8601 rather than unix epoch seconds

### DIFF
--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -37,12 +37,16 @@ workflow database.
 """
 
 import asyncio
+import re
 import json
 from optparse import Values
 import sys
 from typing import Dict
 
 from ansimarkup import ansiprint
+
+from metomi.isodatetime.data import (
+    get_timepoint_from_seconds_since_unix_epoch as seconds2point)
 
 from cylc.flow.exceptions import InputError
 from cylc.flow.id import Tokens
@@ -334,9 +338,19 @@ async def prereqs_and_outputs_query(
                             f'{ext_trig["label"]} ... {state}',
                             state)
                     for xtrig in t_proxy['xtriggers']:
+
+                        wallclock_trigger = re.findall(
+                            r'wall_clock\(trigger_time=(.*)\)', xtrig['id'])
+                        if wallclock_trigger:
+                            label = (
+                                'wall_clock(trigger_time='
+                                f'{str(seconds2point(wallclock_trigger[0]))}'
+                            )
+                        else:
+                            label = xtrig["id"]
                         state = xtrig['satisfied']
                         print_msg_state(
-                            f'xtrigger "{xtrig["label"]} = {xtrig["id"]}"',
+                            f'xtrigger "{xtrig["label"]} = {label}"',
                             state)
     if not results['taskProxies']:
         ansiprint(

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -39,9 +39,8 @@ workflow database.
 import asyncio
 import re
 import json
-from optparse import Values
 import sys
-from typing import Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from ansimarkup import ansiprint
 
@@ -61,6 +60,10 @@ from cylc.flow.option_parsers import (
     ID_MULTI_ARG_DOC,
 )
 from cylc.flow.terminal import cli_function
+
+
+if TYPE_CHECKING:
+    from optparse import Values
 
 
 WORKFLOW_META_QUERY = '''
@@ -338,16 +341,7 @@ async def prereqs_and_outputs_query(
                             f'{ext_trig["label"]} ... {state}',
                             state)
                     for xtrig in t_proxy['xtriggers']:
-
-                        wallclock_trigger = re.findall(
-                            r'wall_clock\(trigger_time=(.*)\)', xtrig['id'])
-                        if wallclock_trigger:
-                            label = (
-                                'wall_clock(trigger_time='
-                                f'{str(seconds2point(wallclock_trigger[0]))}'
-                            )
-                        else:
-                            label = xtrig["id"]
+                        label = get_wallclock_label(xtrig) or xtrig['id']
                         state = xtrig['satisfied']
                         print_msg_state(
                             f'xtrigger "{xtrig["label"]} = {label}"',
@@ -358,6 +352,32 @@ async def prereqs_and_outputs_query(
             file=sys.stderr)
         return 1
     return 0
+
+
+def get_wallclock_label(xtrig: Dict[str, Any]) -> str:
+    """Return a label for an xtrigger if it is a wall_clock trigger.
+
+    Returns:
+        A label or False.
+
+    Examples:
+        >>> this = get_wallclock_label
+
+        >>> this({'id': 'wall_clock(trigger_time=0)'})
+        'wall_clock(trigger_time=1970-01-01T00:00:00Z)'
+
+        >>> this({'id': 'wall_clock(trigger_time=440143843)'})
+        'wall_clock(trigger_time=1983-12-13T06:10:43Z)'
+
+    """
+    wallclock_trigger = re.findall(
+        r'wall_clock\(trigger_time=(.*)\)', xtrig['id'])
+    if wallclock_trigger:
+        return (
+            'wall_clock(trigger_time='
+            f'{str(seconds2point(wallclock_trigger[0], True))})'
+        )
+    return ''
 
 
 async def task_meta_query(


### PR DESCRIPTION
**Built On:** #5780 

Whilst reviewing #5780 I noticed that the xtrigger description returned by `cylc show` gives the wallclock time for the wallclock xtrigger in seconds epoch. This proposes to convert that back into an ISO8601 format.

I'v currently not tested it since I want to canvass objections &c,

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry not included - this is a really minor change that no customer has reported.
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
