### PR TITLE
Error if graph has a dependency offset exclusively on the RHS

### DIFF
--- a/changes.d/fix.5924.md
+++ b/changes.d/fix.5924.md
@@ -1,0 +1,1 @@
+Ensure that graphs with dependency offsets on the right hand side are flagged to users.

--- a/changes.d/fix.5924.md
+++ b/changes.d/fix.5924.md
@@ -1,1 +1,1 @@
-Ensure that graphs with dependency offsets on the right hand side are flagged to users.
+Validation: a cycle offset can only appear on the right of a dependency if the task's cycling is defined elsewhere with no offset.

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -534,12 +534,6 @@ class GraphParser:
         if right.count("(") != right.count(")"):
             raise GraphParseError(mismatch_msg.format(right))
 
-        # Split right side on AND.
-        rights = right.split(self.__class__.OP_AND)
-        if '' in rights or right and not all(rights):
-            raise GraphParseError(
-                f"Null task name in graph: {left} => {right}")
-
         # Ignore/Error cycle point offsets on the right side:
         # (Note we can only ban this for nodes at the end of chains)
         if '[' in right:
@@ -551,6 +545,12 @@ class GraphParser:
             else:
                 # This right hand side is a left elsewhere:
                 return
+
+        # Split right side on AND.
+        rights = right.split(self.__class__.OP_AND)
+        if '' in rights or right and not all(rights):
+            raise GraphParseError(
+                f"Null task name in graph: {left} => {right}")
 
         lefts: Union[List[str], List[Optional[str]]]
         if not left or (self.__class__.OP_OR in left or '(' in left):

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -534,21 +534,23 @@ class GraphParser:
         if right.count("(") != right.count(")"):
             raise GraphParseError(mismatch_msg.format(right))
 
-        # Ignore/Error cycle point offsets on the right side:
-        # (Note we can only ban this for nodes at the end of chains)
-        if '[' in right:
-            if right in terminals:
-                raise GraphParseError(
-                    'ERROR, illegal cycle point offset on the right:'
-                    f' {left} => {right}')
-            else:
-                return
-
         # Split right side on AND.
         rights = right.split(self.__class__.OP_AND)
         if '' in rights or right and not all(rights):
             raise GraphParseError(
                 f"Null task name in graph: {left} => {right}")
+
+        # Ignore/Error cycle point offsets on the right side:
+        # (Note we can only ban this for nodes at the end of chains)
+        if '[' in right:
+            if left and right in terminals:
+                # This right hand side is at the end of a chain:
+                raise GraphParseError(
+                    'ERROR, illegal cycle point offset on the right:'
+                    f' {left} => {right}')
+            else:
+                # This right hand side is a left elsewhere:
+                return
 
         lefts: Union[List[str], List[Optional[str]]]
         if not left or (self.__class__.OP_OR in left or '(' in left):

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -538,7 +538,7 @@ class GraphParser:
             if left and (right in terminals):
                 # This right hand side is at the end of a chain:
                 raise GraphParseError(
-                    'ERROR, illegal cycle point offset on the right:'
+                    'Invalid cycle point offsets only on right hand side of a dependency (must be on left hand side):'
                     f' {left} => {right}')
             else:
                 # This RHS is also a LHS in a chain:

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -538,7 +538,8 @@ class GraphParser:
             if left and (right in terminals):
                 # This right hand side is at the end of a chain:
                 raise GraphParseError(
-                    'Invalid cycle point offsets only on right hand side of a dependency (must be on left hand side):'
+                    'Invalid cycle point offsets only on right hand '
+                    'side of a dependency (must be on left hand side):'
                     f' {left} => {right}')
             else:
                 # This RHS is also a LHS in a chain:

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -916,3 +916,28 @@ def test_RHS_AND(graph: str, expected_triggers: Dict[str, List[str]]):
         for task, trigs in gp.triggers.items()
     }
     assert triggers == expected_triggers
+
+
+@pytest.mark.parametrize(
+    'args, err',
+    (
+        # Error if offset in terminal RHS:
+        param((('a', 'b[-P42M]'), {'b[-P42M]'}), 'illegal cycle point offset'),
+        # No error if offset in NON-terminal RHS:
+        param((('a', 'b[-P42M]'), {}), None),
+        # Null task name in graph warns before cycle point offsets:
+        param((('a', 'b[-P42M] &'), {}), '^Null task name'),
+        # Don't check the left hand side if this has a non-terminal RHS:
+        param((('a &', 'b[-P42M]'), {}), None),
+    )
+)
+def test_proc_dep_pair(args, err):
+    """
+    Unit tests for _proc_dep_pair.
+    """
+    gp = GraphParser()
+    if err:
+        with pytest.raises(GraphParseError, match=err):
+            gp._proc_dep_pair(*args)
+    else:
+        assert gp._proc_dep_pair(*args) is None

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -136,7 +136,7 @@ def test_graph_syntax_errors_2(seq, graph, expected_err):
         param(
             # See https://github.com/cylc/cylc-flow/issues/5844
             "foo => bar[1649]",
-            'illegal cycle point offset on the right',
+            'Invalid cycle point offsets only on right',
             id='no-cycle-point-RHS'
         ),
     ]
@@ -917,7 +917,7 @@ def test_RHS_AND(graph: str, expected_triggers: Dict[str, List[str]]):
     'args, err',
     (
         # Error if offset in terminal RHS:
-        param((('a', 'b[-P42M]'), {'b[-P42M]'}), 'illegal cycle point offset'),
+        param((('a', 'b[-P42M]'), {'b[-P42M]'}), 'Invalid cycle point offset'),
         # No error if offset in NON-terminal RHS:
         param((('a', 'b[-P42M]'), {}), None),
         # Don't check the left hand side if this has a non-terminal RHS:

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -139,27 +139,13 @@ def test_graph_syntax_errors_2(seq, graph, expected_err):
             'illegal cycle point offset on the right',
             id='no-cycle-point-RHS'
         ),
-        param(
-            "foo => bar[1649] => baz",
-            '!illegal cycle point offset on the right',
-            id='ignore-not-exclusively-RHS-cycle-point'
-        ),
-        param(
-            "foo => bar[1649]\nbar[1649] => baz",
-            '!illegal cycle point offset on the right',
-            id='ignore-not-exclusively-RHS-cycle-point2'
-        ),
     ]
 )
 def test_graph_syntax_errors(graph, expected_err):
     """Test various graph syntax errors."""
-    if expected_err[0] == '!':
-        # Assert method doesn't fail:
+    with pytest.raises(GraphParseError) as cm:
         GraphParser().parse_graph(graph)
-    else:
-        with pytest.raises(GraphParseError) as cm:
-            GraphParser().parse_graph(graph)
-        assert expected_err in str(cm.value)
+    assert expected_err in str(cm.value)
 
 
 def test_parse_graph_simple():
@@ -397,7 +383,16 @@ b => c"""
             foo => bar
             bar:succeed => baz
             """
-        ]
+        ],
+        [
+            """
+            foo => bar[1649] => baz
+            """,
+            """
+            foo => bar[1649]
+            bar[1649] => baz
+            """
+        ],
     ]
 )
 def test_trigger_equivalence(graph1, graph2):

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -133,13 +133,33 @@ def test_graph_syntax_errors_2(seq, graph, expected_err):
             "foo || bar => baz",
             "The graph OR operator is '|'"
         ),
+        param(
+            # See https://github.com/cylc/cylc-flow/issues/5844
+            "foo => bar[1649]",
+            'illegal cycle point offset on the right',
+            id='no-cycle-point-RHS'
+        ),
+        param(
+            "foo => bar[1649] => baz",
+            '!illegal cycle point offset on the right',
+            id='ignore-not-exclusively-RHS-cycle-point'
+        ),
+        param(
+            "foo => bar[1649]\nbar[1649] => baz",
+            '!illegal cycle point offset on the right',
+            id='ignore-not-exclusively-RHS-cycle-point2'
+        ),
     ]
 )
 def test_graph_syntax_errors(graph, expected_err):
     """Test various graph syntax errors."""
-    with pytest.raises(GraphParseError) as cm:
+    if expected_err[0] == '!':
+        # Assert method doesn't fail:
         GraphParser().parse_graph(graph)
-    assert expected_err in str(cm.value)
+    else:
+        with pytest.raises(GraphParseError) as cm:
+            GraphParser().parse_graph(graph)
+        assert expected_err in str(cm.value)
 
 
 def test_parse_graph_simple():

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -925,8 +925,6 @@ def test_RHS_AND(graph: str, expected_triggers: Dict[str, List[str]]):
         param((('a', 'b[-P42M]'), {'b[-P42M]'}), 'illegal cycle point offset'),
         # No error if offset in NON-terminal RHS:
         param((('a', 'b[-P42M]'), {}), None),
-        # Null task name in graph warns before cycle point offsets:
-        param((('a', 'b[-P42M] &'), {}), '^Null task name'),
         # Don't check the left hand side if this has a non-terminal RHS:
         param((('a &', 'b[-P42M]'), {}), None),
     )


### PR DESCRIPTION
Closes #5844

Raise an error if a graph has a dependency offset only on the RHS of a graph pair.


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
