### PR TITLE
Tests: fix `contains_ok` UTF-8 issue

### DIFF
--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -386,7 +386,7 @@ contains_ok() {
     local FILE_CONTROL="${2:--}"
     local TEST_NAME
     TEST_NAME="$(basename "${FILE_TEST}")-contains-ok"
-    comm -13 <(sort "${FILE_TEST}") <(sort "${FILE_CONTROL}") \
+    LANG=C comm -13 <(sort "${FILE_TEST}") <(sort "${FILE_CONTROL}") \
         1>"${TEST_NAME}.stdout" 2>"${TEST_NAME}.stderr"
     if [[ -s "${TEST_NAME}.stdout" ]]; then
         mkdir -p "${TEST_LOG_DIR}"


### PR DESCRIPTION
The `comm` command can't tell the difference between ✓ & ⨯ when `$LANG` is set to a UTF-8 setting e.g. `en_US.UTF-8`

See https://stackoverflow.com/q/78678882/3217306

---


Edit: Ah, interesting!

```console
$ cat c.txt
✓
⨯
✓
⨯

$ LANG=en_US.UTF-8 sort c.txt
✓
⨯
✓
⨯

$ LANG=C sort c.txt
✓
✓
⨯
⨯
```

