### PR TITLE
tests: reset global state before each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,13 @@ from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.parsec.validate import cylc_config_validate
 
 
+@pytest.fixture(autouse=True)
+def test_reset(monkeypatch):
+    """Reset global state before all tests."""
+    monkeypatch.setattr('cylc.flow.flags.verbosity', 0)
+    monkeypatch.setattr('cylc.flow.flags.cylc7_back_compat', False)
+
+
 @pytest.fixture(scope='module')
 def mod_monkeypatch():
     """A module-scoped version of the monkeypatch fixture."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,14 @@ from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.parsec.config import ParsecConfig
 from cylc.flow.parsec.validate import cylc_config_validate
+from cylc.flow import flags
 
 
 @pytest.fixture(autouse=True)
-def test_reset(monkeypatch):
+def test_reset():
     """Reset global state before all tests."""
-    monkeypatch.setattr('cylc.flow.flags.verbosity', 0)
-    monkeypatch.setattr('cylc.flow.flags.cylc7_back_compat', False)
+    flags.verbosity = 0
+    flags.cylc7_back_compat = False
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Should help to resolve possible issues where one test sets a flag (but not via monkeypatch) and another accesses that value.