### PR TITLE
id: catch traceback in ID parsing

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -109,12 +109,14 @@ def _parse_cli(*ids: str) -> List[Tokens]:
         >>> parse_back('//cycle')
         Traceback (most recent call last):
         InputError: Relative reference must follow an incomplete one.
-        E.G: workflow //cycle/task
 
         >>> parse_back('workflow//cycle', '//cycle')
         Traceback (most recent call last):
         InputError: Relative reference must follow an incomplete one.
-        E.G: workflow //cycle/task
+
+        >>> parse_back('workflow///cycle/')
+        Traceback (most recent call last):
+        InputError: Invalid ID: workflow///cycle/
 
     """
     # upgrade legacy ids if required
@@ -130,7 +132,11 @@ def _parse_cli(*ids: str) -> List[Tokens]:
             if id_.endswith('/') and not id_.endswith('//'):  # noqa: SIM106
                 # tolerate IDs that end in a single slash on the CLI
                 # (e.g. CLI auto completion)
-                tokens = Tokens(id_[:-1])
+                try:
+                    # this ID is invalid with or without the trailing slash
+                    tokens = Tokens(id_[:-1])
+                except ValueError:
+                    raise InputError(f'Invalid ID: {id_}')
             else:
                 raise InputError(f'Invalid ID: {id_}')
         is_partial = tokens.get('workflow') and not tokens.get('cycle')


### PR DESCRIPTION
Catch a niche traceback for invalid IDs like `workflow///cycle/`.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.