### PR TITLE
scan: add a state-totals output format

### DIFF
--- a/changes.d/6105.feat.md
+++ b/changes.d/6105.feat.md
@@ -1,0 +1,1 @@
+A new "state totals" output format for the Cylc scan command - `cylc scan -t state-totals`.


### PR DESCRIPTION
Small enhancement requested by Dave for ease of working on awkward platforms without the aid of the GUI.

A one line summary line for `cylc scan` which includes the state totals (similar to the "rich" format) but without the multiline summary that follows.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.