### PR TITLE
Made execution time limit unsettable by reload or broadcast.

### DIFF
--- a/changes.d/5902.fix.md
+++ b/changes.d/5902.fix.md
@@ -1,2 +1,1 @@
-Fixed a case where reloading or broadcasting execution time limit=
-would have no effect.
+Fixed a bug that prevented unsetting `execution time limit` by broadcast or reload.

--- a/changes.d/5902.fix.md
+++ b/changes.d/5902.fix.md
@@ -1,0 +1,2 @@
+Fixed a case where reloading or broadcasting execution time limit=
+would have no effect.

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1305,11 +1305,9 @@ class TaskJobManager:
             >>> with raises(ValueError):
             ...     this("🇳🇿")
         """
-        execution_time_limit = None
-        if config_execution_time_limit is not None:
-            with suppress(TypeError):
-                execution_time_limit = float(config_execution_time_limit)
-        return execution_time_limit
+        with suppress(TypeError):
+            return float(config_execution_time_limit)
+        return None
 
     def get_job_conf(
         self,

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1288,24 +1288,21 @@ class TaskJobManager:
     ) -> Union[None, float]:
         """Get execution time limit from config and process it.
 
-        We are making no assumptions about what can be passed in,
-        but passing silently and returning None if the value is
-        not a type convertable to a float:
+        If the etl from the config is a Falsy then return None.
+        Otherwise try and parse value as float.
 
         Examples:
+            >>> from pytest import raises
             >>> this = TaskJobManager.get_execution_time_limit
+
             >>> this(None)
             >>> this("54")
             54.0
             >>> this({})
-
-        N.b.
-            This function does not save you from a value error:
-            >>> from pytest import raises
             >>> with raises(ValueError):
-            ...     this("🇳🇿")
+            ...     this('🇳🇿')
         """
-        with suppress(TypeError):
+        if config_execution_time_limit:
             return float(config_execution_time_limit)
         return None
 

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -135,8 +135,6 @@ async def test__prep_submit_task_job_impl_handles_execution_time_limit(
     flow: Fixture,
     scheduler: Fixture,
     start: Fixture,
-    validate: Fixture,
-    pytestconfig: Fixture
 ):
     """Ensure that emptying the execution time limit unsets it.
 
@@ -158,9 +156,6 @@ async def test__prep_submit_task_job_impl_handles_execution_time_limit(
             }
         }
     })
-    # Debugging only:
-    if pytestconfig.option.verbose > 2:
-        validate(id_)
 
     # Run in live mode - function not called in sim mode.
     schd = scheduler(id_, run_mode='live')

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -166,19 +166,23 @@ async def test__prep_submit_task_job_impl_handles_execution_time_limit(
         with suppress(FileExistsError):
             schd.task_job_mgr._prep_submit_task_job_impl(
                 schd.workflow, task_a, task_a.tdef.rtconfig)
-            assert task_a.summary['execution_time_limit'] == 5.0
+        assert task_a.summary['execution_time_limit'] == 5.0
 
-            # If we delete the etl it gets deleted in the summary:
-            task_a.tdef.rtconfig['execution time limit'] = None
+        # If we delete the etl it gets deleted in the summary:
+        task_a.tdef.rtconfig['execution time limit'] = None
+        with suppress(FileExistsError):
             schd.task_job_mgr._prep_submit_task_job_impl(
                 schd.workflow, task_a, task_a.tdef.rtconfig)
-            assert not task_a.summary.get('execution_time_limit', '')
+        assert not task_a.summary.get('execution_time_limit', '')
 
-            # put everything back and test broadcast too.
-            task_a.tdef.rtconfig['execution time limit'] = 5.0
-            task_a.summary['execution_time_limit'] = 5.0
-            schd.broadcast_mgr.broadcasts = {
-                '1': {'a': {'execution time limit': None}}}
-            schd.task_job_mgr._prep_submit_task_job_impl(
-                schd.workflow, task_a, task_a.tdef.rtconfig)
-            assert not task_a.summary.get('execution_time_limit', '')
+        # put everything back and test broadcast too.
+        task_a.tdef.rtconfig['execution time limit'] = 5.0
+        task_a.summary['execution_time_limit'] = 5.0
+        schd.broadcast_mgr.broadcasts = {
+            '1': {'a': {'execution time limit': None}}}
+        with suppress(FileExistsError):
+            # We run a higher level function here to ensure
+            # that the broadcast is applied.
+            schd.task_job_mgr._prep_submit_task_job(
+                schd.workflow, task_a)
+        assert not task_a.summary.get('execution_time_limit', '')


### PR DESCRIPTION
Closes #5891 

Formerly a suppress statement was supressing cases when we wanted to set itask.summary['execution time limit'] = None.

Added tests.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~ Not req'd
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
