### PR TITLE
Clear all Cylc Rose options after Post-Install plugin

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1263,10 +1263,15 @@ class Scheduler:
     def load_flow_file(self, is_reload=False):
         """Load, and log the workflow definition."""
         # Local workflow environment set therein.
-        # Allow -S and -D to take effect in Cylc VR.
+        # Allow -S and -D and -O to take effect in Cylc VR.
         # https://github.com/cylc/cylc-flow/issues/5968
+        # & https://github.com/cylc/cylc-flow/issues/6058
+        # TODO delete after 8.3.0 when this change will be included in
+        # Cylc Rose
         self.options.rose_template_vars = []
         self.options.defines = []
+        self.options.opt_conf_keys = []
+
         return WorkflowConfig(
             self.workflow,
             self.flow_file,


### PR DESCRIPTION
Closes #6058 , itself a side effect of #5996.

## Explanation

Cylc play ignores -S but not -O so -O overrides -S, but it shouldn't.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests Should be manually tested using examples in #6058 and #5996
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
