### PR TITLE
Fix terminal/log color issues

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -49,7 +49,6 @@ pyproject.toml configuration:
    rulesets = ['style', '728']  # Sets default rulesets to check
    max-line-length = 130        # Max line length for linting
 """
-from colorama import Fore
 import functools
 from pathlib import Path
 import re
@@ -71,7 +70,10 @@ except ImportError:
         TOMLDecodeError,
     )
 from typing import (
-    TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union)
+    TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
+)
+
+from ansimarkup import parse as cparse
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import CylcError
@@ -1214,11 +1216,11 @@ def lint(
                     )
                 else:
                     # write a message to inform the user
-                    write(
-                        Fore.YELLOW +
-                        f'[{index_str}]'
-                        f' {file_rel}:{line_no}: {msg}'
-                    )
+                    write(cparse(
+                        '<yellow>'
+                        f'[{index_str}] {file_rel}:{line_no}: {msg}'
+                        '</yellow>'
+                    ))
         if modify:
             yield line
 
@@ -1449,17 +1451,19 @@ def main(parser: COP, options: 'Values', target=None) -> None:
 
     if counter:
         total_lint_hits = sum(counter.values())
-        msg = (
-            f'\n{Fore.YELLOW}'
+        msg = cparse(
+            '\n<yellow>'
             f'Checked {target} against {check_names} '
             f'rules and found {total_lint_hits} issue'
             f'{"s" if total_lint_hits > 1 else ""}.'
+            '</yellow>'
         )
     else:
-        msg = (
-            f'{Fore.GREEN}'
+        msg = cparse(
+            '<green>'
             f'Checked {target} against {check_names} rules and '
             'found no issues.'
+            '</green>'
         )
 
     print(msg)

--- a/cylc/flow/task_state_prop.py
+++ b/cylc/flow/task_state_prop.py
@@ -26,36 +26,6 @@ from cylc.flow.task_state import (
     TASK_STATUS_FAILED
 )
 
-from colorama import Style, Fore, Back
-
-
-_STATUS_MAP = {
-    TASK_STATUS_WAITING: {
-        "ascii_ctrl": Style.BRIGHT + Fore.CYAN + Back.RESET
-    },
-    TASK_STATUS_PREPARING: {
-        "ascii_ctrl": Style.BRIGHT + Fore.GREEN + Back.RESET
-    },
-    TASK_STATUS_EXPIRED: {
-        "ascii_ctrl": Style.BRIGHT + Fore.WHITE + Back.BLACK
-    },
-    TASK_STATUS_SUBMITTED: {
-        "ascii_ctrl": Style.BRIGHT + Fore.YELLOW + Back.RESET
-    },
-    TASK_STATUS_SUBMIT_FAILED: {
-        "ascii_ctrl": Style.BRIGHT + Fore.BLUE + Back.RESET
-    },
-    TASK_STATUS_RUNNING: {
-        "ascii_ctrl": Style.BRIGHT + Fore.WHITE + Back.GREEN
-    },
-    TASK_STATUS_SUCCEEDED: {
-        "ascii_ctrl": Style.NORMAL + Fore.BLACK + Back.RESET
-    },
-    TASK_STATUS_FAILED: {
-        "ascii_ctrl": Style.BRIGHT + Fore.WHITE + Back.RED
-    },
-}
-
 
 def extract_group_state(child_states, is_stopped=False):
     """Summarise child states as a group."""
@@ -84,13 +54,3 @@ def extract_group_state(child_states, is_stopped=False):
         if state in child_states:
             return state
     return None
-
-
-def get_status_prop(status, key, subst=None):
-    """Return property for a task status."""
-    if key == "ascii_ctrl" and subst is not None:
-        return "%s%s\033[0m" % (_STATUS_MAP[status][key], subst)
-    elif key == "ascii_ctrl":
-        return "%s%s\033[0m" % (_STATUS_MAP[status][key], status)
-    else:
-        return _STATUS_MAP[status][key]

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -271,6 +271,8 @@ def cli_function(
                     wrapped_kwargs['color'] = use_color
 
                 # configure Cylc to use colour
+                # TODO: re-enable autoreset
+                # (https://github.com/cylc/cylc-flow/issues/6076)
                 color_init(autoreset=False, strip=not use_color)
                 if use_color:
                     ansi_log()

--- a/tests/unit/test_task_state_prop.py
+++ b/tests/unit/test_task_state_prop.py
@@ -14,57 +14,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
+import pytest
 
-from cylc.flow.task_state_prop import *
-
-
-def get_test_extract_group_state_order():
-    return [
-        (
-            [TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED],
-            False,
-            TASK_STATUS_SUBMIT_FAILED
-        ),
-        (
-            ["Who?", TASK_STATUS_FAILED],
-            False,
-            TASK_STATUS_FAILED
-        ),
-    ]
+from cylc.flow.task_state import (
+    TASK_STATUS_SUBMIT_FAILED,
+    TASK_STATUS_FAILED
+)
+from cylc.flow.task_state_prop import extract_group_state
 
 
-def get_test_get_status_prop():
-    return [
-        (
-            TASK_STATUS_WAITING,
-            "ascii_ctrl",
-            "ace",
-            "ace"
-        ),
-        (
-            TASK_STATUS_WAITING,
-            "ascii_ctrl",
-            None,
-            TASK_STATUS_WAITING
-        )
-    ]
+def test_extract_group_state_childless():
+    assert extract_group_state(child_states=[]) is None
 
 
-class TestTaskStateProp(unittest.TestCase):
-
-    def test_extract_group_state_childless(self):
-        self.assertTrue(extract_group_state(child_states=[]) is None)
-
-    def test_extract_group_state_order(self):
-        params = get_test_extract_group_state_order()
-        for child_states, is_stopped, expected in params:
-            r = extract_group_state(child_states=child_states,
-                                    is_stopped=is_stopped)
-            self.assertEqual(expected, r)
-
-    def test_get_status_prop(self):
-        params = get_test_get_status_prop()
-        for status, key, subst, expected in params:
-            r = get_status_prop(status=status, key=key, subst=subst)
-            self.assertTrue(expected in r)
+@pytest.mark.parametrize("child_states, is_stopped, expected", [
+    (
+        [TASK_STATUS_SUBMIT_FAILED, TASK_STATUS_FAILED],
+        False,
+        TASK_STATUS_SUBMIT_FAILED
+    ),
+    (
+        ["Who?", TASK_STATUS_FAILED],
+        False,
+        TASK_STATUS_FAILED
+    )
+])
+def test_extract_group_state_order(child_states, is_stopped, expected):
+    assert extract_group_state(
+        child_states=child_states, is_stopped=is_stopped
+    ) == expected

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from optparse import OptionParser
+from optparse import OptionParser, Values
 
 import pytest
 
@@ -23,6 +23,7 @@ from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.terminal import (
     cli_function,
     prompt,
+    should_use_color,
 )
 
 
@@ -202,3 +203,19 @@ def test_prompt(stdinput):
     # test a prompt with an input pre-process method thinggy
     stdinput('YES')
     assert prompt('yes yes yes no', ['yes', 'no'], process=str.lower) == 'yes'
+
+
+@pytest.mark.parametrize('opts, supported, expected', [
+    ({}, True, False),
+    ({'color': 'never'}, True, False),
+    ({'color': 'auto'}, True, True),
+    ({'color': 'auto'}, False, False),
+    ({'color': 'always'}, False, True),
+])
+def test_should_use_color(
+    opts: dict, expected: bool, supported: bool,
+    monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr('cylc.flow.terminal.supports_color', lambda: supported)
+    options = Values(opts)
+    assert should_use_color(options) == expected


### PR DESCRIPTION
- `--color=never` was not always being respected
- The scheduler log would get a spurious color reset char (`ESC[0m`) at the start of the "DONE" line when not in no-detach mode

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included
- [x] No changelog entry as minor
- [x] No docs entry needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
