### PR TITLE
tui: prevent hang on shutdown

### DIFF
--- a/changes.d/fix.6178.md
+++ b/changes.d/fix.6178.md
@@ -1,0 +1,1 @@
+Fix an issue where Tui could hang when closing.

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -216,7 +216,10 @@ def updater_subproc(filters, client_timeout):
         yield updater
     finally:
         updater.terminate()
-        p.join()
+        p.join(4)  # timeout of 4 seconds
+        if p.exitcode is None:
+            # updater did not exit within timeout -> kill it
+            p.terminate()
 
 
 class TuiApp:


### PR DESCRIPTION
It has been reported that Tui can hang on shutdown.

The easiest way to reproduce this is to press "q" as soon as starting Tui. Sometimes this can cause it to hang.

```
$ cylc vip <workflow>
$ cylc tui <workflow>
q
```

This PR adds a timeout on the updater shutdown to prevent any hanging operation stopping Tui from exiting.

This isn't really the "right" way to solve the problem, getting the updater to exit cleanly in all circumstances would be nicer. However, it's a reasonable fail safe and since the updater is a read-only process (i.e. the only "resources" it's managing are Cylc clients which have timeouts built in) there are no ill effects of terminating it.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Not reasonably testable.
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.