### PR TITLE
added chain offset logic

### DIFF
--- a/changes.d/5885.fix.md
+++ b/changes.d/5885.fix.md
@@ -1,1 +1,1 @@
-Fixed bug in using a final cycle point with chained offsets e.g. .
+Fixed bug in using a final cycle point with chained offsets e.g. 'final cycle point = +PT6H+PT1S'.

--- a/changes.d/5885.fix.md
+++ b/changes.d/5885.fix.md
@@ -1,0 +1,1 @@
+Fixed bug in using a final cycle point with chained offsets e.g. .

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -895,7 +895,24 @@ def get_dump_format():
 def get_point_relative(offset_string, base_point):
     """Create a point from offset_string applied to base_point."""
     try:
-        interval = ISO8601Interval(str(interval_parse(offset_string)))
+        if len(re.split('\\+|-', offset_string)) > 2:
+            opperator = '+'
+            base_point_relative = base_point
+            for iso in re.split('(\\+|-)', offset_string):
+                if iso == '+' or iso == '-':
+                    opperator = iso
+                elif iso != '':
+                    if opperator == '-':
+                        base_point_relative = base_point_relative.add(
+                            ISO8601Interval(str(-1 * interval_parse(iso)))
+                        )
+                    elif opperator == '+':
+                        base_point_relative = base_point_relative.add(
+                            ISO8601Interval(str(interval_parse(iso)))
+                        )
+            return base_point_relative
+        else:
+            interval = ISO8601Interval(str(interval_parse(offset_string)))
     except IsodatetimeError:
         return ISO8601Point(str(
             WorkflowSpecifics.abbrev_util.parse_timepoint(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -536,6 +536,17 @@ def test_process_startcp(
             ISO8601_CYCLING_TYPE,
             {
                 'initial cycle point': '2017-02-11',
+                'final cycle point': '+P4D+PT3H-PT2H',
+            },
+            None,
+            '20170215T0100+0530',
+            None,
+            id="Relative fcp chained"
+        ),
+        pytest.param(
+            ISO8601_CYCLING_TYPE,
+            {
+                'initial cycle point': '2017-02-11',
                 'final cycle point': '---04',
             },
             None,


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5047

- When calculating the offeset relative to the base_point it now checks if there are multiple opperators in the expression.
- If there are it splits the expresion into multiple expressions and calculates the offset by adding or subtracting each expression in turn.
- If there are not it executes as it would previously
- Added a unit test to cover chained offset expressions



<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
