### PR TITLE
`cylc lint`: add rule to catch `rose date` usage

### DIFF
--- a/changes.d/5838.feat.md
+++ b/changes.d/5838.feat.md
@@ -1,0 +1,1 @@
+`cylc lint`: added rule to check for `rose date` usage (should be replaced with `isodatetime`).

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -569,7 +569,21 @@ MANUAL_DEPRECATIONS = {
             'job-script-vars/index.html'
         ),
         FUNCTION: check_for_obsolete_environment_variables,
-    }
+    },
+    'U014': {
+        'short': 'Use "isodatetime [ref]" instead of "rose date [-c]"',
+        'rst': (
+            'For datetime operations in task scripts:\n\n'
+            ' * Use ``isodatetime`` instead of ``rose date``\n'
+            ' * Use ``isodatetime ref`` instead of ``rose date -c`` for '
+            'the current cycle point\n'
+        ),
+        'url': (
+            'https://cylc.github.io/cylc-doc/stable/html/7-to-8/'
+            'cheat-sheet.html#datetime-operations'
+        ),
+        FUNCTION: re.compile(r'rose +date').findall,
+    },
 }
 RULESETS = ['728', 'style', 'all']
 EXTRA_TOML_VALIDATION = {

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -103,6 +103,7 @@ TEST_FILE = """
         pre-script = "echo ${CYLC_SUITE_DEF_PATH}"
         script = {{HELLOWORLD}}
         post-script = "echo ${CYLC_SUITE_INITIAL_CYCLE_TIME}"
+        env-script = POINT=$(rose  date 2059 --offset P1M)
         [[[suite state polling]]]
             template = and
         [[[remote]]]


### PR DESCRIPTION
`rose date` → `isodatetime`

Opening on 8.2.x even though this is a feature, as it's hard to see how this could be dangerous

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] https://github.com/cylc/cylc-doc/pull/670
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
