### PR TITLE
Cylc Message Help Contains two patterns of use

### DIFF
--- a/cylc/flow/scripts/message.py
+++ b/cylc/flow/scripts/message.py
@@ -117,13 +117,14 @@ def get_option_parser() -> COP:
         __doc__,
         comms=True,
         argdoc=[
-            COP.optional(WORKFLOW_ID_ARG_DOC),
+            WORKFLOW_ID_ARG_DOC,
+            ('JOB', 'Job ID - CYCLE/TASK_NAME/SUBMIT_NUM'),
             COP.optional(
-                ('JOB', 'Job ID - CYCLE/TASK_NAME/SUBMIT_NUM')
+                ('[SEVERITY:]MESSAGE ...', 'Severity Level:Message')
             ),
-            COP.optional(
-                ('[SEVERITY:]MESSAGE ...', 'Messages')
-            )
+            COP.LINEBREAK,
+            COP.optional(('[SEVERITY:]MESSAGE', 'Severity Level:Message')),
+            COP.optional(('[SEVERITY:]MESSAGE', 'Severity Level:Message')),
         ]
     )
 


### PR DESCRIPTION
Closes #5883 

A single script might have multiple different valid arguments.

for example `cylc message` can be either
```
cylc message -- [WORKFLOW JOB [[SEVERITY:]MESSAGE ...]]] __or__
cylc message --	[[SEVERITY:]MESSAGE ...]]]
```

This PR fixes the Cylc message docs.

- Refactored part of the __init__ method of CylcOptionParser. into a method for ease of testing.
- Added unit tests to get complete coverage of new method.

### Note
The reason for this behaviour is given further down in the doc:

```
For backward compatibility, if number of arguments is less than or equal to 2,
the command assumes the classic interface, where all arguments are messages.
Otherwise, the first 2 arguments are assumed to be workflow ID and job
identifier.
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] This is effectively a documentation change and doesn't need logging in `CHANGES.md` or in the docs.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
