### PR TITLE
add share/bin to env path

### DIFF
--- a/changes.d/6242.fix.md
+++ b/changes.d/6242.fix.md
@@ -1,0 +1,1 @@
+Put `share/bin` in the `PATH` of scheduler environment, event handlers therein will now be found.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1723,8 +1723,21 @@ class WorkflowConfig:
         os.environ['CYLC_CYCLING_MODE'] = self.cfg['scheduling'][
             'cycling mode']
         # Add workflow bin directory to PATH for workflow and event handlers
-        os.environ['PATH'] = os.pathsep.join([
-            os.path.join(self.fdir, 'bin'), os.environ['PATH']])
+        if self.share_dir is not None:
+            os.environ['PATH'] = os.pathsep.join(
+                [
+                    os.path.join(self.share_dir, 'bin'),
+                    os.path.join(self.fdir, 'bin'),
+                    os.environ['PATH']
+                ]
+            )
+        else:
+            os.environ['PATH'] = os.pathsep.join(
+                [
+                    os.path.join(self.fdir, 'bin'),
+                    os.environ['PATH']
+                ]
+            )
 
     def run_mode(self) -> str:
         """Return the run mode."""


### PR DESCRIPTION
closes #6240

Test case:
```
(flow) sutherlander@cortex-vbox:share-bin$ ls
flow.cylc  share-src
(flow) sutherlander@cortex-vbox:share-bin$ cat share-src/bin/hello.sh 
#!/bin/bash

echo 'Hello! handler activated!'
touch ${CYLC_WORKFLOW_SHARE_DIR}/handler_activated
```
```
[meta]
    title = "Test calling a handler from share/bin"
[scheduling]
    cycling mode = integer
    initial cycle point = 1
    [[graph]]
        R1 = "foo => bar"
[runtime]
    [[root]]
        pre-script = sleep 10
        [[[events]]]
            handlers = hello.sh
            handler events = succeeded
    [[foo]]
        script = """
rm -rf ${CYLC_WORKFLOW_SHARE_DIR}/bin
cp -rf ${CYLC_WORKFLOW_RUN_DIR}/share-src/bin ${CYLC_WORKFLOW_SHARE_DIR}/
chmod 0755 ${CYLC_WORKFLOW_SHARE_DIR}/bin/*
"""
    [[bar]]
        script = """
if ! [[ -f ${CYLC_WORKFLOW_SHARE_DIR}/handler_activated ]]; then
    false
fi
"""
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Already covered.
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
