### PR TITLE
example: extending workflow

### DIFF
--- a/cylc/flow/etc/examples/extending-workflow/.validate
+++ b/cylc/flow/etc/examples/extending-workflow/.validate
@@ -1,0 +1,80 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -eux
+
+test_simple () {
+    local ID
+    ID="$(< /dev/urandom tr -dc A-Za-z | head -c6)"
+    
+    # lint
+    cylc lint ./simple
+    
+    # copy into a temp directory
+    local SRC_DIR
+    SRC_DIR="$(mktemp -d)"
+    cp simple/flow.cylc "$SRC_DIR"
+    
+    # speed things up with simulation mode
+    cat >>"${SRC_DIR}/flow.cylc" <<__HERE__
+    [runtime]
+        [[root]]
+            [[[simulation]]]
+                default run length = PT0S
+__HERE__
+    
+    # start the workflow
+    cylc vip \
+        --check-circular \
+        --no-run-name \
+        --no-detach \
+        --workflow-name "$ID" \
+        --mode=simulation \
+        "$SRC_DIR"
+    
+    # it should have reached the 2002 cycle
+    grep '2002/a' "${HOME}/cylc-run/${ID}/log/scheduler/log"
+    if grep '2003/a' "${HOME}/cylc-run/${ID}/log/scheduler/log"; then
+        exit 1
+    fi
+    
+    # edit the "stop after cycle point"
+    sed -i \
+        's/stop after cycle point.*/stop after cycle point = 2004/' \
+        "${SRC_DIR}/flow.cylc"
+    
+    # continue the run
+    cylc vr \
+        --no-detach \
+        --mode=simulation \
+        --yes \
+        "$ID"
+    
+    # it should have reached the 2004 cycle
+    grep '2004/a' "${HOME}/cylc-run/${ID}/log/scheduler/log"
+    if grep '2005/a' "${HOME}/cylc-run/${ID}/log/scheduler/log"; then
+        exit 1
+    fi
+    
+    # clean up
+    cylc clean "$ID"
+    
+    rm -r "${SRC_DIR}"
+}
+
+
+test_simple

--- a/cylc/flow/etc/examples/extending-workflow/index.rst
+++ b/cylc/flow/etc/examples/extending-workflow/index.rst
@@ -1,0 +1,77 @@
+Extending Workflow
+==================
+
+.. cylc-scope:: flow.cylc[scheduling]
+
+Sometimes we may run a workflow to :term:`completion <workflow completion>`,
+but subsequently wish to run it for a few more cycles.
+
+With Cylc 7 this was often done by changing the `final cycle point` and
+restarting the workflow. This approach worked, but was a little awkward.
+It's possible with Cylc 8, but we would recommend moving away from this
+pattern instead.
+
+The recommended approach to this problem (Cylc 6+) is to use the
+`stop after cycle point` rather than the `final cycle point`.
+
+The `stop after cycle point` tells Cylc to **stop** after the workflow passes
+the specified point, whereas the `final cycle point` tells Cylc that the
+workflow **finishes** at the specified point.
+
+When a workflow **finishes**, it is a little awkward to restart as you have to
+tell Cylc which tasks to continue on from. The `stop after cycle point`
+solution avoids this issue.
+
+
+Example
+-------
+
+.. admonition:: Get a copy of this example
+   :class: hint
+
+   .. code-block:: console
+
+      $ cylc get-resources examples/extending-workflow/simple
+
+This workflow will stop at the end of the ``2002`` cycle:
+
+.. literalinclude:: simple/flow.cylc
+   :language: cylc
+
+After it has run and shut down, change the `stop after cycle point` to
+the desired value and restart it. E.g:
+
+.. code-block:: bash
+
+   # install and run the workflow:
+   cylc vip
+
+   # then later edit "stop after cycle point" to "2004"
+
+   # then reinstall and restart the workflow:
+   cylc vr
+
+The workflow will continue from where it left off and run until the end of the
+``2004`` cycle. Because the workflow never hit the `final cycle point` it
+never "finished" so no special steps are required to restart the workflow.
+
+You can also set the `stop after cycle point` when you start the workflow:
+
+.. code-block:: bash
+
+   cylc play --stop-cycle-point=2020 myworkflow
+
+Or change it at any point whilst the workflow is running:
+
+.. code-block:: bash
+
+   cylc stop myworkflow//2030  # change the stop after cycle point to 2030
+
+.. note::
+
+   If you set the `stop after cycle point` on the command line, this value will
+   take precedence over the one in the workflow configuration. Use
+   ``cylc play --stop-cycle-point=reload`` to restart the workflow using the
+   `stop after cycle point` configured in the workflow configuration.
+
+.. cylc-scope::

--- a/cylc/flow/etc/examples/extending-workflow/simple/flow.cylc
+++ b/cylc/flow/etc/examples/extending-workflow/simple/flow.cylc
@@ -1,0 +1,24 @@
+[meta]
+    title = "Basic extendable workflow"
+    description = """
+        Use the "stop after cycle point" rather than the "final cycle point"
+        to allow this workflow to be easily extended at a later date.
+    """
+
+[scheduler]
+    # use the year for the cycle point
+    # (strip off the month, day, hour and minute)
+    cycle point format = CCYY
+
+[scheduling]
+    initial cycle point = 2000
+    stop after cycle point = 2002  # stop after two years of simulated time
+    [[graph]]
+        P1Y = """
+            z[-P1Y] => a
+            a => z
+        """
+
+[runtime]
+    [[a]]
+    [[z]]


### PR DESCRIPTION
> [!IMPORTANT]
> This is #5947 with the "complex" example (to which we do not currently have a generic solution) chopped of. The remainder of that PR will need to wait, however there is pressure for us to get the simple bit documented now.

Document the preferred approach to "extending" a workflow.

Partially addresses: https://github.com/cylc/cylc-doc/issues/525
Partially addresses: https://github.com/cylc/cylc-flow/issues/5875

**Context:**

A common pattern in some areas is to run a workflow until it stops. Then modify the final cycle point to extend the workflow and restart.

This isn't an easy working pattern to port to Cylc 8 due to the difficulty of re-populating the start tasks. We have a plan to make this easier, see https://github.com/cylc/cylc-flow/issues/5416, however, this working pattern is needlessly complex in the first place. It would be much simpler if the workflow didn't "finish" in the first place.

To do this, swap final cycle point for stop after cycle point, now the workflow will not "finish" so the pool will not need re-polulating for the workflow to continue. This is much nicer for Cylc (no discontinuity), the user (no extra commands) and provenance (direct continuation of previous run).


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.