### PR TITLE
`cylc version --long`: ensure correct path is printed for `cylc` executable

### DIFF
--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -88,7 +88,7 @@ def get_version(long=False):
     from pathlib import Path
     version = f"{__version__}"
     if long:
-        version += f" ({Path(sys.executable).parent.parent})"
+        version += f" ({Path(sys.argv[0])})"
     return version
 
 

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -79,12 +79,7 @@ run_ok "${TEST_NAME_BASE}-id" cylc help id
 
 # Check "cylc version --long" output is correct.
 cylc version --long | head -n 1 > long1
-WHICH="$(command -v cylc)"
-PARENT1="$(dirname "${WHICH}")"
-PARENT2="$(dirname "${PARENT1}")"
-echo "$(cylc version) (${PARENT2})" > long2
-# the concise version of the above is a bash quoting nightmare:
-# echo "$(cylc version) ($(dirname $(dirname $(which cylc))))" > long2
+echo "$(cylc version) ($(command -v cylc))" > long2
 cmp_ok long1 long2
 
 # --help with no DISPLAY


### PR DESCRIPTION
While testing on GH Actions MacOS 14, I found that `sys.executable`/`sys.prefix` gave different locations to `$ command -v cylc`. But `sys.argv[0]` is consistent (tested on Ubuntu too).

On the MacOS 14 runner:

```console
$ cylc version --long
8.3.1.dev (/Library/Frameworks/Python.framework/Versions/3.9)
...
```

```console
$ command -v cylc
/Users/runner/hostedtoolcache/Python/3.9.13/arm64/...
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are updated
- [x] Minor change, no changelog entry needed
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
