### PR TITLE
setup: fix colorama upper pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ python_requires = >=3.7
 install_requires =
     ansimarkup>=1.0.0
     async-timeout>=3.0.0
-    colorama>=0.4,<=1
+    colorama>=0.4,<1
     graphene>=2.1,<3
     # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat
     jinja2==3.0.*


### PR DESCRIPTION
Spotted during release, the colorama dependency has a strange upper pin.

This goes right back to before the setup.cfg file (8b510ab4cecc9ca20054ff463df3264a29f7d24e).

Change this to match the correct value in the conda-environment.yml file.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.