### PR TITLE
Tui wait for scan before subscribing

### DIFF
--- a/tests/integration/tui/conftest.py
+++ b/tests/integration/tui/conftest.py
@@ -198,17 +198,20 @@ class RaikuraSession:
 
         Note, this is a blocking wait with no timeout!
         """
-        ids = self.app.wait_until_loaded(*ids, retries=retries)
+        exc = None
+        try:
+            ids = self.app.wait_until_loaded(*ids, retries=retries)
+        except Exception as _exc:
+            exc = _exc
         if ids:
-            self.compare_screenshot(
-                f'fail-{uuid1()}',
-                (
-                    'Requested nodes did not appear in Tui after'
-                    f' {retries} retries: '
-                    + ', '.join(ids)
-                ),
-                1,
+            msg = (
+                'Requested nodes did not appear in Tui after'
+                f' {retries} retries: '
+                + ', '.join(ids)
             )
+            if exc:
+                msg += f'\n{msg}'
+            self.compare_screenshot(f'fail-{uuid1()}', msg, 1)
 
 
 @pytest.fixture

--- a/tests/integration/tui/test_app.py
+++ b/tests/integration/tui/test_app.py
@@ -258,6 +258,9 @@ async def test_navigation(flow, scheduler, start, raikura):
         await schd.update_data_structure()
 
         with raikura(size='80,30') as rk:
+            # wait for the workflow to appear (collapsed)
+            rk.wait_until_loaded('#spring')
+
             rk.compare_screenshot(
                 'on-load',
                 'the workflow should be collapsed when Tui is loaded',
@@ -314,6 +317,8 @@ async def test_auto_expansion(flow, scheduler, start, raikura):
     with raikura(size='80,20') as rk:
         async with start(schd):
             await schd.update_data_structure()
+            # wait for the workflow to appear (collapsed)
+            rk.wait_until_loaded('#spring')
 
             # open the workflow
             rk.force_update()
@@ -351,12 +356,18 @@ async def test_restart_reconnect(one_conf, flow, scheduler, start, raikura):
         # 1- start the workflow
         async with start(schd):
             await schd.update_data_structure()
+            # wait for the workflow to appear (collapsed)
+            rk.wait_until_loaded('#spring')
+
+            # expand the workflow (subscribes to updates from it)
             rk.force_update()
             rk.user_input('down', 'right')
+
+            # wait for workflow to appear (expanded)
             rk.wait_until_loaded(schd.tokens.id)
             rk.compare_screenshot(
                 '1-workflow-running',
-                'the workflow should appear in tui and be expanded on load',
+                'the workflow should appear in tui and be expanded',
             )
 
         # 2 - stop the worlflow
@@ -371,7 +382,6 @@ async def test_restart_reconnect(one_conf, flow, scheduler, start, raikura):
         async with start(schd):
             await schd.update_data_structure()
             rk.wait_until_loaded(schd.tokens.id)
-            # rk.user_input('down', 'right')
             rk.compare_screenshot(
                 '3-workflow-restarted',
                 'the restarted workflow should be expanded',

--- a/tests/integration/tui/test_logs.py
+++ b/tests/integration/tui/test_logs.py
@@ -201,6 +201,9 @@ async def test_scheduler_logs(
 ):
     """Test viewing the scheduler log files."""
     with mod_raikura(size='80,30') as rk:
+        # wait for the workflow to appear (collapsed)
+        rk.wait_until_loaded('#spring')
+
         # open the workflow in Tui
         rk.user_input('down', 'right')
         rk.wait_until_loaded(workflow.tokens.id)
@@ -244,6 +247,9 @@ async def test_task_logs(
     I.E. Test viewing job log files by opening the log view on a task.
     """
     with mod_raikura(size='80,30') as rk:
+        # wait for the workflow to appear (collapsed)
+        rk.wait_until_loaded('#spring')
+
         # open the workflow in Tui
         rk.user_input('down', 'right')
         rk.wait_until_loaded(workflow.tokens.id)
@@ -282,6 +288,9 @@ async def test_job_logs(
     I.E. Test viewing job log files by opening the log view on a job.
     """
     with mod_raikura(size='80,30') as rk:
+        # wait for the workflow to appear (collapsed)
+        rk.wait_until_loaded('#spring')
+
         # open the workflow in Tui
         rk.user_input('down', 'right')
         rk.wait_until_loaded(workflow.tokens.id)
@@ -331,6 +340,9 @@ async def test_errors(
     )
 
     with mod_raikura(size='80,30') as rk:
+        # wait for the workflow to appear (collapsed)
+        rk.wait_until_loaded('#spring')
+
         # open the log view on scheduler
         rk.user_input('down', 'enter', 'down', 'down', 'enter')
 


### PR DESCRIPTION
Test failures are quite hard to replicate locally, but seemingly quite easy to replicate in CI.

Best guess is system loading?

    tests/i: tui - attempt to stabilise tests
    
    * Tests became unstable for unknown reasons.
    * This change attempts to resolve some issues by:
      * Ensuring that the workflow has appeared in the scan results before
        attempting to "expand" it (i.e. subscribe to it).
      * Increasing the sleep time used to wait for nodes to appear to make
        it more robust to a slow running updater (e.g. if FS operations
        become slow).
      * Separate successfull and failed updates when waiting for nodes to
        appear to make it more robust to heavily loaded systems.

Built on #5849


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.