### PR TITLE
job runner handers: update submit method docs

### DIFF
--- a/cylc/flow/job_runner_handlers/documentation.py
+++ b/cylc/flow/job_runner_handlers/documentation.py
@@ -419,6 +419,14 @@ class ExampleHandler():
         Returns:
             (ret_code, out, err)
 
+            ret_code:
+                Subprocess return code.
+            out:
+                Subprocess standard output, note this should be newline
+                terminated.
+            err:
+                Subprocess standard error.
+
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Improve job runner handler docs to cover a likely gotcha.

Cylc expects the output to be lines, so no trailing newline leads to submit-fail.