### PR TITLE
play: print the logo to the user's terminal only

### DIFF
--- a/changes.d/fix.6170.md
+++ b/changes.d/fix.6170.md
@@ -1,0 +1,1 @@
+Fix an issue where the Cylc logo could appear in the workflow log.

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -400,11 +400,11 @@ async def scheduler_cli(
     # upgrade the workflow DB (after user has confirmed upgrade)
     _upgrade_database(db_file)
 
-    # re-execute on another host if required
-    _distribute(options.host, workflow_id_raw, workflow_id, options.color)
-
     # print the start message
     _print_startup_message(options)
+
+    # re-execute on another host if required
+    _distribute(options.host, workflow_id_raw, workflow_id, options.color)
 
     # setup the scheduler
     # NOTE: asyncio.run opens an event loop, runs your coro,
@@ -561,10 +561,14 @@ def _upgrade_database(db_file: Path) -> None:
 
 
 def _print_startup_message(options):
-    """Print the Cylc header including the CLI logo."""
+    """Print the Cylc header including the CLI logo to the user's terminal."""
     if (
         cylc.flow.flags.verbosity > -1
         and (options.no_detach or options.format == 'plain')
+        # don't print the startup message on reinvocation (note
+        # --host=localhost is the best indication we have that reinvokation has
+        # happened)
+        and options.host != 'localhost'
     ):
         print(
             cparse(


### PR DESCRIPTION
Fixes #6166.

We don't have reinvokation tests in CI ATM, so manual testing please. The logo should appear once and only once, in the user's terminal and no where else.

@wxtim, please review and assign (2) when happy.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (no automated testing for this at present).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.