### PR TITLE
xtriggers: doc change

### DIFF
--- a/cylc/flow/xtriggers/workflow_state.py
+++ b/cylc/flow/xtriggers/workflow_state.py
@@ -59,8 +59,17 @@ def workflow_state(
         satisfied:
             True if ``satisfied`` else ``False``.
         result:
-            Dict of workflow, task, point, offset,
-            status, message, trigger, flow_num, run_dir
+            Dict containing the keys:
+
+            * ``workflow``
+            * ``task``
+            * ``point``
+            * ``offset``
+            * ``status``
+            * ``message``
+            * ``trigger``
+            * ``flow_num``
+            * ``run_dir``
 
     .. versionchanged:: 8.3.0
 


### PR DESCRIPTION
The cylc-doc spellcheck doesn't like these return args.