### PR TITLE
workflow_state: reject invalid configurations

### DIFF
--- a/changes.d/6175.fix.md
+++ b/changes.d/6175.fix.md
@@ -1,0 +1,1 @@
+The workflow-state command and xtrigger will now reject invalid polling arguments.

--- a/cylc/flow/scripts/workflow_state.py
+++ b/cylc/flow/scripts/workflow_state.py
@@ -115,7 +115,6 @@ from cylc.flow.dbstatecheck import CylcWorkflowDBChecker
 from cylc.flow.terminal import cli_function
 from cylc.flow.workflow_files import infer_latest_run_from_id
 from cylc.flow.task_state import (
-    TASK_STATUSES_ORDERED,
     TASK_STATUSES_FINAL,
     TASK_STATUSES_ALL,
 )
@@ -178,6 +177,8 @@ class WorkflowPoller(Poller):
         self.alt_cylc_run_dir = alt_cylc_run_dir
         self.old_format = old_format
         self.pretty_print = pretty_print
+        self.is_message = is_message
+        self.is_trigger = is_trigger
 
         try:
             tokens = Tokens(self.id_)
@@ -200,17 +201,6 @@ class WorkflowPoller(Poller):
         self.result: Optional[List[List[str]]] = None
         self._db_checker: Optional[CylcWorkflowDBChecker] = None
 
-        self.is_message = is_message
-        if is_message:
-            self.is_trigger = False
-        else:
-            self.is_trigger = (
-                is_trigger or
-                (
-                    self.selector is not None and
-                    self.selector not in TASK_STATUSES_ORDERED
-                )
-            )
         super().__init__(**kwargs)
 
     def _find_workflow(self) -> bool:

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -19,7 +19,15 @@
 
 from typing import List, Iterable, Set, TYPE_CHECKING
 from cylc.flow.prerequisite import Prerequisite
-from cylc.flow.task_outputs import TaskOutputs
+from cylc.flow.task_outputs import (
+    TASK_OUTPUT_EXPIRED,
+    TASK_OUTPUT_FAILED,
+    TASK_OUTPUT_STARTED,
+    TASK_OUTPUT_SUBMITTED,
+    TASK_OUTPUT_SUBMIT_FAILED,
+    TASK_OUTPUT_SUCCEEDED,
+    TaskOutputs,
+)
 from cylc.flow.wallclock import get_current_time_string
 
 if TYPE_CHECKING:
@@ -144,13 +152,17 @@ TASK_STATUSES_ACTIVE = {
     TASK_STATUS_RUNNING,
 }
 
-# Task statuses that can be manually triggered.
-TASK_STATUSES_TRIGGERABLE = {
-    TASK_STATUS_WAITING,
-    TASK_STATUS_EXPIRED,
-    TASK_STATUS_SUBMIT_FAILED,
-    TASK_STATUS_SUCCEEDED,
-    TASK_STATUS_FAILED,
+# Mapping between task outputs and their corresponding states
+TASK_STATE_MAP = {
+    # status: trigger
+    TASK_STATUS_WAITING: None,
+    TASK_STATUS_EXPIRED: TASK_OUTPUT_EXPIRED,
+    TASK_STATUS_PREPARING: None,
+    TASK_STATUS_SUBMIT_FAILED: TASK_OUTPUT_SUBMIT_FAILED,
+    TASK_STATUS_SUBMITTED: TASK_OUTPUT_SUBMITTED,
+    TASK_STATUS_RUNNING: TASK_OUTPUT_STARTED,
+    TASK_STATUS_FAILED: TASK_OUTPUT_FAILED,
+    TASK_STATUS_SUCCEEDED: TASK_OUTPUT_SUCCEEDED,
 }
 
 

--- a/tests/flakyfunctional/xtriggers/01-workflow_state/flow.cylc
+++ b/tests/flakyfunctional/xtriggers/01-workflow_state/flow.cylc
@@ -8,7 +8,7 @@
     initial cycle point = 2011
     final cycle point = 2016
     [[xtriggers]]
-        upstream = workflow_state("{{UPSTREAM}}//%(point)s/foo:data_ready"):PT1S
+        upstream = workflow_state("{{UPSTREAM}}//%(point)s/foo:data_ready", is_trigger=True):PT1S
    [[graph]]
         P1Y = """
             foo

--- a/tests/functional/shutdown/08-now1/flow.cylc
+++ b/tests/functional/shutdown/08-now1/flow.cylc
@@ -24,7 +24,7 @@
         [[[events]]]
             # wait for the stopping message, sleep a bit, then echo some stuff
             started handlers = """
-                cylc workflow-state %(workflow)s//%(point)s/%(name)s:stopping >/dev/null && sleep 1 && echo 'Hello %(id)s %(event)s'
+                cylc workflow-state %(workflow)s//%(point)s/%(name)s:stopping --triggers >/dev/null && sleep 1 && echo 'Hello %(id)s %(event)s'
             """
         [[[outputs]]]
             stopping = stopping

--- a/tests/functional/workflow-state/05-output.t
+++ b/tests/functional/workflow-state/05-output.t
@@ -27,6 +27,6 @@ workflow_run_ok "${TEST_NAME}" \
     cylc play --reference-test --debug --no-detach "${WORKFLOW_NAME}"
 
 TEST_NAME=${TEST_NAME_BASE}-cli-check
-run_ok "${TEST_NAME}" cylc workflow-state "${WORKFLOW_NAME}//20100101T0000Z/t1:out1" --max-polls=1
+run_ok "${TEST_NAME}" cylc workflow-state "${WORKFLOW_NAME}//20100101T0000Z/t1:out1" --triggers --max-polls=1
 
 purge

--- a/tests/functional/workflow-state/07-message2.t
+++ b/tests/functional/workflow-state/07-message2.t
@@ -29,7 +29,7 @@ workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach "${WORKFLOW_NAME}"
 
 TEST_NAME=${TEST_NAME_BASE}-query
-run_fail "${TEST_NAME}" cylc workflow-state "${WORKFLOW_NAME}//2013/foo:x" --max-polls=1
+run_fail "${TEST_NAME}" cylc workflow-state "${WORKFLOW_NAME}//2013/foo:x" --triggers --max-polls=1
 
 grep_ok "failed after 1 polls" "${TEST_NAME}.stderr"
 

--- a/tests/functional/workflow-state/11-multi.t
+++ b/tests/functional/workflow-state/11-multi.t
@@ -54,15 +54,15 @@ CMD="cylc workflow-state --run-dir=$DBDIR --max-polls=1"
 #   foo|1|[1]|2024-06-05T16:34:02+12:00|2024-06-05T16:34:04+12:00|1|succeeded|0|0
 
 #---------------
-# Test the new-format command line (pre-8.3.0).
+# Test the new-format command line (8.3.0+).
 T=${TEST_NAME_BASE}-cli-c8b
 run_ok "${T}-1" $CMD c8b
 run_ok "${T}-2" $CMD c8b//1
 run_ok "${T}-3" $CMD c8b//1/foo
+run_fail "${T}-4" $CMD c8b//1/foo:waiting
 run_ok "${T}-4" $CMD c8b//1/foo:succeeded
 run_ok "${T}-5" $CMD "c8b//1/foo:the quick brown" --messages
 run_ok "${T}-6" $CMD "c8b//1/foo:x" --triggers
-run_ok "${T}-7" $CMD "c8b//1/foo:x"  # default to trigger if not a status
 run_ok "${T}-8" $CMD c8b//1
 run_ok "${T}-9" $CMD c8b//1:succeeded
 
@@ -86,7 +86,7 @@ run_fail "${T}-2" $CMD "c7//1/foo:the quick brown" --triggers
 run_ok   "${T}-3" $CMD "c7//1/foo:x" --triggers
 
 #---------------
-# Test the old-format command line (8.3.0+).
+# Test the old-format command line (pre-8.3.0).
 T=${TEST_NAME_BASE}-cli-8b-compat
 run_ok "${T}-1" $CMD c8b
 run_ok "${T}-2" $CMD c8b --point=1

--- a/tests/functional/workflow-state/11-multi/flow.cylc
+++ b/tests/functional/workflow-state/11-multi/flow.cylc
@@ -23,7 +23,7 @@
         # Cylc 8 new (from 8.3.0)
         c1 = workflow_state(c8b//1/foo, offset=P0, alt_cylc_run_dir={{ALT}}):PT1S
         c2 = workflow_state(c8b//1/foo:succeeded, offset=P0, alt_cylc_run_dir={{ALT}}):PT1S
-        c3 = workflow_state(c8b//1/foo:x, offset=P0, alt_cylc_run_dir={{ALT}}):PT1S
+        c3 = workflow_state(c8b//1/foo:x, offset=P0, alt_cylc_run_dir={{ALT}}, is_trigger=True):PT1S
         c4 = workflow_state(c8b//1/foo:"the quick brown", offset=P0, is_message=True, alt_cylc_run_dir={{ALT}}):PT1S
 
     [[graph]]

--- a/tests/unit/test_dbstatecheck.py
+++ b/tests/unit/test_dbstatecheck.py
@@ -1,0 +1,44 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from cylc.flow.dbstatecheck import check_polling_config
+from cylc.flow.exceptions import InputError
+
+import pytest
+
+
+def test_check_polling_config():
+    """It should reject invalid or unreliable polling configurations.
+
+    See https://github.com/cylc/cylc-flow/issues/6157
+    """
+    # invalid polling use cases
+    with pytest.raises(InputError, match='No such task state'):
+        check_polling_config('elephant', False, False)
+
+    with pytest.raises(InputError, match='Cannot poll for'):
+        check_polling_config('waiting', False, False)
+
+    with pytest.raises(InputError, match='is not reliable'):
+        check_polling_config('running', False, False)
+
+    # valid polling use cases
+    check_polling_config('started', True, False)
+    check_polling_config('started', False, True)
+
+    # valid query use cases
+    check_polling_config(None, False, True)
+    check_polling_config(None, False, False)

--- a/tests/unit/xtriggers/test_workflow_state.py
+++ b/tests/unit/xtriggers/test_workflow_state.py
@@ -22,7 +22,7 @@ from shutil import copytree, rmtree
 import pytest
 
 from cylc.flow.dbstatecheck import output_fallback_msg
-from cylc.flow.exceptions import WorkflowConfigError
+from cylc.flow.exceptions import WorkflowConfigError, InputError
 from cylc.flow.rundb import CylcWorkflowDAO
 from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.xtriggers.workflow_state import (
@@ -125,8 +125,10 @@ def test_c7_db_back_compat(tmp_run_dir: 'Callable'):
         f'{id_}//2012/mithril:"bag end"', is_message=True
     )
     assert satisfied
-    satisfied, _ = workflow_state(f'{id_}//2012/mithril:pippin')
-    assert not satisfied
+
+    with pytest.raises(InputError, match='No such task state "pippin"'):
+        workflow_state(f'{id_}//2012/mithril:pippin')
+
     satisfied, _ = workflow_state(id_ + '//2012/arkenstone')
     assert not satisfied
 

--- a/tests/unit/xtriggers/test_workflow_state.py
+++ b/tests/unit/xtriggers/test_workflow_state.py
@@ -263,6 +263,8 @@ def test_validate_ok():
     """Validate returns ok with valid args."""
     validate({
         'workflow_task_id': 'foo//1/bar',
+        'is_trigger': False,
+        'is_message': False,
         'offset': 'PT1H',
         'flow_num': 44,
     })
@@ -291,4 +293,34 @@ def test_validate_fail_non_int_flow(flow_num):
             'workflow_task_id': 'foo//1/bar',
             'offset': 'PT1H',
             'flow_num': flow_num,
+        })
+
+
+def test_validate_polling_config():
+    """It should reject invalid or unreliable polling configurations.
+
+    See https://github.com/cylc/cylc-flow/issues/6157
+    """
+    with pytest.raises(WorkflowConfigError, match='No such task state'):
+        validate({
+            'workflow_task_id': 'foo//1/bar:elephant',
+            'is_trigger': False,
+            'is_message': False,
+            'flow_num': 44,
+        })
+
+    with pytest.raises(WorkflowConfigError, match='Cannot poll for'):
+        validate({
+            'workflow_task_id': 'foo//1/bar:waiting',
+            'is_trigger': False,
+            'is_message': False,
+            'flow_num': 44,
+        })
+
+    with pytest.raises(WorkflowConfigError, match='is not reliable'):
+        validate({
+            'workflow_task_id': 'foo//1/bar:submitted',
+            'is_trigger': False,
+            'is_message': False,
+            'flow_num': 44,
         })


### PR DESCRIPTION
* Do not allow users to poll for transient statuses.
* Reject invalid task states.
* Reject polling waiting and preparing tasks (not reliably pollable).
* Closes #6157

(minor bug as upgrade advice encouraged users to adopt invalid configurations which were not subsequently rejected)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.