### PR TITLE
stop: remove reference to Cylc 7 --mode option

### DIFF
--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -40,7 +40,8 @@ Examples:
   $ cylc stop my_workflow//1234/foo
 
 By default stopping workflows wait for submitted and running tasks to complete
-before shutting down. You can change this behaviour with the --mode option.
+before shutting down. You can change this behaviour with the --now or
+--kill options.
 
 There are several shutdown methods:
 


### PR DESCRIPTION
Small docs fix. We removed the `--mode` option a long time ago.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.