### PR TITLE
lint: Warn users that `CYLC_VERSION={{CYLC_VERSION}}` is deprecated

### DIFF
--- a/changes.d/5890.feat.md
+++ b/changes.d/5890.feat.md
@@ -1,0 +1,2 @@
+Cylc Lint to warn users that CYLC_VERSION={{CYLC_VERSION}} is deprecated.
+Additional warnings for ROSE_VERSION and FCM_VERSION in the same manner.

--- a/changes.d/5890.feat.md
+++ b/changes.d/5890.feat.md
@@ -1,2 +1,2 @@
-Cylc Lint to warn users that CYLC_VERSION={{CYLC_VERSION}} is deprecated.
-Additional warnings for ROSE_VERSION and FCM_VERSION in the same manner.
+Lint: Warn users that setting ``CYLC_VERSION``, ``ROSE_VERSION`` or
+``FCM_VERSION`` in the workflow config is deprecated.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -677,7 +677,7 @@ MANUAL_DEPRECATIONS = {
         ),
         FUNCTION: check_for_deprecated_task_event_template_vars,
     },
-    'U016'
+    'U016': {
         'short': 'Deprecated template vars: {vars}',
         'rst': (
             'agoigfva[or]'

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -686,7 +686,8 @@ MANUAL_DEPRECATIONS = {
             'https://cylc.github.io/cylc-doc/stable/html/plugins/'
             'cylc-rose.html#special-variables'
         ),
-        FUNCTION: functools.partial(list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
+        FUNCTION: functools.partial(
+            list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
     },
 }
 RULESETS = ['728', 'style', 'all']

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -680,8 +680,8 @@ MANUAL_DEPRECATIONS = {
     'U016': {
         'short': 'Deprecated template vars: {vars}',
         'rst': (
-            'Variables ``CYLC_VERSION``, ``ROSE_VERSION`` and ``FCM_VERSION``'
-            ' are deprecated.'
+            'It is no longer necessary to configure the environment variables '
+            '``CYLC_VERSION``, ``ROSE_VERSION`` or ``FCM_VERSION``.'
         ),
         'url': (
             'https://cylc.github.io/cylc-doc/stable/html/plugins/'

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -680,7 +680,8 @@ MANUAL_DEPRECATIONS = {
     'U016': {
         'short': 'Deprecated template vars: {vars}',
         'rst': (
-            'agoigfva[or]'
+            'Variables ``CYLC_VERSION``, ``ROSE_VERSION`` and ``FCM_VERSION``'
+            ' are deprecated.'
         ),
         'url': (
             'https://cylc.github.io/cylc-doc/stable/html/plugins/'

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -320,6 +320,10 @@ def check_indentation(line: str) -> bool:
     return bool(len(match[0]) % 4 != 0)
 
 
+CHECK_FOR_OLD_VARS = re.compile(
+    r'CYLC_VERSION\s*=\s*\{\{CYLC_VERSION\}\}|ROSE_VERSION\s*='
+    r'\s*\{\{ROSE_VERSION\}\}|FCM_VERSION\s*=\s*\{\{FCM_VERSION\}\}')
+
 FUNCTION = 'function'
 
 STYLE_GUIDE = (
@@ -655,7 +659,19 @@ MANUAL_DEPRECATIONS = {
             'writing-workflows/runtime.html#task-event-template-variables'
         ),
         FUNCTION: check_for_deprecated_task_event_template_vars,
-    }
+    },
+    'U016'
+        'short': 'Deprecated template vars: {vars}',
+        'rst': (
+            'agoigfva[or]'
+        ),
+        'url': (
+            'https://cylc.github.io/cylc-doc/stable/html/7-to-8/'
+            'cheat-sheet.html#datetime-operations'
+        ),
+        FUNCTION: lambda line: {
+            'vars': '\n    * '.join(CHECK_FOR_OLD_VARS.findall(line))}
+    },
 }
 RULESETS = ['728', 'style', 'all']
 EXTRA_TOML_VALIDATION = {

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -321,8 +321,25 @@ def check_indentation(line: str) -> bool:
 
 
 CHECK_FOR_OLD_VARS = re.compile(
-    r'CYLC_VERSION\s*=\s*\{\{CYLC_VERSION\}\}|ROSE_VERSION\s*='
-    r'\s*\{\{ROSE_VERSION\}\}|FCM_VERSION\s*=\s*\{\{FCM_VERSION\}\}')
+    r'CYLC_VERSION\s*=\s*\{\{\s*CYLC_VERSION\s*\}\}'
+    r'|ROSE_VERSION\s*=\s*\{\{\s*ROSE_VERSION\s*\}\}'
+    r'|FCM_VERSION\s*=\s*\{\{\s*FCM_VERSION\s*\}\}'
+)
+
+
+def list_wrapper(line: str, check: Callable) -> Optional[Dict[str, str]]:
+    """Take a line and a check function and return a Dict if there is a
+    result, None otherwise.
+
+    Returns
+
+        Dict, in for {'vars': Error string}
+    """
+    result = check(line)
+    if result:
+        return {'vars': '\n    * '.join(result)}
+    return None
+
 
 FUNCTION = 'function'
 
@@ -666,11 +683,10 @@ MANUAL_DEPRECATIONS = {
             'agoigfva[or]'
         ),
         'url': (
-            'https://cylc.github.io/cylc-doc/stable/html/7-to-8/'
-            'cheat-sheet.html#datetime-operations'
+            'https://cylc.github.io/cylc-doc/stable/html/plugins/'
+            'cylc-rose.html#special-variables'
         ),
-        FUNCTION: lambda line: {
-            'vars': '\n    * '.join(CHECK_FOR_OLD_VARS.findall(line))}
+        FUNCTION: functools.partial(list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
     },
 }
 RULESETS = ['728', 'style', 'all']

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -214,15 +214,18 @@ def filter_strings(items, contains):
 def assert_contains(items, contains, instances=None):
     """Pass if at least one item contains a given string."""
     filtered = filter_strings(items, contains)
-    if not filtered or (instances and len(filtered) != instances):
+    if not filtered:
         raise Exception(
             f'Could not find: "{contains}" in:\n'
-            + pformat(items)
-        )
+            + pformat(items))
+    elif instances and len(filtered) != instances:
+        raise Exception(
+            f'Expected "{contains}" to appear {instances} times'
+            f', got it {len(filtered)} times.')
 
 
 EXPECT_INSTANCES_OF_ERR = {
-    15: 3,
+    16: 3,
 }
 
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -88,6 +88,8 @@ TEST_FILE = """
     [[mail]]
         task event mail interval    = PT4M # deliberately added lots of spaces.
 
+CYLC_VERSION={{CYLC_VERSION}}
+
 [scheduling]
     max active cycle points = 5
     hold after point = 20220101T0000Z
@@ -151,7 +153,6 @@ LINT_TEST_FILE = """
  [scheduler]
 
 [[dependencies]]
-
 {% set   N = 009 %}
 {% foo %}
 {{foo}}


### PR DESCRIPTION
partially closes https://github.com/cylc/cylc-flow/issues/4917

Also applies to ROSE_VERSION & FCM_VERSION

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
