### PR TITLE
resolvers: optimize "uniq" iteration

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -126,6 +126,27 @@ def uniq(iterable):
     return ret
 
 
+def iter_uniq(iterable):
+    """Iterate over an iterable omitting any duplicate entries.
+
+    Useful for unhashable things like dicts, relies on __eq__ for testing
+    equality.
+
+    Note:
+        More efficient than "uniq" for iteration use cases.
+
+    Examples:
+        >>> list(iter_uniq([1, 1, 2, 3, 5, 8, 1]))
+        [1, 2, 3, 5, 8]
+
+    """
+    cache = set()
+    for item in iterable:
+        if item not in cache:
+            cache.add(item)
+            yield item
+
+
 def workflow_ids_filter(workflow_tokens, items) -> bool:
     """Match id arguments with workflow attributes.
 
@@ -211,7 +232,7 @@ def node_ids_filter(tokens, state, items) -> bool:
                 or get_state_from_selectors(item) == state
             )
         )
-        for item in uniq(items)
+        for item in iter_uniq(items)
     )
 
 
@@ -292,7 +313,7 @@ def get_flow_data_from_ids(data_store, native_ids):
         )
     return [
         data_store[w_id]
-        for w_id in uniq(w_ids)
+        for w_id in iter_uniq(w_ids)
         if w_id in data_store
     ]
 


### PR DESCRIPTION
**Requires:** https://github.com/cylc/cylc-flow/pull/5769

In the data store we sometimes need to strip duplicate items from an iterable whilst maintaining iteration order.

If we didn't need to maintain order, we would use sets. This new method is more efficient than the old one for iteration use cases.

<details>
<summary>Simple performance test:</summary>

```python
from random import random, shuffle                                
from time import time                                             
                                                                  
from cylc.flow.network.resolvers import uniq, iter_uniq           
                                                                  
N = 1000                                                          
M = 1000                                                          
                                                                  
_0 = [round(random(), 5) for _ in range(N)]                       
_10 = [*_0[:int(N * 0.9)], *_0[:int(N * 0.1)]]                    
_50 = [*_0[:int(N * 0.5)], *_0[:int(N * 0.5)]]    
                                                                  
shuffle(_0)                                                       
shuffle(_10)                                                      
shuffle(_50)                                                      
                                                                  
def _uniq():                                                      
    for _ in range(M):                                            
        for _ in uniq(_0):                                        
            pass                                                  
                                                                  
                                                                  
def _iter_uniq():                                                 
    for _ in range(M):                                            
        for _ in iter_uniq(_0):                                   
            pass               
                               
                               
def _set():    
    for _ in range(M):    
        yield from set(_0)      
                                                         
                                                         
start = time()                                           
_uniq()                                                  
end = time()    
print(f'{"uniq":10} {end - start}')                      
                                                         
start = time()      
_iter_uniq()                                             
end = time()                                             
print(f'{"iter_uniq":10} {end - start}')      
     
start = time()      
_set()      
end = time()    
print(f'{"set":10} {end - start}')    
```

</details>

The real world impact of this optimisation is probably quite small.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.