### PR TITLE
GH Actions: limit tutorial workflow to Python 3.11

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.7', '3']
+        python-version: ['3.7', '3.11']
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install docs/tutorial dependencies
         uses: cylc/cylc-doc/.github/actions/install-dependencies@master


### PR DESCRIPTION
I take it Cylc 8.2 will not support Python 3.12 due to report-timings. (8.3 will support it - #5794)

This gets the tutorial tests passing

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests 
- [x] No `CHANGES.md` entry 
- [x] No docs
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
