### PR TITLE
Fix.ensure logger set for all caplog.set level

### DIFF
--- a/tests/unit/test_flow_mgr.py
+++ b/tests/unit/test_flow_mgr.py
@@ -22,6 +22,7 @@ import logging
 
 from cylc.flow.flow_mgr import FlowMgr
 from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
+from cylc.flow import CYLC_LOG
 
 
 FAKE_NOW = datetime.datetime(2020, 12, 25, 17, 5, 55)
@@ -44,7 +45,7 @@ def test_all(
 ):
     db_mgr = WorkflowDatabaseManager()
     flow_mgr = FlowMgr(db_mgr)
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.INFO, CYLC_LOG)
 
     count = 1
     meta = "the quick brown fox"

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import pytest
 
+from cylc.flow import CYLC_LOG
 from cylc.flow.async_util import pipe
 from cylc.flow.exceptions import InputError, WorkflowFilesError
 from cylc.flow.id import detokenise, tokenise, Tokens
@@ -537,7 +538,7 @@ def test_validate_workflow_ids_basic(tmp_run_dir):
 
 def test_validate_workflow_ids_warning(caplog):
     """It should warn when the run number is provided as a cycle point."""
-    caplog.set_level(logging.WARN)
+    caplog.set_level(logging.WARN, CYLC_LOG)
     _validate_workflow_ids(Tokens('workflow/run1//cycle/task'), src_path='')
     assert caplog.messages == []
 


### PR DESCRIPTION
`caplog.set_level` can conflict with other instances of caplog if the logger isn't set in the tests. This was causing the manylinux tests to fail, and would have caused the same problem if all pytests were run in the same task in the fast tests.

https://github.com/wxtim/cylc/actions/runs/7501317283 (PR's with changes to Python tests only trigger the fast-tests workflow - a neat feature, but somewhat unhelpful in this particular case)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] This is a change to testing, no new test, documentation or changelog entries are reqd
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
