### PR TITLE
Fix ID workflow count.

### DIFF
--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -465,14 +465,14 @@ def _infer_latest_runs(tokens_list, src_path, alt_run_dir=None):
 def _validate_number(*tokens_list, max_workflows=None, max_tasks=None):
     if not max_workflows and not max_tasks:
         return
-    workflows_count = 0
+    workflows_seen = set()
     tasks_count = 0
     for tokens in tokens_list:
         if tokens.is_task_like:
             tasks_count += 1
-        else:
-            workflows_count += 1
-    if max_workflows and workflows_count > max_workflows:
+        if tokens["workflow"] is not None:
+            workflows_seen.add(tokens["workflow"])
+    if max_workflows and len(workflows_seen) > max_workflows:
         raise InputError(
             f'IDs contain too many workflows (max {max_workflows})'
         )

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -587,7 +587,12 @@ def test_validate_number():
     _validate_number(t1, max_tasks=1)
     with pytest.raises(InputError):
         _validate_number(t1, t2, max_tasks=1)
-
+    _validate_number(t1, max_tasks=1)
+    _validate_number(Tokens('a//1'), Tokens('a//2'), max_workflows=1)
+    _validate_number(Tokens('a'), Tokens('//2'), Tokens('//3'), max_workflows=1)
+    with pytest.raises(InputError):
+        _validate_number(Tokens('a//1'), Tokens('b//1'), max_workflows=1)
+    _validate_number(Tokens('a//1'), Tokens('b//1'), max_workflows=2)
 
 @pytest.fixture
 def no_scan(monkeypatch):


### PR DESCRIPTION
ID parsing for the CLI is broken with respect to the `max_workflows` constraint - it doesn't count workflows if the ID is "task-like" (which may include workflow).

A pretty trivial fix, so tentatively targeting 8.3.0.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
