### PR TITLE
Fix stall status bug

### DIFF
--- a/changes.d/6200.fix.md
+++ b/changes.d/6200.fix.md
@@ -1,0 +1,1 @@
+Fixed bug where a stalled paused workflow would be incorrectly reported as running, not paused

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -189,16 +189,19 @@ async def stop(
             schd.workflow_db_mgr.put_workflow_stop_cycle_point(
                 schd.options.stopcp
             )
+        schd._update_workflow_state()
     elif clock_time is not None:
         # schedule shutdown after wallclock time passes provided time
         parser = TimePointParser()
         schd.set_stop_clock(
             int(parser.parse(clock_time).seconds_since_unix_epoch)
         )
+        schd._update_workflow_state()
     elif task is not None:
         # schedule shutdown after task succeeds
         task_id = TaskID.get_standardised_taskid(task)
         schd.pool.set_stop_task(task_id)
+        schd._update_workflow_state()
     else:
         # immediate shutdown
         with suppress(KeyError):
@@ -229,6 +232,7 @@ async def release_hold_point(schd: 'Scheduler'):
     yield
     LOG.info("Releasing all tasks and removing hold cycle point.")
     schd.pool.release_hold_point()
+    schd._update_workflow_state()
 
 
 @_command('resume')
@@ -287,6 +291,7 @@ async def set_hold_point(schd: 'Scheduler', point: str):
         "All tasks after this point will be held."
     )
     schd.pool.set_hold_point(cycle_point)
+    schd._update_workflow_state()
 
 
 @_command('pause')

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -85,7 +85,10 @@ from cylc.flow.parsec.util import (
     pdeepcopy,
     poverride
 )
-from cylc.flow.workflow_status import get_workflow_status
+from cylc.flow.workflow_status import (
+    get_workflow_status,
+    get_workflow_status_msg,
+)
 from cylc.flow.task_job_logs import JOB_LOG_OPTS, get_task_job_log
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import (
@@ -2174,8 +2177,8 @@ class DataStoreMgr:
                 w_delta.latest_state_tasks[state].task_proxies[:] = tp_queue
 
         # Set status & msg if changed.
-        status, status_msg = map(
-            str, get_workflow_status(self.schd))
+        status = get_workflow_status(self.schd).value
+        status_msg = get_workflow_status_msg(self.schd)
         if w_data.status != status or w_data.status_msg != status_msg:
             w_delta.status = status
             w_delta.status_msg = status_msg

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -2000,7 +2000,7 @@ class Scheduler:
 
         Call this method whenever the Scheduler's state has changed in a way
         that requires a data store update.
-        See cylc.flow.workflow_status.get_workflow_status() for a
+        See cylc.flow.workflow_status.get_workflow_status_msg() for a
         (non-exhaustive?) list of properties that if changed will require
         this update.
 

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -384,19 +384,6 @@ def get_task_status_summary(flow):
     ]
 
 
-def get_workflow_status_str(flow):
-    """Return a workflow status string for the header.
-
-    Arguments:
-        flow (dict):
-            GraphQL JSON response for this workflow.
-
-    Returns:
-        list - Text list for the urwid.Text widget.
-
-    """
-
-
 def _render_user(node, data):
     return f'~{ME}'
 

--- a/cylc/flow/wallclock.py
+++ b/cylc/flow/wallclock.py
@@ -16,7 +16,7 @@
 """Wall clock related utilities."""
 
 from calendar import timegm
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from metomi.isodatetime.timezone import (
     get_local_time_zone_format, get_local_time_zone, TimeZoneFormatMode)
@@ -209,7 +209,7 @@ def get_time_string_from_unix_time(unix_time, display_sub_seconds=False,
     to use as the time zone designator.
 
     """
-    date_time = datetime.utcfromtimestamp(unix_time)
+    date_time = datetime.fromtimestamp(unix_time, timezone.utc)
     return get_time_string(date_time,
                            display_sub_seconds=display_sub_seconds,
                            use_basic_format=use_basic_format,

--- a/cylc/flow/workflow_status.py
+++ b/cylc/flow/workflow_status.py
@@ -16,7 +16,7 @@
 """Workflow status constants."""
 
 from enum import Enum
-from typing import Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from cylc.flow.wallclock import get_time_string_from_unix_time as time2str
 
@@ -143,62 +143,41 @@ class AutoRestartMode(Enum):
     """Workflow will stop immediately but *not* attempt to restart."""
 
 
-def get_workflow_status(schd: 'Scheduler') -> Tuple[str, str]:
-    """Return the status of the provided workflow.
-
-    This should be a short, concise description of the workflow state.
-
-    Args:
-        schd: The running workflow
-
-    Returns:
-        tuple - (state, state_msg)
-
-        state:
-            The WorkflowState.
-        state_msg:
-            Text describing the current state (may be an empty string).
-
-    """
-    status = WorkflowStatus.RUNNING
-    status_msg = ''
-
+def get_workflow_status(schd: 'Scheduler') -> WorkflowStatus:
+    """Return the status of the provided workflow."""
     if schd.stop_mode is not None:
-        status = WorkflowStatus.STOPPING
-        status_msg = f'stopping: {schd.stop_mode.explain()}'
-    elif schd.reload_pending:
-        status = WorkflowStatus.PAUSED
-        status_msg = f'reloading: {schd.reload_pending}'
-    elif schd.is_stalled:
-        status_msg = 'stalled'
-    elif schd.is_paused:
-        status = WorkflowStatus.PAUSED
-        status_msg = 'paused'
-    elif schd.pool.hold_point:
-        status_msg = (
-            WORKFLOW_STATUS_RUNNING_TO_HOLD %
-            schd.pool.hold_point)
-    elif schd.pool.stop_point:
-        status_msg = (
-            WORKFLOW_STATUS_RUNNING_TO_STOP %
-            schd.pool.stop_point)
-    elif schd.stop_clock_time is not None:
-        status_msg = (
-            WORKFLOW_STATUS_RUNNING_TO_STOP %
-            time2str(schd.stop_clock_time))
-    elif schd.pool.stop_task_id:
-        status_msg = (
-            WORKFLOW_STATUS_RUNNING_TO_STOP %
-            schd.pool.stop_task_id)
-    elif schd.config and schd.config.final_point:
-        status_msg = (
-            WORKFLOW_STATUS_RUNNING_TO_STOP %
-            schd.config.final_point)
-    else:
-        # fallback - running indefinitely
-        status_msg = 'running'
+        return WorkflowStatus.STOPPING
+    if schd.is_paused or schd.reload_pending:
+        return WorkflowStatus.PAUSED
+    return WorkflowStatus.RUNNING
 
-    return (status.value, status_msg)
+
+def get_workflow_status_msg(schd: 'Scheduler') -> str:
+    """Return a short, concise status message for the provided workflow."""
+    if schd.stop_mode is not None:
+        return f'stopping: {schd.stop_mode.explain()}'
+    if schd.reload_pending:
+        return f'reloading: {schd.reload_pending}'
+    if schd.is_stalled:
+        if schd.is_paused:
+            return 'stalled (paused)'
+        return 'stalled'
+    if schd.is_paused:
+        return 'paused'
+    if schd.pool.hold_point:
+        return WORKFLOW_STATUS_RUNNING_TO_HOLD % schd.pool.hold_point
+    if schd.pool.stop_point:
+        return WORKFLOW_STATUS_RUNNING_TO_STOP % schd.pool.stop_point
+    if schd.stop_clock_time is not None:
+        return WORKFLOW_STATUS_RUNNING_TO_STOP % time2str(
+            schd.stop_clock_time
+        )
+    if schd.pool.stop_task_id:
+        return WORKFLOW_STATUS_RUNNING_TO_STOP % schd.pool.stop_task_id
+    if schd.config and schd.config.final_point:
+        return WORKFLOW_STATUS_RUNNING_TO_STOP % schd.config.final_point
+    # fallback - running indefinitely
+    return 'running'
 
 
 class RunMode:


### PR DESCRIPTION
Closes #6199. A stalled paused workflow would incorrectly have a status of running instead of paused.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] No docs entry needed.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
