### PR TITLE
platforms: fix unreachable hosts not reset on platform group failure

### DIFF
--- a/changes.d/fix.6109.md
+++ b/changes.d/fix.6109.md
@@ -1,0 +1,1 @@
+Ensure that if all hosts on all platforms in a group are exhausted at job preparation time that they will be reset.

--- a/changes.d/fix.6109.md
+++ b/changes.d/fix.6109.md
@@ -1,1 +1,1 @@
-Ensure that if all hosts on all platforms in a group are exhausted at job preparation time that they will be reset.
+Fixed bug affecting job submission where the list of bad hosts was not always reset correctly.

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -21,7 +21,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    List,
+    Set,
     NoReturn,
     Optional,
     Tuple,
@@ -445,17 +445,21 @@ class NoPlatformsError(PlatformLookupError):
 
     Args:
         identity: The name of the platform group or install target
+        hosts_consumed: Hosts which have already been tried.
         set_type: Whether the set of platforms is a platform group or an
             install target
         place: Where the attempt to get the platform failed.
     """
     def __init__(
-        self, identity: str, set_type: str = 'group', place: str = '',
-        hosts_consumed: Optional[List[str]] = None
+        self,
+        identity: str,
+        hosts_consumed: Set[str],
+        set_type: str = 'group',
+        place: str = '',
     ):
         self.identity = identity
         self.type = set_type
-        self.hosts_consumed = set(hosts_consumed) if hosts_consumed else set()
+        self.hosts_consumed = hosts_consumed
         if place:
             self.place = f' during {place}.'
         else:

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -21,6 +21,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    List,
     NoReturn,
     Optional,
     Tuple,
@@ -449,10 +450,12 @@ class NoPlatformsError(PlatformLookupError):
         place: Where the attempt to get the platform failed.
     """
     def __init__(
-        self, identity: str, set_type: str = 'group', place: str = ''
+        self, identity: str, set_type: str = 'group', place: str = '',
+        hosts_consumed: Optional[List[str]] = None
     ):
         self.identity = identity
         self.type = set_type
+        self.hosts_consumed = set(hosts_consumed) if hosts_consumed else set()
         if place:
             self.place = f' during {place}.'
         else:

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -304,7 +304,12 @@ def get_platform_from_group(
 
     # Return False if there are no platforms available to be selected.
     if not platform_names:
-        raise NoPlatformsError(group_name)
+        hosts_consumed = [
+            host
+            for platform in group['platforms']
+            for host in platform_from_name(platform)['hosts']]
+        raise NoPlatformsError(
+            group_name, hosts_consumed=hosts_consumed)
 
     # Get the selection method
     method = group['selection']['method']

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -307,9 +307,9 @@ def get_platform_from_group(
         hosts_consumed = {
             host
             for platform in group['platforms']
-            for host in platform_from_name(platform)['hosts']
-        }
-        raise NoPlatformsError(group_name, hosts_consumed)
+            for host in platform_from_name(platform)['hosts']}
+        raise NoPlatformsError(
+            group_name, hosts_consumed
 
     # Get the selection method
     method = group['selection']['method']

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -304,12 +304,12 @@ def get_platform_from_group(
 
     # If there are no platforms available to be selected:
     if not platform_names:
-        hosts_consumed = [
+        hosts_consumed = {
             host
             for platform in group['platforms']
-            for host in platform_from_name(platform)['hosts']]
-        raise NoPlatformsError(
-            group_name, hosts_consumed=hosts_consumed)
+            for host in platform_from_name(platform)['hosts']
+        }
+        raise NoPlatformsError(group_name, hosts_consumed)
 
     # Get the selection method
     method = group['selection']['method']

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -309,7 +309,7 @@ def get_platform_from_group(
             for platform in group['platforms']
             for host in platform_from_name(platform)['hosts']}
         raise NoPlatformsError(
-            group_name, hosts_consumed
+            group_name, hosts_consumed)
 
     # Get the selection method
     method = group['selection']['method']

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -302,7 +302,7 @@ def get_platform_from_group(
     else:
         platform_names = group['platforms']
 
-    # Return False if there are no platforms available to be selected.
+    # If there are no platforms available to be selected:
     if not platform_names:
         hosts_consumed = [
             host

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -230,6 +230,7 @@ class TaskJobManager:
         """
         prepared_tasks = []
         bad_tasks = []
+        out_of_hosts_tasks: list = []
         for itask in itasks:
             if not itask.state(TASK_STATUS_PREPARING):
                 # bump the submit_num *before* resetting the state so that the
@@ -239,11 +240,15 @@ class TaskJobManager:
                 self.data_store_mgr.delta_task_state(itask)
             prep_task = self._prep_submit_task_job(
                 workflow, itask, check_syntax=check_syntax)
-            if prep_task:
+            if prep_task is True:
+                # This is a task whose platform has run out of hosts
+                # it's neither bad or good.
+                out_of_hosts_tasks.append(itask)
+            elif prep_task:
                 prepared_tasks.append(itask)
             elif prep_task is False:
                 bad_tasks.append(itask)
-        return [prepared_tasks, bad_tasks]
+        return [prepared_tasks, bad_tasks, out_of_hosts_tasks]
 
     def submit_task_jobs(self, workflow, itasks, curve_auth,
                          client_pub_key_dir, is_simulation=False):
@@ -265,13 +270,17 @@ class TaskJobManager:
         if is_simulation:
             return self._simulation_submit_task_jobs(itasks, workflow)
         # Prepare tasks for job submission
-        prepared_tasks, bad_tasks = self.prep_submit_task_jobs(
-            workflow, itasks)
+        (
+            prepared_tasks,
+            bad_tasks,
+            out_of_hosts_tasks
+        ) = self.prep_submit_task_jobs(workflow, itasks)
         # Reset consumed host selection results
         self.task_remote_mgr.subshell_eval_reset()
 
-        if not prepared_tasks:
+        if not prepared_tasks and not out_of_hosts_tasks:
             return bad_tasks
+
         auth_itasks = {}  # {platform: [itask, ...], ...}
 
         for itask in prepared_tasks:
@@ -280,6 +289,9 @@ class TaskJobManager:
             auth_itasks[platform_name].append(itask)
         # Submit task jobs for each platform
         done_tasks = bad_tasks
+
+        # Out of host tasks can be considered done for now:
+        [done_tasks.append(itask) for itask in out_of_hosts_tasks]
 
         for _, itasks in sorted(auth_itasks.items()):
             # Find the first platform where >1 host has not been tried and
@@ -1087,7 +1099,8 @@ class TaskJobManager:
         Returns:
             * itask - preparation complete.
             * None - preparation in progress.
-            * False - perparation failed.
+            * False - preparation failed.
+            * True - preparation failed because no platforms were found.
 
         """
         if itask.local_job_file_path:
@@ -1181,6 +1194,14 @@ class TaskJobManager:
                 itask.summary['platforms_used'][itask.submit_num] = ''
                 # Retry delays, needed for the try_num
                 self._create_job_log_path(workflow, itask)
+                if isinstance(exc, NoPlatformsError):
+                    # Todo = need to clear all hosts from all platforms
+                    # in group.
+                    self.bad_hosts -= exc.hosts_consumed
+                    self._set_retry_timers(itask, rtconfig)
+                    self._prep_submit_task_job_error(
+                        workflow, itask, '(no platforms available)', exc)
+                    return True
                 self._prep_submit_task_job_error(
                     workflow, itask, '(platform not defined)', exc)
                 return False

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1091,6 +1091,7 @@ class TaskJobManager:
             * itask - preparation complete.
             * None - preparation in progress.
             * False - preparation failed.
+
         """
         if itask.local_job_file_path:
             return itask

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -1097,7 +1097,8 @@ class TaskJobManager:
             * itask - preparation complete.
             * None - preparation in progress.
             * False - preparation failed.
-            * True - preparation failed because no platforms were found.
+            * NoPlatformsError - preparation failed because no
+              platforms were found.
 
         """
         if itask.local_job_file_path:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -389,7 +389,7 @@ class TaskRemoteMgr:
                 LOG.error(
                     NoPlatformsError(
                         install_target,
-                        Set(),
+                        set(),
                         'install target',
                         'remote tidy'))
         # Wait for commands to complete for a max of 10 seconds

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -388,7 +388,10 @@ class TaskRemoteMgr:
             else:
                 LOG.error(
                     NoPlatformsError(
-                        install_target, Set(), 'install target', 'remote tidy'))
+                        install_target,
+                        Set(),
+                        'install target',
+                        'remote tidy'))
         # Wait for commands to complete for a max of 10 seconds
         timeout = time() + 10.0
         while queue and time() < timeout:

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -388,7 +388,7 @@ class TaskRemoteMgr:
             else:
                 LOG.error(
                     NoPlatformsError(
-                        install_target, 'install target', 'remote tidy'))
+                        install_target, Set(), 'install target', 'remote tidy'))
         # Wait for commands to complete for a max of 10 seconds
         timeout = time() + 10.0
         while queue and time() < timeout:

--- a/tests/integration/test_platforms.py
+++ b/tests/integration/test_platforms.py
@@ -1,0 +1,60 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration testing for platforms functionality.
+"""
+
+
+async def test_foo(flow, scheduler, run, mock_glbl_cfg, validate, monkeypatch):
+    global_conf = '''
+        [platforms]
+            [[myplatform]]
+                hosts = broken
+            [[anotherbad]]
+                hosts = broken2
+        [platform groups]
+            [[mygroup]]
+                platforms = myplatform, anotherbad'''
+    mock_glbl_cfg('cylc.flow.platforms.glbl_cfg', global_conf)
+
+    wid = flow({
+        "scheduling": {
+            "graph": {
+                "R1": "foo"
+            }
+        },
+        "runtime": {
+            "root": {},
+            "print-config": {
+                "script": "cylc config"
+            },
+            "foo": {
+                "script": "sleep 10",
+                "platform": "mygroup",
+                "submission retry delays": '3*PT5S'
+            }
+        }
+    })
+    validate(wid)
+    schd = scheduler(wid, paused_start=False, run_mode='live')
+    async with run(schd) as log:
+        itask = schd.pool.get_tasks()[0]
+
+        # Avoid breaking on trying to create log file path:
+        schd.task_job_mgr._create_job_log_path = lambda *_: None
+        schd.task_job_mgr.bad_hosts = {'broken', 'broken2'}
+        res = schd.task_job_mgr._prep_submit_task_job(schd.workflow, itask)
+        assert res is True
+        assert not schd.task_job_mgr.bad_hosts

--- a/tests/integration/test_platforms.py
+++ b/tests/integration/test_platforms.py
@@ -52,4 +52,5 @@ async def test_prep_submit_task_tries_multiple_platforms(
         schd.task_job_mgr.bad_hosts = {'broken', 'broken2'}
         res = schd.task_job_mgr._prep_submit_task_job(schd.workflow, itask)
         assert res is False
+        # ensure the bad hosts have been cleared
         assert not schd.task_job_mgr.bad_hosts

--- a/tests/integration/test_platforms.py
+++ b/tests/integration/test_platforms.py
@@ -51,5 +51,5 @@ async def test_prep_submit_task_tries_multiple_platforms(
         itask.submit_num = 1
         schd.task_job_mgr.bad_hosts = {'broken', 'broken2'}
         res = schd.task_job_mgr._prep_submit_task_job(schd.workflow, itask)
-        assert isinstance(res, NoPlatformsError)
+        assert res is False
         assert not schd.task_job_mgr.bad_hosts


### PR DESCRIPTION
Closes: https://github.com/cylc/cylc-flow/issues/6100

Bad host reset was only happening if we ran out of hosts during job submission, not during preparation phase, and hosts being added to the list of bad hosts in this way were waiting for the main loop plugin to remove them.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
