### PR TITLE
Xtrigger validation: log traceback for unexpected user validation errors

### DIFF
--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from cylc.flow import LOG
-from cylc.flow.exceptions import XtriggerConfigError
+from cylc.flow.exceptions import WorkflowConfigError, XtriggerConfigError
 import cylc.flow.flags
 from cylc.flow.hostuserutil import get_user
 from cylc.flow.subprocctx import add_kwarg_to_sig
@@ -362,6 +362,8 @@ class XtriggerCollator:
         try:
             xtrig_validate_func(bound_args.arguments)
         except Exception as exc:  # Note: catch all errors
+            if not isinstance(exc, WorkflowConfigError):
+                LOG.exception(exc)
             raise XtriggerConfigError(label, signature_str, exc)
 
     # BACK COMPAT: workflow_state_backcompat


### PR DESCRIPTION
Small change with no associated issue

Can test by installing a custom xtrigger module with a `validate` function that raises a `RuntimeError`, for example

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are not needed
- [x] Changelog entry not needed as minor 
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
