### PR TITLE
Delete public DB if private DB does not exist on scheduler start

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -307,6 +307,11 @@ class Scheduler:
             pub_d=os.path.join(self.workflow_run_dir, 'log')
         )
         self.is_restart = Path(self.workflow_db_mgr.pri_path).is_file()
+        if (
+            not self.is_restart
+            and Path(self.workflow_db_mgr.pub_path).is_file()
+        ):
+            os.unlink(self.workflow_db_mgr.pub_path)
 
         # Map used to track incomplete remote inits for restart
         # {install_target: platform}

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -311,6 +311,8 @@ class Scheduler:
             not self.is_restart
             and Path(self.workflow_db_mgr.pub_path).is_file()
         ):
+            # Delete pub DB if pri DB doesn't exist, as we don't want to
+            # load anything (e.g. template variables) from it
             os.unlink(self.workflow_db_mgr.pub_path)
 
         # Map used to track incomplete remote inits for restart


### PR DESCRIPTION
On scheduler start, it tries to load workflow template variables from the public database. However, if the user has deleted the private database, it is not a restart, so it shouldn't try to load the public DB either.

The simple solution to this is to delete the public DB file (if it exists) immediately after checking and finding the private DB does not exist.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] No changelog entry needed as minor/niche
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
