### PR TITLE
Fix.all xtriggers on an itask are the same

### DIFF
--- a/changes.d/5791.fix.md
+++ b/changes.d/5791.fix.md
@@ -1,0 +1,1 @@
+fix a bug where if multiple clock triggers are set for a task only one was being satisfied.

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -369,7 +369,6 @@ class TaskProxy:
             Absolute trigger time in seconds since Unix epoch.
 
         """
-        # None cannot be used as a dict key:
         offset_str = offset_str if offset_str else 'P0Y'
         if offset_str not in self.clock_trigger_times:
             if offset_str == 'P0Y':

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -362,10 +362,8 @@ class TaskProxy:
         """Compute, cache and return trigger time relative to cycle point.
 
         Args:
-            point:
-                String representing itask string.
-            offset_str:
-                ISO8601Interval string, e.g. "PT2M".
+            point: Task's cycle point.
+            offset_str: ISO8601 interval string, e.g. "PT2M".
                 Can be None for zero offset.
         Returns:
             Absolute trigger time in seconds since Unix epoch.
@@ -373,10 +371,7 @@ class TaskProxy:
         """
         # None cannot be used as a dict key:
         offset_str = offset_str if offset_str else 'P0Y'
-        if (
-            not self.clock_trigger_times
-            or offset_str not in self.clock_trigger_times
-        ):
+        if offset_str not in self.clock_trigger_times:
             if offset_str == 'P0Y':
                 trigger_time = point
             else:

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -372,7 +372,7 @@ class TaskProxy:
 
         """
         # None cannot be used as a dict key:
-        offset_str = offset_str if offset_str else 'no-offset'
+        offset_str = offset_str if offset_str else 'P0Y'
         if (
             not self.clock_trigger_times
             or offset_str not in self.clock_trigger_times

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -388,6 +388,7 @@ class XtriggerManager:
                 # External (clock xtrigger): convert offset to trigger_time.
                 # Datetime cycling only.
                 kwargs["trigger_time"] = itask.get_clock_trigger_time(
+                    itask.point,
                     ctx.func_kwargs["offset"]
                 )
             else:

--- a/tests/integration/test_xtrigger_mgr.py
+++ b/tests/integration/test_xtrigger_mgr.py
@@ -1,0 +1,67 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the behaviour of xtrigger manager.
+"""
+
+
+async def test_2_xtriggers(flow, start, scheduler, monkeypatch):
+    """Test that if an itask has 2 wall_clock triggers with different
+    offsets that xtrigger manager gets both of them.
+
+    https://github.com/cylc/cylc-flow/issues/5783
+
+    n.b. Clock 3 exists to check the memoization path is followed,
+    and causing this test to give greater coverage.
+    """
+    task_point = 1588636800                # 2020-05-05
+    ten_years_ahead = 1904169600           # 2030-05-05
+    monkeypatch.setattr(
+        'cylc.flow.xtriggers.wall_clock.time',
+        lambda: ten_years_ahead - 1
+    )
+    id_ = flow({
+        'scheduler': {
+            'allow implicit tasks': True
+        },
+        'scheduling': {
+            'initial cycle point': '2020-05-05',
+            'xtriggers': {
+                'clock_1': 'wall_clock()',
+                'clock_2': 'wall_clock(offset=P10Y)',
+                'clock_3': 'wall_clock(offset=P10Y)',
+            },
+            'graph': {
+                'R1': '@clock_1 & @clock_2 & @clock_3 => foo'
+            }
+        }
+    })
+    schd = scheduler(id_)
+    async with start(schd):
+        foo_proxy = schd.pool.get_tasks()[0]
+        clock_1_ctx = schd.xtrigger_mgr.get_xtrig_ctx(foo_proxy, 'clock_1')
+        clock_2_ctx = schd.xtrigger_mgr.get_xtrig_ctx(foo_proxy, 'clock_2')
+        clock_3_ctx = schd.xtrigger_mgr.get_xtrig_ctx(foo_proxy, 'clock_2')
+
+        assert clock_1_ctx.func_kwargs['trigger_time'] == task_point
+        assert clock_2_ctx.func_kwargs['trigger_time'] == ten_years_ahead
+        assert clock_3_ctx.func_kwargs['trigger_time'] == ten_years_ahead
+
+        schd.xtrigger_mgr.call_xtriggers_async(foo_proxy)
+        assert foo_proxy.state.xtriggers == {
+            'clock_1': True,
+            'clock_2': False,
+            'clock_3': False,
+        }

--- a/tests/unit/test_task_proxy.py
+++ b/tests/unit/test_task_proxy.py
@@ -60,9 +60,10 @@ def test_get_clock_trigger_time(
     set_cycling_type(itask_point.TYPE)
     mock_itask = Mock(
         point=itask_point.standardise(),
-        clock_trigger_time=None
+        clock_trigger_times={}
     )
-    assert TaskProxy.get_clock_trigger_time(mock_itask, offset_str) == expected
+    assert TaskProxy.get_clock_trigger_time(
+        mock_itask, mock_itask.point, offset_str) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #5783 

The task proxy object was caching the value of clock trigger time. Only the first xtrigger was checked!

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
