### PR TITLE
remote_init: remove trailing space from symlink paths

### DIFF
--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -247,7 +247,7 @@ class TaskRemoteMgr:
         dirs_to_symlink = get_dirs_to_symlink(install_target, self.workflow)
         for key, value in dirs_to_symlink.items():
             if value is not None:
-                cmd.append(f"{key}={quote(value)} ")
+                cmd.append(f"{key}={quote(value)}")
         # Create the ssh command
         try:
             host = get_host_from_platform(


### PR DESCRIPTION
* This line was adding a trailing space onto the end of every symlink dir path.
* Not sure if this was symptomatic but it's definitely not right.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.