### PR TITLE
Log command validation errors

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -761,6 +761,7 @@ class Resolvers(BaseResolvers):
         except Exception as exc:
             # NOTE: keep this exception vague to prevent a bad command taking
             # down the scheduler
+            LOG.warning(f'{log1}\n{exc.__class__.__name__}: {exc}')
             if cylc.flow.flags.verbosity > 1:
                 LOG.exception(exc)  # log full traceback in debug mode
             return (False, str(exc))


### PR DESCRIPTION
Follow up from #6112 

Full exception traceback is reported in debug mode, but nothing gets logged in normal mode which is a tad unhelpful for determining why user's commands failed in retrospect, whoops.

To test, try using this `cylc set` command:

```console
$ cylc vip
$ cylc set <workflow>//1/a --pre=1/a,all
--pre=all must be used alone
```

The error that is returned to the user via the CLI should also be logged in the workflow log like so:

```console
$ cylc cat generic
...
INFO - Pausing the workflow: Paused on start up
WARNING - Command "set" received.
    InputError: --pre=all must be used alone
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.