### PR TITLE
runahead: handle a workflow with an empty graph

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -319,12 +319,15 @@ class TaskPool:
         if not self.active_tasks:
             # Find the earliest sequence point beyond the workflow start point.
             base_point = min(
-                point
-                for point in {
-                    seq.get_first_point(self.config.start_point)
-                    for seq in self.config.sequences
-                }
-                if point is not None
+                (
+                    point
+                    for point in {
+                        seq.get_first_point(self.config.start_point)
+                        for seq in self.config.sequences
+                    }
+                    if point is not None
+                ),
+                default=None,
             )
         else:
             # Find the earliest point with incomplete tasks.

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1750,6 +1750,26 @@ async def test_compute_runahead(
         assert int(str(schd.pool.runahead_limit_point)) == 5  # +1
 
 
+async def test_compute_runahead_with_no_tasks(flow, scheduler, run):
+    """It should handle the case of an empty workflow.
+
+    See https://github.com/cylc/cylc-flow/issues/6225
+    """
+    id_ = flow(
+        {
+            'scheduling': {
+                'initial cycle point': '2000',
+                'graph': {'R1': 'foo'},
+            },
+        }
+    )
+    schd = scheduler(id_, startcp='2002', paused_start=False)
+    async with run(schd):
+        assert schd.pool.compute_runahead() is False
+        assert schd.pool.runahead_limit_point is None
+        assert schd.pool.get_tasks() == []
+
+
 @pytest.mark.parametrize('rhlimit', ['P2D', 'P2'])
 @pytest.mark.parametrize('compat_mode', ['compat-mode', 'normal-mode'])
 async def test_runahead_future_trigger(


### PR DESCRIPTION
* Closes #6225

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users - No changelog required, highly unlikely in real use
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
