### PR TITLE
move code cleaning cylc-rose opts to cylc-rose post install plugin

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1274,11 +1274,6 @@ class Scheduler:
 
     def load_flow_file(self, is_reload=False):
         """Load, and log the workflow definition."""
-        # Local workflow environment set therein.
-        # Allow -S and -D to take effect in Cylc VR.
-        # https://github.com/cylc/cylc-flow/issues/5968
-        self.options.rose_template_vars = []
-        self.options.defines = []
         return WorkflowConfig(
             self.workflow,
             self.flow_file,


### PR DESCRIPTION
Move clearing of Cylc Rose options from Cylc to rose - companion PR of https://github.com/cylc/cylc-rose/pull/308

Should be applied to master instead of #6059 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests Should be manually tested using examples in #6058 and #5996
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
