### PR TITLE
tests/i: remove sleep

### DIFF
--- a/tests/integration/test_dbstatecheck.py
+++ b/tests/integration/test_dbstatecheck.py
@@ -16,10 +16,7 @@
 
 """Tests for the backend method of workflow_state"""
 
-
-from asyncio import sleep
 import pytest
-from textwrap import dedent
 
 from cylc.flow.dbstatecheck import CylcWorkflowDBChecker
 from cylc.flow.scheduler import Scheduler
@@ -36,13 +33,15 @@ async def checker(
     """
     wid = mod_flow({
         'scheduling': {
-            'graph': {'P1Y': dedent('''
-                good:succeeded
-                bad:failed?
-                output:custom_output
-            ''')},
             'initial cycle point': '1000',
-            'final cycle point': '1001'
+            'final cycle point': '1001',
+            'graph': {
+                'P1Y': '''
+                    good:succeeded
+                    bad:failed?
+                    output:custom_output
+                 '''
+            },
         },
         'runtime': {
             'bad': {'simulation': {'fail cycle points': '1000'}},
@@ -51,11 +50,17 @@ async def checker(
     })
     schd: Scheduler = mod_scheduler(wid, paused_start=False)
     async with mod_run(schd):
-        await mod_complete(schd)
-        schd.pool.force_trigger_tasks(['1000/good'], ['2'])
-        # Allow a cycle of the main loop to pass so that flow 2 can be
+        # allow a cycle of the main loop to pass so that flow 2 can be
         # added to db
-        await sleep(1)
+        await mod_complete(schd)
+
+        # trigger a new task in flow 2
+        schd.pool.force_trigger_tasks(['1000/good'], ['2'])
+
+        # update the database
+        schd.process_workflow_db_queue()
+
+        # yield a DB checker
         with CylcWorkflowDBChecker(
             'somestring', 'utterbunkum', schd.workflow_db_mgr.pub_path
         ) as _checker:


### PR DESCRIPTION
Spotted reviewing #6186.

Rather than sleeping for an arbitrary period (flaky), call the update method that the test requires synchronously.

Also remove the dedent (the flow writer does this automatically).