### PR TITLE
Update isodatetime to 3.2

### DIFF
--- a/changes.d/5928.break.md
+++ b/changes.d/5928.break.md
@@ -1,0 +1,1 @@
+Fixed behaviour of `initial cycle point = next(...)` which could result in a time in the past, and equivalently for `previous()`. E.g. if the current time is `2024-01-01T12:30Z`, `next(--01-01)` now evaluates to `2025-01-01T00:00Z` instead of `2024-01-01T00:00Z`.

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - graphviz  # for static graphing
   # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
   - jinja2 >=3.0,<3.1
-  - metomi-isodatetime >=1!3.0.0, <1!3.2.0
+  - metomi-isodatetime >=1!3.2.0, <1!3.3.0
   - packaging
   # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
   - protobuf >=5,<8

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -7,9 +7,8 @@ dependencies:
   - graphql-core >=3.2,<3.3
   - graphene >=3.4.0,<3.5
   - graphviz  # for static graphing
-  # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
   - jinja2 >=3.1
-  - metomi-isodatetime >=1!3.0.0, <1!3.2.0
+  - metomi-isodatetime >=1!3.2.0, <1!3.3.0
   - packaging
   # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
   - protobuf >=5,<8

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -370,7 +370,7 @@ async def stop(
         # schedule shutdown after wallclock time passes provided time
         parser = TimePointParser()
         schd.set_stop_clock(
-            int(parser.parse(clock_time).seconds_since_unix_epoch)
+            parser.parse(clock_time).seconds_since_unix_epoch
         )
         schd._update_workflow_state()
     elif task is not None:

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -21,9 +21,12 @@ import contextlib
 from functools import lru_cache
 import os
 import re
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
-from metomi.isodatetime.data import CALENDAR, Calendar, Duration
+from metomi.isodatetime.data import (
+    CALENDAR,
+    Calendar,
+)
 from metomi.isodatetime.dumpers import TimePointDumper
 from metomi.isodatetime.exceptions import IsodatetimeError
 from metomi.isodatetime.parsers import ISO8601SyntaxError
@@ -85,13 +88,13 @@ _LARGE_LRU_CACHE_SIZE = int(_LRU_CACHE_SIZE / 100) if _LRU_CACHE_SIZE else 0
 class WorkflowSpecifics:
 
     """Store workflow-setup-specific constants and utilities here."""
-    ASSUMED_TIME_ZONE: Tuple[int, int]
+    ASSUMED_TIME_ZONE: tuple[int, int]
     DUMP_FORMAT: str
     abbrev_util: CylcTimeParser
     interval_parser: 'DurationParser'
     point_parser: 'TimePointParser'
     recurrence_parser: 'TimeRecurrenceParser'
-    iso8601_parsers: Tuple[
+    iso8601_parsers: tuple[
         'TimePointParser', 'DurationParser', 'TimeRecurrenceParser'
     ]
     NUM_EXPANDED_YEAR_DIGITS: int = 0
@@ -576,7 +579,7 @@ class ISO8601Sequence(SequenceBase):
 
     def get_next_point_on_sequence(
         self, point: ISO8601Point
-    ) -> Optional[ISO8601Point]:
+    ) -> ISO8601Point | None:
         """Return the on-sequence point > point assuming that point is
         on-sequence, or None if out of bounds."""
         result = None
@@ -596,7 +599,7 @@ class ISO8601Sequence(SequenceBase):
     def get_first_point(
         self,
         point: ISO8601Point
-    ) -> Optional[ISO8601Point]:
+    ) -> ISO8601Point | None:
         """Return the first point >= to point, or None if out of bounds."""
         with contextlib.suppress(KeyError):
             return ISO8601Point(self._cached_first_point_values[point.value])
@@ -676,7 +679,7 @@ def _get_old_anchor_step_recurrence(anchor, step, start_point):
     return str(anchor_point) + "/" + str(step)
 
 
-def ingest_time(value: str, now: Optional[str] = None) -> str:
+def ingest_time(value: str, now: str | None = None) -> str:
     """Handle relative, truncated and prev/next cycle points.
 
     Args:
@@ -723,14 +726,6 @@ def ingest_time(value: str, now: Optional[str] = None) -> str:
         now = get_current_time_string()
     now_point = parser.parse(now)
 
-    # correct for year in 'now' if year is the only date unit specified -
-    # https://github.com/cylc/cylc-flow/issues/4805#issuecomment-1103928604
-    if re.search(r"\(-\d{2}[);T]", value):
-        now_point += Duration(years=1)
-    # likewise correct for month if year and month are the only date units
-    elif re.search(r"\(-\d{4}[);T]", value):
-        now_point += Duration(months=1)
-
     # perform whatever transformation is required
     offset = None
     if is_prev_next:
@@ -752,7 +747,7 @@ def ingest_time(value: str, now: Optional[str] = None) -> str:
 
 def prev_next(
     value: str, now: 'TimePoint', parser: 'TimePointParser'
-) -> Tuple['TimePoint', Optional[str]]:
+) -> tuple['TimePoint', str | None]:
     """Handle previous() and next() syntax.
 
     Args:
@@ -772,13 +767,13 @@ def prev_next(
 
     # break down cycle point into constituent parts.
     direction, tmp = value.split("(")
-    offset: Optional[str]
+    offset: str | None
     tmp, offset = tmp.split(")")
 
     offset = offset.strip() or None
 
-    str_points: List[str] = tmp.split(";")
-    timepoints: List['TimePoint'] = []
+    str_points: list[str] = tmp.split(";")
+    timepoints: list['TimePoint'] = []
 
     # for use with 'previous' below.
     go_back = {
@@ -822,28 +817,6 @@ def prev_next(
     my_diff = [abs(my_time - now) for my_time in timepoints]
 
     cycle_point = timepoints[my_diff.index(min(my_diff))]
-
-    # ensure truncated dates do not have time from 'now' included' -
-    # https://github.com/metomi/isodatetime/issues/212
-    if 'T' not in value.split(')')[0]:
-        # NOTE: Strictly speaking we shouldn't forcefully mutate TimePoints
-        # in this way as they're meant to be immutable since
-        # https://github.com/metomi/isodatetime/pull/165, however it
-        # should be ok as long as the TimePoint is not used as a dict key and
-        # we don't call any of the TimePoint's cached methods until after we've
-        # finished mutating it.
-        cycle_point._hour_of_day = 0
-        cycle_point._minute_of_hour = 0
-        cycle_point._second_of_minute = 0
-    # likewise ensure month and day from 'now' are not included
-    # where they did not appear in the truncated datetime
-    if re.search(r"\(-\d{2}[);T]", value):
-        # case 1 - year only
-        cycle_point._month_of_year = 1
-        cycle_point._day_of_month = 1
-    elif re.search(r"\(-(-\d{2}|\d{4})[;T)]", value):
-        # case 2 - month only or year and month
-        cycle_point._day_of_month = 1
 
     return cycle_point, offset
 

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -426,7 +426,7 @@ class TaskProxy:
         """Compute and store my cycle point as seconds since epoch."""
         if self.point_as_seconds is None:
             iso_timepoint = point_parse(str(self.point))
-            self.point_as_seconds = int(iso_timepoint.seconds_since_unix_epoch)
+            self.point_as_seconds = iso_timepoint.seconds_since_unix_epoch
             if iso_timepoint.time_zone.unknown:
                 utc_offset_hours, utc_offset_minutes = (
                     get_local_time_zone())
@@ -460,7 +460,7 @@ class TaskProxy:
             else:
                 trigger_time = point_time + interval_parse(offset_str)
 
-            self.clock_trigger_times[offset_str] = int(
+            self.clock_trigger_times[offset_str] = (
                 trigger_time.seconds_since_unix_epoch
             )
         return self.clock_trigger_times[offset_str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "graphene>=3.4.0,<3.5",
     # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
     "jinja2==3.0.*",
-    "metomi-isodatetime>=1!3.0.0,<1!3.2.0",
+    "metomi-isodatetime>=1!3.2.0,<1!3.3.0",
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
     "packaging",
     "protobuf>=5,<8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "graphql-core>=3.2,<3.3",
     "graphene>=3.4.0,<3.5",
     "jinja2>=3.1",
-    "metomi-isodatetime>=1!3.0.0,<1!3.2.0",
+    "metomi-isodatetime>=1!3.2.0,<1!3.3.0",
     # Constrain protobuf version for compatible Scheduler-UIS comms across hosts
     "packaging",
     "protobuf>=5,<8",

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -717,7 +717,7 @@ def test_simple(set_cycling_type):
         ('next(--0325)', '20110325T0000Z'),
         ('next(---10)', '20100810T0000Z'),
         ('next(---05T1200Z)', '20100905T1200Z'),
-        param('next(--08-08)', '20110808T0000Z', marks=pytest.mark.xfail),
+        ('next(--08-08)', '20110808T0000Z'),
         ('next(T15)', '20100809T1500Z'),
         ('next(T-41)', '20100808T1541Z'),
     ]
@@ -741,7 +741,7 @@ def test_next_simple(value: str, expected: str, set_cycling_type):
         ('previous(--0325)', '20100325T0000Z'),
         ('previous(---10)', '20100710T0000Z'),
         ('previous(---05T1200Z)', '20100805T1200Z'),
-        param('previous(--08-08)', '20100808T0000Z', marks=pytest.mark.xfail),
+        ('previous(--08-08)', '20100808T0000Z'),
         ('previous(T15)', '20100808T1500Z'),
         ('previous(T-41)', '20100808T1441Z'),
     ]
@@ -887,7 +887,7 @@ def test_weeks_days(set_cycling_type):
         ('previous(--1225)', '20171225T0000Z'),
         ('next(-2006)', '20200601T0000Z'),
         ('previous(-W101)', '20180305T0000Z'),
-        ('next(-W-1; -W-3; -W-5)', '20180314T0000Z'),
+        ('next(-W-1; -W-3; -W-5)', '20180316T0000Z'),
         ('next(-001; -091; -181; -271)', '20180401T0000Z'),
         ('previous(-365T12Z)', '20171231T1200Z'),
     ]

--- a/tests/unit/test_workflow_status.py
+++ b/tests/unit/test_workflow_status.py
@@ -90,7 +90,7 @@ def schd(
             WORKFLOW_STATUS_RUNNING_TO_STOP % 4
         ),
         (
-            {'stop_clock_time': int(STOP_TIME.seconds_since_unix_epoch)},
+            {'stop_clock_time': STOP_TIME.seconds_since_unix_epoch},
             WorkflowStatus.RUNNING,
             WORKFLOW_STATUS_RUNNING_TO_STOP % str(STOP_TIME)
         ),


### PR DESCRIPTION
Fix bug where `next(...)` could return a datetime in the past. E.g. if the current time is `2024-01-01T12:30Z`, `next(--01-01)` now evaluates to `2025-01-01T00:00Z` instead of `2024-01-01T00:00Z`. Equivalent fix for `previous()`.

Closes #5795
Also addresses #4805 (already closed)

Does _not_ tackle #2382

Needs:
- [x] https://github.com/metomi/isodatetime/pull/234
- [ ] Isodatetime 3.2 released

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] https://github.com/cylc/cylc-doc/pull/713
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
