### PR TITLE
post_configure: ensure asyncio tasks created by plugins are awaited

### DIFF
--- a/cylc/flow/plugins.py
+++ b/cylc/flow/plugins.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common functionality related to the loading and calling of plugins."""
+
+import os
+from time import time
+
+from cylc.flow import LOG, iter_entry_points
+from cylc.flow.async_util import async_block as _async_block
+from cylc.flow.exceptions import PluginError
+import cylc.flow.flags
+
+
+async def run_plugins_async(
+    plugin_namespace,
+    *args,
+    async_block=False,
+    **kwargs
+):
+    """Run all installed plugins for the given namespace.
+
+    This runs plugins in series, yielding the results one by one.
+
+    Args:
+        plugin_namespace:
+            The entry point namespace for the plugins to run,
+            e.g. "cylc.post_install".
+        args:
+            Any arguments to call plugins with.
+        async_block:
+            If True, this will wait for any async tasks started by the plugin
+            to complete before moving on to the next plugin.
+        kwargs:
+            Any kwargs to call plugins with.
+
+    Yields:
+        (entry_point, plugin_result)
+
+        See https://github.com/cylc/cylc-rose/issues/274
+
+    """
+    startpoint = os.getcwd()
+    for entry_point in iter_entry_points(plugin_namespace):
+        try:
+            # measure the import+run time for the plugin (debug mode)
+            start_time = time()
+
+            # load the plugin
+            meth = entry_point.load()
+
+            # run the plugin
+            if async_block:
+                # wait for any async tasks started by the plugin to complete
+                async with _async_block():
+                    plugin_result = meth(*args, **kwargs)
+            else:
+                plugin_result = meth(*args, **kwargs)
+
+            # log the import+run time (debug mode)
+            if cylc.flow.flags.verbosity > 1:
+                LOG.debug(
+                    f'ran {entry_point.name} in {time() - start_time:0.05f}s'
+                )
+
+            # yield the result to the caller
+            yield entry_point, plugin_result
+
+        except Exception as exc:  # NOTE: except Exception (purposefully vague)
+            _raise_plugin_exception(exc, plugin_namespace, entry_point)
+
+        finally:
+            # ensure the plugin does not change the CWD
+            os.chdir(startpoint)
+
+
+def run_plugins(plugin_namespace, *args, **kwargs):
+    """Run all installed plugins for the given namespace.
+
+    This runs plugins in series, yielding the results one by one.
+
+    Warning:
+        Use run_plugins_async for "cylc.post_install" plugins.
+        See https://github.com/cylc/cylc-rose/issues/274
+
+    Args:
+        plugin_namespace:
+            The entry point namespace for the plugins to run,
+            e.g. "cylc.post_install".
+        args:
+            Any arguments to call plugins with.
+        kwargs:
+            Any kwargs to call plugins with.
+
+    Yields:
+        (entry_point, plugin_result)
+
+    """
+    startpoint = os.getcwd()
+    for entry_point in iter_entry_points(plugin_namespace):
+        try:
+            # measure the import+run time for the plugin (debug mode)
+            start_time = time()
+
+            # load the plugin
+            meth = entry_point.load()
+
+            # run the plugin
+            plugin_result = meth(*args, **kwargs)
+
+            # log the import+run time (debug mode)
+            if cylc.flow.flags.verbosity > 1:
+                LOG.debug(
+                    f'ran {entry_point.name} in {time() - start_time:0.05f}s'
+                )
+
+            # yield the result to the caller
+            yield entry_point, plugin_result
+
+        except Exception as exc:  # NOTE: except Exception (purposefully vague)
+            _raise_plugin_exception(exc, plugin_namespace, entry_point)
+
+        finally:
+            # ensure the plugin does not change the CWD
+            os.chdir(startpoint)
+
+
+def _raise_plugin_exception(exc, plugin_namespace, entry_point):
+    """Re-Raise an exception captured from a plugin."""
+    if cylc.flow.flags.verbosity > 1:
+        # raise the full exception in debug mode
+        # (this helps plugin developers locate the error in their code)
+        raise
+    # raise a user-friendly exception
+    raise PluginError(
+        plugin_namespace,
+        entry_point.name,
+        exc
+    ) from None

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -369,6 +369,12 @@ async def scheduler_cli(
     functionality.
 
     """
+    if options.starttask:
+        options.starttask = upgrade_legacy_ids(
+            *options.starttask,
+            relative=True,
+        )
+
     # Parse workflow name but delay Cylc 7 suite.rc deprecation warning
     # until after the start-up splash is printed.
     # TODO: singleton
@@ -651,14 +657,4 @@ async def _run(scheduler: Scheduler) -> int:
 @cli_function(get_option_parser)
 def play(parser: COP, options: 'Values', id_: str):
     """Implement cylc play."""
-    return _play(parser, options, id_)
-
-
-def _play(parser: COP, options: 'Values', id_: str):
-    """Allows compound scripts to import play, but supply their own COP."""
-    if options.starttask:
-        options.starttask = upgrade_legacy_ids(
-            *options.starttask,
-            relative=True,
-        )
     return asyncio.run(scheduler_cli(options, id_))

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -133,14 +133,10 @@ ValidateOptions = Options(
 
 @cli_function(get_option_parser)
 def main(parser: COP, options: 'Values', workflow_id: str) -> None:
-    _main(parser, options, workflow_id)
+    asyncio.run(run(parser, options, workflow_id))
 
 
-def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
-    asyncio.run(wrapped_main(parser, options, workflow_id))
-
-
-async def wrapped_main(
+async def run(
     parser: COP, options: 'Values', workflow_id: str
 ) -> None:
     """cylc validate CLI."""

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -62,7 +62,7 @@ from cylc.flow.option_parsers import (
 from cylc.flow.scheduler_cli import PLAY_OPTIONS, scheduler_cli
 from cylc.flow.scripts.validate import (
     VALIDATE_OPTIONS,
-    wrapped_main as cylc_validate
+    run as cylc_validate,
 )
 from cylc.flow.scripts.reinstall import (
     REINSTALL_CYLC_ROSE_OPTIONS,

--- a/tests/functional/cylc-combination-scripts/01-vr-reload.t
+++ b/tests/functional/cylc-combination-scripts/01-vr-reload.t
@@ -51,6 +51,6 @@ named_grep_ok "${TEST_NAME_BASE}-it-logged-reload" \
     "${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 # Clean Up.
-run_ok "teardown (stop workflow)" cylc stop "${WORKFLOW_NAME}" --now --now
+run_ok "${TEST_NAME_BASE}-stop" cylc stop "${WORKFLOW_NAME}" --now --now
 purge
 exit 0

--- a/tests/functional/cylc-combination-scripts/02-vr-restart.t
+++ b/tests/functional/cylc-combination-scripts/02-vr-restart.t
@@ -44,6 +44,6 @@ named_grep_ok "${TEST_NAME_BASE}-it-installed" "$ cylc reinstall" "VIPOUT.txt"
 named_grep_ok "${TEST_NAME_BASE}-it-played" "cylc play" "VIPOUT.txt"
 
 # Clean Up.
-run_ok "teardown (stop workflow)" cylc stop "${WORKFLOW_NAME}" --now --now
+run_ok "${TEST_NAME_BASE}-stop" cylc stop "${WORKFLOW_NAME}" --now --now
 purge
 exit 0

--- a/tests/functional/cylc-combination-scripts/04-vr-fail-validate.t
+++ b/tests/functional/cylc-combination-scripts/04-vr-fail-validate.t
@@ -48,6 +48,6 @@ named_grep_ok "${TEST_NAME_BASE}-it-failed" \
 
 
 # Clean Up:
-run_ok "teardown (stop workflow)" cylc stop "${WORKFLOW_NAME}" --now --now
+run_ok "${TEST_NAME_BASE}-stop" cylc stop "${WORKFLOW_NAME}" --now --now
 purge
 exit 0

--- a/tests/functional/cylc-combination-scripts/05-vr-fail-is-running.t
+++ b/tests/functional/cylc-combination-scripts/05-vr-fail-is-running.t
@@ -41,6 +41,7 @@ run_ok "setup (vip)" \
 
 # Get the workflow into an unreachable state
 CONTACTFILE="${RUN_DIR}/${WORKFLOW_NAME}/.service/contact"
+cp "$CONTACTFILE" "${CONTACTFILE}.old"
 poll test -e "${CONTACTFILE}"
 
 sed -i 's@CYLC_WORKFLOW_HOST=.*@CYLC_WORKFLOW_HOST=elephantshrew@' "${CONTACTFILE}"
@@ -54,7 +55,7 @@ run_fail "${TEST_NAME_BASE}-runs" cylc vr "${WORKFLOW_NAME}"
 grep_ok "on elephantshrew." "${TEST_NAME_BASE}-runs.stderr"
 
 # Clean Up:
-sed -i "s@CYLC_WORKFLOW_HOST=elephantshrew@CYLC_WORKFLOW_HOST=$HOSTNAME@" "${CONTACTFILE}"
-run_ok "teardown (stop workflow)" cylc stop "${WORKFLOW_NAME}" --now --now
+mv "${CONTACTFILE}.old" "$CONTACTFILE"
+run_ok "${TEST_NAME_BASE}-stop" cylc stop "${WORKFLOW_NAME}" --now --now
 purge
 exit 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -465,14 +465,14 @@ def install(test_dir, run_dir):
     Returns:
         Workflow id, including run directory.
     """
-    def _inner(source, **kwargs):
+    async def _inner(source, **kwargs):
         opts = InstallOpts(**kwargs)
         # Note we append the source.name to the string rather than creating
         # a subfolder because the extra layer of directories would exceed
         # Cylc install's default limit.
         opts.workflow_name = (
             f'{str(test_dir.relative_to(run_dir))}.{source.name}')
-        workflow_id, _ = cylc_install(opts, str(source))
+        workflow_id, _ = await cylc_install(opts, str(source))
         workflow_id = infer_latest_run_from_id(workflow_id)
         return workflow_id
     yield _inner

--- a/tests/integration/scripts/test_validate_integration.py
+++ b/tests/integration/scripts/test_validate_integration.py
@@ -29,7 +29,7 @@ async def test_validate_against_source_checks_source(
     """Validation fails if validating against source with broken config.
     """
     src_dir = workflow_source(one_conf)
-    workflow_id = install(src_dir)
+    workflow_id = await install(src_dir)
 
     # Check that the original installation validates OK:
     validate(workflow_id, against_source=True)
@@ -67,7 +67,7 @@ async def test_validate_against_source_gets_old_tvars(
         }
     })
 
-    wf_id = install(src_dir)
+    wf_id = await install(src_dir)
     installed_dir = run_dir / wf_id
 
     # Check that the original installation validates OK:

--- a/tests/integration/test_get_old_tvars.py
+++ b/tests/integration/test_get_old_tvars.py
@@ -20,7 +20,7 @@ from pytest import param
 from cylc.flow.option_parsers import Options
 
 from cylc.flow.scripts.validate import (
-    wrapped_main as validate,
+    run as validate,
     get_option_parser as validate_gop
 )
 from cylc.flow.scripts.view import (

--- a/tests/integration/utils/entry_points.py
+++ b/tests/integration/utils/entry_points.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for working with entry points."""
+
+
+class EntryPointWrapper:
+    """Wraps a method to make it look like an entry point."""
+
+    def __init__(self, fcn):
+        self.name = fcn.__name__
+        self.fcn = fcn
+
+    def load(self):
+        return self.fcn

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -799,7 +799,7 @@ def pre_configure_basic(*_, **__):
 
 def test_plugins_not_called_on_global_config(monkeypatch):
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.iter_entry_points',
+        'cylc.flow.plugins.iter_entry_points',
         lambda x: [pre_configure_basic]
     )
     result = process_plugins('/pennine/way/flow.cylc', {})

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -65,8 +65,10 @@ def pre_configure_error(*_, **__):
 def test_pre_configure(monkeypatch):
     """It should call the plugin."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.iter_entry_points',
-        lambda x: [pre_configure_basic]
+        'cylc.flow.plugins.iter_entry_points',
+        lambda namespace: (
+            [pre_configure_basic] if namespace == 'cylc.pre_configure' else []
+        )
     )
     extra_vars = process_plugins('/', None)
     assert extra_vars == {
@@ -83,11 +85,13 @@ def test_pre_configure(monkeypatch):
 def test_pre_configure_duplicate(monkeypatch):
     """It should error when plugins clash."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.iter_entry_points',
-        lambda x: [
-            pre_configure_basic,
-            pre_configure_basic
-        ]
+        'cylc.flow.plugins.iter_entry_points',
+        lambda namespace: (
+            [
+                pre_configure_basic,
+                pre_configure_basic,
+            ] if namespace == 'cylc.pre_configure' else []
+        )
     )
     with pytest.raises(ParsecError):
         process_plugins('/', None)
@@ -96,11 +100,13 @@ def test_pre_configure_duplicate(monkeypatch):
 def test_pre_configure_templating_detected(monkeypatch):
     """It should error when plugins clash (for templating)."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.iter_entry_points',
-        lambda x: [
-            pre_configure_templating_detected,
-            pre_configure_templating_detected
-        ]
+        'cylc.flow.plugins.iter_entry_points',
+        lambda namespace: (
+            [
+                pre_configure_templating_detected,
+                pre_configure_templating_detected,
+            ] if namespace == 'cylc.pre_configure' else []
+        )
     )
     with pytest.raises(ParsecError):
         process_plugins('/', None)
@@ -109,8 +115,12 @@ def test_pre_configure_templating_detected(monkeypatch):
 def test_pre_configure_exception(monkeypatch):
     """It should wrap plugin errors."""
     monkeypatch.setattr(
-        'cylc.flow.parsec.fileparse.iter_entry_points',
-        lambda x: [pre_configure_error]
+        'cylc.flow.plugins.iter_entry_points',
+        lambda namespace: (
+            [
+                pre_configure_error,
+            ] if namespace == 'cylc.pre_configure' else []
+        )
     )
     with pytest.raises(PluginError) as exc_ctx:
         process_plugins('/', None)


### PR DESCRIPTION
This is one of a triplet of PRs which closes https://github.com/cylc/cylc-rose/issues/274
* https://github.com/cylc/cylc-rose/pull/276
* https://github.com/metomi/rose/pull/2744

---

* Await any background tasks started by a plugin before continuing. See https://github.com/cylc/cylc-rose/issues/274
* Centralise the plugin loading/running/reporting logic.
* Fix the installation test for back-compat-mode.

---

#### Reviewers, please check:

* It does what it says on the tin.
* (re)Install logging works as expected.
* Errors in file installation are reported as expected.

---

#### Testing:

This diff will make file installation take longer:

```diff
diff --git a/metomi/rose/config_processors/fileinstall.py b/metomi/rose/config_processors/fileinstall.py
index 937ed746..9797c042 100644
--- a/metomi/rose/config_processors/fileinstall.py
+++ b/metomi/rose/config_processors/fileinstall.py
@@ -399,6 +399,8 @@ class ConfigProcessorForFile(ConfigProcessorBase):
 
     async def process_job(self, job, conf_tree, loc_dao, work_dir):
         """Process a job, helper for "process"."""
+        import asyncio
+        await asyncio.sleep(1)
         for key, method in [
             (Loc.A_INSTALL, self._target_install),
             (Loc.A_SOURCE, self._source_pull),
```

This diff will disable the new guard:

```diff
diff --git a/cylc/flow/async_util.py b/cylc/flow/async_util.py
index 478c41dc29..14ddc26a80 100644
--- a/cylc/flow/async_util.py
+++ b/cylc/flow/async_util.py
@@ -519,8 +519,8 @@ async def async_block():
         # any tasks two() started will have been awaited by now
     """
     # make a list of all tasks running before we enter the context manager
-    tasks_before = asyncio.all_tasks()
+    # tasks_before = asyncio.all_tasks()
     # run the user code
     yield
     # await any new tasks
-    await asyncio.gather(*(asyncio.all_tasks() - tasks_before))
+    # await asyncio.gather(*(asyncio.all_tasks() - tasks_before))
```

Try installing a workflow with `cylc install --debug`, it will now log the time taken by each plugin.

With the `async_block` it should take >1s (due to the sleep) without the `async_block` (i.e. with the above diff applied) it should take <1s because the sleep will not be awaited.

---

#### CI:

Note that the cylc-rose and metomi-rose tests will fail until both the cylc-flow and metomi-rose branches are merged.

I.E. please run the tests manually due review.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` no - unreleased issue
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.