### PR TITLE
Remove burninated flake8 code

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ ignore=
     ; suggests using f"{!r}" instead of manual quotes (flake8-bugbear)
     ; Doesn't work at 3.7
     B028
-    ; Broken in two cases https://github.com/PyCQA/flake8-bugbear/issues/451
-    B038
 
 exclude=
     build,


### PR DESCRIPTION
Closes #5931

B038 has been changed to an optional "opinionated" warning B909 - [PyCQA/flake8-bugbear#456](https://github.com/PyCQA/flake8-bugbear/pull/456)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] No tests needed
- [x] No changelog needed
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
