### PR TITLE
Lint  

### DIFF
--- a/cylc/flow/broadcast_report.py
+++ b/cylc/flow/broadcast_report.py
@@ -72,7 +72,7 @@ def get_broadcast_change_iter(modified_settings, is_cancel=False):
         value = setting
         keys_str = ""
         while isinstance(value, dict):
-            key, value = list(value.items())[0]
+            key, value = next(iter(value.items()))
             if isinstance(value, dict):
                 keys_str += "[" + key + "]"
             else:

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -129,7 +129,7 @@ def _clean_check(opts: 'Values', id_: str, run_dir: Path) -> None:
     except ContactFileExists as exc:
         raise ServiceFileError(
             f"Cannot clean running workflow {id_}.\n\n{exc}"
-        )
+        ) from None
 
 
 def init_clean(id_: str, opts: 'Values') -> None:
@@ -173,7 +173,7 @@ def init_clean(id_: str, opts: 'Values') -> None:
             try:
                 platform_names = get_platforms_from_db(local_run_dir)
             except ServiceFileError as exc:
-                raise ServiceFileError(f"Cannot clean {id_} - {exc}")
+                raise ServiceFileError(f"Cannot clean {id_} - {exc}") from None
             except sqlite3.OperationalError as exc:
                 # something went wrong with the query
                 # e.g. the table/field we need isn't there
@@ -184,7 +184,7 @@ def init_clean(id_: str, opts: 'Values') -> None:
                     ' with to remove it.'
                     '\nOtherwise please delete the database file.'
                 )
-                raise ServiceFileError(f"Cannot clean {id_} - {exc}")
+                raise ServiceFileError(f"Cannot clean {id_} - {exc}") from exc
 
         if platform_names and platform_names != {'localhost'}:
             remote_clean(
@@ -359,7 +359,8 @@ def remote_clean(
     except PlatformLookupError as exc:
         raise PlatformLookupError(
             f"Cannot clean {id_} on remote platforms as the workflow database "
-            f"is out of date/inconsistent with the global config - {exc}")
+            f"is out of date/inconsistent with the global config - {exc}"
+        ) from None
 
     queue: Deque[RemoteCleanQueueTuple] = deque()
     remote_clean_cmd = partial(

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -70,7 +70,7 @@ def flow_opts(flows: List[str], flow_wait: bool) -> None:
             try:
                 int(val)
             except ValueError:
-                raise InputError(ERR_OPT_FLOW_VAL.format(val))
+                raise InputError(ERR_OPT_FLOW_VAL.format(val)) from None
 
     if flow_wait and flows[0] in [FLOW_NEW, FLOW_NONE]:
         raise InputError(ERR_OPT_FLOW_WAIT)

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -208,7 +208,7 @@ async def stop(
         try:
             mode = StopMode(mode)
         except ValueError:
-            raise CommandFailedError(f"Invalid stop mode: '{mode}'")
+            raise CommandFailedError(f"Invalid stop mode: '{mode}'") from None
         schd._set_stop(mode)
         if mode is StopMode.REQUEST_KILL:
             schd.time_next_kill = time()
@@ -304,7 +304,7 @@ async def set_verbosity(schd: 'Scheduler', level: Union[int, str]):
         lvl = int(level)
         LOG.setLevel(lvl)
     except (TypeError, ValueError) as exc:
-        raise CommandFailedError(exc)
+        raise CommandFailedError(exc) from None
     cylc.flow.flags.verbosity = log_level_to_verbosity(lvl)
 
 

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -199,11 +199,11 @@ def interpolate_template(tmpl, params_dict):
     try:
         return tmpl % params_dict
     except KeyError:
-        raise ParamExpandError('bad parameter')
+        raise ParamExpandError('bad parameter') from None
     except TypeError:
-        raise ParamExpandError('wrong data type for parameter')
+        raise ParamExpandError('wrong data type for parameter') from None
     except ValueError:
-        raise ParamExpandError('bad template syntax')
+        raise ParamExpandError('bad template syntax') from None
 
 
 class WorkflowConfig:
@@ -480,8 +480,8 @@ class WorkflowConfig:
                             get_interval(offset_string).standardise())
                     except IntervalParsingError:
                         raise WorkflowConfigError(
-                            "Illegal %s spec: %s" % (
-                                s_type, offset_string))
+                            "Illegal %s spec: %s" % (s_type, offset_string)
+                        ) from None
                     extn = "(" + offset_string + ")"
 
                 # Replace family names with members.
@@ -709,7 +709,7 @@ class WorkflowConfig:
                 try:
                     icp = ingest_time(orig_icp, get_current_time_string())
                 except IsodatetimeError as exc:
-                    raise WorkflowConfigError(str(exc))
+                    raise WorkflowConfigError(str(exc)) from None
         if orig_icp != icp:
             # now/next()/previous() was used, need to store
             # evaluated point in DB
@@ -761,7 +761,7 @@ class WorkflowConfig:
                     for taskid in self.options.starttask
                 ]
             except ValueError as exc:
-                raise InputError(str(exc))
+                raise InputError(str(exc)) from None
             self.start_point = min(
                 get_point(cycle).standardise()
                 for cycle in cycle_points if cycle
@@ -1114,7 +1114,7 @@ class WorkflowConfig:
                     f'\n  {expr}'
                     '\nThe "finished" output cannot be used in completion'
                     ' expressions, use "succeeded or failed".'
-                )
+                ) from None
 
             for alt_qualifier, qualifier in ALT_QUALIFIERS.items():
                 _alt_compvar = trigger_to_completion_variable(alt_qualifier)
@@ -1125,21 +1125,21 @@ class WorkflowConfig:
                         f'\n  {expr}'
                         f'\nUse "{_compvar}" not "{_alt_compvar}" '
                         'in completion expressions.'
-                    )
+                    ) from None
 
             raise WorkflowConfigError(
                 # NOTE: str(exc) == "name 'x' is not defined" tested in
                 # tests/integration/test_optional_outputs.py
                 f'Error in [runtime][{task_name}]completion:'
                 f'\n{error}'
-            )
+            ) from None
         except Exception as exc:  # includes InvalidCompletionExpression
             # expression contains non-whitelisted syntax or any other error in
             # the expression e.g. SyntaxError
             raise WorkflowConfigError(
                 f'Error in [runtime][{task_name}]completion:'
                 f'\n{str(exc)}'
-            )
+            ) from None
 
         # ensure consistency between the graph and the completion expression
         for compvar in (
@@ -1415,11 +1415,12 @@ class WorkflowConfig:
                     c3_single.mro(name))
             except RecursionError:
                 raise WorkflowConfigError(
-                    "circular [runtime] inheritance?")
+                    "circular [runtime] inheritance?"
+                ) from None
             except Exception as exc:
                 # catch inheritance errors
                 # TODO - specialise MRO exceptions
-                raise WorkflowConfigError(str(exc))
+                raise WorkflowConfigError(str(exc)) from None
 
         for name in self.cfg['runtime']:
             ancestors = self.runtime['linearized ancestors'][name]
@@ -1758,7 +1759,7 @@ class WorkflowConfig:
                                     f' {taskdef.name}:'
                                     f' {handler_template}:'
                                     f' {repr(exc)}'
-                                )
+                                ) from None
 
     def _check_special_tasks(self):
         """Check declared special tasks are valid, and detect special
@@ -1865,7 +1866,9 @@ class WorkflowConfig:
         try:
             expr_list = listify(lexpression)
         except SyntaxError:
-            raise WorkflowConfigError('Error in expression "%s"' % lexpression)
+            raise WorkflowConfigError(
+                'Error in expression "%s"' % lexpression
+            ) from None
 
         triggers = {}
         xtrig_labels = set()
@@ -1942,7 +1945,9 @@ class WorkflowConfig:
                 xtrig = xtrigs[label]
             except KeyError:
                 if label != 'wall_clock':
-                    raise WorkflowConfigError(f"xtrigger not defined: {label}")
+                    raise WorkflowConfigError(
+                        f"xtrigger not defined: {label}"
+                    ) from None
                 else:
                     # Allow "@wall_clock" in graph as implicit zero-offset.
                     xtrig = SubFuncContext('wall_clock', 'wall_clock', [], {})
@@ -2276,7 +2281,7 @@ class WorkflowConfig:
                 msg += ' (final cycle point=%s)' % fcp
                 if isinstance(exc, CylcError):
                     msg += ' %s' % exc.args[0]
-                raise WorkflowConfigError(msg)
+                raise WorkflowConfigError(msg) from None
             self.sequences.append(seq)
             parser = GraphParser(
                 family_map,
@@ -2431,7 +2436,7 @@ class WorkflowConfig:
             except TaskDefError as exc:
                 if orig_expr:
                     LOG.error(orig_expr)
-                raise WorkflowConfigError(str(exc))
+                raise WorkflowConfigError(str(exc)) from None
             else:
                 # Record custom message outputs from [runtime].
                 for output, message in (
@@ -2443,14 +2448,14 @@ class WorkflowConfig:
                             f'Invalid task output "'
                             f'[runtime][{name}][outputs]'
                             f'{output} = {message}" - {msg}'
-                        )
+                        ) from None
                     valid, msg = TaskMessageValidator.validate(message)
                     if not valid:
                         raise WorkflowConfigError(
                             f'Invalid task message "'
                             f'[runtime][{name}][outputs]'
                             f'{output} = {message}" - {msg}'
-                        )
+                        ) from None
                     self.taskdefs[name].add_output(output, message)
 
         return self.taskdefs[name]
@@ -2462,7 +2467,7 @@ class WorkflowConfig:
         try:
             rtcfg = self.cfg['runtime'][name]
         except KeyError:
-            raise WorkflowConfigError("Task not defined: %s" % name)
+            raise WorkflowConfigError("Task not defined: %s" % name) from None
         # We may want to put in some handling for cases of changing the
         # initial cycle via restart (accidentally or otherwise).
 
@@ -2554,7 +2559,9 @@ class WorkflowConfig:
                     'workflow': self.workflow,
                 }
             except (KeyError, ValueError):
-                raise InputError(f'Invalid template [meta]URL: {url}')
+                raise InputError(
+                    f'Invalid template [meta]URL: {url}'
+                ) from None
             else:
                 LOG.warning(
                     'Detected deprecated template variables in [meta]URL.'
@@ -2590,7 +2597,9 @@ class WorkflowConfig:
                         'task': name,
                     }
                 except (KeyError, ValueError):
-                    raise InputError(f'Invalid template [meta]URL: {url}')
+                    raise InputError(
+                        f'Invalid template [meta]URL: {url}'
+                    ) from None
                 else:
                     LOG.warning(
                         'Detected deprecated template variables in'

--- a/cylc/flow/cycling/integer.py
+++ b/cylc/flow/cycling/integer.py
@@ -150,7 +150,7 @@ class IntegerPoint(PointBase):
         try:
             self.value = str(int(self))
         except (TypeError, ValueError) as exc:
-            raise PointParsingError(type(self), self.value, exc)
+            raise PointParsingError(type(self), self.value, exc) from None
         return self
 
     def __int__(self):

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -102,7 +102,7 @@ class ISO8601Point(PointBase):
                     WorkflowSpecifics.NUM_EXPANDED_YEAR_DIGITS)
             else:
                 message = str(exc)
-            raise PointParsingError(type(self), self.value, message)
+            raise PointParsingError(type(self), self.value, message) from None
         return self
 
     def sub(self, other):
@@ -176,7 +176,7 @@ class ISO8601Interval(IntervalBase):
         try:
             self.value = str(interval_parse(self.value))
         except IsodatetimeError:
-            raise IntervalParsingError(type(self), self.value)
+            raise IntervalParsingError(type(self), self.value) from None
         return self
 
     def add(self, other):
@@ -782,7 +782,7 @@ def prev_next(
             raise WorkflowConfigError(
                 f'Invalid offset: {my_time}:'
                 f' Offset lists are semicolon separated, try {suggest}'
-            )
+            ) from None
 
         timepoints.append(parsed_point + now)
 

--- a/cylc/flow/dbstatecheck.py
+++ b/cylc/flow/dbstatecheck.py
@@ -78,7 +78,7 @@ class CylcWorkflowDBChecker:
         try:
             self.db_point_fmt = self._get_db_point_format()
             self.c7_back_compat_mode = False
-        except sqlite3.OperationalError as exc:
+        except sqlite3.OperationalError:
             # BACK COMPAT: Cylc 7 DB (see method below).
             try:
                 self.db_point_fmt = self._get_db_point_format_compat()
@@ -86,7 +86,7 @@ class CylcWorkflowDBChecker:
             except sqlite3.OperationalError:
                 with suppress(Exception):
                     self.conn.close()
-                raise exc  # original error
+                raise
 
     def __enter__(self):
         return self
@@ -137,7 +137,7 @@ class CylcWorkflowDBChecker:
             raise InputError(
                 f'Cycle point "{cycle}" is not compatible'
                 f' with DB point format "{self.db_point_fmt}"'
-            )
+            ) from None
         return cycle
 
     @staticmethod

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -346,7 +346,7 @@ class GraphParser:
                         raise GraphParseError(
                             f"Dangling {seq}:"
                             f"{this_line}"
-                        )
+                        ) from None
             part_lines.append(this_line)
 
             # Check that a continuation sequence doesn't end this line and
@@ -638,7 +638,8 @@ class GraphParser:
                     except KeyError:
                         # "FAM:bad => foo" in LHS (includes "FAM => bar" too).
                         raise GraphParseError(
-                            f"Illegal family trigger in {expr}")
+                            f"Illegal family trigger in {expr}"
+                        ) from None
                 else:
                     # Not a family.
                     if trig in self.__class__.fam_to_mem_trigger_map:
@@ -911,7 +912,8 @@ class GraphParser:
                 except KeyError:
                     # Illegal family trigger on RHS of a pair.
                     raise GraphParseError(
-                        f"Illegal family trigger: {name}:{output}")
+                        f"Illegal family trigger: {name}:{output}"
+                    ) from None
             else:
                 fam = False
                 if not output:

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -373,7 +373,7 @@ def _filter_by_ranking(hosts, rankings, results, data=None):
                     f'\n    Expression: {item}'
                     f'\n    Configuration: {GLBL_CFG_STR}'
                     f'\n    Error: {exc}'
-                )
+                ) from None
             if isinstance(result, bool):
                 host_rankings[item] = result
                 data[host][item] = result

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -128,7 +128,7 @@ class Tokens(dict):
             return dict.__getitem__(self, key)
         except KeyError:
             if key not in self._KEYS:
-                raise ValueError(f'Invalid token: {key}')
+                raise ValueError(f'Invalid token: {key}') from None
             return None
 
     def __str__(self):

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -347,7 +347,7 @@ async def parse_ids_async(
     if src:
         if not flow_file_path:
             # get the workflow file path from the run dir
-            flow_file_path = get_flow_file(list(workflows)[0])
+            flow_file_path = get_flow_file(next(iter(workflows)))
         return workflows, flow_file_path
     return workflows, multi_mode
 
@@ -375,7 +375,7 @@ async def parse_id_async(
             'max_tasks': 1,
         },
     )
-    workflow_id = list(workflows)[0]
+    workflow_id = next(iter(workflows))
     tokens_list = workflows[workflow_id]
     tokens: Optional[Tokens]
     if tokens_list:

--- a/cylc/flow/id_cli.py
+++ b/cylc/flow/id_cli.py
@@ -167,9 +167,9 @@ def _parse_cli(*ids: str) -> List[Tokens]:
                     # this ID is invalid with or without the trailing slash
                     tokens = cli_tokenise(id_[:-1])
                 except ValueError:
-                    raise InputError(f'Invalid ID: {id_}')
+                    raise InputError(f'Invalid ID: {id_}') from None
             else:
-                raise InputError(f'Invalid ID: {id_}')
+                raise InputError(f'Invalid ID: {id_}') from None
         is_partial = tokens.get('workflow') and not tokens.get('cycle')
         is_relative = not tokens.get('workflow')
 

--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -328,7 +328,7 @@ def install_workflow(
         # This occurs when the file exists but is _not_ a directory.
         raise WorkflowFilesError(
             f"Cannot install as there is an existing file at {rundir}."
-        )
+        ) from None
     if relink:
         link_runN(rundir)
     rsync_cmd = get_rsync_rund_cmd(source, rundir)
@@ -529,7 +529,7 @@ def parse_cli_sym_dirs(symlink_dirs: str) -> Dict[str, Dict[str, Any]]:
                 'There is an error in --symlink-dirs option:'
                 f' {pair}. Try entering option in the form '
                 '--symlink-dirs=\'log=$DIR, share=$DIR2, ...\''
-            )
+            ) from None
         if key not in possible_symlink_dirs:
             dirs = ', '.join(possible_symlink_dirs)
             raise InputError(

--- a/cylc/flow/install_plugins/log_vc_info.py
+++ b/cylc/flow/install_plugins/log_vc_info.py
@@ -253,7 +253,7 @@ def _run_cmd(
     except FileNotFoundError as exc:
         # This will only be raised if the VCS command is not installed,
         # otherwise Popen() will succeed with a non-zero return code
-        raise VCSNotInstalledError(vcs, exc)
+        raise VCSNotInstalledError(vcs, exc) from None
     if stdout == PIPE:
         out, err = pipe_poller(proc, proc.stdout, proc.stderr)
     else:

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -206,7 +206,7 @@ class RotatingLogFileHandler(logging.FileHandler):
             self.stream.seek(0, 2)
         except ValueError as exc:
             # intended to catch - ValueError: I/O operation on closed file
-            raise SystemExit(exc)
+            raise SystemExit(exc) from None
         return self.stream.tell() + len(msg.encode('utf8')) >= max_bytes
 
     @property

--- a/cylc/flow/main_loop/__init__.py
+++ b/cylc/flow/main_loop/__init__.py
@@ -329,14 +329,14 @@ def load(config, additional_plugins=None):
                 f'No main-loop plugin: "{plugin_name}"\n'
                 + '    Available plugins:\n'
                 + indent('\n'.join(sorted(entry_points)), '        ')
-            )
+            ) from None
         # load plugin
         try:
             module = entry_point.load()
         except Exception as exc:
             raise PluginError(
                 'cylc.main_loop', entry_point.name, exc
-            )
+            ) from None
         # load coroutines
         log = []
         for coro_name, coro in getmembers(module):

--- a/cylc/flow/main_loop/health_check.py
+++ b/cylc/flow/main_loop/health_check.py
@@ -56,4 +56,4 @@ def _check_contact_file(scheduler):
         raise CylcError(
             '%s: contact file corrupted/modified and may be left'
             % workflow_files.get_contact_file_path(scheduler.workflow)
-        )
+        ) from None

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -326,7 +326,7 @@ class WorkflowRuntimeClient(  # type: ignore[misc]
             raise ClientError(
                 error.get('message'),  # type: ignore
                 error.get('traceback'),  # type: ignore
-            )
+            ) from None
 
     def get_header(self) -> dict:
         """Return "header" data to attach to each request for traceability.

--- a/cylc/flow/network/multi.py
+++ b/cylc/flow/network/multi.py
@@ -235,7 +235,7 @@ def _report(
     """
     try:
         ret: List[Tuple[Optional[str], Optional[str], bool]] = []
-        for _mutation_name, mutation_response in response.items():
+        for mutation_response in response.values():
             # extract the result of each mutation result in the response
             success, msg = mutation_response['result'][0]['response']
             out = None

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -750,7 +750,7 @@ class Resolvers(BaseResolvers):
         try:
             meth = COMMANDS[command]
         except KeyError:
-            raise ValueError(f"Command '{command}' not found")
+            raise ValueError(f"Command '{command}' not found") from None
 
         try:
             # Initiate the command. Validation may be performed at this point,

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -271,7 +271,7 @@ def field_name_from_type(
     try:
         return NODE_MAP[named_type.name]
     except KeyError:
-        raise ValueError(f"'{named_type.name}' is not a node type")
+        raise ValueError(f"'{named_type.name}' is not a node type") from None
 
 
 def get_resolvers(info: 'ResolveInfo') -> 'BaseResolvers':

--- a/cylc/flow/network/ssh_client.py
+++ b/cylc/flow/network/ssh_client.py
@@ -90,7 +90,7 @@ class WorkflowRuntimeClient(WorkflowRuntimeClientBase):
                 f"Command exceeded the timeout {timeout}s. "
                 "This could be due to network problems. "
                 "Check the workflow log."
-            )
+            ) from None
 
     def prepare_command(
         self, command: str, args: Optional[dict], timeout: Union[float, str]

--- a/cylc/flow/param_expand.py
+++ b/cylc/flow/param_expand.py
@@ -195,8 +195,9 @@ class NameExpander:
             try:
                 results.append((tmpl % current_values, current_values))
             except KeyError as exc:
-                raise ParamExpandError('parameter %s is not '
-                                       'defined.' % str(exc.args[0]))
+                raise ParamExpandError(
+                    'parameter %s is not ' 'defined.' % str(exc.args[0])
+                ) from None
         else:
             for param_val in params[0][1]:
                 spec_vals[params[0][0]] = param_val
@@ -306,8 +307,8 @@ class NameExpander:
                     used[item] = param_values[item]
                 except KeyError:
                     raise ParamExpandError(
-                        "parameter '%s' undefined in '%s'" % (
-                            item, origin))
+                        "parameter '%s' undefined in '%s'" % (item, origin)
+                    ) from None
 
         # For each parameter substitute the param_tmpl_cfg.
         tmpl = tmpl.format(**self.param_tmpl_cfg)
@@ -425,8 +426,9 @@ class GraphExpander:
                 try:
                     repl = tmpl % param_values
                 except KeyError as exc:
-                    raise ParamExpandError('parameter %s is not '
-                                           'defined.' % str(exc.args[0]))
+                    raise ParamExpandError(
+                        'parameter %s is not ' 'defined.' % str(exc.args[0])
+                    ) from None
                 line = line.replace('<' + p_group + '>', repl)
             if line:
                 line_set.add(line)

--- a/cylc/flow/parsec/config.py
+++ b/cylc/flow/parsec/config.py
@@ -150,10 +150,12 @@ class ParsecConfig:
                         # setting not present in __MANY__ section:
                         key in self.spec.get(*parents)
                     ):
-                        raise ItemNotFoundError(itemstr(parents, key))
+                        raise ItemNotFoundError(
+                            itemstr(parents, key)
+                        ) from None
                     raise InvalidConfigError(
                         itemstr(parents, key), self.spec.name
-                    )
+                    ) from None
                 else:
                     parents.append(key)
 

--- a/cylc/flow/parsec/empysupport.py
+++ b/cylc/flow/parsec/empysupport.py
@@ -66,7 +66,7 @@ def empyprocess(
         raise EmPyError(
             str(exc),
             lines={'<template>': flines[max(lineno - 4, 0): lineno]},
-        )
+        ) from None
     finally:
         interpreter.shutdown()
         xworkflow = xtempl.getvalue()

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -493,8 +493,10 @@ def read_and_proc(
             try:
                 from cylc.flow.parsec.empysupport import empyprocess
             except ImportError:
-                raise ParsecError('EmPy Python package must be installed '
-                                  'to process file: ' + fpath)
+                raise ParsecError(
+                    'EmPy Python package must be installed '
+                    'to process file: ' + fpath
+                ) from None
             flines = empyprocess(
                 fpath, flines, fdir, template_vars
             )
@@ -513,8 +515,10 @@ def read_and_proc(
             try:
                 from cylc.flow.parsec.jinja2support import jinja2process
             except ImportError:
-                raise ParsecError('Jinja2 Python package must be installed '
-                                  'to process file: ' + fpath)
+                raise ParsecError(
+                    'Jinja2 Python package must be installed '
+                    'to process file: ' + fpath
+                ) from None
             flines = jinja2process(
                 fpath, flines, fdir, template_vars
             )

--- a/cylc/flow/parsec/jinja2support.py
+++ b/cylc/flow/parsec/jinja2support.py
@@ -75,7 +75,7 @@ class PyModuleLoader(BaseLoader):
         try:
             mdict = __import__(name, fromlist=['*']).__dict__
         except ImportError:
-            raise TemplateNotFound(name)
+            raise TemplateNotFound(name) from None
 
         # inject module dict into the context of an empty template
         def root_render_func(context, *args, **kwargs):
@@ -297,12 +297,12 @@ def jinja2process(
             exc,
             lines=get_error_lines(fpath, flines),
             filename=filename
-        )
+        ) from None
     except Exception as exc:
         raise Jinja2Error(
             exc,
             lines=get_error_lines(fpath, flines),
-        )
+        ) from None
 
     # Ignore blank lines (lone Jinja2 statements leave blank lines behind)
     return [line for line in lines if line.strip()]

--- a/cylc/flow/parsec/upgrade.py
+++ b/cylc/flow/parsec/upgrade.py
@@ -110,7 +110,7 @@ class upgrader:
                 raise UpgradeError(
                     f'{self.show_keys(keys[:-1], True)}'
                     f' ("{keys[-2]}" should be a [section] not a setting)'
-                )
+                ) from None
         return item
 
     def put_item(self, keys, val):

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -280,7 +280,7 @@ class ParsecValidator:
         try:
             return float(value)
         except ValueError as exc:
-            raise IllegalValueError('float', keys, value, exc=exc)
+            raise IllegalValueError('float', keys, value, exc=exc) from None
 
     @classmethod
     def coerce_float_list(cls, value, keys):
@@ -309,7 +309,7 @@ class ParsecValidator:
         try:
             return int(value)
         except ValueError as exc:
-            raise IllegalValueError('int', keys, value, exc=exc)
+            raise IllegalValueError('int', keys, value, exc=exc) from None
 
     @classmethod
     def coerce_int_list(cls, value, keys):
@@ -480,13 +480,17 @@ class ParsecValidator:
                 try:
                     lvalues.append(type_(item))
                 except ValueError as exc:
-                    raise IllegalValueError('list', keys, item, exc=exc)
+                    raise IllegalValueError(
+                        'list', keys, item, exc=exc
+                    ) from None
             else:
                 # mult * val
                 try:
                     lvalues += int(mult) * [type_(val)]
                 except ValueError as exc:
-                    raise IllegalValueError('list', keys, item, exc=exc)
+                    raise IllegalValueError(
+                        'list', keys, item, exc=exc
+                    ) from None
         return lvalues
 
     @classmethod
@@ -832,7 +836,9 @@ class CylcConfigValidator(ParsecValidator):
                     parser.parse(value)
                 return value
             except IsodatetimeError as exc:
-                raise IllegalValueError('cycle point', keys, value, exc=exc)
+                raise IllegalValueError(
+                    'cycle point', keys, value, exc=exc
+                ) from None
         try:
             TimePointParser().parse(value)
         except IsodatetimeError as exc:
@@ -841,7 +847,9 @@ class CylcConfigValidator(ParsecValidator):
                 details = {'msg': "Invalid cycle point"}
             else:
                 details = {'exc': exc}
-            raise IllegalValueError('cycle point', keys, value, **details)
+            raise IllegalValueError(
+                'cycle point', keys, value, **details
+            ) from None
         return value
 
     @classmethod
@@ -883,7 +891,7 @@ class CylcConfigValidator(ParsecValidator):
             except IsodatetimeError as exc:
                 raise IllegalValueError(
                     'cycle point format', keys, value, exc=exc
-                )
+                ) from None
             return value
         if 'X' in value:
             for i in range(1, 101):
@@ -898,7 +906,9 @@ class CylcConfigValidator(ParsecValidator):
         try:
             dumper.dump(test_timepoint, value)
         except IsodatetimeError as exc:
-            raise IllegalValueError('cycle point format', keys, value, exc=exc)
+            raise IllegalValueError(
+                'cycle point format', keys, value, exc=exc
+            ) from None
         return value
 
     @classmethod
@@ -932,7 +942,7 @@ class CylcConfigValidator(ParsecValidator):
         except ValueError as exc:  # not IsodatetimeError as too specific
             raise IllegalValueError(
                 'cycle point time zone format', keys, value, exc=exc
-            )
+            ) from None
         return value
 
     @classmethod
@@ -951,7 +961,9 @@ class CylcConfigValidator(ParsecValidator):
         try:
             interval = DurationParser().parse(value)
         except IsodatetimeError as exc:
-            raise IllegalValueError("ISO 8601 interval", keys, value, exc=exc)
+            raise IllegalValueError(
+                "ISO 8601 interval", keys, value, exc=exc
+            ) from None
         return DurationFloat(interval.get_seconds())
 
     @classmethod
@@ -1012,8 +1024,11 @@ class CylcConfigValidator(ParsecValidator):
                 except ValueError:
                     if can_only_be == int:
                         raise IllegalValueError(
-                            'parameter', keys, value,
-                            'mixing int range and str')
+                            'parameter',
+                            keys,
+                            value,
+                            'mixing int range and str',
+                        ) from None
                     can_only_be = str
                 items.append(item)
             else:
@@ -1248,7 +1263,8 @@ class BroadcastConfigValidator(CylcConfigValidator):
                 interval = DurationParser().parse(str(DurationFloat(value)))
             except IsodatetimeError as exc:
                 raise IllegalValueError(
-                    "ISO 8601 interval", keys, value, exc=exc)
+                    "ISO 8601 interval", keys, value, exc=exc
+                ) from None
         return DurationFloat(interval.get_seconds())
 
 

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -272,7 +272,7 @@ def make_symlink_dir(path: Union[Path, str], target: Union[Path, str]) -> bool:
         except OSError as exc:
             raise WorkflowFilesError(
                 f"Failed to remove broken symlink {path}\n{exc}"
-            )
+            ) from None
     try:
         target.mkdir(parents=True, exist_ok=False)
     except FileExistsError:
@@ -280,7 +280,7 @@ def make_symlink_dir(path: Union[Path, str], target: Union[Path, str]) -> bool:
             f"Symlink dir target already exists: ({path} ->) {target}\n"
             "Tip: in future, use 'cylc clean' instead of manually deleting "
             "workflow run dirs."
-        )
+        ) from None
 
     # This is needed in case share and share/cycle have the same symlink dir:
     if path.exists():
@@ -291,7 +291,7 @@ def make_symlink_dir(path: Union[Path, str], target: Union[Path, str]) -> bool:
         path.symlink_to(target)
         return True
     except OSError as exc:
-        raise WorkflowFilesError(f"Error when symlinking\n{exc}")
+        raise WorkflowFilesError(f"Error when symlinking\n{exc}") from None
 
 
 def remove_dir_and_target(path: Union[Path, str]) -> None:

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -195,7 +195,8 @@ class Prerequisite:
                 err_msg += (
                     " (could be unmatched parentheses in the graph string?)")
             raise TriggerExpressionError(
-                '"%s":\n%s' % (self.get_raw_conditional_expression(), err_msg))
+                '"%s":\n%s' % (self.get_raw_conditional_expression(), err_msg)
+            ) from None
         return res
 
     def satisfy_me(self, outputs: Iterable['Tokens']) -> 'Set[Tokens]':

--- a/cylc/flow/resources.py
+++ b/cylc/flow/resources.py
@@ -18,7 +18,7 @@
 
 from contextlib import suppress
 from pathlib import Path
-from random import shuffle
+from random import choice
 import shutil
 import sys
 from typing import Optional
@@ -205,12 +205,9 @@ def get_api_key() -> str:
     load over a larger number of keys to prevent hitting the cap with group
     sessions.
     """
-    keys = []
     with open((TUTORIAL_DIR / 'api-keys'), 'r') as api_keys:
-        for api_key in api_keys:
-            keys.append(api_key)
-    shuffle(keys)
-    return keys[0].strip()
+        return choice(list(api_keys)).strip()  # nosec
+        # (the randomness of this choice is not a security concern)
 
 
 def set_api_key(tgt):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -917,7 +917,7 @@ class Scheduler:
         # Remaining unprocessed messages have no corresponding task proxy.
         # For example, if I manually set a running task to succeeded, the
         # proxy can be removed, but the orphaned job still sends messages.
-        for _id, tms in messages.items():
+        for tms in messages.values():
             warn = "Undeliverable task messages received and ignored:"
             for _, msg in tms:
                 warn += f'\n  {msg.job_id}: {msg.severity} - "{msg.message}"'

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -360,7 +360,7 @@ async def run(options: 'Values', workflow_id):
                 # TODO validate showtask?
                 raise InputError(
                     'TASK_ID_GLOB must be in the format: cycle/task'
-                )
+                ) from None
         result = await pclient.async_request('graphql', query_kwargs)
         for wflow in result['workflows']:
             settings = wflow['broadcasts']

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -495,7 +495,7 @@ def _main(
                     raise InputError(
                         f"--rotation {rotation_number} invalid "
                         f"(max value is {len(logs) - 1})"
-                    )
+                    ) from None
             else:
                 raise InputError('Log file not found.')
         else:

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -157,7 +157,7 @@ def parse_timeout(opts: 'Values') -> None:
                 raise InputError(
                     f"Invalid timeout: {opts.remote_timeout}. Must be "
                     "an ISO 8601 duration or number of seconds."
-                )
+                ) from None
         opts.remote_timeout = str(timeout)
 
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -612,7 +612,7 @@ def pycoverage(cmd_args):  # pragma: no cover
             'Could not initiate coverage, likely because Cylc was not '
             'installed in editable mode.'
             '\n\n*****************************\n\n'
-        )
+        ) from None
 
     # start the coverage running
     cov.start()

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -296,4 +296,5 @@ async def dump(workflow_id, options, write=print):
                         write(', '.join(values))
     except Exception as exc:
         raise CylcError(
-            json.dumps(workflows, indent=4) + '\n' + str(exc) + '\n')
+            json.dumps(workflows, indent=4) + '\n' + str(exc) + '\n'
+        ) from None

--- a/cylc/flow/scripts/ext_trigger.py
+++ b/cylc/flow/scripts/ext_trigger.py
@@ -145,7 +145,7 @@ def main(
             LOG.exception(exc)
             LOG.info(MSG_SEND_FAILED, i_try + 1, max_n_tries)
             if i_try == max_n_tries - 1:  # final attempt
-                raise CylcError('send failed')
+                raise CylcError('send failed') from None
             LOG.info(MSG_SEND_RETRY, retry_intvl_secs, options.comms_timeout)
             sleep(retry_intvl_secs)
         else:

--- a/cylc/flow/scripts/get_workflow_contact.py
+++ b/cylc/flow/scripts/get_workflow_contact.py
@@ -49,10 +49,10 @@ def main(parser: COP, options: 'Values', workflow_id: str) -> None:
     )
     try:
         data = load_contact_file(workflow_id)
-    except ServiceFileError:
+    except ServiceFileError as exc:
         raise CylcError(
             f"{workflow_id}: cannot get contact info, workflow not running?"
-        )
+        ) from exc
     else:
         for key, value in sorted(data.items()):
             print("%s=%s" % (key, value))

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -805,7 +805,7 @@ def get_pyproject_toml(dir_: Path) -> Dict[str, Any]:
         try:
             loadeddata = toml_loads(tomlfile.read_text())
         except TOMLDecodeError as exc:
-            raise CylcError(f'pyproject.toml did not load: {exc}')
+            raise CylcError(f'pyproject.toml did not load: {exc}') from None
 
         _tool, _cylc, _lint = LINT_TABLE
         try:

--- a/cylc/flow/scripts/report_timings.py
+++ b/cylc/flow/scripts/report_timings.py
@@ -257,7 +257,7 @@ class TimingSummary:
             raise CylcError(
                 'Cannot import pandas - summary unavailable.'
                 ' try: pip install cylc-flow[report-timings]'
-            )
+            ) from None
         else:
             del pandas
 
@@ -402,5 +402,5 @@ class HTMLTimingSummary(TimingSummary):
         except ImportError:
             raise CylcError(
                 'Cannot import matplotlib - HTML summary unavailable.'
-            )
+            ) from None
         super(HTMLTimingSummary, self)._check_imports()

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -490,7 +490,7 @@ def main(_, options: 'Values', *ids) -> None:
         constraint='mixed',
         max_workflows=1,
     )
-    workflow_id = list(workflow_args)[0]
+    workflow_id = next(iter(workflow_args))
     tokens_list = workflow_args[workflow_id]
 
     if tokens_list and options.task_defs:

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -181,7 +181,8 @@ async def run(
             continue
         except Exception as exc:
             raise WorkflowConfigError(
-                'failed to instantiate task %s: %s' % (name, exc))
+                'failed to instantiate task %s: %s' % (name, exc)
+            ) from None
 
         # force trigger evaluation now
         try:
@@ -189,17 +190,21 @@ async def run(
         except TriggerExpressionError as exc:
             err = str(exc)
             if '@' in err:
-                print(f"ERROR, {name}: xtriggers can't be in conditional"
-                      f" expressions: {err}",
-                      file=sys.stderr)
+                print(
+                    f"ERROR, {name}: xtriggers can't be in conditional"
+                    f" expressions: {err}",
+                    file=sys.stderr,
+                )
             else:
-                print('ERROR, %s: bad trigger: %s' % (name, err),
-                      file=sys.stderr)
-            raise WorkflowConfigError("ERROR: bad trigger")
+                print(
+                    'ERROR, %s: bad trigger: %s' % (name, err), file=sys.stderr
+                )
+            raise WorkflowConfigError("ERROR: bad trigger") from None
         except Exception as exc:
             print(str(exc), file=sys.stderr)
             raise WorkflowConfigError(
-                '%s: failed to evaluate triggers.' % name)
+                '%s: failed to evaluate triggers.' % name
+            ) from None
         if cylc.flow.flags.verbosity > 0:
             print('  + %s ok' % itask.identity)
 

--- a/cylc/flow/scripts/workflow_state.py
+++ b/cylc/flow/scripts/workflow_state.py
@@ -179,7 +179,7 @@ class WorkflowPoller(Poller):
         try:
             tokens = Tokens(self.id_)
         except ValueError as exc:
-            raise InputError(exc)
+            raise InputError(exc) from None
 
         self.workflow_id_raw = tokens.workflow_id
         self.selector = (
@@ -404,7 +404,8 @@ def main(parser: COP, options: 'Values', *ids: str) -> None:
                 options.depr_point = os.environ["CYLC_TASK_CYCLE_POINT"]
             except KeyError:
                 raise InputError(
-                    "--task-point: $CYLC_TASK_CYCLE_POINT is not defined")
+                    "--task-point: $CYLC_TASK_CYCLE_POINT is not defined"
+                ) from None
 
         if options.depr_point is not None:
             id_ += f"//{options.depr_point}"

--- a/cylc/flow/task_id.py
+++ b/cylc/flow/task_id.py
@@ -92,7 +92,8 @@ class TaskID:
         except PointParsingError as exc:
             # (This is only needed to raise a clearer error message).
             raise ValueError(
-                "Invalid cycle point: %s (%s)" % (point_string, exc))
+                "Invalid cycle point: %s (%s)" % (point_string, exc)
+            ) from None
         return point_string
 
     @classmethod

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -870,8 +870,8 @@ class TaskPool:
         if self.active_tasks_changed:
             self.active_tasks_changed = False
             self._active_tasks_list = []
-            for _, itask_id_map in self.active_tasks.items():
-                for __, itask in itask_id_map.items():
+            for itask_id_map in self.active_tasks.values():
+                for itask in itask_id_map.values():
                     self._active_tasks_list.append(itask)
         return self._active_tasks_list
 

--- a/cylc/flow/time_parser.py
+++ b/cylc/flow/time_parser.py
@@ -255,7 +255,7 @@ class CylcTimeParser:
             except CylcMissingContextPointError:
                 raise CylcMissingFinalCyclePointError(
                     "This workflow requires a final cycle point."
-                )
+                ) from None
 
             exclusion_points = []
             # Convert the exclusion strings to ISO8601 points

--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -408,11 +408,11 @@ def online_mutate(mutation, selection):
     except WorkflowStopped:
         raise Exception(
             f'Cannot peform command {mutation} on a stopped workflow'
-        )
+        ) from None
     except (ClientError, ClientTimeout) as exc:
         raise Exception(
             f'Error connecting to workflow: {exc}'
-        )
+        ) from None
 
     request_string = generate_mutation(mutation, variables)
     client(

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -281,7 +281,7 @@ def restricted_evaluator(
                 error_class,
                 f'{exc.msg}: {exc.text}',
                 {'expr': expr}
-            )
+            ) from None
 
         # check against whitelisted types
         try:
@@ -302,7 +302,7 @@ def restricted_evaluator(
                     'error_node': error_node,
                     'error_type': error_node.__class__.__name__,
                 },
-            )
+            ) from None
 
         # run the expresion
         # Note: this may raise runtime errors

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -701,7 +701,9 @@ class WorkflowDatabaseManager:
                 [cls.KEY_CYLC_VERSION]
             ).fetchone()[0]
         except (TypeError, OperationalError):
-            raise ServiceFileError(f"{INCOMPAT_MSG}, or is corrupted.")
+            raise ServiceFileError(
+                f"{INCOMPAT_MSG}, or is corrupted."
+            ) from None
         return parse_version(last_run_ver)
 
     @classmethod

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -426,7 +426,7 @@ def _is_process_running(
         raise CylcError(
             f'Attempt to determine whether workflow is running on {host}'
             ' timed out after 10 seconds.'
-        )
+        ) from None
 
     if proc.returncode == 2:
         # the psutil call failed to gather metrics on the process
@@ -505,7 +505,7 @@ def detect_old_contact_file(
         # this can happen if contact file is from an outdated version of Cylc
         raise ServiceFileError(
             f'Found contact file with incomplete data:\n{exc}.'
-        )
+        ) from None
 
     # check if the workflow process is running ...
     # NOTE: can raise CylcError
@@ -631,7 +631,7 @@ def load_contact_file(id_: str, run_dir=None) -> Dict[str, str]:
         with open(path) as f:
             file_content = f.read()
     except IOError:
-        raise ServiceFileError("Couldn't load contact file")
+        raise ServiceFileError("Couldn't load contact file") from None
     data: Dict[str, str] = {}
     for line in file_content.splitlines():
         key, value = [item.strip() for item in line.split("=", 1)]
@@ -914,7 +914,7 @@ def infer_latest_run(
     try:
         id_ = str(path.relative_to(cylc_run_dir))
     except ValueError:
-        raise ValueError(f"{path} is not in the cylc-run directory")
+        raise ValueError(f"{path} is not in the cylc-run directory") from None
 
     if not path.exists():
         raise InputError(

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -250,12 +250,12 @@ class XtriggerCollator:
         try:
             func = get_xtrig_func(fctx.mod_name, fctx.func_name, fdir)
         except (ImportError, AttributeError) as exc:
-            raise XtriggerConfigError(label, sig_str, exc)
+            raise XtriggerConfigError(label, sig_str, exc) from None
         try:
             sig = signature(func)
         except TypeError as exc:
             # not callable
-            raise XtriggerConfigError(label, sig_str, exc)
+            raise XtriggerConfigError(label, sig_str, exc) from None
 
         sig = cls._handle_sequential_kwarg(label, fctx, sig)
 
@@ -269,7 +269,7 @@ class XtriggerCollator:
                     label, fctx, err
                 )
             else:
-                raise err
+                raise err from None
 
         # Specific xtrigger.validate(), if available.
         # Note arg string templating has not been done at this point.
@@ -293,7 +293,7 @@ class XtriggerCollator:
                     raise XtriggerConfigError(
                         label, sig_str,
                         f"Illegal template in xtrigger: {match}",
-                    )
+                    ) from None
 
         # check for deprecated template variables
         deprecated_variables = template_vars & {
@@ -364,7 +364,7 @@ class XtriggerCollator:
         except Exception as exc:  # Note: catch all errors
             if not isinstance(exc, WorkflowConfigError):
                 LOG.exception(exc)
-            raise XtriggerConfigError(label, signature_str, exc)
+            raise XtriggerConfigError(label, signature_str, exc) from None
 
     # BACK COMPAT: workflow_state_backcompat
     # from: 8.0.0
@@ -390,7 +390,7 @@ class XtriggerCollator:
             bound_args = sig.bind(*fctx.func_args, **fctx.func_kwargs)
         except TypeError:
             # failed signature check for backcompat function
-            raise err  # original signature check error
+            raise
 
         old_sig_str = fctx.get_signature()
         upg_sig_str = "workflow_state({})".format(

--- a/cylc/flow/xtriggers/wall_clock.py
+++ b/cylc/flow/xtriggers/wall_clock.py
@@ -75,4 +75,6 @@ def validate(args: Dict[str, Any]):
     try:
         interval_parse(args["offset"])
     except (ValueError, AttributeError):
-        raise WorkflowConfigError(f"Invalid offset: {args['offset']}")
+        raise WorkflowConfigError(
+            f"Invalid offset: {args['offset']}"
+        ) from None


### PR DESCRIPTION
Small lint fixes for rules not currently covered by our CI, low priority.

Took `ruff` for a spin to see how handy its code fixers are (it's not just a linter, it can fix some issues for you). Some of the fixers are kinda useful, but most the good rules have to be done manually, so turns out they aren't that helpful for us, worth a try, never mind.

Kept a four of the fixes and turned them into this PR. They're mostly small, but [B904](https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/) created a good bit of diff. Long story short, if you're re-raising an exception with a more helpful class/message, you generally want to do `raise Exception(...) from None`, otherwise the context of the exception you're re-raising is included in the traceback which kinda defates the object.

I.E:

```python
from cylc.flow.exceptions import InputError

try:
    # the general exception we are catching
    raise Exception('foo')
except Exception as exc:
    # the specific exception we are raising
    raise InputError('bar')
```

Preserves the parent exception context resulting in a confusing traceback:

```
Traceback (most recent call last):
  File "/var/tmp/tmp.wlysihZu3M/mess.py", line 5, in <module>
    raise Exception('foo')
Exception: foo

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/tmp/tmp.wlysihZu3M/mess.py", line 8, in <module>
    raise InputError('bar')
cylc.flow.exceptions.InputError: bar
```

Whereas:

```python
from cylc.flow.exceptions import InputError

try:
    # the general exception we are catching
    raise Exception('foo')
except Exception as exc:
    # the specific exception we are raising
    raise InputError('bar') from None
```

Chops off the parent context:

```
Traceback (most recent call last):
  File "/var/tmp/tmp.wlysihZu3M/mess.py", line 8, in <module>
    raise InputError('bar') from None
cylc.flow.exceptions.InputError: bar
```

Using `from exc` is the same as the default behaviour (just more explicit).

Raising the whole exception tree is a useful feature for debugging uncaught errors, but not so good for errors we are trying to niceify for users.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.