### PR TITLE
flow-nums data-store fix

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -2544,7 +2544,6 @@ class DataStoreMgr:
             tp_id, PbTaskProxy(id=tp_id))
         tp_delta.stamp = f'{tp_id}@{update_time}'
         self._process_internal_task_proxy(itask, tp_delta)
-
         self.updates_pending = True
 
     # -----------

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1159,11 +1159,11 @@ class DataStoreMgr:
             source_tokens
             point
             flow_nums
-            is_parent:
-                Used to determine whether to load DB state.
-            itask:
-                Update task-node from corresponding task proxy object.
+            is_parent: Used to determine whether to load DB state.
+            itask: Update task-node from corresponding task proxy object.
             n_depth: n-window graph edge distance.
+            replace_existing: Replace any existing data for task as it may
+                be out of date (e.g. flow nums).
         """
         tp_id = tokens.id
         if (

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -789,8 +789,9 @@ class DataStoreMgr:
             source_tokens,
             point,
             flow_nums,
-            False,
-            itask
+            is_parent=False,
+            itask=itask,
+            replace_existing=True,
         )
 
         # Pre-populate from previous walks
@@ -1150,6 +1151,7 @@ class DataStoreMgr:
         is_parent: bool = False,
         itask: Optional['TaskProxy'] = None,
         n_depth: int = 0,
+        replace_existing: bool = False,
     ) -> None:
         """Create task-point element populated with static data.
 
@@ -1168,6 +1170,8 @@ class DataStoreMgr:
             tp_id in self.data[self.workflow_id][TASK_PROXIES]
             or tp_id in self.added[TASK_PROXIES]
         ):
+            if replace_existing and itask is not None:
+                self.delta_from_task_proxy(itask)
             return
 
         name = tokens['task']
@@ -2521,6 +2525,27 @@ class DataStoreMgr:
             xtrigger.satisfied = satisfied
             xtrigger.time = update_time
             self.updates_pending = True
+
+    def delta_from_task_proxy(self, itask: TaskProxy) -> None:
+        """Create delta from existing pool task proxy.
+
+        Args:
+            itask (cylc.flow.task_proxy.TaskProxy):
+                Update task-node from corresponding task proxy
+                objects from the workflow task pool.
+
+        """
+        tproxy: Optional[PbTaskProxy]
+        tp_id, tproxy = self.store_node_fetcher(itask.tokens)
+        if not tproxy:
+            return
+        update_time = time()
+        tp_delta = self.updated[TASK_PROXIES].setdefault(
+            tp_id, PbTaskProxy(id=tp_id))
+        tp_delta.stamp = f'{tp_id}@{update_time}'
+        self._process_internal_task_proxy(itask, tp_delta)
+
+        self.updates_pending = True
 
     # -----------
     # Job Deltas

--- a/tests/functional/cylc-show/06-past-present-future.t
+++ b/tests/functional/cylc-show/06-past-present-future.t
@@ -46,7 +46,7 @@ TEST_NAME="${TEST_NAME_BASE}-show.present"
 contains_ok "${WORKFLOW_RUN_DIR}/show-c.txt" <<__END__
 state: running
 prerequisites: ('⨯': not satisfied)
-  ✓ 1/b succeeded
+  ⨯ 1/b succeeded
 __END__
 
 TEST_NAME="${TEST_NAME_BASE}-show.future"


### PR DESCRIPTION
closes #6114

Using example from above produces:
![image](https://github.com/cylc/cylc-flow/assets/11400777/0afacc63-3eda-4f17-ae43-15eef938d579)

The solution was to create a delta from the new task proxy (instead of trying to overwrite the existing).


existing tests should cover code (?)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] No changelog entry needed as not yet user-facing
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
