### PR TITLE
clear cylc options at reload

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1262,11 +1262,17 @@ class Scheduler:
 
     def load_flow_file(self, is_reload=False):
         """Load, and log the workflow definition."""
-        # Local workflow environment set therein.
-        # Allow -S and -D to take effect in Cylc VR.
-        # https://github.com/cylc/cylc-flow/issues/5968
-        self.options.rose_template_vars = []
-        self.options.defines = []
+        if is_reload:
+            # If the workflow is reloaded clear any existing rose options
+            # The reload command doesn't have the ability to set these but
+            # if the user has used VR to re-install before reload they will
+            # expect the changed values not the ones stored on the scheduler.
+            # Note: Does NOT apply to reload on restart, because the play
+            # command used to restart can have template variables attached.
+            # See https://github.com/cylc/cylc-flow/pull/5996
+            self.options.rose_template_vars = []
+            self.options.defines = []
+            self.options.opt_conf_keys = []
         return WorkflowConfig(
             self.workflow,
             self.flow_file,


### PR DESCRIPTION
Closes #5968 _and_ #6058  (Which was an accidental by product of #5996 

I've tried to include as much info as possible here, to prevent reviewers having to re-hash the investigation or handle a web of issues and PRs for what turns out to be a simple problem with complex ramifications.

## Full statement of the problem.

The original problem (#5968 ) was that on reload CLI rose options (`-S`, `-D` and `-O`) are already stored on the scheduler, and because reload doesn't take those arguments they do not get updated. In Cylc VR the user can update the stored copy, but the reload cannot override the variables stored on the scheduler.

The first fix (#5996) cleared `-S` and `-D`, but not `-O` which led to inconsistencies on reload, and an apparent change in priority between variables set in different manner.

## Testing

This issue is a complex interaction between Cylc and the Cylc Rose plugin. Unfortunately the plugin is not as stand-alone as I would like. I think that there are 3 possible ways of testing this change:

1. (https://github.com/cylc/cylc-rose/pull/310) Functional and End-to-End testing in Cylc Rose. This allows me to demonstrate the actual cases where this is a problem, but is ugly because Cylc Rose does not currently have infrastructure equivalent to Cylc for creating schedulers. 
2. Functional testing in Cylc - Cylc has all the infrastructure to carry out these tests neatly, except for a requirement for Cylc Rose to be present. I chose not to because I didn't want to add that requirement, not even for testing.
3. Integration testing in Cylc Rose - Chose not to do this because I'd have to either copy a big pile of infrastructure from Cylc, which would then be something we would have to maintain, or spin the Cylc Test utilities into a new repo or do something strange and complex to make the tests available from Cylc flow if it's an editable install...
4. Unit testing in Cylc: I chose not to do this because it doesn't help document _why_ this change is being made, and ends up mocking so much of what's going on it seems nearly pointless.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included in a companion cylc rose PR https://github.com/cylc/cylc-rose/pull/310
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
