### PR TITLE
Improve error message for `cylc cat-log`

### DIFF
--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -401,6 +401,15 @@ def main(
     options: 'Values',
     *ids,
     color: bool = False
+):
+    _main(parser, options, *ids, color)
+
+
+def _main(
+    parser: COP,
+    options: 'Values',
+    *ids,
+    color: bool = False
 ) -> None:
     """Implement cylc cat-log CLI.
 
@@ -481,10 +490,13 @@ def main(
                 ),
                 reverse=True
             )
-            try:
-                log_file_path = Path(logs[rotation_number])
-            except IndexError:
-                raise InputError("max rotation %d" % (len(logs) - 1))
+            if logs:
+                try:
+                    log_file_path = Path(logs[rotation_number])
+                except IndexError:
+                    raise InputError("max rotation %d" % (len(logs) - 1))
+            else:
+                raise InputError('Log file not found.')
         else:
             log_file_path = Path(log_dir, file_name)
 

--- a/tests/integration/scripts/test_cat_log.py
+++ b/tests/integration/scripts/test_cat_log.py
@@ -1,0 +1,53 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration test for the cat log script.
+"""
+
+import pytest
+
+from cylc.flow.exceptions import InputError
+from cylc.flow.option_parsers import Options
+from cylc.flow.scripts.cat_log import (
+    _main as cat_log,
+    get_option_parser as cat_log_gop
+)
+
+
+def test_fail_no_file(flow):
+    """It produces a helpful error if there is no workflow log file.
+    """
+    parser = cat_log_gop()
+    id_ = flow({})
+    with pytest.raises(InputError, match='Log file not found.'):
+        cat_log(parser, Options(parser)(), id_)
+
+
+def test_fail_rotation_out_of_range(flow):
+    """It produces a helpful error if rotation number > number of log files.
+    """
+    parser = cat_log_gop()
+    id_ = flow({})
+    path = flow.args[1]
+    name = id_.split('/')[-1]
+    logpath = (path / name / 'log/scheduler')
+    logpath.mkdir(parents=True)
+    (logpath / '01-start-01.log').touch()
+
+    with pytest.raises(SystemExit):
+        cat_log(parser, Options(parser)(rotation_num=0), id_)
+
+    with pytest.raises(InputError, match='max rotation 0'):
+        cat_log(parser, Options(parser)(rotation_num=1), id_)


### PR DESCRIPTION
Closes #5825 : TL;DR If Cylc cat-log can't find a log file it produces an unhelpful error message.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] ~`CHANGES.md` entry included if this is a change that can affect users~ Such a small change that it's probably overkill to add to the changelog.
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
