### PR TITLE
Add a new entry_point for xtriggers

### DIFF
--- a/changes.d/5831.feat.md
+++ b/changes.d/5831.feat.md
@@ -1,0 +1,1 @@
+Add capability to install xtriggers via a new cylc.xtriggers entry point

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -69,8 +69,11 @@ def _killpg(proc, signal):
 def get_func(func_name, src_dir):
     """Find and return an xtrigger function from a module of the same name.
 
-    Can be in <src_dir>/lib/python, in Python path, or defined via an
-    entry_point. Loctions checked are in this order.
+    These locations are checked in this order:
+    - <src_dir>/lib/python/
+    - `$CYLC_PYTHONPATH`
+    - defined via a `cylc.xtriggers` entry point for an
+      installed Python package.
 
     Workflow source directory passed in as this is executed in an independent
     process in the command pool and therefore doesn't know about the workflow.

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -28,7 +28,7 @@ from time import time
 from subprocess import DEVNULL, run  # nosec
 from typing import Any, Callable, List, Optional
 
-from cylc.flow import LOG
+from cylc.flow import LOG, iter_entry_points
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.cylc_subproc import procopen
 from cylc.flow.exceptions import PlatformLookupError
@@ -69,29 +69,38 @@ def _killpg(proc, signal):
 def get_func(func_name, src_dir):
     """Find and return an xtrigger function from a module of the same name.
 
-    Can be in <src_dir>/lib/python, CYLC_MOD_LOC, or in Python path.
+    Can be in <src_dir>/lib/python, in Python path, or defined via an
+    entry_point. Loctions checked are in this order.
+
     Workflow source directory passed in as this is executed in an independent
     process in the command pool and therefore doesn't know about the workflow.
 
     """
     if func_name in _XTRIG_FUNCS:
         return _XTRIG_FUNCS[func_name]
+
     # First look in <src-dir>/lib/python.
     sys.path.insert(0, os.path.join(src_dir, 'lib', 'python'))
     mod_name = func_name
     try:
         mod_by_name = __import__(mod_name, fromlist=[mod_name])
     except ImportError:
-        # Then look in built-in xtriggers.
-        mod_name = "%s.%s" % ("cylc.flow.xtriggers", func_name)
-        try:
-            mod_by_name = __import__(mod_name, fromlist=[mod_name])
-        except ImportError:
-            raise
+        # Look for xtriggers via entry_points for external sources.
+        # Do this after the lib/python and PYTHONPATH approaches to allow
+        # users to override entry_point definitions with local/custom
+        # implementations.
+        for entry_point in iter_entry_points('cylc.xtriggers'):
+            if func_name == entry_point.name:
+                _XTRIG_FUNCS[func_name] = entry_point.load()
+                return _XTRIG_FUNCS[func_name]
+
+        # Still unable to find anything so abort
+        raise
+
     try:
         _XTRIG_FUNCS[func_name] = getattr(mod_by_name, func_name)
     except AttributeError:
-        # Module func_name has no function func_name.
+        # Module func_name has no function func_name, nor an entry_point entry.
         raise
     return _XTRIG_FUNCS[func_name]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -215,6 +215,12 @@ cylc.main_loop =
 cylc.pre_configure =
 cylc.post_install =
     log_vc_info = cylc.flow.install_plugins.log_vc_info:main
+# NOTE: Built-in xtriggers
+cylc.xtriggers =
+    echo = cylc.flow.xtriggers.echo:echo
+    wall_clock = cylc.flow.xtriggers.wall_clock:wall_clock
+    workflow_state = cylc.flow.xtriggers.workflow_state:workflow_state
+    xrandom = cylc.flow.xtriggers.xrandom:xrandom
 
 [bdist_rpm]
 requires =

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
@@ -33,8 +33,7 @@ run_ok "${TEST_NAME_BASE}-val" cylc validate --debug "${WORKFLOW_NAME}"
 TEST_NAME="${TEST_NAME_BASE}-run"
 workflow_run_ok "${TEST_NAME}" cylc play --no-detach --debug "${WORKFLOW_NAME}"
 
-# Check the broadcast result of xtrigger.
-cylc cat-log "${WORKFLOW_NAME}" >'scheduler.log.out'
-grep_ok "echo overridden, args=('the_args',)" 'scheduler.log.out'
+# Check the result of xtrigger.
+grep_workflow_log_ok "${TEST_NAME_BASE}-grep" "echo overridden, args=('the_args',)"
 
 purge

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
@@ -16,14 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #------------------------------------------------------------------------------
 
-# Test persistence of xtrigger results across restart. A cycling task depends
-# on a non cycle-point dependent custom xtrigger called "faker". In the first
-# cycle point the xtrigger succeeds and returns a result, then a task shuts
-# the workflow down.  Then we replace the custom xtrigger function with one that
-# will fail if called again - which should not happen because the original
-# result should be remembered (as this xtrigger is not cycle point dependent).
-# Also test the correct result is broadcast to the dependent task before and
-# after workflow restart.
+# An xtrigger added to $CYLC_PYTHONPATH should take precedence
+# over a `cylc.xtriggers` entry point of the same name
 
 . "$(dirname "$0")/test_header"
 set_test_number 3

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#------------------------------------------------------------------------------
+
+# Test persistence of xtrigger results across restart. A cycling task depends
+# on a non cycle-point dependent custom xtrigger called "faker". In the first
+# cycle point the xtrigger succeeds and returns a result, then a task shuts
+# the workflow down.  Then we replace the custom xtrigger function with one that
+# will fail if called again - which should not happen because the original
+# result should be remembered (as this xtrigger is not cycle point dependent).
+# Also test the correct result is broadcast to the dependent task before and
+# after workflow restart.
+
+. "$(dirname "$0")/test_header"
+set_test_number 3
+
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+# Install the succeeding xtrigger function.
+export CYLC_PYTHONPATH=${WORKFLOW_RUN_DIR}/dir:${CYLC_PYTHONPATH:-}
+
+# Validate the test workflow.
+run_ok "${TEST_NAME_BASE}-val" cylc validate --debug "${WORKFLOW_NAME}"
+
+# Run the first cycle, till auto shutdown by task.
+TEST_NAME="${TEST_NAME_BASE}-run"
+workflow_run_ok "${TEST_NAME}" cylc play --no-detach --debug "${WORKFLOW_NAME}"
+
+# Check the broadcast result of xtrigger.
+cylc cat-log "${WORKFLOW_NAME}" >'scheduler.log.out'
+grep_ok "echo overridden, args=('the_args',)" 'scheduler.log.out'
+
+purge

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath.t
@@ -36,7 +36,6 @@ export CYLC_PYTHONPATH=${WORKFLOW_RUN_DIR}/dir:${CYLC_PYTHONPATH:-}
 # Validate the test workflow.
 run_ok "${TEST_NAME_BASE}-val" cylc validate --debug "${WORKFLOW_NAME}"
 
-# Run the first cycle, till auto shutdown by task.
 TEST_NAME="${TEST_NAME_BASE}-run"
 workflow_run_ok "${TEST_NAME}" cylc play --no-detach --debug "${WORKFLOW_NAME}"
 

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath/dir/echo.py
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath/dir/echo.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def echo(*args, **kwargs):
+    print(f"echo overridden, args={args}")
+    return (True, {})

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath/flow.cylc
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath/flow.cylc
@@ -1,15 +1,8 @@
-[scheduler]
-    cycle point format = %Y
 [scheduling]
-    initial cycle point = 2010
-    final cycle point = 2011
     [[xtriggers]]
         x1 = echo("the_args")
     [[graph]]
-        R1 = "@x1 => foo => shutdown"
-        P1Y = "@x1 => foo"
+        R1 = @x1 => foo
 [runtime]
     [[foo]]
         script = true
-    [[shutdown]]
-        script = "cylc shutdown $CYLC_WORKFLOW_ID"

--- a/tests/functional/xtriggers/04-respect-cylc-pythonpath/flow.cylc
+++ b/tests/functional/xtriggers/04-respect-cylc-pythonpath/flow.cylc
@@ -1,0 +1,15 @@
+[scheduler]
+    cycle point format = %Y
+[scheduling]
+    initial cycle point = 2010
+    final cycle point = 2011
+    [[xtriggers]]
+        x1 = echo("the_args")
+    [[graph]]
+        R1 = "@x1 => foo => shutdown"
+        P1Y = "@x1 => foo"
+[runtime]
+    [[foo]]
+        script = true
+    [[shutdown]]
+        script = "cylc shutdown $CYLC_WORKFLOW_ID"


### PR DESCRIPTION
This creates a clean way to add xtriggers from python packages. xtriggers no longer need to be directly in the PYTHONPATH but can instead be from a general installation location using an entry_point `cylc.xtriggers`. Similar could be done for other things perhaps, like Jinja2Globals, although I have not looked.

I do not have an Issue for this, but I think it may be or at least relate to #3456, although I do not add the built in xtriggers with this PR, perhaps they should be but I think that can be a bit of work for someone else.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened https://github.com/cylc/cylc-doc/pull/671

I've not added tests as I've not looked at how it coudl be done (can it cleanly?). I'll update CHANGES and cylc doc only if/when this is agreed to.

Example of use below, but note that with this approach, you do not actually need to have a file per xtrigger with a function in it with the same name as the filename.

```
def xtriggers():
    return {
        'xtrig1': xtrig1.xtrig1,
        'xtrig2': xtrig2.xtrig2,
        'abc': abc.abc,
    }
```

Then in pyproject.toml

```
[project.entry-points."cylc.xtriggers"]
my_package = "my_package.cylc_configure:xtriggers"
```