### PR TITLE
tui: handle client timeout more elegantly and make it configurable

### DIFF
--- a/cylc/flow/scripts/tui.py
+++ b/cylc/flow/scripts/tui.py
@@ -61,6 +61,21 @@ def get_option_parser() -> COP:
         color=False
     )
 
+    parser.add_option(
+        '--comms-timeout',
+        metavar='SEC',
+        help=(
+            "Set a timeout for network connections"
+            " to the running workflow. The default is no timeout."
+            " For task messaging connections see"
+            " site/user config file documentation."
+        ),
+        action='store',
+        default=3,
+        dest='comms_timeout',
+        type=int,
+    )
+
     return parser
 
 
@@ -76,5 +91,9 @@ def main(_, options: 'Values', workflow_id: Optional[str] = None) -> None:
         workflow_id = tokens.duplicate(user=getuser()).id
 
     # start Tui
-    with suppress_logging(), TuiApp().main(workflow_id):
+    with suppress_logging(), TuiApp().main(
+        workflow_id,
+        client_timeout=options.comms_timeout,
+    ):
+        # tui stops according to user input
         pass

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -200,7 +200,7 @@ class TuiNode(urwid.ParentNode):
 
 
 @contextmanager
-def updater_subproc(filters):
+def updater_subproc(filters, client_timeout):
     """Runs the Updater in its own process.
 
     The updater provides the data for Tui to render. Running the updater
@@ -209,7 +209,7 @@ def updater_subproc(filters):
     decoupling the application update logic from the data update logic.
     """
     # start the updater
-    updater = Updater()
+    updater = Updater(client_timeout=client_timeout)
     p = Process(target=updater.start, args=(filters,))
     try:
         p.start()
@@ -285,7 +285,13 @@ class TuiApp:
         self.filters = get_default_filters()
 
     @contextmanager
-    def main(self, w_id=None, id_filter=None, interactive=True):
+    def main(
+        self,
+        w_id=None,
+        id_filter=None,
+        interactive=True,
+        client_timeout=3,
+    ):
         """Start the Tui app.
 
         With interactive=False, this does not start the urwid event loop to
@@ -299,7 +305,7 @@ class TuiApp:
         """
         self.set_initial_filters(w_id, id_filter)
 
-        with updater_subproc(self.filters) as updater:
+        with updater_subproc(self.filters, client_timeout) as updater:
             self.updater = updater
 
             # pre-subscribe to the provided workflow if requested


### PR DESCRIPTION
Spotted whilst investigating a large workflow.

Client timeouts weren't getting reported so the workflow just looked like it's loading. This:

* Reports timeouts and other errors.
* Makes the `--comms-timeout` configurable.

Due to a [lazy] implementation detail, updates are blocking to each other, i.e. if one workflow takes a while to respond, no other updates will come through from other workflows in the mean time. As a result, configuring a low timeout is preferable.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` - no - unrelased
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.