### PR TITLE
lint - S011 no longer warns against 0{{a}}

### DIFF
--- a/changes.d/5841.fix.md
+++ b/changes.d/5841.fix.md
@@ -1,0 +1,1 @@
+Improve handling of S011 to not warn if the # is '#$' (e.g. shell base arithmetic)

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -437,7 +437,7 @@ STYLE_CHECKS = {
         'evaluate commented lines': True,
         FUNCTION: functools.partial(
             check_if_jinja2,
-            function=re.compile(r'(?<!{)#.*?{[{%]').findall
+            function=re.compile(r'(?<!{)#[^$].*?{[{%]').findall
         )
     },
     'S012': {

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -334,6 +334,12 @@ def test_check_cylc_file_jinja2_comments():
     assert not any('S011' in msg for msg in lint.messages)
 
 
+def test_check_cylc_file_jinja2_comments_shell_arithmetic_not_warned():
+    """Jinja2 after a $((10#$variable)) should not warn"""
+    lint = lint_text('#!jinja2\na = b$((10#$foo+5)) {{ BAR }}', ['style'])
+    assert not any('S011' in msg for msg in lint.messages)
+
+
 @pytest.mark.parametrize(
     # 11 won't be tested because there is no jinja2 shebang
     'number', set(range(1, len(MANUAL_DEPRECATIONS) + 1)) - {11}


### PR DESCRIPTION
Previously something like `a = $((10#$foo)) {{ bar }}` would trigger S011 in Cylc Lint, assuming that this was jinja after a comment. I've made it ignore this synatx. By ignoring this syntax there is of course a potential that `#$  a real comment {{ jinja }}` will be ignored, but I think it quite unlikely an edge case which would require making the regex more complex to work through.

This is not a perfect fix for https://github.com/cylc/cylc-flow/issues/5682 but an improvement. Perhaps a sufficient enough fix that it can be closed though.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] N/A Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] N/A [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
