### PR TITLE
update documentation for string templates on "External Triggers" page

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -54,3 +54,4 @@ Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>                   
 Tomek Trzeciak             <tomasz.trzeciak@metoffice.gov.uk>   TomekTrzeciak       <tomasz.trzeciak@metoffice.gov.uk>
 github-actions[bot]        <github-actions@noreply.github.com>                      <41898282+github-actions[bot]@users.noreply.github.com> 
 github-actions[bot]        <github-actions@noreply.github.com>  GitHub Action
+Diquan Jabbour             <165976689+Diquan-BOM@users.noreply.github.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ requests_).
  - (Andrew Huang)
  - Cheng Da
  - Mark Dawson
+ - Diquan Jabbour
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -60,7 +60,7 @@ class TemplateVariables(Enum):
        [scheduling]
            initial cycle point = now
            [[xtriggers]]
-               my_xtrigger = my_xtrigger_fcn('%(workflow)', '%(point)')
+               my_xtrigger = my_xtrigger_fcn('%(workflow)s', '%(point)s')
 
     For an explanation of the substitution syntax, see
     `String Formatting Operations in the Python documentation


### PR DESCRIPTION
add s after string templates in documentation
closes  #6050
tests im assuming arent needed for change, since its only a 2 character change to documentation.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
