### PR TITLE
replace pkg_resources with importlib_metadata and packaging

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
-      fail-fast: false # Don't let a failed MacOS run stop the Ubuntu runs
+      fail-fast: false # don't stop on first failure
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
@@ -39,7 +39,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck sqlite3
+          sudo apt-get install -y sqlite3
 
       - name: Install
         run: |
@@ -48,37 +48,10 @@ jobs:
       - name: Configure git  # Needed by the odd test
         uses: cylc/release-actions/configure-git@v1
 
-      - name: Check changelog
-        if: startsWith(matrix.os, 'ubuntu')
-        run: towncrier build --draft
-
-      - name: Style
-        if: startsWith(matrix.os, 'ubuntu')
-        run: |
-          flake8
-          etc/bin/shellchecker
-
-      # note: exclude python 3.10+ from mypy checks as these produce false
-      # positives in installed libraries for python 3.7
-      - name: Typing
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.python-version, 3.9)
-        run: mypy
-
-      - name: Doctests
-        timeout-minutes: 4
-        run: |
-          pytest cylc/flow
-
       - name: Unit Tests
-        timeout-minutes: 4
+        timeout-minutes: 5
         run: |
-          pytest tests/unit
-
-      - name: Bandit
-        if: ${{ matrix.python-version == '3.7' }}
-        # https://github.com/PyCQA/bandit/issues/658
-        run: |
-          bandit -r --ini .bandit cylc/flow
+          pytest cylc/flow tests/unit
 
       - name: Integration Tests
         timeout-minutes: 6
@@ -104,9 +77,47 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
+  lint:
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    steps:
+      - name: Apt-Get Install
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # note: exclude python 3.10+ from mypy checks as these produce false
+      # positives in installed libraries for python 3.7
+      - name: Configure Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install
+        run: |
+          pip install -e ."[tests]"
+
+      - name: Flake8
+        run: flake8
+
+      - name: Bandit
+        run: |
+          bandit -r --ini .bandit cylc/flow
+
+      - name: Shellchecker
+        run: etc/bin/shellchecker
+
+      - name: MyPy
+        run: mypy
+
+      - name: Towncrier
+        run: towncrier build --draft
+
       - name: Linkcheck
-        if: startsWith(matrix.python-version, '3.10')
-        run: pytest -m linkcheck --dist=load tests/unit
+        run: pytest -m linkcheck --dist=load --color=yes -n 10 tests/unit/test_links.py
 
   codecov:
     needs: test

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -10,13 +10,13 @@ dependencies:
   # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
   - jinja2 >=3.0,<3.1
   - metomi-isodatetime >=1!3.0.0, <1!3.2.0
+  - packaging
   # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
   - protobuf >=4.21.2,<4.22.0
   - psutil >=5.6.0
   - python
   - pyzmq >=22
-  - setuptools >=49,!=67.*
-  - importlib_metadata # [py<3.8]
+  - importlib_metadata >=5.0 # [py<3.12]
   - urwid >=2,<3
   - tomli >=2 # [py<3.11]
 

--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -58,11 +58,19 @@ __version__ = '8.3.0.dev'
 
 def iter_entry_points(entry_point_name):
     """Iterate over Cylc entry points."""
-    import pkg_resources
+    import sys
+    if sys.version_info[:2] > (3, 11):
+        from importlib.metadata import entry_points
+    else:
+        # BACK COMPAT: importlib_metadata
+        #   importlib.metadata was added in Python 3.8. The required interfaces
+        #   were completed by 3.12. For lower versions we must use the
+        #   importlib_metadata backport.
+        # FROM: Python 3.7
+        # TO: Python: 3.12
+        from importlib_metadata import entry_points
     yield from (
         entry_point
-        for entry_point in pkg_resources.iter_entry_points(entry_point_name)
-        # Filter out the cylc namespace as it should be empty.
-        # All cylc packages should take the form cylc-<name>
-        if entry_point.dist.key != 'cylc'
+        # for entry_point in entry_points()[entry_point_name]
+        for entry_point in entry_points().select(group=entry_point_name)
     )

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from typing import List, Optional, Tuple, Any, Union
 
 from contextlib import suppress
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version, Version
 
 from cylc.flow import LOG
 from cylc.flow import __version__ as CYLC_VERSION
@@ -1866,8 +1866,7 @@ def get_version_hierarchy(version: str) -> List[str]:
         ['', '8', '8.0', '8.0.1', '8.0.1a2', '8.0.1a2.dev']
 
     """
-    smart_ver: Any = parse_version(version)
-    # (No type anno. yet for Version in pkg_resources.extern.packaging.version)
+    smart_ver: Version = parse_version(version)
     base = [str(i) for i in smart_ver.release]
     hierarchy = ['']
     hierarchy += ['.'.join(base[:i]) for i in range(1, len(base) + 1)]

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -50,10 +50,8 @@ from pathlib import Path
 import re
 from typing import AsyncGenerator, Dict, Iterable, List, Optional, Tuple, Union
 
-from pkg_resources import (
-    parse_requirements,
-    parse_version
-)
+from packaging.version import parse as parse_version
+from packaging.specifiers import SpecifierSet
 
 from cylc.flow import LOG
 from cylc.flow.async_util import (
@@ -354,11 +352,7 @@ async def validate_contact_info(flow):
 
 def parse_requirement(requirement_string):
     """Parse a requirement from a requirement string."""
-    # we have to give the requirement a name but what we call it doesn't
-    # actually matter
-    for req in parse_requirements(f'x {requirement_string}'):
-        # there should only be one requirement
-        return (req,), {}
+    return (SpecifierSet(requirement_string),), {}
 
 
 @pipe(preproc=parse_requirement)
@@ -373,7 +367,7 @@ async def cylc_version(flow, requirement):
         flow (dict):
             Flow information dictionary, provided by scan through the pipe.
         requirement (str):
-            Requirement specifier in pkg_resources format e.g. ``> 8, < 9``
+            Requirement specifier in PEP 440 format e.g. ``> 8, < 9``
 
     """
     return parse_version(flow[ContactFileFields.VERSION]) in requirement
@@ -391,7 +385,7 @@ async def api_version(flow, requirement):
         flow (dict):
             Flow information dictionary, provided by scan through the pipe.
         requirement (str):
-            Requirement specifier in pkg_resources format e.g. ``> 8, < 9``
+            Requirement specifier in PEP 440 format e.g. ``> 8, < 9``
 
     """
     return parse_version(flow[ContactFileFields.API]) in requirement

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -277,7 +277,7 @@ def process_plugins(fpath, opts):
         try:
             # If you want it to work on sourcedirs you need to get the options
             # to here.
-            plugin_result = entry_point.resolve()(
+            plugin_result = entry_point.load()(
                 srcdir=fpath, opts=opts
             )
         except Exception as exc:

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -25,7 +25,7 @@ from shlex import quote
 import sys
 from typing import TYPE_CHECKING
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from cylc.flow import LOG, __version__
 from cylc.flow.exceptions import (

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -43,12 +43,28 @@ def pythonpath_manip():
 
 pythonpath_manip()
 
+if sys.version_info[:2] > (3, 11):
+    from importlib.metadata import (
+        entry_points,
+        files,
+    )
+else:
+    # BACK COMPAT: importlib_metadata
+    #   importlib.metadata was added in Python 3.8. The required interfaces
+    #   were completed by 3.12. For lower versions we must use the
+    #   importlib_metadata backport.
+    # FROM: Python 3.7
+    # TO: Python: 3.12
+    from importlib_metadata import (
+        entry_points,
+        files,
+    )
+
 import argparse
 from contextlib import contextmanager
 from typing import Iterator, NoReturn, Optional, Tuple
 
 from ansimarkup import parse as cparse
-import pkg_resources
 
 from cylc.flow import __version__, iter_entry_points
 from cylc.flow.option_parsers import (
@@ -306,9 +322,9 @@ def execute_cmd(cmd: str, *args: str) -> NoReturn:
         args: Command line arguments to pass to that command.
 
     """
-    entry_point: pkg_resources.EntryPoint = COMMANDS[cmd]
+    entry_point = COMMANDS[cmd]
     try:
-        entry_point.resolve()(*args)
+        entry_point.load()(*args)
     except ModuleNotFoundError as exc:
         msg = handle_missing_dependency(entry_point, exc)
         print(msg, file=sys.stderr)
@@ -401,7 +417,7 @@ def iter_commands() -> Iterator[Tuple[str, Optional[str], Optional[str]]]:
     """
     for cmd, entry_point in sorted(COMMANDS.items()):
         try:
-            module = __import__(entry_point.module_name, fromlist=[''])
+            module = __import__(entry_point.module, fromlist=[''])
         except ModuleNotFoundError as exc:
             handle_missing_dependency(entry_point, exc)
             continue
@@ -417,18 +433,10 @@ def print_id_help():
 
 
 def print_license() -> None:
-    try:
-        from importlib.metadata import files
-    except ImportError:
-        # BACK COMPAT: importlib_metadata
-        #   importlib.metadata was added in Python 3.8
-        # FROM: Python 3.7
-        # TO: Python: 3.8
-        from importlib_metadata import files  # type: ignore[no-redef]
-    license_file = next(filter(
-        lambda f: f.name == 'COPYING', files('cylc-flow')
-    ))
-    print(license_file.read_text())
+    for file in files('cylc-flow') or []:
+        if file.name == 'COPYING':
+            print(file.read_text())
+            return
 
 
 def print_command_list(commands=None, indent=0):
@@ -467,54 +475,57 @@ def cli_version(long_fmt=False):
     """Wrapper for get_version."""
     print(get_version(long_fmt))
     if long_fmt:
-        print(list_plugins())
+        print(cparse(list_plugins()))
     sys.exit(0)
 
 
 def list_plugins():
-    entry_point_names = [
-        entry_point_name
-        for entry_point_name
-        in pkg_resources.get_entry_map('cylc-flow').keys()
-        if entry_point_name.startswith('cylc.')
-    ]
+    from cylc.flow.terminal import DIM, format_grid
+    # go through all Cylc entry points
+    _dists = set()
+    __entry_points = {}
+    for entry_point in entry_points():
+        if (
+            # all Cylc entry points are under the "cylc" namespace
+            entry_point.group.startswith('cylc.')
+            # don't list cylc-flow entry-points (i.e. built-ins)
+            and not entry_point.value.startswith('cylc.flow')
+        ):
+            _dists.add(entry_point.dist)
+            __entry_points.setdefault(
+                entry_point.group,
+                [],
+            ).append(entry_point)
 
-    entry_point_groups = {
-        entry_point_name: [
-            entry_point
-            for entry_point
-            in iter_entry_points(entry_point_name)
-            if not entry_point.module_name.startswith('cylc.flow')
-        ]
-        for entry_point_name in entry_point_names
-    }
+    # list all the distriutions which provide Cylc entry points
+    _plugins = []
+    for dist in _dists:
+        _plugins.append((
+            '',
+            f'<light-blue>{dist.name}</light-blue>',
+            dist.version,
+            f'<{DIM}>{dist.locate_file("__init__.py").parent}</{DIM}>',
+        ))
 
-    dists = {
-        entry_point.dist
-        for entry_points in entry_point_groups.values()
-        for entry_point in entry_points
-    }
+    # list all of the entry points by "group" (e.g. "cylc.command")
+    _entry_points = []
+    for group, points in sorted(__entry_points.items()):
+        _entry_points.append((f'  {group}:', '', ''))
+        for entry_point in points:
+            _entry_points.append((
+                f'    {entry_point.name}',
+                f'<light-blue>{entry_point.dist.name}</light-blue>',
+                f'<{DIM}>{entry_point.value}</{DIM}>',
+            ))
 
-    lines = []
-    if dists:
-        lines.append('\nPlugins:')
-        maxlen1 = max(len(dist.project_name) for dist in dists) + 2
-        maxlen2 = max(len(dist.version) for dist in dists) + 2
-        for dist in dists:
-            lines.append(
-                f'  {dist.project_name.ljust(maxlen1)}'
-                f' {dist.version.ljust(maxlen2)}'
-                f' {dist.module_path}'
-            )
-
-        lines.append('\nEntry Points:')
-        for entry_point_name, entry_points in entry_point_groups.items():
-            if entry_points:
-                lines.append(f'  {entry_point_name}:')
-                for entry_point in entry_points:
-                    lines.append(f'    {entry_point}')
-
-    return '\n'.join(lines)
+    return '\n'.join((
+        '\n<bold>Plugins:</bold>',
+        *format_grid(_plugins),
+        '\n<bold>Entry Points:</bold>',
+        *format_grid(
+            _entry_points
+        ),
+    ))
 
 
 @contextmanager
@@ -686,7 +697,7 @@ def main():
 
 
 def handle_missing_dependency(
-    entry_point: pkg_resources.EntryPoint,
+    entry_point,
     err: ModuleNotFoundError
 ) -> str:
     """Return a suitable error message for a missing optional dependency.
@@ -698,12 +709,8 @@ def handle_missing_dependency(
 
     Re-raises the given ModuleNotFoundError if it is unexpected.
     """
-    try:
-        # Check for missing optional dependencies
-        entry_point.require()
-    except pkg_resources.DistributionNotFound as exc:
-        # Confirmed missing optional dependencies
-        return f"cylc {entry_point.name}: {exc}"
-    else:
-        # Error not due to missing optional dependencies; this is unexpected
-        raise err
+    msg = f'"cylc {entry_point.name}" requires "{entry_point.dist.name}'
+    if entry_point.extras:
+        msg += f'[{",".join(entry_point.extras)}]'
+    msg += f'"\n\n{err.__class__.__name__}: {err}'
+    return msg

--- a/cylc/flow/scripts/install.py
+++ b/cylc/flow/scripts/install.py
@@ -301,7 +301,7 @@ def install(
         'cylc.pre_configure'
     ):
         try:
-            entry_point.resolve()(srcdir=source, opts=opts)
+            entry_point.load()(srcdir=source, opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors
@@ -329,7 +329,7 @@ def install(
         'cylc.post_install'
     ):
         try:
-            entry_point.resolve()(
+            entry_point.load()(
                 srcdir=source_dir,
                 opts=opts,
                 rundir=str(rundir)

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -338,7 +338,7 @@ def pre_configure(opts: 'Values', src_dir: Path) -> None:
         'cylc.pre_configure'
     ):
         try:
-            entry_point.resolve()(srcdir=src_dir, opts=opts)
+            entry_point.load()(srcdir=src_dir, opts=opts)
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)
             # this is to separate plugin from core Cylc errors
@@ -355,7 +355,7 @@ def post_install(opts: 'Values', src_dir: Path, run_dir: Path) -> None:
         'cylc.post_install'
     ):
         try:
-            entry_point.resolve()(
+            entry_point.load()(
                 srcdir=src_dir,
                 opts=opts,
                 rundir=str(run_dir)

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -94,6 +94,48 @@ def print_contents(contents, padding=5, char='.', indent=0):
             print(f'{indent}  {" " * title_width}{" " * padding}{line}')
 
 
+def format_grid(rows, gutter=2):
+    """Format gridded text.
+
+    This takes a 2D table of text and formats it to the maximum width of each
+    column and adds a bit of space between them.
+
+    Args:
+        rows:
+            2D list containing the text to format.
+        gutter:
+            The width of the gutter between columns.
+
+    Examples:
+        >>> format_grid([
+        ...     ['a', 'b', 'ccccc'],
+        ...     ['ddddd', 'e', 'f'],
+        ... ])
+        ['a      b  ccccc  ',
+         'ddddd  e  f      ']
+
+        >>> format_grid([])
+        []
+
+    """
+    if not rows:
+        return rows
+    templ = [
+        '{col:%d}' % (max(
+            len(row[ind])
+            for row in rows
+        ) + gutter)
+        for ind in range(len(rows[0]))
+    ]
+    lines = []
+    for row in rows:
+        ret = ''
+        for ind, col in enumerate(row):
+            ret += templ[ind].format(col=col)
+        lines.append(ret)
+    return lines
+
+
 def supports_color():
     """Determine if running in a terminal which supports color.
 

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -25,13 +25,14 @@ This module provides the logic to:
 
 import json
 import os
-from pkg_resources import parse_version
 from shutil import copy, rmtree
 from sqlite3 import OperationalError
 from tempfile import mkstemp
 from typing import (
     Any, AnyStr, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
 )
+
+from packaging.version import parse as parse_version
 
 from cylc.flow import LOG
 from cylc.flow.broadcast_report import get_broadcast_change_iter

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,12 +69,11 @@ install_requires =
     jinja2==3.0.*
     metomi-isodatetime>=1!3.0.0,<1!3.2.0
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
+    packaging
     protobuf>=4.21.2,<4.22.0
     psutil>=5.6.0
     pyzmq>=22
-    # https://github.com/pypa/setuptools/issues/3802
-    setuptools>=49,!=67.*
-    importlib_metadata; python_version < "3.8"
+    importlib_metadata>=5.0; python_version < "3.12"
     urwid==2.*
     # unpinned transient dependencies used for type checking
     rx
@@ -127,7 +126,6 @@ tests =
     # Type annotation stubs
     # http://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
     types-Jinja2>=0.1.3
-    types-pkg_resources>=0.1.2
     types-protobuf>=0.1.10
     types-six>=0.1.6
     typing-extensions>=4

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -19,7 +19,7 @@
 
 . "$(dirname "$0")/test_header"
 # Number of tests depends on the number of 'cylc' commands.
-set_test_number 26
+set_test_number 28
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -72,6 +72,10 @@ run_ok "${TEST_NAME_BASE}-version.stdout" \
     test -n "${TEST_NAME_BASE}-version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}---version.stdout"
 cmp_ok "${TEST_NAME_BASE}-version.stdout" "${TEST_NAME_BASE}-V.stdout"
+
+# Supplementary help
+run_ok "${TEST_NAME_BASE}-all" cylc help all
+run_ok "${TEST_NAME_BASE}-id" cylc help id
 
 # Check "cylc version --long" output is correct.
 cylc version --long | head -n 1 > long1

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -162,7 +162,7 @@ def test_install_gets_back_compat_mode_for_plugins(
     class failIfDeprecated:
         """A fake Cylc Plugin entry point"""
         @staticmethod
-        def resolve():
+        def load():
             return failIfDeprecated.raiser
 
         @staticmethod

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -31,7 +31,7 @@ class EntryPointWrapper:
         self.name = fcn.__name__
         self.fcn = fcn
 
-    def resolve(self):
+    def load(self):
         return self.fcn
 
 

--- a/tests/unit/scripts/test_completion_server.py
+++ b/tests/unit/scripts/test_completion_server.py
@@ -398,18 +398,17 @@ def test_list_options(monkeypatch):
     assert list_options('zz9+za') == []
 
     # patch the logic to turn off the auto_add behaviour of CylcOptionParser
-    def _resolve():
-        def _parser_function():
-            parser = get_option_parser()
-            del parser.auto_add
-            return parser
-
-        return SimpleNamespace(parser_function=_parser_function)
-
-    monkeypatch.setattr(
-        COMMANDS['trigger'],
-        'resolve',
-        _resolve
+    class EntryPoint:
+        def load(self):
+            def _parser_function():
+                parser = get_option_parser()
+                del parser.auto_add
+                return parser
+            return SimpleNamespace(parser_function=_parser_function)
+    monkeypatch.setitem(
+        COMMANDS,
+        'trigger',
+        EntryPoint(),
     )
 
     # with auto_add turned off the --color option should be absent
@@ -674,7 +673,7 @@ def test_check_completion_script_compatibility(monkeypatch, capsys):
     # set the completion script compatibility range to >=1.0.0, <2.0.0
     monkeypatch.setattr(
         'cylc.flow.scripts.completion_server.REQUIRED_SCRIPT_VERSION',
-        'completion-script >=1.0.0, <2.0.0',
+        '>=1.0.0, <2.0.0',
     )
     monkeypatch.setattr(
         'cylc.flow.scripts.completion_server'

--- a/tests/unit/scripts/test_cylc.py
+++ b/tests/unit/scripts/test_cylc.py
@@ -45,7 +45,7 @@ def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
             # an entry point with all dependencies installed:
             'good': SimpleNamespace(
                 name='good',
-                module_name='os.path',
+                module='os.path',
                 load=_resolve_ok,
                 extras=[],
                 dist=SimpleNamespace(name='a'),
@@ -53,7 +53,7 @@ def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
             # an entry point with optional dependencies missing:
             'missing': SimpleNamespace(
                 name='missing',
-                module_name='not.a.python.module',  # force an import error
+                module='not.a.python.module',  # force an import error
                 load=_load_fail,
                 extras=[],
                 dist=SimpleNamespace(name='foo'),
@@ -64,7 +64,7 @@ def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
             # missing:
             commands['bad'] = SimpleNamespace(
                 name='bad',
-                module_name='not.a.python.module',
+                module='not.a.python.module',
                 load=_load_fail,
                 require=_require_ok,
                 extras=[],

--- a/tests/unit/scripts/test_cylc.py
+++ b/tests/unit/scripts/test_cylc.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import pkg_resources
 import sys
 from types import SimpleNamespace
 from typing import Callable
@@ -32,11 +31,8 @@ from ..conftest import MonkeyMock
 @pytest.fixture
 def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
     """Mock a range of entry points."""
-    def _resolve_fail(*args, **kwargs):
+    def _load_fail(*args, **kwargs):
         raise ModuleNotFoundError('foo')
-
-    def _require_fail(*args, **kwargs):
-        raise pkg_resources.DistributionNotFound('foo', ['my_extras'])
 
     def _resolve_ok(*args, **kwargs):
         return Mock()
@@ -50,23 +46,17 @@ def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
             'good': SimpleNamespace(
                 name='good',
                 module_name='os.path',
-                resolve=_resolve_ok,
-                require=_require_ok,
+                load=_resolve_ok,
+                extras=[],
+                dist=SimpleNamespace(name='a'),
             ),
             # an entry point with optional dependencies missing:
             'missing': SimpleNamespace(
                 name='missing',
                 module_name='not.a.python.module',  # force an import error
-                resolve=_resolve_fail,
-                require=_require_fail,
-            ),
-            # an entry point with optional dependencies missing, but they
-            # are not needed for the core functionality of the entry point:
-            'partial': SimpleNamespace(
-                name='partial',
-                module_name='os.path',
-                resolve=_resolve_ok,
-                require=_require_fail,
+                load=_load_fail,
+                extras=[],
+                dist=SimpleNamespace(name='foo'),
             ),
         }
         if include_bad:
@@ -75,8 +65,10 @@ def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
             commands['bad'] = SimpleNamespace(
                 name='bad',
                 module_name='not.a.python.module',
-                resolve=_resolve_fail,
+                load=_load_fail,
                 require=_require_ok,
+                extras=[],
+                dist=SimpleNamespace(name='d'),
             )
         monkeypatch.setattr('cylc.flow.scripts.cylc.COMMANDS', commands)
 
@@ -90,14 +82,13 @@ def test_iter_commands(mock_entry_points):
     """
     mock_entry_points()
     commands = list(iter_commands())
-    assert [i[0] for i in commands] == ['good', 'partial']
+    assert [i[0] for i in commands] == ['good']
 
 
 def test_iter_commands_bad(mock_entry_points):
-    """Test listing commands fails if there is an unexpected import error."""
+    """Test listing commands doesn't fail on import error."""
     mock_entry_points(include_bad=True)
-    with pytest.raises(ModuleNotFoundError):
-        list(iter_commands())
+    list(iter_commands())
 
 
 def test_execute_cmd(
@@ -125,19 +116,16 @@ def test_execute_cmd(
     execute_cmd('missing')
     capexit.assert_any_call(1)
     assert capsys.readouterr().err.strip() == (
-        "cylc missing: The 'foo' distribution was not found and is"
-        " required by my_extras"
+        '"cylc missing" requires "foo"\n\nModuleNotFoundError: foo'
     )
 
-    # the "partial" entry point should exit 0
-    capexit.reset_mock()
-    execute_cmd('partial')
-    capexit.assert_called_once_with()
-    assert capsys.readouterr().err == ''
+    # the "bad" entry point should log an error
+    execute_cmd('bad')
+    capexit.assert_any_call(1)
 
-    # the "bad" entry point should raise an exception
-    with pytest.raises(ModuleNotFoundError):
-        execute_cmd('bad')
+    stderr = capsys.readouterr().err.strip()
+    assert '"cylc bad" requires "d"' in stderr
+    assert 'ModuleNotFoundError: foo' in stderr
 
 
 def test_pythonpath_manip(monkeypatch):


### PR DESCRIPTION
* Closes #5775
* Replace the pkg_resources library (deprecated) with newer alternatives.
* This resolves an efficiency issue due to the high import time of pkg_resources. This import time hits every single Cylc command including `cylc message`.

#### Test Import Time

The pkg_resources library can take a glacial age to import. To see this for yourself and test the difference try this:

```python
# test.py

# the imports required to call the cylc message script
from cylc.flow.scripts import cylc
from cylc.flow.scripts import message
```

```console
$ python -X importtime test.py 2> import.log
$ pip install tuna
$ tuna import.log
```

Results:

<table>
<tr>
<td>

<b>Before</b>

![Screenshot from 2023-10-25 13-58-25](https://github.com/cylc/cylc-flow/assets/16705946/4890007f-63a8-4733-a75f-c70a7676c95a)

</td><td>

<b>After</b>

![Screenshot from 2023-10-25 13-58-36](https://github.com/cylc/cylc-flow/assets/16705946/dd8e6a81-1105-41e0-8786-1ed2decb1057)

</td>
</tr>
</table>

#### Test CLI Time

To measure the impact of this change on end-to-end performance, I used this diff to turn off the actual work of `cylc message`:

```diff
diff --git a/cylc/flow/task_message.py b/cylc/flow/task_message.py
index 3ea753e73..e4b96f5bf 100644
--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -81,6 +81,7 @@ def record_messages(workflow: str, job_id: str, messages: List[list]) -> None:
         job_id: Job identifier "CYCLE/TASK_NAME/SUBMIT_NUM".
         messages: List of messages "[[severity, message], ...]".
     """
+    return
     # Record the event time, in case the message is delayed in some way.
     event_time = get_current_time_string(
         override_use_utc=(os.getenv('CYLC_UTC') == 'True'))
```

Note, without this diff, execution times vary wildly due to IO.

Results (average of 5 calls):
* Before: 0.832s
* After: 0.516s

So a ~0.3 second difference, which is good, but less of a saving than the ~1s indicated by `python -X importtime`.

I don't understand the disparity between the two, but at least the number is heading in the right direction.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.