### PR TITLE
backport fix from #5712

### DIFF
--- a/changes.d/fix.5712.md
+++ b/changes.d/fix.5712.md
@@ -1,0 +1,1 @@
+Fixed a bug preventing simulation of task retries if job submission unset.

--- a/changes.d/fix.5712.md
+++ b/changes.d/fix.5712.md
@@ -1,1 +1,1 @@
-Fixed a bug preventing simulation of task retries if job submission unset.
+Fixed a bug preventing simulation of task retries if `submission retry delays` unset.

--- a/changes.d/fix.5712.md
+++ b/changes.d/fix.5712.md
@@ -1,1 +1,1 @@
-Fixed a bug preventing simulation of task retries if `submission retry delays` unset.
+Fixed a bug preventing simulation of execution retries when `submission retry delays` is not set.

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -778,7 +778,6 @@ class TaskEventsManager():
 
         if (
                 itask.state(TASK_STATUS_WAITING)
-                and itask.tdef.run_mode == 'live'
                 and
                 (
                     (
@@ -804,13 +803,13 @@ class TaskEventsManager():
                     f"[{itask}] "
                     f"{self.FLAG_RECEIVED_IGNORED}{message}{timestamp}"
                 )
-
-            else:
+                return False
+            elif flag == self.FLAG_POLLED_IGNORED:
                 LOG.warning(
                     f"[{itask}] "
                     f"{self.FLAG_POLLED_IGNORED}{message}{timestamp}"
                 )
-            return False
+                return False
 
         severity = cast(int, LOG_LEVELS.get(severity, INFO))
         # Demote log level to DEBUG if this is a message that duplicates what

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -778,6 +778,7 @@ class TaskEventsManager():
 
         if (
                 itask.state(TASK_STATUS_WAITING)
+                and itask.tdef.run_mode == 'live'
                 and
                 (
                     (

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1000,7 +1000,10 @@ class TaskJobManager:
             itask.waiting_on_job_prep = False
             itask.submit_num += 1
             self._set_retry_timers(itask)
-            itask.platform = {'name': 'SIMULATION'}
+            itask.platform = {
+                'name': 'SIMULATION',
+                'submission retry delays': [1]
+            }
             itask.summary['job_runner_name'] = 'SIMULATION'
             itask.summary[self.KEY_EXECUTE_TIME_LIMIT] = (
                 itask.tdef.rtconfig['job']['simulated run length']

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -979,8 +979,8 @@ class TaskJobManager:
             rtconfig = itask.tdef.rtconfig
 
         submit_delays = (
-            rtconfig['submission retry delays']
-            or itask.platform['submission retry delays']
+            rtconfig.get('submission retry delays', [])
+            or itask.platform.get('submission retry delays', [])
         )
 
         for key, delays in [
@@ -1000,10 +1000,7 @@ class TaskJobManager:
             itask.waiting_on_job_prep = False
             itask.submit_num += 1
             self._set_retry_timers(itask)
-            itask.platform = {
-                'name': 'SIMULATION',
-                'submission retry delays': [1]
-            }
+            itask.platform = {'name': 'SIMULATION'}
             itask.summary['job_runner_name'] = 'SIMULATION'
             itask.summary[self.KEY_EXECUTE_TIME_LIMIT] = (
                 itask.tdef.rtconfig['job']['simulated run length']

--- a/tests/functional/modes/03-simulation.t
+++ b/tests/functional/modes/03-simulation.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that simulation mode runs, and reruns a failed task successfully
+# when execution retry delays is configured.
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-run" \
+    cylc play \
+        --no-detach \
+        --mode=simulation \
+        --reference-test "${WORKFLOW_NAME}"
+purge
+exit

--- a/tests/functional/modes/03-simulation/flow.cylc
+++ b/tests/functional/modes/03-simulation/flow.cylc
@@ -1,0 +1,16 @@
+[scheduler]
+    [[events]]
+        workflow timeout = PT30S
+
+[scheduling]
+    initial cycle point = 2359
+    [[graph]]
+        R1 = get_observations
+
+[runtime]
+    [[get_observations]]
+        execution retry delays = PT2S
+        [[[simulation]]]
+            fail cycle points = all
+            fail try 1 only = True
+

--- a/tests/functional/modes/03-simulation/reference.log
+++ b/tests/functional/modes/03-simulation/reference.log
@@ -1,0 +1,2 @@
+23590101T0000Z/get_observations -triggered off [] in flow 1
+23590101T0000Z/get_observations -triggered off [] in flow 1


### PR DESCRIPTION
Backport simulation mode fixes from master #5712 

> I found bugs in #5712 , as part of the simulation mode refactor. They (the fixes) ought to be backported.
> 
> ## Bug 1
> To replicate:
> 
> ```ini
> [scheduling]
>     initial cycle point = 1100
>     [[graph]]
>         R1 = foo
> 
> [runtime]
>     [[foo]]
>         execution retry delays = 'PT3S'
>         [[[simulation]]]
>             fail try 1 only = true
>             fail cycle points = all
> ```
> 
> ```
> cylc vip --mode simulation
> ```
> 
> will give traceback, caused by there being no default value of submission retry delays in the config.
> 
> ## Bug 2
> Add the `.get` fix to bug 1 and run the same workflow again. This one will go into an endless loop of resubmission. We don't want that!


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
