### PR TITLE
Upgrade Pandas Version to ensure compatibility with Python 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ main_loop-log_memory =
 main_loop-log_db =
     sqlparse
 report-timings =
-    pandas==1.*
+    pandas>=2.1.1
     matplotlib
 tests =
     async_generator


### PR DESCRIPTION
It looks like Python 3.12 is incompatible with Pandas < 2.1.1 - As a result CI workflows like [this one](https://github.com/cylc/cylc-flow/actions/runs/6664973705/job/18113632014) fail.

[This ticket on pandas dev](https://github.com/pandas-dev/pandas/issues/53665) details the process of making Pandas compatible with Python 3.12.

I've done some manual testing, but I cannot find any automated tests to check this change against. Have I missed any @trwhitcomb ?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Dependency changes only. Test by installing on Python 3.12
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
