### PR TITLE
uis subscription data sync info (UIS-597)

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -3089,6 +3089,23 @@ class DataStoreMgr:
 
         return workflow_msg
 
+    def get_workflow_only(self):
+        """Gather workflow summary data into a Protobuf message.
+
+        No tasks / cycles, etc, just workflow stuff.
+
+        Returns:
+            cylc.flow.data_messages_pb2.PbEntireWorkflow
+
+        """
+
+        workflow_msg = PbEntireWorkflow()
+        workflow_msg.workflow.CopyFrom(
+            self.data[self.workflow_id][WORKFLOW]
+        )
+
+        return workflow_msg
+
     def get_publish_deltas(self):
         """Return deltas for publishing."""
         all_deltas = DELTAS_MAP[ALL_DELTAS]()
@@ -3136,3 +3153,16 @@ class DataStoreMgr:
                 f'$edge|{left_tokens.relative_id}|{right_tokens.relative_id}'
             )
         ).id
+
+    # subscription stubs
+    def graphql_sub_interrogate(self, sub_id, info):
+        """Scope data requirements."""
+        pass
+
+    async def graphql_sub_data_match(self, w_id, sub_id):
+        """Match store data level to requested graphql subscription."""
+        pass
+
+    async def graphql_sub_discard(self, sub_id):
+        """Discard graphql subscription references."""
+        pass

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -69,6 +69,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Literal,
     Optional,
@@ -3165,4 +3166,13 @@ class DataStoreMgr:
 
     async def graphql_sub_discard(self, sub_id):
         """Discard graphql subscription references."""
+        pass
+
+    async def set_query_sync_levels(
+        self,
+        w_ids: Iterable[str],
+        level: Optional[str] = None,
+        expire_delay: Optional[float] = None,
+    ):
+        """Set a workflow sync level."""
         pass

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -3090,20 +3090,26 @@ class DataStoreMgr:
 
         return workflow_msg
 
-    def get_workflow_only(self):
-        """Gather workflow summary data into a Protobuf message.
+    def get_data_elements(self, elements: Iterable):
+        """Gather data requested elements into a Protobuf message.
 
-        No tasks / cycles, etc, just workflow stuff.
+        Args:
+            elements (Iterable):
+                Iterable of keys from DATA dictionary.
 
         Returns:
             cylc.flow.data_messages_pb2.PbEntireWorkflow
 
         """
 
+        data = self.data[self.workflow_id]
+
         workflow_msg = PbEntireWorkflow()
-        workflow_msg.workflow.CopyFrom(
-            self.data[self.workflow_id][WORKFLOW]
-        )
+        for element in (e for e in elements if e in DATA_TEMPLATE):
+            if element == WORKFLOW:
+                getattr(workflow_msg, element).CopyFrom(data[element])
+            else:
+                getattr(workflow_msg, element).extend(data[element].values())
 
         return workflow_msg
 
@@ -3122,7 +3128,7 @@ class DataStoreMgr:
         self.publish_pending = True
         return deepcopy(result)
 
-    def get_data_elements(self, element_type):
+    def get_delta_elements(self, element_type):
         """Get elements of a given type in the form of a delta.
 
         Args:
@@ -3171,7 +3177,7 @@ class DataStoreMgr:
     async def set_query_sync_levels(
         self,
         w_ids: Iterable[str],
-        level: Optional[str] = None,
+        level: Optional[Iterable[str]] = None,
         expire_delay: Optional[float] = None,
     ):
         """Set a workflow sync level."""

--- a/cylc/flow/network/graphql.py
+++ b/cylc/flow/network/graphql.py
@@ -51,6 +51,15 @@ STRIP_OPS = {'query', 'subscription'}
 U = TypeVar("U")
 
 
+def extract_ast_fields(ast: Any, fields: set) -> Any:
+    """Recurse through a document/AST to extract field names."""
+    if ast.kind == 'field':
+        fields.add(ast.name.value)
+    if getattr(ast, 'selection_set', None):
+        for selection in ast.selection_set.selections:
+            extract_ast_fields(selection, fields)
+
+
 def grow_tree(tree, path, leaves=None):
     """Additively grows tree with leaves at terminal of new branch.
 

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -576,9 +576,14 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         yielded GraphQL subscription objects.
 
         """
-        # NOTE: we don't expect workflows to be returned in definition order
-        # so it is ok to use `set` here
-        workflow_ids = set(args.get('workflows', args.get('ids', ())))
+
+        args['workflows'] = [
+            Tokens(w_id)
+            for w_id in args.get('workflows', args.get('ids', ()))
+        ]
+        # NOTE: we don't expect workflows to be returned in definition
+        # order so it is ok to use `set` here
+        workflow_ids = {w.id for w in args['workflows']}
 
         sub_id = uuid4()
         info.context['sub_id'] = sub_id
@@ -602,19 +607,26 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         flow_delta_queues: Dict[str, queue.Queue[Tuple[str, dict]]] = {}
         try:
             # Iterate over the queue yielding deltas
-            w_ids = workflow_ids
             sub_resolver = SUB_RESOLVERS.get(to_snake_case(info.field_name))
             interval = args['ignore_interval']
             old_time = 0.0
+            w_ids = workflow_ids
             while True:
+                old_ids = w_ids
                 if not workflow_ids:
-                    old_ids = w_ids
                     # NOTE: we don't expect workflows to be returned in
                     # definition order so it is ok to use `set` here
                     w_ids = set(delta_queues.keys())
-                    for remove_id in old_ids.difference(w_ids):
-                        if remove_id in self.delta_store[sub_id]:
-                            del self.delta_store[sub_id][remove_id]
+                elif not w_ids.issubset(self.data_store_mgr.data):
+                    # make sure new flows matching the args are picked up
+                    w_ids = {
+                        flow[WORKFLOW].id
+                        for flow in self.data_store_mgr.data.values()
+                        if workflow_filter(flow, args)
+                    }
+                for remove_id in old_ids.difference(w_ids):
+                    if remove_id in self.delta_store[sub_id]:
+                        del self.delta_store[sub_id][remove_id]
                 for w_id in w_ids:
                     if w_id in self.data_store_mgr.data:
                         if sub_id not in delta_queues[w_id]:

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -628,7 +628,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             import traceback
             logger.warning(traceback.format_exc())
         finally:
-            self.data_store_mgr.graphql_sub_discard(sub_id)
+            await self.data_store_mgr.graphql_sub_discard(sub_id)
             for w_id in w_ids:
                 if delta_queues.get(w_id, {}).get(sub_id):
                     del delta_queues[w_id][sub_id]

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -310,9 +310,14 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
     async def get_workflow_by_id(self, args):
         """Return a workflow store by ID."""
         try:
-            if 'sub_id' in args and args['delta_store']:
-                return self.delta_store[args['sub_id']][args['id']][
-                    args['delta_type']][WORKFLOW]
+            if 'sub_id' in args:
+                if args['delta_store']:
+                    return self.delta_store[args['sub_id']][args['id']][
+                        args['delta_type']][WORKFLOW]
+            else:
+                await self.data_store_mgr.set_query_sync_levels(
+                    [self.data_store_mgr.data[args['id']][WORKFLOW].id]
+                )
             return self.data_store_mgr.data[args['id']][WORKFLOW]
         except KeyError:
             return None
@@ -320,12 +325,21 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
     async def get_workflows_data(self, args: Dict[str, Any]):
         """Return list of data from workflows."""
         # Both cases just as common so 'if' not 'try'
-        if 'sub_id' in args and args['delta_store']:
-            return [
-                delta[args['delta_type']]
-                for key, delta in self.delta_store[args['sub_id']].items()
-                if workflow_filter(self.data_store_mgr.data[key], args)
-            ]
+        if 'sub_id' in args:
+            if args['delta_store']:
+                return [
+                    delta[args['delta_type']]
+                    for key, delta in self.delta_store[args['sub_id']].items()
+                    if workflow_filter(self.data_store_mgr.data[key], args)
+                ]
+        else:
+            await self.data_store_mgr.set_query_sync_levels(
+                [
+                    workflow[WORKFLOW].id
+                    for workflow in self.data_store_mgr.data.values()
+                    if workflow_filter(workflow, args)
+                ]
+            )
         return [
             workflow
             for workflow in self.data_store_mgr.data.values()
@@ -338,6 +352,22 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             [flow[WORKFLOW]
              for flow in await self.get_workflows_data(args)],
             args)
+
+    async def get_flow_data_from_ids(self, data_store, native_ids):
+        """Return workflow data by id."""
+        w_ids = []
+        for native_id in native_ids:
+            w_ids.append(
+                Tokens(native_id).workflow_id
+            )
+        await self.data_store_mgr.set_query_sync_levels(
+            set(w_ids)
+        )
+        return [
+            data_store[w_id]
+            for w_id in iter_uniq(w_ids)
+            if w_id in data_store
+        ]
 
     # nodes
     def get_node_state(self, node, node_type):
@@ -378,14 +408,18 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         """Return protobuf node objects for given id."""
         nat_ids = uniq(args.get('native_ids', []))
         # Both cases just as common so 'if' not 'try'
-        if 'sub_id' in args and args['delta_store']:
-            flow_data = [
-                delta[args['delta_type']]
-                for delta in get_flow_data_from_ids(
-                    self.delta_store[args['sub_id']], nat_ids)
-            ]
+        if 'sub_id' in args:
+            if args['delta_store']:
+                flow_data = [
+                    delta[args['delta_type']]
+                    for delta in get_flow_data_from_ids(
+                        self.delta_store[args['sub_id']], nat_ids)
+                ]
+            else:
+                flow_data = get_flow_data_from_ids(
+                    self.data_store_mgr.data, nat_ids)
         else:
-            flow_data = get_flow_data_from_ids(
+            flow_data = await self.get_flow_data_from_ids(
                 self.data_store_mgr.data, nat_ids)
 
         if node_type == PROXY_NODES:
@@ -414,10 +448,14 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         w_id = Tokens(n_id).workflow_id
         # Both cases just as common so 'if' not 'try'
         try:
-            if 'sub_id' in args and args.get('delta_store'):
-                flow = self.delta_store[
-                    args['sub_id']][w_id][args['delta_type']]
+            if 'sub_id' in args:
+                if args.get('delta_store'):
+                    flow = self.delta_store[
+                        args['sub_id']][w_id][args['delta_type']]
+                else:
+                    flow = self.data_store_mgr.data[w_id]
             else:
+                await self.data_store_mgr.set_query_sync_levels([w_id])
                 flow = self.data_store_mgr.data[w_id]
         except KeyError:
             return None
@@ -439,14 +477,18 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
     async def get_edges_by_ids(self, args):
         """Return protobuf edge objects for given id."""
         nat_ids = uniq(args.get('native_ids', []))
-        if 'sub_id' in args and args['delta_store']:
-            flow_data = [
-                delta[args['delta_type']]
-                for delta in get_flow_data_from_ids(
-                    self.delta_store[args['sub_id']], nat_ids)
-            ]
+        if 'sub_id' in args:
+            if args['delta_store']:
+                flow_data = [
+                    delta[args['delta_type']]
+                    for delta in get_flow_data_from_ids(
+                        self.delta_store[args['sub_id']], nat_ids)
+                ]
+            else:
+                flow_data = get_flow_data_from_ids(
+                    self.data_store_mgr.data, nat_ids)
         else:
-            flow_data = get_flow_data_from_ids(
+            flow_data = await self.get_flow_data_from_ids(
                 self.data_store_mgr.data, nat_ids)
 
         return sort_elements(
@@ -466,6 +508,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         edge_ids = set()
         # Setup for edgewise search.
         new_nodes = root_nodes
+        is_sub = 'sub_id' in args
         for _ in range(args['distance']):
             # Gather edges.
             # Edges should be unique (graph not circular),
@@ -476,10 +519,19 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                 for e_id in n.edges
             }.difference(edge_ids)
             edge_ids.update(new_edge_ids)
+            if is_sub:
+                flow_data = get_flow_data_from_ids(
+                    self.data_store_mgr.data,
+                    new_edge_ids
+                )
+            else:
+                flow_data = await self.get_flow_data_from_ids(
+                    self.data_store_mgr.data,
+                    new_edge_ids
+                )
             new_edges = [
                 edge
-                for flow in get_flow_data_from_ids(
-                    self.data_store_mgr.data, new_edge_ids)
+                for flow in flow_data
                 for edge in get_data_elements(flow, new_edge_ids, EDGES)
             ]
             edges += new_edges
@@ -494,10 +546,19 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             if not new_node_ids:
                 break
             node_ids.update(new_node_ids)
+            if is_sub:
+                flow_data = get_flow_data_from_ids(
+                    self.data_store_mgr.data,
+                    new_node_ids
+                )
+            else:
+                flow_data = await self.get_flow_data_from_ids(
+                    self.data_store_mgr.data,
+                    new_node_ids
+                )
             new_nodes = [
                 node
-                for flow in get_flow_data_from_ids(
-                    self.data_store_mgr.data, new_node_ids)
+                for flow in flow_data
                 for node in get_data_elements(flow, new_node_ids, TASK_PROXIES)
             ]
             nodes += new_nodes
@@ -675,8 +736,11 @@ class Resolvers(BaseResolvers):
         meta: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Mutate workflow."""
-        w_ids = [flow[WORKFLOW].id
-                 for flow in await self.get_workflows_data(w_args)]
+        w_ids = [
+            workflow[WORKFLOW].id
+            for workflow in self.data_store_mgr.data.values()
+            if workflow_filter(workflow, w_args)
+        ]
         if not w_ids:
             workflows = list(self.data_store_mgr.data.keys())
             return [{

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -534,6 +534,8 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         delta_queues = self.data_store_mgr.delta_queues
         deltas_queue: DeltaQueue = queue.Queue()
 
+        self.data_store_mgr.graphql_sub_interrogate(sub_id, info)
+
         counters: Dict[str, int] = {}
         delta_yield_queue: DeltaQueue = queue.Queue()
         flow_delta_queues: Dict[str, queue.Queue[Tuple[str, dict]]] = {}
@@ -556,6 +558,9 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                     if w_id in self.data_store_mgr.data:
                         if sub_id not in delta_queues[w_id]:
                             delta_queues[w_id][sub_id] = deltas_queue
+                            await self.data_store_mgr.graphql_sub_data_match(
+                                w_id, sub_id
+                            )
                             # On new yield workflow data-store as added delta
                             if args.get('initial_burst'):
                                 delta_store = create_delta_store(
@@ -623,6 +628,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             import traceback
             logger.warning(traceback.format_exc())
         finally:
+            self.data_store_mgr.graphql_sub_discard(sub_id)
             for w_id in w_ids:
                 if delta_queues.get(w_id, {}).get(sub_id):
                     del delta_queues[w_id][sub_id]

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -309,7 +309,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
     # Query resolvers
     async def get_workflow_by_id(self, args):
         """Return a workflow store by ID."""
-        try:
+        with suppress(KeyError):
             if 'sub_id' in args:
                 if args['delta_store']:
                     return self.delta_store[args['sub_id']][args['id']][
@@ -319,8 +319,6 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                     [self.data_store_mgr.data[args['id']][WORKFLOW].id]
                 )
             return self.data_store_mgr.data[args['id']][WORKFLOW]
-        except KeyError:
-            return None
 
     async def get_workflows_data(self, args: Dict[str, Any]):
         """Return list of data from workflows."""

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -270,20 +270,6 @@ def node_filter(node, node_type, args, state):
     )
 
 
-def get_flow_data_from_ids(data_store, native_ids):
-    """Return workflow data by id."""
-    w_ids = []
-    for native_id in native_ids:
-        w_ids.append(
-            Tokens(native_id).workflow_id
-        )
-    return [
-        data_store[w_id]
-        for w_id in iter_uniq(w_ids)
-        if w_id in data_store
-    ]
-
-
 def get_data_elements(flow, nat_ids, element_type):
     """Return data elements by id."""
     flow_element = flow[element_type]
@@ -351,16 +337,17 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
              for flow in await self.get_workflows_data(args)],
             args)
 
-    async def get_flow_data_from_ids(self, data_store, native_ids):
+    async def get_flow_data_from_ids(self, data_store, native_ids, is_sub):
         """Return workflow data by id."""
         w_ids = []
         for native_id in native_ids:
             w_ids.append(
                 Tokens(native_id).workflow_id
             )
-        await self.data_store_mgr.set_query_sync_levels(
-            set(w_ids)
-        )
+        if not is_sub:
+            await self.data_store_mgr.set_query_sync_levels(
+                set(w_ids)
+            )
         return [
             data_store[w_id]
             for w_id in iter_uniq(w_ids)
@@ -406,29 +393,20 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         """Return protobuf node objects for given id."""
         nat_ids = uniq(args.get('native_ids', []))
         # Both cases just as common so 'if' not 'try'
-        if 'sub_id' in args:
-            if args['delta_store']:
-                flow_data = [
-                    delta[args['delta_type']]
-                    for delta in get_flow_data_from_ids(
-                        self.delta_store[args['sub_id']], nat_ids)
-                ]
-            else:
-                flow_data = get_flow_data_from_ids(
-                    self.data_store_mgr.data, nat_ids)
+        is_sub = 'sub_id' in args
+        if is_sub and args['delta_store']:
+            flow_data = [
+                delta[args['delta_type']]
+                for delta in await self.get_flow_data_from_ids(
+                    self.delta_store[args['sub_id']], nat_ids, is_sub)
+            ]
         else:
             flow_data = await self.get_flow_data_from_ids(
-                self.data_store_mgr.data, nat_ids)
-
-        if node_type == PROXY_NODES:
-            node_types = [TASK_PROXIES, FAMILY_PROXIES]
-        else:
-            node_types = [node_type]
+                self.data_store_mgr.data, nat_ids, is_sub)
         return sort_elements(
             [
                 node
                 for flow in flow_data
-                for node_type in node_types
                 for node in get_data_elements(flow, nat_ids, node_type)
                 if node_filter(
                     node,
@@ -445,7 +423,7 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         n_id = args.get('id')
         w_id = Tokens(n_id).workflow_id
         # Both cases just as common so 'if' not 'try'
-        try:
+        with suppress(KeyError):
             if 'sub_id' in args:
                 if args.get('delta_store'):
                     flow = self.delta_store[
@@ -455,13 +433,11 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             else:
                 await self.data_store_mgr.set_query_sync_levels([w_id])
                 flow = self.data_store_mgr.data[w_id]
-        except KeyError:
-            return None
-        if node_type == PROXY_NODES:
-            return (
-                flow[TASK_PROXIES].get(n_id) or
-                flow[FAMILY_PROXIES].get(n_id))
-        return flow[node_type].get(n_id)
+            if node_type == PROXY_NODES:
+                return (
+                    flow[TASK_PROXIES].get(n_id) or
+                    flow[FAMILY_PROXIES].get(n_id))
+            return flow[node_type].get(n_id)
 
     # edges
     async def get_edges_all(self, args):
@@ -475,19 +451,16 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
     async def get_edges_by_ids(self, args):
         """Return protobuf edge objects for given id."""
         nat_ids = uniq(args.get('native_ids', []))
-        if 'sub_id' in args:
-            if args['delta_store']:
-                flow_data = [
-                    delta[args['delta_type']]
-                    for delta in get_flow_data_from_ids(
-                        self.delta_store[args['sub_id']], nat_ids)
-                ]
-            else:
-                flow_data = get_flow_data_from_ids(
-                    self.data_store_mgr.data, nat_ids)
+        is_sub = 'sub_id' in args
+        if is_sub and args['delta_store']:
+            flow_data = [
+                delta[args['delta_type']]
+                for delta in await self.get_flow_data_from_ids(
+                    self.delta_store[args['sub_id']], nat_ids, is_sub)
+            ]
         else:
             flow_data = await self.get_flow_data_from_ids(
-                self.data_store_mgr.data, nat_ids)
+                self.data_store_mgr.data, nat_ids, is_sub)
 
         return sort_elements(
             [edge
@@ -517,16 +490,11 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                 for e_id in n.edges
             }.difference(edge_ids)
             edge_ids.update(new_edge_ids)
-            if is_sub:
-                flow_data = get_flow_data_from_ids(
-                    self.data_store_mgr.data,
-                    new_edge_ids
-                )
-            else:
-                flow_data = await self.get_flow_data_from_ids(
-                    self.data_store_mgr.data,
-                    new_edge_ids
-                )
+            flow_data = await self.get_flow_data_from_ids(
+                self.data_store_mgr.data,
+                new_edge_ids,
+                is_sub
+            )
             new_edges = [
                 edge
                 for flow in flow_data
@@ -544,16 +512,11 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
             if not new_node_ids:
                 break
             node_ids.update(new_node_ids)
-            if is_sub:
-                flow_data = get_flow_data_from_ids(
-                    self.data_store_mgr.data,
-                    new_node_ids
-                )
-            else:
-                flow_data = await self.get_flow_data_from_ids(
-                    self.data_store_mgr.data,
-                    new_node_ids
-                )
+            flow_data = await self.get_flow_data_from_ids(
+                self.data_store_mgr.data,
+                new_node_ids,
+                is_sub
+            )
             new_nodes = [
                 node
                 for flow in flow_data

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -59,8 +59,8 @@ if TYPE_CHECKING:
 # maps server methods to the protobuf message (for client/UIS import)
 PB_METHOD_MAP: Dict[str, Any] = {
     'pb_entire_workflow': PbEntireWorkflow,
-    'pb_workflow_only': PbEntireWorkflow,
-    'pb_data_elements': DELTAS_MAP
+    'pb_data_elements': PbEntireWorkflow,
+    'pb_delta_elements': DELTAS_MAP
 }
 
 
@@ -432,17 +432,20 @@ class WorkflowRuntimeServer:
         return pb_msg.SerializeToString()
 
     @expose
-    def pb_workflow_only(self, **_kwargs) -> bytes:
-        """Send only the workflow data, not tasks etc.
+    def pb_data_elements(self, elements: Iterable, **_kwargs) -> bytes:
+        """Send only the selected data elements.
+
+        Args:
+            elements: Keys from DATA_TEMPLATE dictionary.
 
         Returns serialised Protobuf message
         """
-        pb_msg = self.schd.data_store_mgr.get_workflow_only()
+        pb_msg = self.schd.data_store_mgr.get_data_elements(elements)
         return pb_msg.SerializeToString()
 
     @expose
-    def pb_data_elements(self, element_type: str, **_kwargs) -> bytes:
-        """Send the specified data elements in delta form.
+    def pb_delta_elements(self, element_type: str, **_kwargs) -> bytes:
+        """Send the specified data elements in delta added form.
 
         Args:
             element_type: Key from DELTAS_MAP dictionary.
@@ -450,5 +453,5 @@ class WorkflowRuntimeServer:
         Returns serialised Protobuf message
 
         """
-        pb_msg = self.schd.data_store_mgr.get_data_elements(element_type)
+        pb_msg = self.schd.data_store_mgr.get_delta_elements(element_type)
         return pb_msg.SerializeToString()

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -440,7 +440,6 @@ class WorkflowRuntimeServer:
         pb_msg = self.schd.data_store_mgr.get_workflow_only()
         return pb_msg.SerializeToString()
 
-    @authorise()
     @expose
     def pb_data_elements(self, element_type: str, **_kwargs) -> bytes:
         """Send the specified data elements in delta form.

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 # maps server methods to the protobuf message (for client/UIS import)
 PB_METHOD_MAP: Dict[str, Any] = {
     'pb_entire_workflow': PbEntireWorkflow,
+    'pb_workflow_only': PbEntireWorkflow,
     'pb_data_elements': DELTAS_MAP
 }
 
@@ -430,6 +431,16 @@ class WorkflowRuntimeServer:
         pb_msg = self.schd.data_store_mgr.get_entire_workflow()
         return pb_msg.SerializeToString()
 
+    @expose
+    def pb_workflow_only(self, **_kwargs) -> bytes:
+        """Send only the workflow data, not tasks etc.
+
+        Returns serialised Protobuf message
+        """
+        pb_msg = self.schd.data_store_mgr.get_workflow_only()
+        return pb_msg.SerializeToString()
+
+    @authorise()
     @expose
     def pb_data_elements(self, element_type: str, **_kwargs) -> bytes:
         """Send the specified data elements in delta form.

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -16,6 +16,7 @@
 """Server for workflow runtime API."""
 
 import asyncio
+from contextlib import suppress
 from queue import Queue
 from textwrap import dedent
 from time import sleep
@@ -373,14 +374,12 @@ class WorkflowRuntimeServer:
                 if getattr(getattr(self, method), 'exposed', False)
             ]
 
-        try:
+        with suppress(AttributeError):
             method = getattr(self, endpoint)
-        except AttributeError:
-            return 'No method by name "%s"' % endpoint
-        if method.exposed:
-            head, tail = method.__doc__.split('\n', 1)
-            tail = dedent(tail)
-            return '%s\n%s' % (head, tail)
+            if method.exposed:
+                head, tail = method.__doc__.split('\n', 1)
+                tail = dedent(tail)
+                return '%s\n%s' % (head, tail)
         return 'No method by name "%s"' % endpoint
 
     @expose

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -431,7 +431,11 @@ class WorkflowRuntimeServer:
         return pb_msg.SerializeToString()
 
     @expose
-    def pb_data_elements(self, elements: Iterable, **_kwargs) -> bytes:
+    def pb_data_elements(
+        self,
+        elements: Optional[Iterable] = None,
+        **_kwargs
+    ) -> bytes:
         """Send only the selected data elements.
 
         Args:
@@ -439,7 +443,16 @@ class WorkflowRuntimeServer:
 
         Returns serialised Protobuf message
         """
-        pb_msg = self.schd.data_store_mgr.get_data_elements(elements)
+        if elements is None:
+            elements = {}
+
+        # BACK COMPAT: CYLC_VERSION < 8.7
+        # elements is Optional for this reason.
+        if not elements and _kwargs.get('element_type'):
+            pb_msg = self.schd.data_store_mgr.get_delta_elements(
+                _kwargs.get('element_type'))
+        else:
+            pb_msg = self.schd.data_store_mgr.get_data_elements(elements)
         return pb_msg.SerializeToString()
 
     @expose

--- a/cylc/flow/network/subscriber.py
+++ b/cylc/flow/network/subscriber.py
@@ -93,6 +93,16 @@ class WorkflowSubscriber(ZMQSocketBase):
         for topic in self.topics:
             self.socket.setsockopt(zmq.SUBSCRIBE, topic)
 
+    def unsubscribe_topic(self, topic):
+        if topic in self.topics:
+            self.socket.setsockopt(zmq.UNSUBSCRIBE, topic)
+            self.topics.discard(topic)
+
+    def subscribe_topic(self, topic):
+        if topic not in self.topics:
+            self.socket.setsockopt(zmq.SUBSCRIBE, topic)
+            self.topics.add(topic)
+
     async def subscribe(self, msg_handler, *args, **kwargs):
         """Subscribe to updates from the provided socket."""
         while True:

--- a/cylc/flow/network/subscriber.py
+++ b/cylc/flow/network/subscriber.py
@@ -106,17 +106,16 @@ class WorkflowSubscriber(ZMQSocketBase):
     async def subscribe(self, msg_handler, *args, **kwargs):
         """Subscribe to updates from the provided socket."""
         while True:
-            if self.stopping:
-                break
             try:
                 [topic, msg] = await self.socket.recv_multipart(
                     flags=zmq.NOBLOCK)
+                if callable(msg_handler):
+                    msg_handler(topic, msg, *args, **kwargs)
+                else:
+                    data = json.loads(msg)
+                    sys.stdout.write(
+                        json.dumps(data, indent=4) + '\n')
             except zmq.ZMQError:
                 await asyncio.sleep(NO_RECEIVE_INTERVAL)
-                continue
-            if callable(msg_handler):
-                msg_handler(topic, msg, *args, **kwargs)
-            else:
-                data = json.loads(msg)
-                sys.stdout.write(
-                    json.dumps(data, indent=4) + '\n')
+            if self.stopping:
+                break

--- a/tests/integration/network/test_graphql.py
+++ b/tests/integration/network/test_graphql.py
@@ -425,6 +425,215 @@ async def test_subscription_basic(harness):
             await subscription.aclose()
     assert has_item
 
+    # test args
+    document, kwargs = gather_subscription_args(
+        schd,
+        '''
+            subscription {
+                workflows (deltaStore: true)  { id }
+            }
+        ''',
+    )
+    subscription = await subscribe(
+        schema.graphql_schema,
+        document,
+        **kwargs
+    )
+    has_item = False
+    with suppress(GeneratorExit):
+        async for response in subscription:
+            has_item = True
+            assert response.data['workflows'][0]['id'] == w_tokens.id
+            await subscription.aclose()
+    assert has_item
+
+    # test task
+    t_token = w_tokens.duplicate(Tokens('1/a', relative=True))
+    document, kwargs = gather_subscription_args(
+        schd,
+        f'''
+            subscription {{
+                taskProxy (id: "{t_token.id}", deltaStore: true)  {{ id }}
+            }}
+        ''',
+    )
+    subscription = await subscribe(
+        schema.graphql_schema,
+        document,
+        **kwargs
+    )
+    has_item = False
+    with suppress(GeneratorExit):
+        async for response in subscription:
+            has_item = True
+            assert response.data['taskProxy']['id'] == t_token.id
+            await subscription.aclose()
+    assert has_item
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_subscription_edges(harness):
+    """Test a edge/node subscriptions."""
+    schd, _, w_tokens = harness
+
+    # Window size increase to get more edges
+    schd.data_store_mgr.set_graph_window_extent(2)
+    schd.data_store_mgr.update_data_structure()
+
+    t_tokens = [
+        w_tokens.duplicate(
+            cycle='1',
+            task=namespace,
+        )
+        # NOTE: task "d" is in the n=2 window
+        for namespace in ('a', 'b', 'c', 'd')
+    ]
+    edges = [
+        (t_tokens[0], t_tokens[1]),
+        (t_tokens[0], t_tokens[2]),
+        (t_tokens[1], t_tokens[3]),
+        (t_tokens[2], t_tokens[3]),
+    ]
+    e_ids = sorted([
+        w_tokens.duplicate(
+            cycle=(
+                '$edge'
+                f'|{left.relative_id}'
+                f'|{right.relative_id}'
+            )
+        ).id
+        for left, right in edges
+    ])
+
+    # Basic edges
+    res_comp = {
+        'edges': [
+            {'id': id_}
+            for id_ in e_ids
+        ],
+    }
+
+    document, kwargs = gather_subscription_args(
+        schd,
+        '''
+            subscription {
+                edges (deltaStore: true) {
+                    id
+                }
+            }
+        '''
+    )
+    subscription = await subscribe(
+        schema.graphql_schema,
+        document,
+        **kwargs
+    )
+    has_item = False
+    with suppress(GeneratorExit):
+        async for response in subscription:
+            response.data['edges'].sort(key=lambda x: x['id'])
+            has_item = True
+            assert response.data == res_comp
+            await subscription.aclose()
+    assert has_item
+
+    # basic nodesEdges
+    res_comp = {
+        'nodesEdges': {
+            'nodes': [
+                {'id': tokens.id}
+                for tokens in t_tokens
+            ],
+            'edges': [
+                {'id': id_}
+                for id_ in e_ids
+            ],
+        },
+    }
+
+    document, kwargs = gather_subscription_args(
+        schd,
+        '''
+            subscription {
+                nodesEdges {
+                    nodes { id }
+                    edges { id }
+                }
+            },
+        '''
+    )
+    subscription = await subscribe(
+        schema.graphql_schema,
+        document,
+        **kwargs
+    )
+    has_item = False
+    with suppress(GeneratorExit):
+        async for response in subscription:
+            response.data['nodesEdges']['nodes'].sort(key=lambda x: x['id'])
+            response.data['nodesEdges']['edges'].sort(key=lambda x: x['id'])
+            has_item = True
+            assert response.data == res_comp
+            await subscription.aclose()
+    assert has_item
+
+    # test distance from root node nodeEdges
+    res_comp = {
+        'nodesEdges': {
+            'nodes': [
+                {'id': tokens.id}
+                for tokens in t_tokens
+            ],
+            'edges': [
+                {
+                    'id': id_,
+                    'sourceNode': {
+                        'id': w_tokens.duplicate(
+                            Tokens(id_.split('|')[1], relative=True)
+                        ).id,
+                        'state': 'waiting'
+                    }
+                }
+                for id_ in e_ids
+            ],
+        },
+    }
+    document, kwargs = gather_subscription_args(
+        schd,
+        '''
+            subscription {
+                nodesEdges (
+                    ids: ["*//1/a"],
+                    distance: 2,
+                    deltaStore: false
+                ) {
+                    nodes { id }
+                    edges {
+                        id
+                        sourceNode {
+                            id
+                            state
+                        }
+                    }
+                }
+            },
+        '''
+    )
+    subscription = await subscribe(
+        schema.graphql_schema,
+        document,
+        **kwargs
+    )
+    has_item = False
+    with suppress(GeneratorExit):
+        async for response in subscription:
+            response.data['nodesEdges']['nodes'].sort(key=lambda x: x['id'])
+            response.data['nodesEdges']['edges'].sort(key=lambda x: x['id'])
+            has_item = True
+            assert response.data == res_comp
+            await subscription.aclose()
+    assert has_item
+
 
 @pytest.mark.asyncio(loop_scope="module")
 async def test_subscription_deltas(one, start):
@@ -484,6 +693,101 @@ async def test_subscription_deltas(one, start):
             )
         )
         aitem = await subscription.__anext__()
+        assert aitem.data['deltas']['updated']['workflow'] == {
+            'id': one.id,
+        }
+        with suppress(GeneratorExit):
+            await subscription.aclose()
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_subscription_args(one, start):
+    """Test the full subscription with selection field args."""
+    async with start(one):
+        document, kwargs = gather_subscription_args(
+            one,
+            '''
+                subscription {
+                    deltas (stripNull: true) {
+                        id
+                        added {
+                            workflow (deltaStore: true, deltaType: "added") {
+                                id
+                                host
+                                status
+                                tasks {
+                                    name
+                                }
+                            }
+                            taskProxies (
+                                deltaStore: false,
+                                states: ["waiting"]
+                            ) {
+                                name
+                                state
+                                firstParent {
+                                    name
+                                }
+                            }
+                        }
+                        updated {
+                            workflow (deltaStore: false) {
+                                id
+                            }
+                            taskProxies {
+                                name
+                                state
+                                firstParent {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            ''',
+        )
+        subscription = await subscribe(
+            schema.graphql_schema,
+            document,
+            **kwargs
+        )
+        aitem = await subscription.__anext__()
+        assert aitem.data['deltas']['added'] == {
+            'workflow': {
+                'id': one.id,
+                'host': one.host,
+                'status': 'paused',
+                'tasks': [{'name': 'one'}]
+            },
+        }
+        # Workflow one is paused on start
+        await one.update_data_structure()
+        assert (
+            one.data_store_mgr.data[one.id]['workflow'].status
+            == get_workflow_status(one).value
+        )
+        # Get the all delta, process, then add it to the subscription queue.
+        btopic, delta, _ = one.data_store_mgr.publish_deltas[-1]
+        _, sub_queue = next(
+            iter(one.data_store_mgr.delta_queues[one.id].items())
+        )
+        sub_queue.put(
+            (
+                one.id,
+                btopic.decode('utf-8'),
+                create_delta_store(delta, one.id)
+            )
+        )
+        aitem = await subscription.__anext__()
+        assert aitem.data['deltas']['added'] == {
+            'taskProxies': [
+                {
+                    'name': 'one',
+                    'state': 'waiting',
+                    'firstParent': {'name': 'root'}
+                }
+            ]
+        }
         assert aitem.data['deltas']['updated']['workflow'] == {
             'id': one.id,
         }

--- a/tests/integration/network/test_publisher.py
+++ b/tests/integration/network/test_publisher.py
@@ -32,8 +32,12 @@ async def test_publisher(flow, scheduler, run, one_conf, port_range):
             schd.workflow,
             host=schd.host,
             port=schd.server.pub_port,
-            topics=[b'workflow']
+            topics=[b'shutdown']
         )
+
+        subscriber.unsubscribe_topic(b'shutdown')
+        subscriber.subscribe_topic(b'workflow')
+        assert subscriber.topics == {b'workflow'}
 
         async with asyncio.timeout(2):
             # wait for the first delta from the workflow

--- a/tests/integration/network/test_resolvers.py
+++ b/tests/integration/network/test_resolvers.py
@@ -133,8 +133,8 @@ async def test_get_nodes_by_ids(mock_flow, node_args):
     node_args['workflows'].append({
         'user': mock_flow.owner,
         'workflow': mock_flow.name,
-        'workflow_sel': None
     })
+    node_args['ids'] = [Tokens('*/*:waiting', relative=True)]
     nodes = await mock_flow.resolvers.get_nodes_by_ids(TASK_PROXIES, node_args)
     assert len(nodes) == 0
 

--- a/tests/integration/network/test_server.py
+++ b/tests/integration/network/test_server.py
@@ -86,9 +86,7 @@ def test_pb_workflow_only(myflow):
     """Test Protobuf workflow only endpoint method."""
     data = PB_METHOD_MAP['pb_workflow_only']()
     data.ParseFromString(
-        call_server_method(
-            myflow.server.pb_workflow_only
-        )
+        myflow.server.pb_workflow_only()
     )
     assert data.workflow.id == myflow.id
 

--- a/tests/integration/network/test_server.py
+++ b/tests/integration/network/test_server.py
@@ -63,12 +63,12 @@ def test_graphql_error(myflow):
         assert "Cannot query field 'alsonotafield'" in excinfo
 
 
-def test_pb_data_elements(myflow):
+def test_pb_delta_elements(myflow):
     """Test Protobuf elements endpoint method."""
     element_type = 'workflow'
-    data = PB_METHOD_MAP['pb_data_elements'][element_type]()
+    data = PB_METHOD_MAP['pb_delta_elements'][element_type]()
     data.ParseFromString(
-        myflow.server.pb_data_elements(element_type)
+        myflow.server.pb_delta_elements(element_type)
     )
     assert data.added.id == myflow.id
 
@@ -82,13 +82,14 @@ def test_pb_entire_workflow(myflow):
     assert data.workflow.id == myflow.id
 
 
-def test_pb_workflow_only(myflow):
-    """Test Protobuf workflow only endpoint method."""
-    data = PB_METHOD_MAP['pb_workflow_only']()
+def test_pb_data_elements(myflow):
+    """Test Protobuf elements endpoint method."""
+    element_type = 'workflow'
+    data = PB_METHOD_MAP['pb_data_elements']()
     data.ParseFromString(
-        myflow.server.pb_workflow_only()
+        myflow.server.pb_data_elements([element_type])
     )
-    assert data.workflow.id == myflow.id
+    assert getattr(data, element_type).id == myflow.id
 
 
 async def test_stop(one: Scheduler, start):

--- a/tests/integration/network/test_server.py
+++ b/tests/integration/network/test_server.py
@@ -82,6 +82,17 @@ def test_pb_entire_workflow(myflow):
     assert data.workflow.id == myflow.id
 
 
+def test_pb_workflow_only(myflow):
+    """Test Protobuf workflow only endpoint method."""
+    data = PB_METHOD_MAP['pb_workflow_only']()
+    data.ParseFromString(
+        call_server_method(
+            myflow.server.pb_workflow_only
+        )
+    )
+    assert data.workflow.id == myflow.id
+
+
 async def test_stop(one: Scheduler, start):
     """Test stop."""
     async with start(one):

--- a/tests/integration/network/test_server.py
+++ b/tests/integration/network/test_server.py
@@ -33,6 +33,21 @@ async def myflow(mod_flow, mod_scheduler, mod_run, mod_one_conf):
         yield schd
 
 
+def test_api(myflow):
+    """Test api endpoint."""
+    # method exists and is exposed
+    ret = myflow.server.api(endpoint='api')
+    assert 'Return information about this API.' in ret
+
+    # method does not exist
+    ret = myflow.server.api(endpoint='spaghetti')
+    assert ret == 'No method by name "spaghetti"'
+
+    # method exists but not exposed
+    ret = myflow.server.api(endpoint='operate')
+    assert ret == 'No method by name "operate"'
+
+
 def test_graphql(myflow):
     """Test GraphQL endpoint method."""
     request_string = f'''

--- a/tests/integration/network/test_subscriber.py
+++ b/tests/integration/network/test_subscriber.py
@@ -1,0 +1,83 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import io
+import json
+from contextlib import redirect_stdout
+
+from cylc.flow.network.subscriber import (
+    WorkflowSubscriber,
+    process_delta_msg,
+)
+
+
+def bespoke_encoder(data):
+    return data.encode('utf-8')
+
+
+async def test_subscriber(flow, scheduler, run, one_conf, port_range):
+    """It should recieve publish deltas when the flow starts."""
+    id_ = flow(one_conf)
+    schd = scheduler(id_, paused_start=False)
+    async with run(schd):
+        # create a subscriber
+        subscriber = WorkflowSubscriber(
+            schd.workflow,
+            host=schd.host,
+            port=schd.server.pub_port,
+            topics=[b'shutdown']
+        )
+
+        subscriber.unsubscribe_topic(b'shutdown')
+        # test unsubscribe non-subscribed
+        subscriber.unsubscribe_topic(b'workflow')
+        assert subscriber.topics == set()
+        subscriber.subscribe_topic(b'workflow')
+        # test subscribe to already-subscribed
+        subscriber.subscribe_topic(b'workflow')
+        assert subscriber.topics == {b'workflow'}
+
+        # create a subscriber2 with no specified host/port and
+        # a bespoke topic/message
+        subscriber2 = WorkflowSubscriber(
+            schd.workflow,
+            topics=[b'bespoke']
+        )
+        bespoke_msg = {'this': 'that'}
+        bespoke_json = json.dumps(bespoke_msg, indent=4)
+        await schd.server.publisher.publish(
+            *[(b'bespoke', bespoke_json, bespoke_encoder)]
+        )
+
+        async with asyncio.timeout(2):
+            # wait for the first delta from the workflow
+            btopic, msg = await subscriber.socket.recv_multipart()
+            # get the published bespoke msg
+            f = io.StringIO()
+            with redirect_stdout(f):
+                subscriber2.stopping = True
+                await subscriber2.subscribe(msg_handler=None)
+        # test the default message handling
+        assert f.getvalue() == bespoke_json + '\n'
+
+        _, delta = process_delta_msg(btopic, msg, None)
+        for key in ('added', 'updated'):
+            if getattr(getattr(delta, key), 'id', None):
+                assert schd.id == getattr(delta, key).id
+                break
+        else:
+            raise Exception("Delta wasn't added or updated")

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -235,15 +235,17 @@ def test_generate_graph_elements(mod_harness):
     assert len(data[TASK_PROXIES]) == len(task_defs)
 
 
-def test_get_data_elements(mod_harness):
+def test_get_data_delta_elements(mod_harness):
     schd, data = mod_harness
-    flow_msg = schd.data_store_mgr.get_data_elements(TASK_PROXIES)
-    assert len(flow_msg.added) == len(data[TASK_PROXIES])
+    w_id = schd.data_store_mgr.workflow_id
+    flow_msg = schd.data_store_mgr.get_data_elements([TASK_PROXIES, WORKFLOW])
+    assert len(getattr(flow_msg, TASK_PROXIES)) == len(data[TASK_PROXIES])
+    assert getattr(flow_msg, WORKFLOW).id == w_id
 
-    flow_msg = schd.data_store_mgr.get_data_elements(WORKFLOW)
+    flow_msg = schd.data_store_mgr.get_delta_elements(WORKFLOW)
     assert flow_msg.added.last_updated == data[WORKFLOW].last_updated
 
-    none_msg = schd.data_store_mgr.get_data_elements('fraggle')
+    none_msg = schd.data_store_mgr.get_delta_elements('fraggle')
     assert len(none_msg.ListFields()) == 0
 
 
@@ -794,7 +796,10 @@ async def test_flow_numbers(flow, scheduler, start):
         await schd.update_data_structure()
 
         # the task should not have a flow number as it is n>0
-        ds_task = schd.data_store_mgr.get_data_elements(TASK_PROXIES).added[1]
+        ds_task = getattr(
+            schd.data_store_mgr.get_data_elements([TASK_PROXIES]),
+            TASK_PROXIES
+        )[1]
         assert ds_task.name == 'b'
         assert ds_task.flow_nums == '[]'
 
@@ -805,7 +810,7 @@ async def test_flow_numbers(flow, scheduler, start):
         await schd.update_data_structure()
 
         # the task should now exist in the new flow
-        ds_task = schd.data_store_mgr.get_data_elements(TASK_PROXIES).added[1]
+        ds_task = schd.data_store_mgr.get_delta_elements(TASK_PROXIES).added[1]
         assert ds_task.name == 'b'
         assert ds_task.flow_nums == '[2]'
 

--- a/tests/unit/network/test_graphql.py
+++ b/tests/unit/network/test_graphql.py
@@ -25,7 +25,13 @@ from graphql import (
 
 from cylc.flow.data_messages_pb2 import PbTaskProxy, PbPrerequisite
 from cylc.flow.network.graphql import (
-    CylcVisitor, null_setter, strip_null, async_next, NULL_VALUE, grow_tree
+    CylcVisitor,
+    null_setter,
+    strip_null,
+    async_next,
+    NULL_VALUE,
+    grow_tree,
+    extract_ast_fields
 )
 from cylc.flow.network.schema import schema
 
@@ -242,3 +248,62 @@ async def test_strip_null(pre_result, expected_result):
 def test_grow_tree(expect, tree, path, leaves):
     grow_tree(tree, path, leaves)
     assert tree == expect
+
+
+@pytest.mark.parametrize(
+    'query,'
+    'expected_result',
+    [
+        pytest.param(
+            '''
+            query {
+                workflows {
+                    id
+                }
+            }
+            ''',
+            {'workflows', 'id'},
+            id="simple query"
+        ),
+        pytest.param(
+            '''
+            query {
+                ...WorkflowData
+            }
+            fragment WorkflowData on workflows {
+                workflows {
+                    id
+                }
+            }
+            ''',
+            {'workflows', 'id'},
+            id="query with a fragment"
+        ),
+        pytest.param(
+            '''
+            subscription {
+                workflows {
+                    taskProxies {
+                        id
+                        jobs {
+                            id
+                            state
+                        }
+                    }
+                }
+            }
+            ''',
+            {'workflows', 'taskProxies', 'id', 'jobs', 'state'},
+            id="subscription with nested selection sets"
+        ),
+    ]
+)
+def test_extract_ast_fields(query, expected_result):
+    """Test field extraction on basic doc string."""
+    document = parse(query)
+    fields = set()
+    for _def in document.definitions:
+        extract_ast_fields(_def, fields)
+    for frag in getattr(document, 'fragments', {}).values():
+        extract_ast_fields(frag, fields)
+    assert fields == expected_result


### PR DESCRIPTION
sibling of https://github.com/cylc/cylc-uiserver/pull/597

Have included testing some of the changes, however the parts not tested are used by cylc-uiserver not cylc-flow.

This end is to:
- hook into resolvers to extract which workflows a subscription/query is targeting
- adds an API endpoint and store stub

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests included (limited), as functionality is only used UIS side.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
