### PR TITLE
Turn off flake8-bugbear check 038 becuase it gave false positives.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ ignore=
     ; suggests using f"{!r}" instead of manual quotes (flake8-bugbear)
     ; Doesn't work at 3.7
     B028
+    ; Broken in two cases https://github.com/PyCQA/flake8-bugbear/issues/451
+    B038
 
 exclude=
     build,


### PR DESCRIPTION
See https://github.com/PyCQA/flake8-bugbear/issues/451

The following files fail the new flake8-bugbear B038 check:

- The two cases in `async_util` are probably legitimate exceptions to the rule, parly because they are while loops using the modification to empty an object.
- The one in `broadcast_report` is also using a while loop, but might not need to: It's not a quick fix though - it's 9 YO code and as far as I can see has no unit tests. IMO needs a suite of unit tests existing behaviour before changing. Not a quick win.
- The one is in `network/scan.py` and `option_parsers.py` are the result of the bug.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
- [x] This change doesn't require any public facing docs.
- [ ] Create an issue to undo this when:
    * Bugbear have fixed their issue.
    * When we have time to devote to the other three issues.