### PR TITLE
Command validation: include more in validation step

### DIFF
--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -252,7 +252,14 @@ def is_tasks(tasks: Iterable[str]):
         ...
         cylc.flow.exceptions.InputError: This command does not take job ids:
         * */baz/12
+
+        >>> is_tasks([])
+        Traceback (most recent call last):
+        ...
+        cylc.flow.exceptions.InputError: No tasks specified
     """
+    if not tasks:
+        raise InputError("No tasks specified")
     bad_tasks: List[str] = []
     for task in tasks:
         tokens = Tokens('//' + task)

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -278,10 +278,10 @@ async def hold(schd: 'Scheduler', tasks: Iterable[str]):
 @_command('set_hold_point')
 async def set_hold_point(schd: 'Scheduler', point: str):
     """Hold all tasks after the specified cycle point."""
-    yield
     cycle_point = TaskID.get_standardised_point(point)
     if cycle_point is None:
         raise CyclingError("Cannot set hold point to None")
+    yield
     LOG.info(
         f"Setting hold cycle point: {cycle_point}\n"
         "All tasks after this point will be held."
@@ -299,13 +299,13 @@ async def pause(schd: 'Scheduler'):
 @_command('set_verbosity')
 async def set_verbosity(schd: 'Scheduler', level: Union[int, str]):
     """Set workflow verbosity."""
-    yield
     try:
         lvl = int(level)
         LOG.setLevel(lvl)
     except (TypeError, ValueError) as exc:
         raise CommandFailedError(exc)
     cylc.flow.flags.verbosity = log_level_to_verbosity(lvl)
+    yield
 
 
 @_command('remove_tasks')
@@ -439,5 +439,6 @@ async def force_trigger_tasks(
 ):
     """Manual task trigger."""
     validate.is_tasks(tasks)
+    validate.flow_opts(flow, flow_wait)
     yield
     yield schd.pool.force_trigger_tasks(tasks, flow, flow_wait, flow_descr)

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -45,7 +45,6 @@ from functools import partial
 import sys
 from typing import TYPE_CHECKING
 
-from cylc.flow import command_validation
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import (
@@ -115,7 +114,6 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
 @cli_function(get_option_parser)
 def main(parser: COP, options: 'Values', *ids: str):
     """CLI for "cylc trigger"."""
-    command_validation.flow_opts(options.flow or ['all'], options.flow_wait)
     rets = call_multi(
         partial(run, options),
         *ids,


### PR DESCRIPTION
While working on `cylc remove`, I had a bit of a look at the new command validation and think there are a couple of things that can be moved into the first validation step when running commands

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are not needed
- [x] No changelog as minor
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
