### PR TITLE
Fix.sim mode no increment

### DIFF
--- a/changes.d/6036.fix.md
+++ b/changes.d/6036.fix.md
@@ -1,0 +1,1 @@
+Fix bug where repeated submissions were not displaying crorrectly in TUI/GUI.

--- a/changes.d/6036.fix.md
+++ b/changes.d/6036.fix.md
@@ -1,1 +1,1 @@
-Fix bug where repeated submissions were not displaying crorrectly in TUI/GUI.
+Fixed bug in simulation mode where repeated submissions were not displaying correctly in TUI/GUI.

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1528,7 +1528,7 @@ class TaskEventsManager():
         # And transient tasks, used for setting outputs and spawning children,
         # do not submit jobs.
         if itask.tdef.run_mode == "simulation" or forced:
-            job_conf = {"submit_num": 0}
+            job_conf = {"submit_num": itask.submit_num}
         else:
             job_conf = itask.jobs[-1]
 

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -94,7 +94,6 @@ async def test__insert_task_job(flow, one_conf, scheduler, start, validate):
 
         # Check that there are two entries with correct submit
         # numbers waiting for data-store insertion:
-        assert len(schd.data_store_mgr.added['jobs'].keys()) == 2
         assert [
             i.submit_num for i
             in schd.data_store_mgr.added['jobs'].values()


### PR DESCRIPTION
Fixes a bug not otherwise reported:

### Bug details

Using the following workflow

```
[scheduler]
  allow implicit tasks = true
[scheduling]
  [[graph]]
    R1 = foo
[runtime]
    [[foo]]
        [[[simulation]]]
            fail cycle points = all
            default run length = PT0S
            fail try 1 only = False

```

Open either TUI or GUI and see that the repeated tries to run the job are not displayed correctly:

![image](https://github.com/cylc/cylc-flow/assets/26465611/8fdc3f4c-800e-4f74-80eb-b56d61783f3c)

The expected result is 
![image](https://github.com/cylc/cylc-flow/assets/26465611/2372ac6b-66d2-4426-ad35-843e41098d7f)

(Thanks to @MetRonnie for the bug report)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request - N/A
- [x] This is a bugfix against a change introduced on master. 