### PR TITLE
Tokens: handle ISO 8601 long format cycle points

### DIFF
--- a/changes.d/6123.fix.md
+++ b/changes.d/6123.fix.md
@@ -1,0 +1,1 @@
+Allow long-format datetime cycle points in IDs used on the command line.

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -403,7 +403,7 @@ class Tokens(dict):
 # //cycle[:sel][/task[:sel][/job[:sel]]]
 RELATIVE_PATTERN = rf'''
     //
-    (?P<{IDTokens.Cycle.value}>[^~\/:\n]+)
+    (?P<{IDTokens.Cycle.value}>[^~\/:\n][^~\/\n]*?)
     (?:
       :
       (?P<{IDTokens.Cycle.value}_sel>[^\/:\n]+)

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -186,7 +186,7 @@ def test_universal_id_matches_hierarchical(identifier):
         '//~',
         '//:',
         '//workflow//cycle',
-        '//task:task_sel:task_sel'
+        '//cycle/task:task_sel:task_sel'
     ]
 )
 def test_relative_id_illegal(identifier):


### PR DESCRIPTION
Closes #6110 

Before:
```python-console
>>> from cylc.flow.id import tokenise

>>> dict(tokenise('//2050-01-01T00:00Z'))
{'cycle': '2050-01-01T00', 'cycle_sel': '00Z'}
```

After:
```pyth-console
>> from cylc.flow.id_cli import cli_tokenise

>>> dict(cli_tokenise('//2050-01-01T00:00Z'))
{'cycle': '2050-01-01T00:00Z'}

>>> dict(cli_tokenise('//2050-01-01T00:fail'))
{'cycle': '2050-01-01T00', 'cycle_sel': 'fail'}
```

I decided to have a go at supporting the long format rather than disallowing it, seeing as it isn't much diff. Performance-wise this should have negligible impact as the "expensive" part of it is only going to be hit once by users running a CLI command.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
