### PR TITLE
Play should have no cylc rose options

### DIFF
--- a/changes.d/6068.break.md
+++ b/changes.d/6068.break.md
@@ -1,0 +1,1 @@
+Removed the Rose Options (`-S`, `-O`, `-D`) from `cylc play`. If you need these use them with `cylc install`.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1262,11 +1262,6 @@ class Scheduler:
 
     def load_flow_file(self, is_reload=False):
         """Load, and log the workflow definition."""
-        # Local workflow environment set therein.
-        # Allow -S and -D to take effect in Cylc VR.
-        # https://github.com/cylc/cylc-flow/issues/5968
-        self.options.rose_template_vars = []
-        self.options.defines = []
         return WorkflowConfig(
             self.workflow,
             self.flow_file,

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -309,7 +309,7 @@ def get_option_parser(add_std_opts: bool = False) -> COP:
         argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
-    options = parser.get_cylc_rose_options() + PLAY_OPTIONS
+    options = PLAY_OPTIONS
     for option in options:
         if isinstance(option, OptionSettings):
             parser.add_option(*option.args, **option.kwargs)

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -309,12 +309,8 @@ def get_option_parser(add_std_opts: bool = False) -> COP:
         argdoc=[WORKFLOW_ID_ARG_DOC]
     )
 
-    options = PLAY_OPTIONS
-    for option in options:
-        if isinstance(option, OptionSettings):
-            parser.add_option(*option.args, **option.kwargs)
-        else:
-            parser.add_option(*option['args'], **option['kwargs'])
+    for option in PLAY_OPTIONS:
+        parser.add_option(*option.args, **option.kwargs)
 
     if add_std_opts:
         # This is for the API wrapper for integration tests. Otherwise (CLI


### PR DESCRIPTION
& Reload should not mess with Cylc Rose CLI options.

Companion to https://github.com/cylc/cylc-rose/pull/312

Cylc Play was ([according to the proposal doc](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-cylc-rose-installing-rose-configs.md)) never intended to take Rose config CLI options (`-O`, `-D` and `-S`).

For example:

```
cylc install -S 'foo=1'
cylc play -S 'foo=2' --pause
```
Would lead to foo = 2 being stored on the scheduler as `self.options.rose_template_vars`: If we then do

```
cylc reinstall -S 'foo=3'
cylc reload  

# or

cylc vr -S 'foo=3'
```

Will lead to the installed files updating, but reload cannot update the `self.options.rose_template_vars` object created by Cylc Play, so we cannot get rid of `foo=2`.

Without the scheduler storing these items, reload can examine all the files and get the updated value.



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests not included:
  - [x] Cylc play having rose options was never tested, or intended to work.
  - [x] Tests for the removal of the Cylc-Rose config items were only manual when they were added.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
