### PR TITLE
Do not allow plugins to act on global.cylc

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -111,7 +111,7 @@ TEMPLATING_DETECTED = 'templating_detected'
 EXTRA_VARS_TEMPLATE = {
     'env': {},
     'template_variables': {},
-    'templating_detected': None
+    TEMPLATING_DETECTED: None
 }
 
 
@@ -322,7 +322,7 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
         ):
             # Don't allow subsequent plugins with different templating_detected
             raise ParsecError(
-                "Can't merge templating languages"
+                "Can't merge templating languages "
                 f"{extra_vars[TEMPLATING_DETECTED]} and "
                 f"{templating_detected}"
             )

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -282,8 +282,6 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
     if fpath.name == 'global.cylc':
         return extra_vars
 
-    fpath = fpath.parent
-
     # Run entry point pre_configure items, trying to merge values with each.:
     for entry_point in iter_entry_points(
         'cylc.pre_configure'
@@ -292,7 +290,7 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
             # If you want it to work on sourcedirs you need to get the options
             # to here.
             plugin_result = entry_point.load()(
-                srcdir=fpath, opts=opts
+                srcdir=fpath.parent, opts=opts
             )
         except Exception as exc:
             # NOTE: except Exception (purposefully vague)

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -108,9 +108,10 @@ _UNCLOSED_MULTILINE = re.compile(
     r'(?<![\w>])\[.*\]'
 )
 TEMPLATING_DETECTED = 'templating_detected'
+TEMPLATE_VARIABLES = 'template_variables'
 EXTRA_VARS_TEMPLATE = {
     'env': {},
-    'template_variables': {},
+    TEMPLATE_VARIABLES: {},
     TEMPLATING_DETECTED: None
 }
 
@@ -261,14 +262,15 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
             or ``empy``.
 
     args:
-        fpath: Directory where the plugin will look for a config.
+        fpath: Path to a config file. Plugin will look at the parent
+            directory of this file.
         opts: Command line options to be passed to the plugin.
 
     Returns: Dictionary in the form:
         extra_vars = {
             'env': {},
             'template_variables': {},
-            'templating_detected': None
+            TEMPLATING_DETECTED: None
         }
     """
     fpath = Path(fpath)
@@ -300,7 +302,7 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
                 entry_point.name,
                 exc
             ) from None
-        for section in ['env', 'template_variables']:
+        for section in ['env', TEMPLATE_VARIABLES]:
             if section in plugin_result and plugin_result[section] is not None:
                 # Raise error if multiple plugins try to update the same keys.
                 section_update = plugin_result.get(section, {})
@@ -359,7 +361,7 @@ def merge_template_vars(
         {'FOO': 42, 'BAZ': 3.14159, 'BAR': 'Hello World'}
     """
     if plugin_result[TEMPLATING_DETECTED] is not None:
-        plugin_tvars = plugin_result['template_variables']
+        plugin_tvars = plugin_result[TEMPLATE_VARIABLES]
         will_be_overwritten = (
             native_tvars.keys() &
             plugin_tvars.keys()

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -326,7 +326,7 @@ def process_plugins(fpath: 'Union[str, Path]', opts: 'Values'):
                 f"{extra_vars[TEMPLATING_DETECTED]} and "
                 f"{templating_detected}"
             )
-        elif plugin_result.get(TEMPLATING_DETECTED, None) is not None:
+        else:
             extra_vars[TEMPLATING_DETECTED] = templating_detected
 
     return extra_vars

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -52,7 +52,7 @@ from cylc.flow.workflow_files import (
 
 if t.TYPE_CHECKING:
     from optparse import Values
-    from typing import Dict, Union
+    from typing import Union
 
 
 # heading/sections can contain commas (namespace name lists) and any

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -109,7 +109,7 @@ _UNCLOSED_MULTILINE = re.compile(
 )
 TEMPLATING_DETECTED = 'templating_detected'
 TEMPLATE_VARIABLES = 'template_variables'
-EXTRA_VARS_TEMPLATE = {
+EXTRA_VARS_TEMPLATE: t.Dict[str, t.Any] = {
     'env': {},
     TEMPLATE_VARIABLES: {},
     TEMPLATING_DETECTED: None

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -68,7 +68,7 @@ def test_pre_configure(monkeypatch):
         'cylc.flow.parsec.fileparse.iter_entry_points',
         lambda x: [pre_configure_basic]
     )
-    extra_vars = process_plugins(None, None)
+    extra_vars = process_plugins('/', None)
     assert extra_vars == {
         'env': {
             'ANSWER': '42'
@@ -90,7 +90,7 @@ def test_pre_configure_duplicate(monkeypatch):
         ]
     )
     with pytest.raises(ParsecError):
-        process_plugins(None, None)
+        process_plugins('/', None)
 
 
 def test_pre_configure_templating_detected(monkeypatch):
@@ -103,7 +103,7 @@ def test_pre_configure_templating_detected(monkeypatch):
         ]
     )
     with pytest.raises(ParsecError):
-        process_plugins(None, None)
+        process_plugins('/', None)
 
 
 def test_pre_configure_exception(monkeypatch):
@@ -113,7 +113,7 @@ def test_pre_configure_exception(monkeypatch):
         lambda x: [pre_configure_error]
     )
     with pytest.raises(PluginError) as exc_ctx:
-        process_plugins(None, None)
+        process_plugins('/', None)
     # the context of the original error should be preserved in the raised
     # exception
     assert exc_ctx.value.entry_point == 'cylc.pre_configure'


### PR DESCRIPTION
Plugins should not be called when parsing global.cylc. This can become problematic if the plugin wants to access the global config.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
