### PR TITLE
Log subprocpool stdout/stderr at debug level

### DIFF
--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -248,18 +248,18 @@ def make_symlink_dir(path: Union[Path, str], target: Union[Path, str]) -> bool:
             # correct symlink already exists
             return False
         # symlink name is in use by a physical file or directory
-        # log and return
-        LOG.debug(
-            f"Unable to create symlink to {target}. "
-            f"The path {path} already exists.")
+        LOG.warning(
+            f"Path {path} already exists. Cannot create symlink to {target}."
+        )
         return False
     elif path.is_symlink():
         # remove a bad symlink.
         try:
             path.unlink()
-        except OSError:
+        except OSError as exc:
             raise WorkflowFilesError(
-                f"Error when symlinking. Failed to unlink bad symlink {path}.")
+                f"Failed to remove broken symlink {path}\n{exc}"
+            )
     try:
         target.mkdir(parents=True, exist_ok=False)
     except FileExistsError:

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -205,6 +205,7 @@ class SubProcPool:
             if ctx.err is None:
                 ctx.err = ''
             ctx.err += err + err_xtra
+        LOG.debug(ctx)
         self._run_command_exit(
             ctx, bad_hosts=bad_hosts,
             callback=callback, callback_args=callback_args,

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -124,8 +124,6 @@ def log_task_job_activity(ctx, workflow, point, name, submit_num=None):
         LOG.info(ctx_str)
     if ctx.cmd and ctx.ret_code:
         LOG.error(ctx_str)
-    elif ctx.cmd:
-        LOG.debug(ctx_str)
 
 
 class EventData(Enum):

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -720,8 +720,6 @@ class TaskJobManager:
             or (ctx.ret_code and ctx.ret_code != 255)
         ):
             LOG.error(ctx)
-        else:
-            LOG.debug(ctx)
         # A dict for easy reference of (CYCLE, NAME, SUBMIT_NUM) -> TaskProxy
         #
         # Note for "reload": A TaskProxy instance may be replaced on reload, so
@@ -891,7 +889,7 @@ class TaskJobManager:
         log_task_job_activity(ctx, workflow, itask.point, itask.tdef.name)
 
     def _run_job_cmd(
-        self, cmd_key, workflow, itasks, callback, callback_255=None
+        self, cmd_key, workflow, itasks, callback, callback_255
     ):
         """Run job commands, e.g. poll, kill, etc.
 
@@ -948,6 +946,7 @@ class TaskJobManager:
                     )
                 except NoHostsError:
                     ctx.err = f'No available hosts for {platform["name"]}'
+                    LOG.debug(ctx)
                     callback_255(ctx, workflow, itasks)
                     continue
                 else:

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -502,7 +502,6 @@ class XtriggerManager:
         Raises:
             ValueError: if the context given is not active
         """
-        LOG.debug(ctx)
         sig = ctx.get_signature()
         self.active.remove(sig)
         try:

--- a/tests/functional/events/02-multi.t
+++ b/tests/functional/events/02-multi.t
@@ -22,12 +22,15 @@
 set_test_number 3
 
 init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    [[events]]
+        inactivity timeout = PT30S
 [scheduling]
-   [[graph]]
-      R1 = t1
+    [[graph]]
+        R1 = t1
 [runtime]
     [[t1]]
-        script=true
+        script = true
         [[[events]]]
             started handlers = echo %(workflow)s, echo %(name)s, echo %(start_time)s
 __FLOW_CONFIG__

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -67,7 +67,7 @@ async def test_run_job_cmd_no_hosts_error(
     })
 
     # start the workflow
-    schd = scheduler(id_)
+    schd: Scheduler = scheduler(id_)
     async with start(schd) as log:
         # set logging to debug level
         log.set_level(logging.DEBUG, CYLC_LOG)
@@ -124,6 +124,7 @@ async def test__run_job_cmd_logs_platform_lookup_fail(
             schd.task_job_mgr.JOBS_POLL,
             'foo',
             [SimpleNamespace(platform={'name': 'culdee fell summit'})],
+            None,
             None
         )
         warning = caplog.records[-1]


### PR DESCRIPTION
Otherwise they get swallowed and there is no way to see that symlink dir creation failed due the path already existing (e.g. caused by mirror task such as fcm_make2)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] No changelog entry as minor
- [x] No need for docs
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
