### PR TITLE
Handle parentheses on RHS of trigger expression

### DIFF
--- a/changes.d/5801.fix.md
+++ b/changes.d/5801.fix.md
@@ -1,0 +1,1 @@
+Fix traceback when using parentheses on right hand side of graph trigger.

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -23,7 +23,8 @@ from typing import (
     Dict,
     List,
     Tuple,
-    Optional
+    Optional,
+    Union
 )
 
 import cylc.flow.flags
@@ -535,16 +536,15 @@ class GraphParser:
             raise GraphParseError(
                 f"Null task name in graph: {left} => {right}")
 
+        lefts: Union[List[str], List[Optional[str]]]
         if not left or (self.__class__.OP_OR in left or '(' in left):
-            # Treat conditional or bracketed expressions as a single entity.
+            # Treat conditional or parenthesised expressions as a single entity
             # Can get [None] or [""] here
-            lefts: List[Optional[str]] = [left]
+            lefts = [left]
         else:
             # Split non-conditional left-side expressions on AND.
             # Can get [""] here too
-            # TODO figure out how to handle this wih mypy:
-            #   assign List[str] to List[Optional[str]]
-            lefts = left.split(self.__class__.OP_AND)  # type: ignore
+            lefts = left.split(self.__class__.OP_AND)
         if '' in lefts or left and not all(lefts):
             raise GraphParseError(
                 f"Null task name in graph: {left} => {right}")


### PR DESCRIPTION
#### Description

Fix a bug where using parentheses on the right hand side of a graph trigger would cause traceback.

#### Reproduction

```
R1 = a => (b & c)
```
```console
$ cylc validate
```

<details><summary>Traceback</summary>
<p>

```
Traceback (most recent call last):
  File "~/.conda/envs/cylc8/bin/cylc", line 8, in <module>
    sys.exit(main())
  File "~/cylc-flow/cylc/flow/scripts/cylc.py", line 660, in main
    execute_cmd(command, *cmd_args)
  File "~/cylc-flow/cylc/flow/scripts/cylc.py", line 286, in execute_cmd
    entry_point.resolve()(*args)
  File "~/cylc-flow/cylc/flow/terminal.py", line 232, in wrapper
    wrapped_function(*wrapped_args, **wrapped_kwargs)
  File "~/cylc-flow/cylc/flow/scripts/validate.py", line 133, in main
    _main(parser, options, workflow_id)
  File "~/cylc-flow/cylc/flow/scripts/validate.py", line 137, in _main
    asyncio.run(wrapped_main(parser, options, workflow_id))
  File "~/.conda/envs/cylc8/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "~/.conda/envs/cylc8/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "~/cylc-flow/cylc/flow/scripts/validate.py", line 155, in wrapped_main
    cfg = WorkflowConfig(
  File "~/cylc-flow/cylc/flow/config.py", line 518, in __init__
    self.load_graph()
  File "~/cylc-flow/cylc/flow/config.py", line 2123, in load_graph
    parser.parse_graph(graph)
  File "~/cylc-flow/cylc/flow/graph_parser.py", line 465, in parse_graph
    self._proc_dep_pair(pair)
  File "~/cylc-flow/cylc/flow/graph_parser.py", line 627, in _proc_dep_pair
    self._families_all_to_all(expr, rights, info, family_trig_map)
  File "~/cylc-flow/cylc/flow/graph_parser.py", line 671, in _families_all_to_all
    self._compute_triggers(expr, rights, n_expr, n_info)
  File "~/cylc-flow/cylc/flow/graph_parser.py", line 852, in _compute_triggers
    suicide_char, name, output, opt_char = m.groups()  # type: ignore
AttributeError: 'NoneType' object has no attribute 'groups'
```

</p>
</details> 

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry included
- [x] No docs update needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
