### PR TITLE
Bump pytest-asyncio version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: 'macos-latest'
-            python: '3.7'
+            python: '3.8'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           # mac os test
           - os: 'macos-11'
-            python-version: '3.7'  # oldest supported version
+            python-version: '3.8'  # oldest supported version
           # non-utc timezone test
           - os: 'ubuntu-latest'
             python-version: '3.9'  # not the oldest, not the most recent version

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ tests =
     flake8>=3.0.0
     mypy>=0.910,<1.9
     # https://github.com/pytest-dev/pytest-asyncio/issues/706
-    pytest-asyncio>=0.17,!=0.23.*
+    pytest-asyncio>=0.17,!=0.23.0,!=0.23.1
     pytest-cov>=2.8.0
     pytest-xdist>=2
     pytest-env>=0.6.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ tests =
     flake8>=3.0.0
     mypy>=0.910,<1.9
     # https://github.com/pytest-dev/pytest-asyncio/issues/706
-    pytest-asyncio>=0.17,!=0.23.0,!=0.23.1
+    pytest-asyncio>=0.21.2,!=0.23.*
     pytest-cov>=2.8.0
     pytest-xdist>=2
     pytest-env>=0.6.2


### PR DESCRIPTION
Don't use Python 3.7 on MacOs on CI.

Exclude non-function releases of pytest-asyncio

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] This is a small dependency change PR
