### PR TITLE
Upper-pin MyPy to <1.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,7 @@ tests =
     flake8-mutable>=1.2.0
     flake8-simplify>=0.14.0
     flake8>=3.0.0
-    mypy>=0.910
+    mypy>=0.910,<1.9
     # https://github.com/pytest-dev/pytest-asyncio/issues/706
     pytest-asyncio>=0.17,!=0.23.*
     pytest-cov>=2.8.0


### PR DESCRIPTION
MyPy 1.9 has dropped support for Python 3.7.

n.b. Cancelled all but the fast tests, I think that's enough for this.

### Checklist

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] This is a dependency change, no changes to documentation or tests required.