### PR TITLE
CLI: glob and hold help tweaks

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -328,14 +328,14 @@ class CylcOptionParser(OptionParser):
     """Common options for all cylc CLI commands."""
 
     MULTITASK_USAGE = cparse(dedent('''
-        This command can operate on multiple tasks, globs and selectors may
-        be used:
+        This command can operate on multiple tasks. Globs and selectors may
+        be used to match active tasks:
             Multiple Tasks:
                 <dim># Operate on two tasks</dim>
                 workflow //cycle-1/task-1 //cycle-2/task-2
 
             Globs (note: globs should be quoted and only match active tasks):
-                <dim># Match any the active task "foo" in all cycles</dim>
+                <dim># Match any active task "foo" in all cycles</dim>
                 '//*/foo'
 
                 <dim># Match the tasks "foo-1" and "foo-2"</dim>
@@ -348,7 +348,7 @@ class CylcOptionParser(OptionParser):
             See `cylc help id` for more details.
     '''))
     MULTIWORKFLOW_USAGE = cparse(dedent('''
-        This command can operate on multiple workflows, globs may also be used:
+        This command can operate on multiple workflows. Globs may be used:
             Multiple Workflows:
                 <dim># Operate on two workflows</dim>
                 workflow-1 workflow-2

--- a/cylc/flow/scripts/hold.py
+++ b/cylc/flow/scripts/hold.py
@@ -20,7 +20,13 @@
 
 Hold task(s) in a workflow.
 
-Held tasks do not submit their jobs even if ready to run.
+Held tasks do not submit jobs even if ready.
+
+Any task can be held.
+
+Note: a held running task will not submit more jobs itself (e.g. by retries)
+until released, but the running job may still complete outputs that cause
+non-held downstream tasks to trigger.
 
 To pause an entire workflow use "cylc pause".
 


### PR DESCRIPTION
- (re)emphasize that globs only match active tasks
- fix a typo and minor grammar issues 
- document that a held running task can still spawn downstream action

One quick review should do.