### PR TITLE
cylc.nanorc

### DIFF
--- a/changes.d/6072.feat.md
+++ b/changes.d/6072.feat.md
@@ -1,0 +1,1 @@
+Nano Syntax Highlighting now available. See

--- a/changes.d/6072.feat.md
+++ b/changes.d/6072.feat.md
@@ -1,1 +1,1 @@
-Nano Syntax Highlighting now available. See
+Nano Syntax Highlighting now available.

--- a/cylc/flow/etc/syntax/cylc.nanorc
+++ b/cylc/flow/etc/syntax/cylc.nanorc
@@ -1,0 +1,30 @@
+# How to use this file:
+# cylc get-resources cylc.nanorc ~/.config/nano/cylc.nanorc
+# Add the following to ~/.nanorc
+# include ~/.config/nano/cylc.nanorc
+
+# Supports `.cylc` files
+syntax "Cylc" "\.cylc$"
+
+## Multiline
+color yellow start="\"\"\"" end="\"\"\""
+color yellow start="'''" end="'''"
+color yellow start="\[" end="\]"
+
+## Values
+color yellow "=(.*)$"
+color green "=[^>]"
+color brightmagenta "=>|&|\|\\"
+
+## Valid headings
+color green "^\[.*\]$"
+color green "^\s{4}\[\[.*\]\]+$"
+color green "^\s{8}\[\[\[.*\]\]\]+$"
+
+## Comments (keep at the end of this file!)
+color cyan "#.*$"
+
+## Jinja2
+icolor brightcyan "^#!Jinja2"
+color brightcyan "\{%.*%\}"
+color brightcyan "\{\{.*\}\}"

--- a/cylc/flow/etc/syntax/cylc.nanorc
+++ b/cylc/flow/etc/syntax/cylc.nanorc
@@ -17,9 +17,9 @@ color green "=[^>]"
 color brightmagenta "=>|&|\|\\"
 
 ## Valid headings
-color green "^\[.*\]$"
-color green "^\s{4}\[\[.*\]\]+$"
-color green "^\s{8}\[\[\[.*\]\]\]+$"
+color green "^\s*\[.*\]"
+color green "^\s*\[\[.*\]\]"
+color green "^\s*\[\[\[.*\]\]\]"
 
 ## Comments (keep at the end of this file!)
 color cyan "#.*$"


### PR DESCRIPTION
Add a limited amount of Cylc syntax highlighting for Nano - I wrote this a while back, because Nano is my in terminal editor of choice, and handy for smaller toy workflows.

![image](https://github.com/cylc/cylc-flow/assets/26465611/ccf3e6ad-4665-4c8a-982b-24fc07d16160)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are not included: This is provided as is, on the basis of being better than nothing...
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/718
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
