### PR TITLE
Add an option to the workflow config to force use of compat mode

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -880,7 +880,7 @@ class WorkflowConfig:
             )
         # Allow implicit tasks in back-compat mode unless rose-suite.conf
         # present (to maintain compat with Rose 2019)
-        elif not (self.fdir / "rose-suite.conf").is_file():
+        elif not (self.fpath.parent / "rose-suite.conf").is_file():
             LOG.debug(msg)
             return
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -228,8 +228,10 @@ class WorkflowConfig:
             fpath: workflow config file path
             options: CLI options
             force_compat_mode:
-                Override compatibility mode checks.
-                https://github.com/cylc/cylc-rose/issues/319
+                If True, forces Cylc to use compatibility mode
+                overriding compatibility mode checks.
+                See https://github.com/cylc/cylc-rose/issues/319
+
         """
         check_deprecation(Path(fpath), force_compat_mode=force_compat_mode)
         self.mem_log = mem_log_func

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -218,7 +218,7 @@ class WorkflowConfig:
         log_dir: Optional[str] = None,
         work_dir: Optional[str] = None,
         share_dir: Optional[str] = None,
-        force_compat_mode: Optional[bool] = False,
+        force_compat_mode: bool = False,
     ) -> None:
         """
         Initialize the workflow config object.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -217,7 +217,8 @@ class WorkflowConfig:
         run_dir: Optional[str] = None,
         log_dir: Optional[str] = None,
         work_dir: Optional[str] = None,
-        share_dir: Optional[str] = None
+        share_dir: Optional[str] = None,
+        force_compat_mode: Optional[bool] = False,
     ) -> None:
         """
         Initialize the workflow config object.
@@ -226,8 +227,11 @@ class WorkflowConfig:
             workflow: workflow ID
             fpath: workflow config file path
             options: CLI options
+            force_compat_mode:
+                Override compatibility mode checks.
+                https://github.com/cylc/cylc-rose/issues/319
         """
-        check_deprecation(Path(fpath))
+        check_deprecation(Path(fpath), force_compat_mode=force_compat_mode)
         self.mem_log = mem_log_func
         if self.mem_log is None:
             self.mem_log = lambda x: None
@@ -876,7 +880,7 @@ class WorkflowConfig:
             )
         # Allow implicit tasks in back-compat mode unless rose-suite.conf
         # present (to maintain compat with Rose 2019)
-        elif not (self.fpath.parent / "rose-suite.conf").is_file():
+        elif not (self.fdir / "rose-suite.conf").is_file():
             LOG.debug(msg)
             return
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -783,6 +783,15 @@ def check_deprecation(path, warn=True, force_compat_mode=False):
     """Warn and turn on back-compat flag if Cylc 7 suite.rc detected.
 
     Path can point to config file or parent directory (i.e. workflow name).
+
+    Args:
+        warn:
+            If True, then a warning will be logged when compatibility
+            mode is activated.
+        force_compat_mode:
+            If True, forces Cylc to use compatibility mode
+            overriding compatibility mode checks.
+            See https://github.com/cylc/cylc-rose/issues/319
     """
     if (
         # Don't want to log if it's already been set True.

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -779,7 +779,7 @@ def get_workflow_title(id_):
     return title
 
 
-def check_deprecation(path, warn=True):
+def check_deprecation(path, warn=True, force_compat_mode=False):
     """Warn and turn on back-compat flag if Cylc 7 suite.rc detected.
 
     Path can point to config file or parent directory (i.e. workflow name).
@@ -790,6 +790,7 @@ def check_deprecation(path, warn=True):
         and (
             path.resolve().name == WorkflowFiles.SUITE_RC
             or (path / WorkflowFiles.SUITE_RC).is_file()
+            or force_compat_mode
         )
     ):
         cylc.flow.flags.cylc7_back_compat = True

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,6 +29,7 @@ from cylc.flow.config import WorkflowConfig
 from cylc.flow.cycling import loader
 from cylc.flow.cycling.loader import INTEGER_CYCLING_TYPE, ISO8601_CYCLING_TYPE
 from cylc.flow.exceptions import (
+    GraphParseError,
     PointParsingError,
     InputError,
     WorkflowConfigError,
@@ -1675,3 +1676,20 @@ def test_cylc_env_at_parsing(
             assert var in cylc_env
         else:
             assert var not in cylc_env
+
+
+def test_force_workflow_compat_mode(tmp_path):
+    fpath = (tmp_path / 'flow.cylc')
+    from textwrap import dedent
+    fpath.write_text(dedent("""
+        [scheduler]
+            allow implicit tasks = true
+        [scheduling]
+            [[graph]]
+                R1 = a:succeeded | a:failed => b
+    """))
+    # It fails without compat mode:
+    with pytest.raises(GraphParseError, match='Opposite outputs'):
+        WorkflowConfig('foo', str(fpath), {})
+    # It succeeds with compat mode:
+    WorkflowConfig('foo', str(fpath), {}, force_compat_mode=True)


### PR DESCRIPTION
Works with https://github.com/cylc/cylc-rose/pull/322 to close https://github.com/cylc/cylc-rose/issues/319.

Functional test provided by https://github.com/metomi/rose/pull/2779

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] This small change does not require documentation
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
