### PR TITLE
`cylc clean` remote timeout improvements

### DIFF
--- a/changes.d/5872.feat.md
+++ b/changes.d/5872.feat.md
@@ -1,0 +1,1 @@
+Improvements to `cylc clean` remote timeout handling.

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -44,9 +44,6 @@ from typing import (
     Union,
 )
 
-from metomi.isodatetime.exceptions import ISO8601SyntaxError
-from metomi.isodatetime.parsers import DurationParser
-
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import (
@@ -362,9 +359,6 @@ def remote_clean(
         raise PlatformLookupError(
             f"Cannot clean {id_} on remote platforms as the workflow database "
             f"is out of date/inconsistent with the global config - {exc}")
-
-    with suppress(ISO8601SyntaxError):
-        timeout = str(DurationParser().parse(timeout).get_seconds())
 
     queue: Deque[RemoteCleanQueueTuple] = deque()
     remote_clean_cmd = partial(

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -120,9 +120,11 @@ def get_option_parser():
 
     parser.add_option(
         '--timeout',
-        help=("The number of seconds to wait for cleaning to take place on "
-              r"remote hosts before cancelling. Default: %default."),
-        action='store', default='120', dest='remote_timeout'
+        help=(
+            "The length of time to wait for cleaning to take place on "
+            r"remote hosts before cancelling. Default: %default."
+        ),
+        action='store', default='PT5M', dest='remote_timeout'
     )
 
     parser.add_option(

--- a/tests/functional/cylc-clean/01-remote.t
+++ b/tests/functional/cylc-clean/01-remote.t
@@ -25,7 +25,7 @@ SSH_CMD="$(cylc config -d -i "[platforms][${CYLC_TEST_PLATFORM}]ssh command") ${
 if ! $SSH_CMD command -v 'tree' > '/dev/null'; then
     skip_all "'tree' command not available on remote host ${CYLC_TEST_HOST}"
 fi
-set_test_number 10
+set_test_number 12
 
 # Generate random name for symlink dirs to avoid any clashes with other tests
 SYM_NAME="$(mktemp -u)"
@@ -108,7 +108,13 @@ __TREE__
 
 # -----------------------------------------------------------------------------
 
-TEST_NAME="cylc-clean"
+TEST_NAME="cylc-clean-timeout"
+run_fail "$TEST_NAME" cylc clean --timeout 'PT0,1S' "$WORKFLOW_NAME"
+dump_std "$TEST_NAME"
+grep_ok 'cylc clean timed out after 0.1s' "${TEST_NAME}.stderr"
+
+
+TEST_NAME="cylc-clean-ok"
 run_ok "$TEST_NAME" cylc clean "$WORKFLOW_NAME"
 dump_std "$TEST_NAME"
 

--- a/tests/functional/cylc-clean/01-remote.t
+++ b/tests/functional/cylc-clean/01-remote.t
@@ -25,7 +25,7 @@ SSH_CMD="$(cylc config -d -i "[platforms][${CYLC_TEST_PLATFORM}]ssh command") ${
 if ! $SSH_CMD command -v 'tree' > '/dev/null'; then
     skip_all "'tree' command not available on remote host ${CYLC_TEST_HOST}"
 fi
-set_test_number 12
+set_test_number 10
 
 # Generate random name for symlink dirs to avoid any clashes with other tests
 SYM_NAME="$(mktemp -u)"
@@ -108,14 +108,9 @@ __TREE__
 
 # -----------------------------------------------------------------------------
 
-TEST_NAME="cylc-clean-timeout"
-run_fail "$TEST_NAME" cylc clean --timeout 'PT0,1S' "$WORKFLOW_NAME"
-dump_std "$TEST_NAME"
-grep_ok 'cylc clean timed out after 0.1s' "${TEST_NAME}.stderr"
-
-
 TEST_NAME="cylc-clean-ok"
-run_ok "$TEST_NAME" cylc clean "$WORKFLOW_NAME"
+run_ok "$TEST_NAME" cylc clean "$WORKFLOW_NAME" --timeout PT2M
+# (timeout opt is covered by unit tests but no harm double-checking here)
 dump_std "$TEST_NAME"
 
 TEST_NAME="run-dir-not-exist-post-clean.local"


### PR DESCRIPTION
Closes #5867 

- Increase default remote `--timeout` to 5 mins and allow ISO 8601 durations
- Provide a shorter and clearer error message for remote timeouts

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
