### PR TITLE
option parsers: fix "-z" option help text

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -421,12 +421,13 @@ class CylcOptionParser(OptionParser):
             ['-z', '--set-list', '--template-list'],
             metavar='NAME=VALUE1,VALUE2,...',
             help=(
-                'Set the value of a Jinja2 template variable in the'
-                ' workflow definition as a comma separated'
-                ' list of Python strings.'
-                ' Values containing commas must be quoted.'
-                " e.g. '+s STR=a,b,c' => ['a', 'b', 'c']"
-                " or '+ s STR=a,\"b,c\"' => ['a', 'b,c']"
+                'A more convenient alternative to --set for defining a list'
+                ' of strings. E.G.'
+                ' "-z FOO=a,b,c" is shorthand for'
+                ' "-s FOO=[\'a\',\'b\',\'c\']".'
+                ' Commas can be present in values if quoted, e.g.'
+                ' "-z FOO=a,\'b,c\'" is shorthand for'
+                ' "-s FOO=[\'a\',\'b,c\']".'
                 + CAN_BE_USED_MULTIPLE
                 + NOTE_PERSIST_ACROSS_RESTARTS
             ),


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5964

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.