### PR TITLE
tui: avoid deprecated import

### DIFF
--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -22,7 +22,13 @@ from multiprocessing import Process
 import re
 
 import urwid
-from urwid.wimp import SelectableIcon
+try:
+    from urwid.widget import SelectableIcon
+except ImportError:
+    # BACK COMPAT: urwid.wimp
+    # From: urwid 2.0
+    # To: urwid 2.2
+    from urwid.wimp import SelectableIcon
 
 from cylc.flow.id import Tokens
 from cylc.flow.task_state import (


### PR DESCRIPTION
* Respond to deprecation warning:

  > DeprecationWarning: 'urwid.wimp' is not expected to be imported
  > directly. Please use public access from "urwid" package. Module
  > 'urwid.wimp' is deprecated and will be removed in the future.
  > from cylc.flow.tui.app import TuiApp

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.