### PR TITLE
client: fix SSH client

### DIFF
--- a/cylc/flow/network/ssh_client.py
+++ b/cylc/flow/network/ssh_client.py
@@ -67,6 +67,7 @@ class WorkflowRuntimeClient(WorkflowRuntimeClientBase):
                     'ssh command': ssh_cmd,
                     'cylc path': cylc_path,
                     'use login shell': login_sh,
+                    'ssh forward environment variables': [],
                 }
                 # NOTE: this can not raise NoHostsError
                 # because we have provided the host


### PR DESCRIPTION
Bug discovered when running local tests in preparation for 8.3.0 release.

* SSH->TCP client was missing the `ssh forward environment variables` key.
* This PR gives it an empty placeholder value for now.

To replicate the bug try:

```console
$ ctb -p _remote_background_shared_ssh -v tests/functional/remote/02-install-target.t
```

Or try running any of the other SSH client tests.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.