### PR TITLE
Add new 'RAW' variables for SHARE and WORK variables to ensure share/work dirs are created with broken symlinks

### DIFF
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -73,6 +73,10 @@ cylc__job__main() {
     export CYLC_WORKFLOW_LOG_DIR="${CYLC_WORKFLOW_RUN_DIR}/log/scheduler"
     export CYLC_WORKFLOW_SHARE_DIR="${CYLC_WORKFLOW_RUN_DIR}/share"
     export CYLC_WORKFLOW_WORK_DIR="${CYLC_WORKFLOW_RUN_DIR}/work"
+    # Make sure the 'raw' version of SHARE and WORK are defined.
+    # Default to the ones defined above.
+    export CYLC_WORKFLOW_SHARE_DIR_RAW="${CYLC_WORKFLOW_SHARE_DIR_RAW:-"${CYLC_WORKFLOW_SHARE_DIR}"}"
+    export CYLC_WORKFLOW_WORK_DIR_RAW="${CYLC_WORKFLOW_WORK_DIR_RAW:-"${CYLC_WORKFLOW_WORK_DIR}"}"
     export CYLC_TASK_CYCLE_POINT="${CYLC_TASK_JOB%%/*}"
     export CYLC_TASK_NAME="${CYLC_TASK_JOB#*/}"
     CYLC_TASK_NAME="${CYLC_TASK_NAME%/*}"
@@ -95,6 +99,7 @@ cylc__job__main() {
         CYLC_TASK_WORK_DIR_BASE="${CYLC_TASK_CYCLE_POINT}/${CYLC_TASK_NAME}"
     fi
     export CYLC_TASK_WORK_DIR="${CYLC_WORKFLOW_WORK_DIR}/${CYLC_TASK_WORK_DIR_BASE}"
+    export CYLC_TASK_WORK_DIR_RAW="${CYLC_WORKFLOW_WORK_DIR_RAW}/${CYLC_TASK_WORK_DIR_BASE}"
     typeset contact="${CYLC_WORKFLOW_RUN_DIR}/.service/contact"
     if [[ -f "${contact}" ]]; then
         # (contact file not present for polled platforms)
@@ -134,9 +139,8 @@ cylc__job__main() {
     export PATH="${CYLC_WORKFLOW_RUN_DIR}/share/bin:${CYLC_WORKFLOW_RUN_DIR}/bin:${PATH}"
     export PYTHONPATH="${CYLC_WORKFLOW_RUN_DIR}/share/lib/python:${CYLC_WORKFLOW_RUN_DIR}/lib/python:${PYTHONPATH:-}"
     # Create share and work directories
-    mkdir -p "${CYLC_WORKFLOW_SHARE_DIR}" || true
-    mkdir -p "$(dirname "${CYLC_TASK_WORK_DIR}")" || true
-    mkdir -p "${CYLC_TASK_WORK_DIR}"
+    mkdir -p "${CYLC_WORKFLOW_SHARE_DIR_RAW}" || true
+    mkdir -p "${CYLC_TASK_WORK_DIR_RAW}"
     cd "${CYLC_TASK_WORK_DIR}"
     # Env-Script, User Environment, Pre-Script, Script and Post-Script
     # Run user scripts in subshell to protect cylc job script from interference.

--- a/cylc/flow/job_file.py
+++ b/cylc/flow/job_file.py
@@ -205,6 +205,14 @@ class JobFileWriter:
             if var not in ('CYLC_DEBUG', 'CYLC_VERBOSE', 'CYLC_WORKFLOW_ID'):
                 handle.write('\n    export %s="%s"' % (var, val))
 
+        for dir_ in ("share", "work"):
+            val = job_conf["symlink_dirs"].get(dir_, None)
+            if val is not None:
+                handle.write(
+                    '\n    '
+                    f'export CYLC_WORKFLOW_{dir_.upper()}_DIR_RAW="{val}"'
+                )
+
         if str(self.workflow_env.get('CYLC_UTC')) == 'True':
             handle.write('\n    export TZ="UTC"')
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -55,7 +55,10 @@ from cylc.flow.parsec.util import (
     pdeepcopy,
     poverride
 )
-from cylc.flow.pathutil import get_remote_workflow_run_job_dir
+from cylc.flow.pathutil import (
+    get_dirs_to_symlink,
+    get_remote_workflow_run_job_dir,
+)
 from cylc.flow.platforms import (
     get_host_from_platform,
     get_install_target_from_platform,
@@ -1345,6 +1348,9 @@ class TaskJobManager:
             'pre-script': rtconfig['pre-script'],
             'script': rtconfig['script'],
             'submit_num': itask.submit_num,
+            'symlink_dirs': get_dirs_to_symlink(
+                itask.platform['install target'], workflow
+            ),
             'flow_nums': itask.flow_nums,
             'workflow_name': workflow,
             'task_id': itask.identity,


### PR DESCRIPTION
Closes #5567

CYLC_WORKFLOW_SHARE_DIR_RAW and CYLC_WORKFLOW_WORK_DIR_RAW added. These are then used for 'mkdir' to ensure directories are created. Currently, if SHARE_DIR and WORK_DIR are symlinks, and the dir they point to does not exist, the dirs will not be created, and tasks may fail. The new variables ensure the correct directories are always created.

I've not fully tested this (and am honestly not sure where to test this in an automated sense or what I can leverage from the existing infrastructure) but wanted to open up for comment before I spend any more time on it. 

* Are you happy with this approach or bin the code?
* Any advice on where I can look to test this, preferably from unit tests, but maybe that isn't sufficient?
* If proceed, do you want the variable name changed? I could not think of a name I am really happy with
* Are you happy with the variables being exported or do you want the scope changed to not be generally available?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.

