### PR TITLE
coverage: exclude report-timings and set 90% as the lower limit

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,18 +17,19 @@ coverage:
     project:
       default:
         # commits below this threshold will be marked as failed
-        target: '85%'
+        target: '92%'
         # how much we allow the coverage to drop
         threshold: '2%'
     patch:
       default:
-        target: '95%'
+        target: '97%'
         threshold: '5%'
 
 # files to ignore
 ignore:
   - "tests/**"
   - "ws_messages_pb2.py"
+  - "cylc/flow/scripts/report_timings.py"
 
 flag_management:
   default_rules:

--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,7 @@ omit =
     tests/*
     */cylc/flow/*_pb2.py
     cylc/flow/etc/*
+    cylc/flow/scripts/report_timings.py
 parallel = True
 source = ./cylc
 timid = False


### PR DESCRIPTION
* Exclude the deprecated report-timings command from code coverage.
* Don't allow coverage to dip below 90%.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.