### PR TITLE
pool: warn when triggering queued tasks in different flows

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2166,6 +2166,15 @@ class TaskPool:
             if itask.state(TASK_STATUS_PREPARING, *TASK_STATUSES_ACTIVE):
                 LOG.warning(f"[{itask}] ignoring trigger - already active")
                 continue
+            if (
+                itask.state(TASK_STATUS_WAITING, is_queued=True)
+                and flow_nums != self._get_active_flow_nums()
+            ):
+                LOG.warning(
+                    f"[{itask}] ignoring trigger - already queued"
+                    " (cannot change flow)"
+                )
+                continue
             self._force_trigger(itask)
 
         # Spawn and trigger future tasks.


### PR DESCRIPTION
* The `--flow` argument is ignored if you trigger a queued task.
* It would be possible, though tricky, to merge the flows at this point as queued tasks already have database entries.
* Merging is the correct solution, but for now, this PR will log a warning to let the user know / leave some record that the trigger did not take effect (i.e. continue the status quo but explain what's happening).
* Might be easier to come back to the merging problem post cylc-remove to see what requirement there is for recording the flow number *before* a task has run once that work is in.
* Closes #6174

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users (v minor, unreported issue)
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
