### PR TITLE
actions: patch DNS issues on Mac OS runners

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -51,6 +51,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y sqlite3
 
+      - name: Patch DNS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          # see https://github.com/actions/runner-images/issues/8649#issuecomment-1779548056
+          echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+          dscacheutil -q host -a name $(hostname -f)
+
       - name: Install
         run: |
           pip install -e ."[all]"

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -106,17 +106,19 @@ jobs:
       - name: Patch DNS
         if: startsWith(matrix.os, 'macos')
         run: |
+          # patch over DNS issues
           # see https://github.com/actions/runner-images/issues/8649#issuecomment-1779548056
           echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
           dscacheutil -q host -a name $(hostname -f)
+
+          # configure host identification by IP
+          # (hostnames are unstable on the GH runners, but IP's seem ok)
           CONF_PATH="$HOME/.cylc/flow/8"
           mkdir -p "$CONF_PATH"
           cat > "$CONF_PATH/global.cylc" <<__HERE__
-          [platforms]
-            [[localhost, $(hostname -f), $(hostname -s)]]
-              hosts = localhost
-              install target = localhost
-              ssh command = ssh -oBatchMode=yes -oConnectTimeout=8 -oStrictHostKeyChecking=no
+          [scheduler]
+              [[host self-identification]]
+                  method = address
           __HERE__
           cp "$CONF_PATH/global.cylc" "$CONF_PATH/global-tests.cylc"
           echo "# $CONF_PATH/global-tests.cylc"

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -103,6 +103,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Patch DNS
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          # see https://github.com/actions/runner-images/issues/8649#issuecomment-1779548056
+          echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+          dscacheutil -q host -a name $(hostname -f)
+          CONF_PATH="$HOME/.cylc/flow/8"
+          mkdir -p "$CONF_PATH"
+          cat > "$CONF_PATH/global.cylc" <<__HERE__
+          [platforms]
+            [[localhost, $(hostname -f), $(hostname -s)]]
+              hosts = localhost
+              install target = localhost
+              ssh command = ssh -oBatchMode=yes -oConnectTimeout=8 -oStrictHostKeyChecking=no
+          __HERE__
+          cp "$CONF_PATH/global.cylc" "$CONF_PATH/global-tests.cylc"
+          echo "# $CONF_PATH/global-tests.cylc"
+          cat "$CONF_PATH/global-tests.cylc"
+
       - name: Brew Install
         if: startsWith(matrix.os, 'macos')
         run: |


### PR DESCRIPTION
There are DNS issues with the GitHub Mac OS runners resulting in reverse lookup failures causing Cylc test failures.

Hopefully the networking will be fixed before long, in the mean time, this workaround was suggested on the ticket.

See https://github.com/actions/runner-images/issues/8649