### PR TITLE
Lint packaged workflows

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -39,6 +39,13 @@ jobs:
       - name: install cylc-flow
         run: pip install .[all]
 
+      - name: lint tutorials
+        run: |
+          cylc get-resources tutorial
+          for f in $(find "${HOME}/cylc-src" -name flow*.cylc -exec dirname {} \;);
+            do cylc lint $f -r style
+          done
+
       - name: run tutorial workflow
         timeout-minutes: 6
         run: |

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -39,13 +39,6 @@ jobs:
       - name: install cylc-flow
         run: pip install .[all]
 
-      - name: lint tutorials
-        run: |
-          cylc get-resources tutorial
-          for f in $(find "${HOME}/cylc-src" -name flow*.cylc -exec dirname {} \;);
-            do cylc lint $f -r style
-          done
-
       - name: run tutorial workflow
         timeout-minutes: 6
         run: |

--- a/changes.d/5873.feat.md
+++ b/changes.d/5873.feat.md
@@ -1,0 +1,3 @@
+- Allow use of `#noqa: S001` comments to skip Cylc lint
+  checks for a single line.
+- Stop Cylc lint objecting to `%include <file>` syntax.

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/.validate
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/.validate
@@ -18,4 +18,5 @@
 
 set -eux
 
+cylc lint .
 cylc validate . --icp=2000

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/.validate
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/.validate
@@ -18,6 +18,7 @@
 set -eux
 APIKEY="$(head --lines 1 ../api-keys)"
 FLOW_NAME="$(< /dev/urandom tr -dc A-Za-z | head -c6)"
+cylc lint .
 cylc install --workflow-name "$FLOW_NAME" --no-run-name
 sed -i "s/DATAPOINT_API_KEY/$APIKEY/" "$HOME/cylc-run/$FLOW_NAME/flow.cylc"
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"

--- a/cylc/flow/etc/tutorial/retries-tutorial/.validate
+++ b/cylc/flow/etc/tutorial/retries-tutorial/.validate
@@ -18,4 +18,5 @@
 
 set -eux
 
+cylc lint .
 cylc validate --check-circular . --icp=2000

--- a/cylc/flow/etc/tutorial/retries-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/retries-tutorial/flow.cylc
@@ -16,8 +16,8 @@
             DIE_2=$((RANDOM%6 + 1))
             echo "Rolled $DIE_1 and $DIE_2..."
             if (($DIE_1 == $DIE_2)); then
-               echo "doubles!"
+                echo "doubles!"
             else
-               exit 1
+                exit 1
             fi
         """

--- a/cylc/flow/etc/tutorial/runtime-introduction/.validate
+++ b/cylc/flow/etc/tutorial/runtime-introduction/.validate
@@ -18,6 +18,7 @@
 set -eux
 FLOW_NAME="$(< /dev/urandom tr -dc A-Za-z | head -c6)"
 SRC=$(cylc get-resources tutorial 2>&1 | head -n1 | awk '{print $NF}')
+cylc lint .
 cylc install "${SRC}/runtime-introduction" --workflow-name "$FLOW_NAME" --no-run-name
 cylc validate --check-circular --icp=2000 "$FLOW_NAME"
 cylc play --no-detach --abort-if-any-task-fails "$FLOW_NAME"

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -37,6 +37,12 @@ A non-zero return code will be returned if any issues are identified.
 This can be overridden by providing the "--exit-zero" flag.
 """
 
+NOQA = """
+Individual errors can be ignored using the ``# noqa`` line comment.
+It is good practice to specify specific errors you wish to ignore using
+``# noqa: S002 S007 U999``
+"""
+
 TOMLDOC = """
 pyproject.toml configuration:{}
    [cylc-lint]                     # any of {}
@@ -1202,7 +1208,11 @@ def target_version_check(
 
 def get_option_parser() -> COP:
     parser = COP(
-        COP_DOC + TOMLDOC.format('', str(LINT_SECTIONS)),
+        (
+            COP_DOC
+            + NOQA.replace('``', '"')
+            + TOMLDOC.format('', str(LINT_SECTIONS))
+        ),
         argdoc=[
             COP.optional(WORKFLOW_ID_OR_PATH_ARG_DOC)
         ],
@@ -1327,4 +1337,5 @@ def main(parser: COP, options: 'Values', target=None) -> None:
 
 # NOTE: use += so that this works with __import__
 # (docstring needed for `cylc help all` output)
+__doc__ += NOQA
 __doc__ += get_reference('all', 'rst')

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -323,7 +323,7 @@ STYLE_CHECKS = {
         'short': 'Item not indented.',
         # Non-indented items should be sections:
         'url': STYLE_GUIDE + 'indentation',
-        FUNCTION: re.compile(r'^[^\{\[|\s]').findall
+        FUNCTION: re.compile(r'^[^%\{\[|\s]').findall
     },
     "S003": {
         'short': 'Top level sections should not be indented.',

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -142,6 +142,8 @@ TEST_FILE = """
     [[and_another_thing]]
         [[[remote]]]
             host = `rose host-select thingy`
+
+%include foo.cylc
 """
 
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -636,3 +636,18 @@ def test_indents(spaces, expect):
         assert expect in result
     else:
         assert not result
+
+
+def test_noqa():
+    """Comments turn of checks.
+
+    """
+    output = lint_text(
+        'foo = bar#noqa\n'
+        'qux = baz # noqa: S002\n'
+        'buzz = food # noqa: S007\n'
+        'quixotic = foolish # noqa: S007, S992 S002\n',
+        ['style']
+    )
+    assert len(output.messages) == 1
+    assert 'flow.cylc:3' in output.messages[0]


### PR DESCRIPTION
Closes #5095 

- [x] Ensure that workflows packaged with Cylc (in `cylc/flow/etc/tutorial`) pass Cylc Lint.
- [x] Add the ability to create `# noqa` comments: This will allow us to make sure all the test workflows are also linted because it will allow us to exclude deliberately bad lines.
- [x] Don't object to `%include` if unindented.
- [x] Lint the packaged workflows in CI.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
