### PR TITLE
Allow manual trigger when workflow paused.

### DIFF
--- a/changes.d/6192.feat.md
+++ b/changes.d/6192.feat.md
@@ -1,0 +1,1 @@
+All manual triggering of tasks when the workflow is paused.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -329,7 +329,7 @@ async def reload_workflow(schd: 'Scheduler'):
 
     # flush out preparing tasks before attempting reload
     schd.reload_pending = 'waiting for pending tasks to submit'
-    while schd.release_queued_tasks():
+    while schd.release_tasks_to_run():
         # Run the subset of main-loop functionality required to push
         # preparing through the submission pipeline and keep the workflow
         # responsive (e.g. to the `cylc stop` command).
@@ -437,9 +437,12 @@ async def force_trigger_tasks(
     flow: List[str],
     flow_wait: bool = False,
     flow_descr: Optional[str] = None,
+    now: bool = False
 ):
     """Manual task trigger."""
     validate.is_tasks(tasks)
     validate.flow_opts(flow, flow_wait)
     yield
-    yield schd.pool.force_trigger_tasks(tasks, flow, flow_wait, flow_descr)
+    yield schd.pool.force_trigger_tasks(
+        tasks, flow, flow_wait, flow_descr, now
+    )

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2156,7 +2156,12 @@ class Trigger(Mutation, TaskMutation):
         resolver = partial(mutator, command='force_trigger_tasks')
 
     class Arguments(TaskMutation.Arguments, FlowMutationArguments):
-        ...
+        now = Boolean(
+            default_value=False,
+            description=sstrip('''
+                Trigger now, even if the workflow is paused.
+            ''')
+        )
 
 
 def _mut_field(cls):

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2143,7 +2143,7 @@ class SetPrereqsAndOutputs(Mutation, TaskMutation):
 class Trigger(Mutation, TaskMutation):
     class Meta:
         description = sstrip('''
-            Manually trigger tasks.
+            Manually trigger tasks, even in a paused workflow.
 
             Warning: waiting tasks that are queue-limited will be queued if
             triggered, to submit as normal when released by the queue; queued

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -478,6 +478,7 @@ class Scheduler:
                 get_workflow_test_log_path(self.workflow)))
 
         self.pool = TaskPool(
+            self.start_job_submission,
             self.tokens,
             self.config,
             self.workflow_db_mgr,
@@ -1317,9 +1318,13 @@ class Scheduler:
         # Return, if no tasks to submit.
         else:
             return False
+
         if not pre_prep_tasks:
             return False
 
+        return self.start_job_submission(pre_prep_tasks)
+
+    def start_job_submission(self, pre_prep_tasks) -> bool:
         # Start the job submission process.
         self.is_updated = True
         self.reset_inactivity_timer()

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1291,7 +1291,8 @@ class Scheduler:
 
         """
         if (
-            self.stop_mode is None
+            not self.is_paused
+            and self.stop_mode is None
             and self.auto_restart_time is None
             and self.reload_pending is False
         ):
@@ -1959,7 +1960,7 @@ class Scheduler:
         if msg:
             _msg += f': {msg}'
         LOG.info(_msg)
-        self.is_paused = self.pool.task_queue_mgr.is_paused = True
+        self.is_paused = True
         self.workflow_db_mgr.put_workflow_paused(True)
         self.update_data_store()
 
@@ -1981,7 +1982,7 @@ class Scheduler:
             return
         if not quiet:
             LOG.info("RESUMING the workflow now")
-        self.is_paused = self.pool.task_queue_mgr.is_paused = False
+        self.is_paused = False
         self.workflow_db_mgr.put_workflow_paused(False)
         self.update_data_store()
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1291,8 +1291,7 @@ class Scheduler:
 
         """
         if (
-            not self.is_paused
-            and self.stop_mode is None
+            self.stop_mode is None
             and self.auto_restart_time is None
             and self.reload_pending is False
         ):
@@ -1960,7 +1959,7 @@ class Scheduler:
         if msg:
             _msg += f': {msg}'
         LOG.info(_msg)
-        self.is_paused = True
+        self.is_paused = self.pool.task_queue_mgr.is_paused = True
         self.workflow_db_mgr.put_workflow_paused(True)
         self.update_data_store()
 
@@ -1982,7 +1981,7 @@ class Scheduler:
             return
         if not quiet:
             LOG.info("RESUMING the workflow now")
-        self.is_paused = False
+        self.is_paused = self.pool.task_queue_mgr.is_paused = False
         self.workflow_db_mgr.put_workflow_paused(False)
         self.update_data_store()
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1324,8 +1324,15 @@ class Scheduler:
 
         return self.start_job_submission(pre_prep_tasks)
 
-    def start_job_submission(self, pre_prep_tasks) -> bool:
-        # Start the job submission process.
+    def start_job_submission(self, itasks: 'Iterable[TaskProxy]') -> bool:
+        """Start the job submission process for some tasks.
+
+        Return True if any were started, else False.
+
+        """
+        if self.stop_mode is not None:
+            return False
+
         self.is_updated = True
         self.reset_inactivity_timer()
 
@@ -1338,7 +1345,7 @@ class Scheduler:
 
         for itask in self.task_job_mgr.submit_task_jobs(
             self.workflow,
-            pre_prep_tasks,
+            itasks,
             self.server.curve_auth,
             self.server.client_pub_key_dir,
             is_simulation=(self.get_run_mode() == RunMode.SIMULATION)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -742,10 +742,10 @@ class Scheduler:
                 self.uuid_str = dict(params)['uuid_str']
             else:
                 self.uuid_str = str(uuid4())
+            self.task_events_mgr.uuid_str = self.uuid_str
 
             self._configure_contact()
             await self.configure(params)
-            self.task_events_mgr.uuid_str = self.uuid_str
         except (KeyboardInterrupt, asyncio.CancelledError, Exception) as exc:
             await self.handle_exception(exc)
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1335,6 +1335,7 @@ class Scheduler:
         log = LOG.debug
         if self.options.reftest or self.options.genref:
             log = LOG.info
+
         for itask in self.task_job_mgr.submit_task_jobs(
             self.workflow,
             pre_prep_tasks,

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,7 +17,7 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-Force tasks to run regardless of prerequisites.
+Force tasks to run regardless of prerequisites, even in a paused worklfow.
 
 * Triggering an unqueued waiting task queues it, regardless of prerequisites.
 * Triggering a queued task submits it, regardless of queue limiting.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2151,7 +2151,7 @@ class TaskPool:
                 itask.state_reset(is_queued=True)
                 self.data_store_mgr.delta_task_state(itask)
 
-        # else release it from the queue run now
+        # else release it from the queue to run now
         elif self.task_queue_mgr.force_release_task(itask):
             itask.state_reset(is_queued=False)
             self.data_store_mgr.delta_task_state(itask)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2166,7 +2166,8 @@ class TaskPool:
         self.check_spawn_psx_task(itask)
 
     def force_trigger_tasks(
-        self, items: Iterable[str],
+        self,
+        items: Iterable[str],
         flow: List[str],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -457,14 +457,9 @@ class TaskProxy:
     def is_ready_to_run(self) -> Tuple[bool, ...]:
         """Is this task ready to run?
 
-        Takes account of all dependence: on other tasks, xtriggers, and
-        old-style ext-triggers. Or, manual triggering.
+        Return True if not held, no active try timers, and prerequisites done.
 
         """
-        if self.is_manual_submit:
-            # Manually triggered tasks are run by this mechansim.
-            # TODO GET RID OF THIS
-            return (False,)
         if self.state.is_held:
             # A held task is not ready to run.
             return (False,)

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -462,8 +462,9 @@ class TaskProxy:
 
         """
         if self.is_manual_submit:
-            # Manually triggered, ignore unsatisfied prerequisites.
-            return (True,)
+            # Manually triggered tasks are run by this mechansim.
+            # TODO GET RID OF THIS
+            return (False,)
         if self.state.is_held:
             # A held task is not ready to run.
             return (False,)

--- a/cylc/flow/task_queues/__init__.py
+++ b/cylc/flow/task_queues/__init__.py
@@ -40,12 +40,12 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
            * descendants: runtime family dict
 
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def push_task(self, itask: 'TaskProxy') -> None:
         """Queue the given task."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def push_task_if_limited(
@@ -56,17 +56,17 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
         Requires current active task counts.
         Return True if queued, else False.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def release_tasks(self, active: Counter[str]) -> 'List[TaskProxy]':
         """Release tasks, given current active task counts."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def remove_task(self, itask: 'TaskProxy') -> bool:
         """Try to remove a task from the queues. Return True if done."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def force_release_task(self, itask: 'TaskProxy') -> bool:
@@ -74,12 +74,12 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
 
         Return True if released, else False
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt tasks with defs removed by scheduler reload or restart."""
-        pass
+        raise NotImplementedError
 
     def _expand_families(self,
                          qconfig: dict,

--- a/cylc/flow/task_queues/__init__.py
+++ b/cylc/flow/task_queues/__init__.py
@@ -48,6 +48,17 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def push_task_if_limited(
+            self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Queue the task only if the queue limit is reached.
+
+        Requires current active task counts.
+        Return True if queued, else False.
+        """
+        pass
+
+    @abstractmethod
     def release_tasks(self, active: Counter[str]) -> 'List[TaskProxy]':
         """Release tasks, given current active task counts."""
         pass
@@ -58,10 +69,10 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def force_release_task(self, itask: 'TaskProxy') -> None:
+    def force_release_task(self, itask: 'TaskProxy') -> bool:
         """Remove a task from whichever queue it belongs to.
 
-        To be returned when release_tasks() is next called.
+        Return True if released, else False
         """
         pass
 

--- a/cylc/flow/task_queues/independent.py
+++ b/cylc/flow/task_queues/independent.py
@@ -40,6 +40,21 @@ class LimitedTaskQueue:
         if itask.tdef.name in self.members:
             self.deque.appendleft(itask)
 
+    def push_task_if_limited(
+        self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Queue task if in my membership and the queue limit is reached."""
+        n_active: int = 0
+        for mem in self.members:
+            n_active += active[mem]
+        if (
+            self.limit and n_active >= self.limit
+            and itask.tdef.name in self.members
+        ):
+            self.deque.appendleft(itask)
+            return True
+        return False
+
     def release(self, active: Counter[str]) -> List['TaskProxy']:
         """Release tasks if below the active limit."""
         # The "active" argument counts active tasks by name.
@@ -113,34 +128,37 @@ class IndepQueueManager(TaskQueueManagerBase):
                 config["limit"], config["members"]
             )
 
-        self.force_released: Set['TaskProxy'] = set()
-
     def push_task(self, itask: 'TaskProxy') -> None:
         """Push a task to the appropriate queue."""
         for queue in self.queues.values():
             queue.push_task(itask)
+
+    def push_task_if_limited(
+        self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Push a task to its queue only if the queue limit is reached."""
+        return any(
+            queue.push_task_if_limited(itask, active)
+            for queue in self.queues.values()
+        )
 
     def release_tasks(self, active: Counter[str]) -> List['TaskProxy']:
         """Release tasks up to the queue limits."""
         released: List['TaskProxy'] = []
         for queue in self.queues.values():
             released += queue.release(active)
-        if self.force_released:
-            released.extend(self.force_released)
-            self.force_released = set()
         return released
 
     def remove_task(self, itask: 'TaskProxy') -> bool:
         """Try to remove a task from the queues. Return True if done."""
         return any(queue.remove(itask) for queue in self.queues.values())
 
-    def force_release_task(self, itask: 'TaskProxy') -> None:
+    def force_release_task(self, itask: 'TaskProxy') -> bool:
         """Remove a task from whichever queue it belongs to.
 
-        To be returned when release_tasks() is next called.
+        Return True if released, else False.
         """
-        if self.remove_task(itask):
-            self.force_released.add(itask)
+        return self.remove_task(itask)
 
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt orphaned tasks to the default group."""

--- a/tests/functional/restart/58-waiting-manual-triggered.t
+++ b/tests/functional/restart/58-waiting-manual-triggered.t
@@ -40,6 +40,7 @@ __EOF__
 
 # It should restart and shut down normally, not stall with 2/foo waiting on 1/foo.
 workflow_run_ok "${TEST_NAME_BASE}-restart" cylc play --no-detach "${WORKFLOW_NAME}"
+
 # Check that 2/foo job 02 did run before shutdown.
 grep_workflow_log_ok "${TEST_NAME_BASE}-grep" "\[2\/foo\/02:running\] => succeeded"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,7 @@ from cylc.flow.util import serialise_set
 from cylc.flow.wallclock import get_current_time_string
 from cylc.flow.workflow_files import infer_latest_run_from_id
 from cylc.flow.workflow_status import StopMode
+from cylc.flow.task_state import TASK_STATUS_SUBMITTED
 
 from .utils import _rm_if_empty
 from .utils.flow_tools import (
@@ -403,6 +404,8 @@ def capture_submission():
 
         def _submit_task_jobs(_, itasks, *args, **kwargs):
             nonlocal submitted_tasks
+            for itask in itasks:
+                itask.state_reset(TASK_STATUS_SUBMITTED)
             submitted_tasks.update(itasks)
             return itasks
 

--- a/tests/integration/scripts/test_dump.py
+++ b/tests/integration/scripts/test_dump.py
@@ -46,7 +46,7 @@ async def test_dump_tasks(flow, scheduler, start):
     })
     schd = scheduler(id_)
     async with start(schd):
-        # schd.release_queued_tasks()
+        # schd.release_tasks_to_run()
         await schd.update_data_structure()
         ret = []
         await dump(

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -396,7 +396,7 @@ async def test_flow_numbers(flow, scheduler, start):
         assert ds_task.flow_nums == '[1]'
 
         # force trigger the task in a new flow
-        schd.pool.force_trigger_tasks(['1/b'], ['2'])
+        schd.pool.force_trigger_tasks(['1/b'], ['2'], now=True)
 
         # update the data store
         await schd.update_data_structure()

--- a/tests/integration/test_dbstatecheck.py
+++ b/tests/integration/test_dbstatecheck.py
@@ -55,7 +55,7 @@ async def checker(
         await mod_complete(schd)
 
         # trigger a new task in flow 2
-        schd.pool.force_trigger_tasks(['1000/good'], ['2'])
+        schd.pool.force_trigger_tasks(['1000/good'], ['2'], now=True)
 
         # update the database
         schd.process_workflow_db_queue()

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -65,22 +65,26 @@ async def test_trigger_workflow_paused(
         assert len(submitted_tasks) == 0
 
         # manually trigger 1/x - it should be submitted
-        schd.pool.force_trigger_tasks(['1/x'], [1])
+        schd.pool.force_trigger_tasks(['1/x'], [1], now=True)
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 1
 
         # manually trigger 1/y - it should not be submitted
         # (the queue limit is 1)
-        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.pool.force_trigger_tasks(['1/y'], [1], now=True)
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 1
 
         # manually trigger 1/y again - it should be submitted
         # (triggering a queued task runs it regardless of queue limit)
-        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.pool.force_trigger_tasks(['1/y'], [1], now=True)
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 2
 
         # manually trigger 1/y yet again - the trigger should be ignored
         # (task already active)
-        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.pool.force_trigger_tasks(['1/y'], [1], now=True)
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 2
         assert log_filter(
             log, level=logging.ERROR,

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -29,7 +29,7 @@ async def test_trigger_workflow_paused(
     log_filter: Callable
 ):
     """
-    Tasks can be trigger manually when the workflow is paused.
+    Test manual triggering when the workflow is paused.
 
     The usual queue limiting behaviour is expected.
 
@@ -60,20 +60,27 @@ async def test_trigger_workflow_paused(
 
         # capture task submissions (prevents real submissions)
         submitted_tasks = capture_submission(schd)
+
+        # paused at start-up so no tasks should be submitted
         assert len(submitted_tasks) == 0
 
+        # manually trigger 1/x - it should be submitted
         schd.pool.force_trigger_tasks(['1/x'], [1])
         assert len(submitted_tasks) == 1
 
+        # manually trigger 1/y - it should not be submitted
+        # (the queue limit is 1)
         schd.pool.force_trigger_tasks(['1/y'], [1])
         assert len(submitted_tasks) == 1
 
+        # manually trigger 1/y again - it should not be submitted
         schd.pool.force_trigger_tasks(['1/y'], [1])
         assert len(submitted_tasks) == 2
 
+        # manually trigger 1/y yet again - the trigger should be ignored
+        # (task already active)
         schd.pool.force_trigger_tasks(['1/y'], [1])
         assert len(submitted_tasks) == 2
-
         assert log_filter(
             log, level=logging.ERROR,
             contains="ignoring trigger - already active"

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -73,7 +73,8 @@ async def test_trigger_workflow_paused(
         schd.pool.force_trigger_tasks(['1/y'], [1])
         assert len(submitted_tasks) == 1
 
-        # manually trigger 1/y again - it should not be submitted
+        # manually trigger 1/y again - it should be submitted
+        # (triggering a queued task runs it regardless of queue limit)
         schd.pool.force_trigger_tasks(['1/y'], [1])
         assert len(submitted_tasks) == 2
 

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -1,0 +1,80 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import (
+    Any as Fixture,
+    Callable
+)
+
+import logging
+
+async def test_trigger_workflow_paused(
+    flow: 'Fixture',
+    scheduler: 'Fixture',
+    start: 'Fixture',
+    capture_submission: 'Fixture',
+    log_filter: Callable
+):
+    """
+    Tasks can be trigger manually when the workflow is paused.
+
+    The usual queue limiting behaviour is expected.
+
+    https://github.com/cylc/cylc-flow/issues/6192
+
+    """
+    id_ = flow({
+        'scheduler': {
+            'allow implicit tasks': True,
+        },
+        'scheduling': {
+            'queues': {
+                'default': {
+                    'limit': 1,
+                },
+            },
+            'graph': {
+                'R1': '''
+                    a => x & y & z
+                ''',
+            },
+        },
+    })
+    schd = scheduler(id_, paused_start=True)
+
+    # start the scheduler (but don't set the main loop running)
+    async with start(schd) as log:
+
+        # capture task submissions (prevents real submissions)
+        submitted_tasks = capture_submission(schd)
+        assert len(submitted_tasks) == 0
+
+        schd.pool.force_trigger_tasks(['1/x'], [1])
+        assert len(submitted_tasks) == 1
+
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        assert len(submitted_tasks) == 1
+
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        assert len(submitted_tasks) == 2
+
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        assert len(submitted_tasks) == 2
+
+        assert log_filter(
+            log, level=logging.ERROR,
+            contains="ignoring trigger - already active"
+        )

--- a/tests/integration/test_optional_outputs.py
+++ b/tests/integration/test_optional_outputs.py
@@ -193,7 +193,7 @@ async def test_expire_orthogonality(flow, scheduler, start):
 
         # wait for the task to submit
         while not a_1.state(TASK_STATUS_WAITING, TASK_STATUS_PREPARING):
-            schd.release_queued_tasks()
+            schd.release_tasks_to_run()
 
         # NOTE: The submit number isn't presently incremented via this code
         # pathway so we have to hack it here. If the task messages in this test
@@ -425,7 +425,7 @@ async def test_clock_expiry(
         two.state_reset(TASK_STATUS_PREPARING)
 
         # the third task (force-triggered)
-        schd.pool.force_trigger_tasks(['20100101T0000Z/x'], ['1'])
+        schd.pool.force_trigger_tasks(['20100101T0000Z/x'], ['1'], now=True)
         three = schd.pool.get_task(ISO8601Point('20100101T0000Z'), 'x')
         assert three
 

--- a/tests/integration/test_queues.py
+++ b/tests/integration/test_queues.py
@@ -87,13 +87,13 @@ async def test_queue_release(
         # (if scheduler is paused we should not have any submissions)
         # (otherwise a number of tasks up to the limit should be released)
         schd.pool.release_runahead_tasks()
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == expected_submissions
 
         for _ in range(3):
             # release runahead/queued tasks
             # (no further tasks should be released)
-            schd.release_queued_tasks()
+            schd.release_tasks_to_run()
             assert len(submitted_tasks) == expected_submissions
 
 
@@ -125,7 +125,7 @@ async def test_queue_held_tasks(
 
         # release queued tasks
         # (no tasks should be released from the queues because they are held)
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 0
 
         # un-hold tasks
@@ -133,5 +133,5 @@ async def test_queue_held_tasks(
 
         # release queued tasks
         # (tasks should now be released from the queues)
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 1

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -170,7 +170,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
         # release runahead/queued tasks
         # (nothing should happen because the scheduler is paused)
         one.pool.release_runahead_tasks()
-        one.release_queued_tasks()
+        one.release_tasks_to_run()
         assert submitted_tasks == set()
 
         # hold all tasks & resume the workflow
@@ -179,7 +179,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
 
         # release queued tasks
         # (there should be no change because the task is still held)
-        one.release_queued_tasks()
+        one.release_tasks_to_run()
         assert submitted_tasks == set()
 
         # release all tasks
@@ -187,7 +187,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
 
         # release queued tasks
         # (the task should be submitted)
-        one.release_queued_tasks()
+        one.release_tasks_to_run()
         assert len(submitted_tasks) == 1
 
 
@@ -387,7 +387,7 @@ async def test_restart_timeout(
         assert log_filter(log, contains='restart timer starts NOW')
 
         # when we trigger tasks the timeout should be cleared
-        schd.pool.force_trigger_tasks(['1/one'], {1})
+        schd.pool.force_trigger_tasks(['1/one'], {1}, now=True)
 
         # allow time for the log to update
         await asyncio.sleep(3)

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -97,7 +97,7 @@ async def test_trigger(sequential, start):
         assert list_cycles(sequential) == ['2000']
 
         foo = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
-        sequential.pool.force_trigger_tasks([foo.identity], {1})
+        sequential.pool.force_trigger_tasks([foo.identity], {1}, now=True)
         foo.state_reset('succeeded')
         sequential.pool.spawn_on_output(foo, 'succeeded')
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2182,47 +2182,6 @@ async def test_reload_xtriggers(flow, scheduler, start):
             'c': 'wall_clock(trigger_time=946688400)',
         }
 
-        
-async def test_trigger_unqueued(flow, scheduler, start):
-    """Test triggering an unqueued active task.
-
-    It should not add to the force_released list.
-    See https://github.com/cylc/cylc-flow/pull/6337
-
-    """
-    conf = {
-        'scheduler': {'allow implicit tasks': 'True'},
-        'scheduling': {
-            'graph': {
-                'R1': 'a & b => c'
-            }
-        }
-    }
-    schd = scheduler(
-        flow(conf),
-        run_mode='simulation',
-        paused_start=False
-    )
-
-    async with start(schd):
-        # Release tasks 1/a and 1/b
-        schd.pool.release_runahead_tasks()
-        schd.release_queued_tasks()
-        assert pool_get_task_ids(schd.pool) == ['1/a', '1/b']
-
-        # Mark 1/a as succeeded and spawn 1/c
-        task_a = schd.pool.get_task(IntegerPoint("1"), "a")
-        schd.pool.task_events_mgr.process_message(task_a, 1, 'succeeded')
-        assert pool_get_task_ids(schd.pool) == ['1/b', '1/c']
-
-        # Trigger the partially satisified (and not queued) task 1/c
-        schd.pool.force_trigger_tasks(['1/c'], [FLOW_ALL])
-
-        # It should not add to the queue managers force_released list.
-        assert not schd.pool.task_queue_mgr.force_released, (
-            "Triggering an unqueued task should not affect the force_released list"
-        )
-
 
 @pytest.mark.parametrize('expire_type', ['clock-expire', 'manual'])
 async def test_expire_dequeue_with_retries(flow, scheduler, start, expire_type):

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -511,7 +511,7 @@ async def test_trigger_states(
         task.state.reset(status)
 
         # try triggering the task
-        one.pool.force_trigger_tasks(['1/one'], [FLOW_ALL])
+        one.pool.force_trigger_tasks(['1/one'], [FLOW_ALL], now=True)
 
         # check whether the task triggered
         assert task.is_manual_submit == should_trigger
@@ -705,7 +705,7 @@ async def test_restart_prereqs(
     async with start(schd):
         # Release tasks 1/a and 1/b
         schd.pool.release_runahead_tasks()
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert list_tasks(schd) == expected_1
 
         # Mark 1/a as succeeded and spawn 1/z
@@ -828,7 +828,7 @@ async def test_reload_prereqs(
     async with start(schd):
         # Release tasks 1/a and 1/b
         schd.pool.release_runahead_tasks()
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert list_tasks(schd) == expected_1
 
         # Mark 1/a as succeeded and spawn 1/z
@@ -865,7 +865,7 @@ async def _test_restart_prereqs_sat():
 
     # Release tasks 1/a and 1/b
     schd.pool.release_runahead_tasks()
-    schd.release_queued_tasks()
+    schd.release_tasks_to_run()
     assert list_tasks(schd) == [
         ('1', 'a', 'running'),
         ('1', 'b', 'running')
@@ -1973,7 +1973,7 @@ async def test_remove_by_suicide(
 
         # ensure that we are able to bring 1/b back by triggering it
         log.clear()
-        schd.pool.force_trigger_tasks(['1/b'], ['1'])
+        schd.pool.force_trigger_tasks(['1/b'], ['1'], now=True)
         assert log_filter(
             log,
             regex='1/b.*added to active task pool',
@@ -1988,7 +1988,7 @@ async def test_remove_by_suicide(
 
         # ensure that we are able to bring 1/b back by triggering it
         log.clear()
-        schd.pool.force_trigger_tasks(['1/b'], ['1'])
+        schd.pool.force_trigger_tasks(['1/b'], ['1'], now=True)
         assert log_filter(
             log,
             regex='1/b.*added to active task pool',
@@ -2095,7 +2095,7 @@ async def test_trigger_queue(one, run, db_select, complete):
         assert task.flow_nums == {1}
 
         # trigger this task even though is already queued in flow 1
-        one.pool.force_trigger_tasks([task.identity], '2')
+        one.pool.force_trigger_tasks([task.identity], '2', now=True)
 
         # the merged flow should continue
         one.resume_workflow()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -111,6 +111,8 @@ def test_release_queued_tasks__auto_restart():
     # Should not actually release any more tasks, just submit the
     # preparing ones
     mock_schd.pool.release_queued_tasks.assert_not_called()
+
+    Scheduler.start_job_submission(mock_schd, mock_schd.pool.get_tasks())
     mock_schd.task_job_mgr.submit_task_jobs.assert_called()
 
 

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -91,8 +91,8 @@ def test_should_auto_restart_now(
     assert Scheduler.should_auto_restart_now(mock_schd) == expected
 
 
-def test_release_queued_tasks__auto_restart():
-    """Test that Scheduler.release_queued_tasks() works as expected
+def test_release_tasks_to_run__auto_restart():
+    """Test that Scheduler.release_tasks_to_run() works as expected
     during auto restart."""
     mock_schd = Mock(
         auto_restart_time=(time() - 100),
@@ -107,7 +107,7 @@ def test_release_queued_tasks__auto_restart():
         options=RunOptions(),
         task_job_mgr=MagicMock()
     )
-    Scheduler.release_queued_tasks(mock_schd)
+    Scheduler.release_tasks_to_run(mock_schd)
     # Should not actually release any more tasks, just submit the
     # preparing ones
     mock_schd.pool.release_queued_tasks.assert_not_called()


### PR DESCRIPTION
Close #5963 

I've added the "question" label because there's some disagreement on the issue itself:

@oliver-sanders has argued that manual triggering (i.e., with immediate effect) should only be allowed with `cylc hold */*` (hold all tasks individually) and not `cylc pause` (pause the workflow).

However:
- we haven't implemented `cylc hold */*` yet, and it may not be trivial to do it
- the only solution at the moment is "hold after cycle point", which is not intuitive at all
- two primary Cylc sites have highlighted this as a must-have for operational migration - @dwsutherland, @ColemanTom
- this is very easy to implement (`+13/-7` code lines without tests) so at the very least it provides a working interim solution [UPDATE: unfortunately no longer such a small diff after a change of approach!]
- and finally, I cannot see any problem with allowing manual triggering in a paused workflow - there's nothing wrong with defining workflow pause as *pausing all **automatic** job submission*

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/778
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
