### PR TITLE
Prevent commands which take Tasks IDs taking Job IDs.

### DIFF
--- a/changes.d/6130.fix.md
+++ b/changes.d/6130.fix.md
@@ -1,0 +1,1 @@
+Prevent commands taking a list of task ID's from submitting job ids.

--- a/changes.d/6130.fix.md
+++ b/changes.d/6130.fix.md
@@ -1,1 +1,1 @@
-Prevent commands taking a list of task ID's from submitting job ids.
+Prevent commands accepting job IDs where it doesn't make sense.

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -228,3 +228,40 @@ def consistency(
     """
     if outputs and prereqs:
         raise InputError("Use --prerequisite or --output, not both.")
+
+
+def is_tasks(tasks: List[str]):
+    """All tasks in a list of tasks are task ID's
+    without trailing job ID.
+    
+    Examples:
+
+        # All legal
+        >>> is_tasks(['1/foo', '1/bar', '*/baz', '*/*'])
+        True
+
+        # Some legal
+        >>> is_tasks(['1/foo/NN', '1/bar', '*/baz', '*/*/42'])
+        Traceback (most recent call last):
+        ...
+        Exception: This command does not take job ids:
+        * 1/foo/NN
+        * */*/42
+
+        # None legal
+        >>> is_tasks(['1/', '*/baz/12'])
+        Traceback (most recent call last):
+        ...
+        Exception: This command does not take job ids:
+        * 1/
+        * */baz/12
+    """
+    bad_tasks: List[str] = []
+    for task in tasks:
+        tokens = Tokens('//' + task)
+        if tokens.lowest_token < 'task':
+            bad_tasks.append(task)
+    if bad_tasks:
+        msg = 'This command does not take job ids:\n * '
+        raise Exception(msg + '\n * '.join(bad_tasks))
+    return True

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -233,6 +233,7 @@ def consistency(
 def is_tasks(tasks: List[str]):
     """All tasks in a list of tasks are task ID's
     without trailing job ID.
+
     Examples:
 
         # All legal

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -232,20 +232,17 @@ def consistency(
 
 
 def is_tasks(tasks: Iterable[str]):
-    """All tasks in a list of tasks are task ID's
-    without trailing job ID.
+    """All tasks in a list of tasks are task ID's without trailing job ID.
 
     Examples:
-
         # All legal
         >>> is_tasks(['1/foo', '1/bar', '*/baz', '*/*'])
-        True
 
         # Some legal
         >>> is_tasks(['1/foo/NN', '1/bar', '*/baz', '*/*/42'])
         Traceback (most recent call last):
         ...
-        Exception: This command does not take job ids:
+        cylc.flow.exceptions.InputError: This command does not take job ids:
         * 1/foo/NN
         * */*/42
 
@@ -253,7 +250,7 @@ def is_tasks(tasks: Iterable[str]):
         >>> is_tasks(['*/baz/12'])
         Traceback (most recent call last):
         ...
-        Exception: This command does not take job ids:
+        cylc.flow.exceptions.InputError: This command does not take job ids:
         * */baz/12
     """
     bad_tasks: List[str] = []
@@ -263,5 +260,4 @@ def is_tasks(tasks: Iterable[str]):
             bad_tasks.append(task)
     if bad_tasks:
         msg = 'This command does not take job ids:\n * '
-        raise Exception(msg + '\n * '.join(bad_tasks))
-    return True
+        raise InputError(msg + '\n * '.join(bad_tasks))

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -253,13 +253,12 @@ def is_tasks(tasks: List[str]):
         Traceback (most recent call last):
         ...
         Exception: This command does not take job ids:
-        * 1/
         * */baz/12
     """
     bad_tasks: List[str] = []
     for task in tasks:
         tokens = Tokens('//' + task)
-        if tokens.lowest_token < 'task':
+        if tokens.lowest_token == 'job':
             bad_tasks.append(task)
     if bad_tasks:
         msg = 'This command does not take job ids:\n * '

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -233,7 +233,6 @@ def consistency(
 def is_tasks(tasks: List[str]):
     """All tasks in a list of tasks are task ID's
     without trailing job ID.
-    
     Examples:
 
         # All legal

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -18,6 +18,7 @@
 
 
 from typing import (
+    Iterable,
     List,
     Optional,
 )
@@ -230,7 +231,7 @@ def consistency(
         raise InputError("Use --prerequisite or --output, not both.")
 
 
-def is_tasks(tasks: List[str]):
+def is_tasks(tasks: Iterable[str]):
     """All tasks in a list of tasks are task ID's
     without trailing job ID.
 
@@ -249,7 +250,7 @@ def is_tasks(tasks: List[str]):
         * */*/42
 
         # None legal
-        >>> is_tasks(['1/', '*/baz/12'])
+        >>> is_tasks(['*/baz/12'])
         Traceback (most recent call last):
         ...
         Exception: This command does not take job ids:
@@ -258,7 +259,7 @@ def is_tasks(tasks: List[str]):
     bad_tasks: List[str] = []
     for task in tasks:
         tokens = Tokens('//' + task)
-        if tokens.lowest_token == IDTokens.Job:
+        if tokens.lowest_token == IDTokens.Job.value:
             bad_tasks.append(task)
     if bad_tasks:
         msg = 'This command does not take job ids:\n * '

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from cylc.flow.exceptions import InputError
-from cylc.flow.id import Tokens
+from cylc.flow.id import IDTokens, Tokens
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.flow_mgr import FLOW_ALL, FLOW_NEW, FLOW_NONE
 
@@ -258,7 +258,7 @@ def is_tasks(tasks: List[str]):
     bad_tasks: List[str] = []
     for task in tasks:
         tokens = Tokens('//' + task)
-        if tokens.lowest_token == 'job':
+        if tokens.lowest_token == IDTokens.Job:
             bad_tasks.append(task)
     if bad_tasks:
         msg = 'This command does not take job ids:\n * '

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -145,6 +145,7 @@ async def set_prereqs_and_outputs(
     outputs = validate.outputs(outputs)
     prerequisites = validate.prereqs(prerequisites)
     validate.flow_opts(flow, flow_wait)
+    validate.is_tasks(tasks)
 
     yield
 
@@ -172,6 +173,8 @@ async def stop(
     task: Optional[str] = None,
     flow_num: Optional[int] = None,
 ):
+    if task:
+        validate.is_tasks([task])
     yield
     if flow_num:
         schd.pool.stop_flow(flow_num)

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -214,6 +214,7 @@ async def stop(
 @_command('release')
 async def release(schd: 'Scheduler', tasks: Iterable[str]):
     """Release held tasks."""
+    validate.is_tasks(tasks)
     yield
     yield schd.pool.release_held_tasks(tasks)
 
@@ -237,6 +238,7 @@ async def resume(schd: 'Scheduler'):
 @_command('poll_tasks')
 async def poll_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     """Poll pollable tasks or a task or family if options are provided."""
+    validate.is_tasks(tasks)
     yield
     if schd.get_run_mode() == RunMode.SIMULATION:
         yield 0
@@ -248,6 +250,7 @@ async def poll_tasks(schd: 'Scheduler', tasks: Iterable[str]):
 @_command('kill_tasks')
 async def kill_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     """Kill all tasks or a task/family if options are provided."""
+    validate.is_tasks(tasks)
     yield
     itasks, _, bad_items = schd.pool.filter_task_proxies(tasks)
     if schd.get_run_mode() == RunMode.SIMULATION:
@@ -264,6 +267,7 @@ async def kill_tasks(schd: 'Scheduler', tasks: Iterable[str]):
 @_command('hold')
 async def hold(schd: 'Scheduler', tasks: Iterable[str]):
     """Hold specified tasks."""
+    validate.is_tasks(tasks)
     yield
     yield schd.pool.hold_tasks(tasks)
 
@@ -304,6 +308,7 @@ async def set_verbosity(schd: 'Scheduler', level: Union[int, str]):
 @_command('remove_tasks')
 async def remove_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     """Remove tasks."""
+    validate.is_tasks(tasks)
     yield
     yield schd.pool.remove_tasks(tasks)
 
@@ -430,5 +435,6 @@ async def force_trigger_tasks(
     flow_descr: Optional[str] = None,
 ):
     """Manual task trigger."""
+    validate.is_tasks(tasks)
     yield
     yield schd.pool.force_trigger_tasks(tasks, flow, flow_wait, flow_descr)


### PR DESCRIPTION
Doing so can cause the scheduler to crash.

Branched from #6112 - drafted until that is in.
Closes #6125 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] Whilst this is technically a bug fix, I'm using a feature only available on a branch targetting master to fix it.
