### PR TITLE
set CYLC_DEBUG env var when set-verbosity DEBUG

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -193,7 +193,7 @@ def log_level_to_verbosity(lvl: int) -> int:
         >>> log_level_to_verbosity(logging.NOTSET)
         2
         >>> log_level_to_verbosity(logging.DEBUG)
-        1
+        2
         >>> log_level_to_verbosity(logging.INFO)
         0
         >>> log_level_to_verbosity(logging.WARNING)
@@ -201,7 +201,7 @@ def log_level_to_verbosity(lvl: int) -> int:
         >>> log_level_to_verbosity(logging.ERROR)
         -1
     """
-    if lvl < logging.DEBUG:
+    if lvl <= logging.DEBUG:
         return 2
     if lvl < logging.INFO:
         return 1


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5829

The `CYLC_DEBUG` environment variable was not being set when using `cylc set-verbosity DEBUG`
This pr fixes this by correcting a conditional in the `log_level_to_verbosity` utility function

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
