### PR TITLE
Fix seq xtriggers doc-698

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -811,7 +811,7 @@ with Conf(
             This setting can be overridden by the reserved keyword argument
             ``sequential`` in individual xtrigger declarations.
 
-            One sequential xtrigger on a parentless task with multiple
+            One sequential xtrigger on a parent-less task with multiple
             xtriggers will cause sequential spawning.
 
             .. versionadded:: 8.3.0


### PR DESCRIPTION
Fixes spelling failure for https://github.com/cylc/cylc-doc/pull/698

one review will do...

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
