### PR TITLE
tests/f: make shutdown/08 more explicit

### DIFF
--- a/tests/functional/shutdown/08-now1/flow.cylc
+++ b/tests/functional/shutdown/08-now1/flow.cylc
@@ -7,12 +7,26 @@
 
 [scheduling]
     [[graph]]
-        R1 = t1:finish => t2
+        R1 = t1 => t2
 
 [runtime]
     [[t1]]
-        script = cylc__job__wait_cylc_message_started; cylc stop --now "${CYLC_WORKFLOW_ID}"
+        script = """
+            # wait for the started message to be sent
+            cylc__job__wait_cylc_message_started;
+            # issue the stop command
+            cylc stop --now "${CYLC_WORKFLOW_ID}"
+            # wait for the stop command to be recieved
+            cylc__job__poll_grep_workflow_log 'Command "stop" received'
+            # send a message telling the started handler to exit
+            cylc message -- stopping
+        """
         [[[events]]]
-            started handlers = sleep 10 && echo 'Hello %(id)s %(event)s'
+            # wait for the stopping message, sleep a bit, then echo some stuff
+            started handlers = """
+                cylc workflow-state %(workflow)s//%(point)s/%(name)s:stopping >/dev/null && sleep 1 && echo 'Hello %(id)s %(event)s'
+            """
+        [[[outputs]]]
+            stopping = stopping
     [[t2]]
         script = true


### PR DESCRIPTION
Low priority test improvement for an issue spotted whilst reviewing #6181

* Test relied on an action occurring within an arbitrary sleep period which is potentially flaky.
* Replaced the sleep with a poller to make it more reliable.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.