### PR TITLE
Add "valid for" states to schema def for `cylc set`

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2103,6 +2103,8 @@ class SetPrereqsAndOutputs(Mutation, TaskMutation):
              - ``started`` implies ``submitted``.
              - ``succeeded`` and ``failed`` imply ``started``.
              - custom outputs and ``expired`` do not imply any other outputs.
+
+            Valid for: paused, running, stopping workflows.
         """)
         resolver = partial(mutator, command='set')
 


### PR DESCRIPTION
Follow-up to #5658

This is needed by the UI to disable mutations that are not valid for the workflow state. At present, "set" is not disabled for stopped workflows as it should be:

![image](https://github.com/cylc/cylc-flow/assets/61982285/a821c592-c4b5-449b-a95d-43e72034b0ad)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry needed
- [x] No docs PR needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
