### PR TITLE
`cylc set` bug fix for new flows

### DIFF
--- a/changes.d/6186.fix.md
+++ b/changes.d/6186.fix.md
@@ -1,0 +1,1 @@
+Fixed bug where using flow numbers with `cylc set` would not work correctly.

--- a/cylc/flow/scripts/set.py
+++ b/cylc/flow/scripts/set.py
@@ -177,7 +177,7 @@ def get_option_parser() -> COP:
     return parser
 
 
-def validate_tokens(tokens_list: Tuple['Tokens']) -> None:
+def validate_tokens(tokens_list: Tuple['Tokens', ...]) -> None:
     """Check the cycles/tasks provided.
 
     This checks that cycle/task selectors have not been provided in the IDs.
@@ -214,7 +214,7 @@ def validate_tokens(tokens_list: Tuple['Tokens']) -> None:
 async def run(
     options: 'Values',
     workflow_id: str,
-    *tokens_list
+    *tokens_list: 'Tokens'
 ):
     validate_tokens(tokens_list)
 

--- a/cylc/flow/scripts/set.py
+++ b/cylc/flow/scripts/set.py
@@ -90,7 +90,7 @@ Examples:
 
 from functools import partial
 import sys
-from typing import Tuple, TYPE_CHECKING
+from typing import Iterable, TYPE_CHECKING
 
 from cylc.flow.exceptions import InputError
 from cylc.flow.network.client_factory import get_client
@@ -177,7 +177,7 @@ def get_option_parser() -> COP:
     return parser
 
 
-def validate_tokens(tokens_list: Tuple['Tokens', ...]) -> None:
+def validate_tokens(tokens_list: Iterable['Tokens']) -> None:
     """Check the cycles/tasks provided.
 
     This checks that cycle/task selectors have not been provided in the IDs.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1578,8 +1578,8 @@ class TaskPool:
 
     def _get_task_history(
         self, name: str, point: 'PointBase', flow_nums: Set[int]
-    ) -> Tuple[bool, int, str, bool]:
-        """Get history of previous submits for this task.
+    ) -> Tuple[int, Optional[str], bool]:
+        """Get submit_num, status, flow_wait for point/name in flow_nums.
 
         Args:
             name: task name
@@ -1587,41 +1587,33 @@ class TaskPool:
             flow_nums: task flow numbers
 
         Returns:
-            never_spawned: if task never spawned before
-            submit_num: submit number of previous submit
-            prev_status: task status of previous sumbit
-            prev_flow_wait: if previous submit was a flow-wait task
+           (submit_num, status, flow_wait)
+           If no matching history, status will be None
 
         """
+        submit_num: int = 0
+        status: Optional[str] = None
+        flow_wait = False
+
         info = self.workflow_db_mgr.pri_dao.select_prev_instances(
             name, str(point)
         )
-        try:
-            submit_num: int = max(s[0] for s in info)
-        except ValueError:
-            # never spawned in any flow
-            submit_num = 0
-            never_spawned = True
-        else:
-            never_spawned = False
-            # (submit_num could still be zero, if removed before submit)
+        with suppress(ValueError):
+            submit_num = max(s[0] for s in info)
 
-        prev_status: str = TASK_STATUS_WAITING
-        prev_flow_wait = False
-
-        for _snum, f_wait, old_fnums, status in info:
+        for _snum, f_wait, old_fnums, old_status in info:
             if set.intersection(flow_nums, old_fnums):
                 # matching flows
-                prev_status = status
-                prev_flow_wait = f_wait
-                if prev_status in TASK_STATUSES_FINAL:
+                status = old_status
+                flow_wait = f_wait
+                if status in TASK_STATUSES_FINAL:
                     # task finished
                     break
                 # Else continue: there may be multiple entries with flow
                 # overlap due to merges (they'll have have same snum and
                 # f_wait); keep going to find the finished one, if any.
 
-        return never_spawned, submit_num, prev_status, prev_flow_wait
+        return submit_num, status, flow_wait
 
     def _load_historical_outputs(self, itask: 'TaskProxy') -> None:
         """Load a task's historical outputs from the DB."""
@@ -1664,40 +1656,32 @@ class TaskPool:
         force: bool = False,
         flow_wait: bool = False,
     ) -> Optional[TaskProxy]:
-        """Return task proxy if not completed in this flow, or if forced.
+        """Return a new task proxy for the given flow if possible.
 
-        If finished previously with flow wait, just try to spawn children.
+        We need to hit the DB for:
+        - submit number
+        - task status
+        - flow-wait
+        - completed outputs (e.g. via "cylc set")
 
-        Note finished tasks may be incomplete, but we don't automatically
-        re-run incomplete tasks in the same flow.
+        If history records a final task status (for this flow):
+        - if not flow wait, don't spawn (return None)
+        - if flow wait, don't spawn (return None) but do spawn children
+        - if outputs are incomplete, don't auto-rerun it (return None)
 
-        For every task spawned, we need a DB lookup for submit number,
-        and flow-wait.
+        Otherwise, spawn the task and load any completed outputs.
 
         """
-        if not self.can_be_spawned(name, point):
-            return None
-
-        never_spawned, submit_num, prev_status, prev_flow_wait = (
+        submit_num, prev_status, prev_flow_wait = (
             self._get_task_history(name, point, flow_nums)
         )
 
-        spawned_but_not_submitted = False
-        if (
-            not never_spawned and
-            not prev_flow_wait and
-            submit_num == 0
-        ):
-            # Task previously spawned but never submitted, which implies:
-            #  - removed before completing any outputs
-            #  - or some outputs were set manually
-            spawned_but_not_submitted = True
-
+        # Create the task proxy with any completed outputs loaded.
         itask = self._get_task_proxy_db_outputs(
             point,
             self.config.get_taskdef(name),
             flow_nums,
-            status=prev_status,
+            status=prev_status or TASK_STATUS_WAITING,
             submit_num=submit_num,
             flow_wait=flow_wait,
         )
@@ -1705,14 +1689,16 @@ class TaskPool:
             return None
 
         if (
-            spawned_but_not_submitted and
-            not itask.state.outputs.get_completed_outputs()
+            prev_status is not None
+            and not itask.state.outputs.get_completed_outputs()
         ):
-            # Task spawned but never submitted and has no completed outputs,
-            # so we can infer it was removed as waiting and not manually set.
-            # Return None to avoid respawning it now (e.g. via a prerequisite
-            # that was not satisfied yet at removal time).
-            # TODO: this test will fail if any outputs were set before removal.
+            # If itask has any history in this flow but no completed outputs
+            # we can infer it was deliberately removed, so don't respawn it.
+            # TODO (follow-up work):
+            # - this logic fails if task removed after some outputs completed
+            # - this is does not conform to future "cylc remove" flow-erasure
+            #   behaviour which would result in respawning of the removed task
+            # See github.com/cylc/cylc-flow/pull/6186/#discussion_r1669727292
             LOG.debug(f"Not respawning {point}/{name} - task was removed")
             return None
 
@@ -1982,6 +1968,7 @@ class TaskPool:
         self.data_store_mgr.delta_task_outputs(itask)
         self.workflow_db_mgr.put_update_task_state(itask)
         self.workflow_db_mgr.put_update_task_outputs(itask)
+        self.workflow_db_mgr.process_queued_ops()
 
     def _set_prereqs_itask(
         self,
@@ -2187,10 +2174,9 @@ class TaskPool:
             if not self.can_be_spawned(name, point):
                 continue
 
-            _, submit_num, _prev_status, prev_fwait = (
+            submit_num, _, prev_fwait = (
                 self._get_task_history(name, point, flow_nums)
             )
-
             itask = TaskProxy(
                 self.tokens,
                 self.config.get_taskdef(name),

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1708,11 +1708,12 @@ class TaskPool:
             spawned_but_not_submitted and
             not itask.state.outputs.get_completed_outputs()
         ):
-            # spawned but never submitted, and has no completed outputs.
-            # This implies it was removed, rather than manually set.
-            # TODO: Detecting removal after completion of some outputs probably
-            # TODO: requires recording removal in the DB (set :expired maybe?).
-            LOG.debug(f"Not spawning {point}/{name} - task was removed")
+            # Task spawned but never submitted and has no completed outputs,
+            # so we can infer it was removed as waiting and not manually set.
+            # Return None to avoid respawning it now (e.g. via a prerequisite
+            # that was not satisfied yet at removal time).
+            # TODO: this test will fail if any outputs were set before removal.
+            LOG.debug(f"Not respawning {point}/{name} - task was removed")
             return None
 
         if prev_status in TASK_STATUSES_FINAL:

--- a/tests/integration/test_dbstatecheck.py
+++ b/tests/integration/test_dbstatecheck.py
@@ -51,18 +51,14 @@ async def checker(
     })
     schd: Scheduler = mod_scheduler(wid, paused_start=False)
     async with mod_run(schd):
-        print("ONE")
         await mod_complete(schd)
-        print("TWO")
         schd.pool.force_trigger_tasks(['1000/good'], ['2'])
         # Allow a cycle of the main loop to pass so that flow 2 can be
         # added to db
         await sleep(1)
-        print("FOU")
         with CylcWorkflowDBChecker(
             'somestring', 'utterbunkum', schd.workflow_db_mgr.pub_path
         ) as _checker:
-            print("FIV")
             yield _checker
 
 

--- a/tests/integration/test_dbstatecheck.py
+++ b/tests/integration/test_dbstatecheck.py
@@ -51,14 +51,18 @@ async def checker(
     })
     schd: Scheduler = mod_scheduler(wid, paused_start=False)
     async with mod_run(schd):
+        print("ONE")
         await mod_complete(schd)
+        print("TWO")
         schd.pool.force_trigger_tasks(['1000/good'], ['2'])
         # Allow a cycle of the main loop to pass so that flow 2 can be
         # added to db
         await sleep(1)
+        print("FOU")
         with CylcWorkflowDBChecker(
             'somestring', 'utterbunkum', schd.workflow_db_mgr.pub_path
         ) as _checker:
+            print("FIV")
             yield _checker
 
 
@@ -73,7 +77,7 @@ def test_basic(checker):
         ['output', '10000101T0000Z', 'succeeded'],
         ['output', '10010101T0000Z', 'succeeded'],
         ['good', '10000101T0000Z', 'waiting', '(flows=2)'],
-    ]
+        ['good', '10010101T0000Z', 'waiting', '(flows=2)'], ]
     assert result == expect
 
 
@@ -131,5 +135,6 @@ def test_flownum(checker):
     result = checker.workflow_state_query(flow_num=2)
     expect = [
         ['good', '10000101T0000Z', 'waiting', '(flows=2)'],
+        ['good', '10010101T0000Z', 'waiting', '(flows=2)'],
     ]
     assert result == expect

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2036,8 +2036,8 @@ async def test_set_future_flow(flow, scheduler, start, log_filter):
     spawned before in an earlier flow.
 
     """
-    # Scenario: set c2:succeeded in a future flow so when b succeeds
-    # in that flow it will spawn c1 but not c2.
+    # Scenario: after flow 1, set c1:succeeded in a future flow so
+    # when b succeeds in the new flow it will spawn c2 but not c1.
     id_ = flow({
         'scheduler': {
             'allow implicit tasks': True
@@ -2045,30 +2045,24 @@ async def test_set_future_flow(flow, scheduler, start, log_filter):
         'scheduling': {
             'cycling mode': 'integer',
             'graph': {
-                'R1': 'a => b => c1 & c2 => z',
+                'R1': 'b => c1 & c2',
             },
         },
     })
     schd: 'Scheduler' = scheduler(id_)
     async with start(schd, level=logging.DEBUG) as log:
 
-        a1 = schd.pool.get_task(IntegerPoint("1"), "a")
-        assert a1, '1/a should have been spawned on startup'
+        assert schd.pool.get_task(IntegerPoint("1"), "b") is not None, '1/b should be spawned on startup'
 
-        # set a:succeeded, b:succeeded, c2:succeeded, and c1:failed, in flow 1
-        schd.pool.set_prereqs_and_outputs(['1/a', '1/b', '1/c2'], prereqs=[], outputs=[], flow=[1])
-        schd.pool.set_prereqs_and_outputs(['1/c1'], prereqs=[], outputs=["failed"], flow=[1])
+        # set b, c1, c2 succeeded in flow 1
+        schd.pool.set_prereqs_and_outputs(['1/b', '1/c1', '1/c2'], prereqs=[], outputs=[], flow=[1])
         schd.workflow_db_mgr.process_queued_ops()
 
-        # set task c2:succeeded in flow 2
-        schd.pool.set_prereqs_and_outputs(['1/c2'], prereqs=[], outputs=[], flow=[2])
+        # set task c1:succeeded in flow 2
+        schd.pool.set_prereqs_and_outputs(['1/c1'], prereqs=[], outputs=[], flow=[2])
         schd.workflow_db_mgr.process_queued_ops()
 
-        # set b:succeeded in flow 2
+        # set b:succeeded in flow 2 and check downstream spawning
         schd.pool.set_prereqs_and_outputs(['1/b'], prereqs=[], outputs=[], flow=[2])
-
-        c1 = schd.pool.get_task(IntegerPoint("1"), "c1")
-        assert c1, '1/c1 (flow 2) should have been spawned after 1/b:succeeded'
-
-        c2 = schd.pool.get_task(IntegerPoint("1"), "c2")
-        assert c2 is None, '1/c2 (flow 2) should not have been spawned after 1/b:succeeded'
+        assert schd.pool.get_task(IntegerPoint("1"), "c1") is None, '1/c1 (flow 2) should not be spawned after 1/b:succeeded'
+        assert schd.pool.get_task(IntegerPoint("1"), "c2") is not None, '1/c2 (flow 2) should be spawned after 1/b:succeeded' 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1893,7 +1893,7 @@ async def test_fast_respawn(
     # attempt to spawn it again
     itask = task_pool.spawn_task("foo", IntegerPoint("1"), {1})
     assert itask is None
-    assert "Not spawning 1/foo - task was removed" in caplog.text
+    assert "Not respawning 1/foo - task was removed" in caplog.text
 
 
 async def test_remove_active_task(
@@ -2019,7 +2019,7 @@ async def test_remove_no_respawn(flow, scheduler, start, log_filter):
         # respawned as a result
         schd.pool.spawn_on_output(b1, TASK_OUTPUT_SUCCEEDED)
         assert log_filter(
-            log, contains='Not spawning 1/z - task was removed'
+            log, contains='Not respawning 1/z - task was removed'
         )
         z1 = schd.pool.get_task(IntegerPoint("1"), "z")
         assert (


### PR DESCRIPTION
Damn it, found a bug in 8.3.0 for `cylc set --flow=new` on future tasks: the task_outputs table won't be updated because of "WHERE flow is n" in the DB statement.

From: https://github.com/hjoliver/ecox-interventions?tab=readme-ov-file#scenario-2-rerun-some-tasks-from-upstream-of-a-failed-task

Example:
```ini
[task parameters]
    m = 1..3
[scheduling]
    [[graph]]
        R1 = "a => b => c<m> => d"
[runtime]
    [[root]]
        pre-script = sleep 5
    [[a, b, d]]
    [[c<m>]]
    [[c<m=2>]]
        script = """
            if (( CYLC_TASK_SUBMIT_NUMBER == 1 )); then
                false
            fi
        """
```
The scenario:
- `1/c_m2` fails, stalling the workflow due to a corrupted output from `1/b`
- want to rerun `1/b` and `1/c_m2`, but not `1/c_m1, m3`, then continue to `1/d` and finish

Method: 
- run a new flow (2) from `1/b` after setting `1/c_m1, m3` to succeeded in the new flow

1. `cylc set test //1/c_m1 //1/c_m2 --flow=2`
2. `cylc trigger test//1/b --flow=2`

On master this reruns `1/c_m1` and `1/c_m3` because the `set` outputs don't end up in the DB.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
