### PR TITLE
Test.sim mode changes on restart

### DIFF
--- a/changes.d/5789.fix.md
+++ b/changes.d/5789.fix.md
@@ -1,0 +1,1 @@
+Stop users changing run modes on restart.

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -606,6 +606,19 @@ class CylcWorkflowDAO:
         result = self.connect().execute(stmt).fetchone()
         return int(result[0]) if result else 0
 
+    def select_workflow_params_run_mode(self):
+        """Return original run_mode for workflow_params."""
+        stmt = rf"""
+            SELECT
+                value
+            FROM
+                {self.TABLE_WORKFLOW_PARAMS}
+            WHERE
+                key == 'run_mode'
+        """  # nosec (table name is code constant)
+        result = self.connect().execute(stmt).fetchone()
+        return result[0] if result else None
+
     def select_workflow_template_vars(self, callback):
         """Select from workflow_template_vars.
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -434,6 +434,18 @@ class Scheduler:
             # Mark this exc as expected (see docstring for .schd_expected):
             exc.schd_expected = True
             raise exc
+
+        # Prevent changing mode on restart.
+        if self.is_restart:
+            # check run mode against db
+            og_run_mode = self.workflow_db_mgr.get_pri_dao(
+            ).select_workflow_params_run_mode()
+            run_mode = self.config.run_mode()
+            if run_mode != og_run_mode:
+                raise InputError(
+                    f'This workflow was originally run in {og_run_mode} mode:'
+                    f' Will not restart in {run_mode} mode.')
+
         self.profiler.log_memory("scheduler.py: after load_flow_file")
 
         self.workflow_db_mgr.on_workflow_start(self.is_restart)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -439,7 +439,7 @@ class Scheduler:
         if self.is_restart:
             # check run mode against db
             og_run_mode = self.workflow_db_mgr.get_pri_dao(
-            ).select_workflow_params_run_mode()
+            ).select_workflow_params_run_mode() or 'live'
             run_mode = self.config.run_mode()
             if run_mode != og_run_mode:
                 raise InputError(

--- a/tests/integration/test_mode_on_restart.py
+++ b/tests/integration/test_mode_on_restart.py
@@ -1,0 +1,47 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""What happens to the mode on restart?
+
++--------------------+--------+-------+-------+
+| ↓restart \ start → | live   | sim   | dummy |
++====================+========+=======+=======+
+| live               | live   | sim * | ???   |
+| sim                | live * | sim   | ???   |
+| dummy              | ???    | ???   | dummy |
++--------------------+--------+-------+-------+
+
+* A warning ought to be emitted, since the user doesn't otherwise know
+  what's happening.
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize('mode_before', (('live'), ('simulation')))
+@pytest.mark.parametrize('mode_after', (('live'), ('simulation')))
+async def test_restart_mode(
+    flow, scheduler, start, one_conf, mode_before, mode_after
+):
+    """Restarting a workflow in live mode leads to workflow in live mode
+    """
+    id_ = flow(one_conf)
+    schd = scheduler(id_, run_mode=mode_before)
+    async with start(schd):
+        assert schd.config.run_mode() == mode_before
+
+    schd.options.run_mode = mode_after
+    async with start(schd):
+        assert schd.config.run_mode() == mode_before


### PR DESCRIPTION
Closes #5781 

There is some debate on the ticket about what action Cylc should take if `if run_mode != og_run_mode` - it probably makes sense to discuss that on #5781 - but the rest of the logic can be reviewed.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
