### PR TITLE
check towncrier message format in lint ci

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -100,6 +100,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check Towncrier Files
+        run: |
+          set -eu pipefail
+          if ls changes.d | grep ^[a-z].*.md; then
+            echo "the following towncrier files may be wrong:"
+            ls changes.d | grep ^[a-z].*.md
+            exit 1
+          fi
+
       # note: exclude python 3.10+ from mypy checks as these produce false
       # positives in installed libraries for python 3.7
       - name: Configure Python


### PR DESCRIPTION
Oliver and I have both now made the mistake of mis-forming the towncrier messages, so here's an auto-check.

Example of it failing (correctly) on master
https://github.com/wxtim/cylc/actions/runs/9871865449/job/27260726283