### PR TITLE
glblcfg: replicate platforms rather than overriding them

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -40,7 +40,7 @@ from cylc.flow.parsec.exceptions import (
     ValidationError,
 )
 from cylc.flow.parsec.upgrade import upgrader
-from cylc.flow.parsec.util import printcfg, expand_many_section
+from cylc.flow.parsec.util import printcfg, expand_many_section, replicate
 from cylc.flow.parsec.validate import (
     CylcConfigValidator as VDR,
     DurationFloat,
@@ -2076,8 +2076,11 @@ class GlobalConfig(ParsecConfig):
         platforms[bar].
         """
         if self.sparse.get('platforms'):
-            self.sparse['platforms'] = expand_many_section(
-                self.sparse['platforms']
+            expanded_platforms = expand_many_section(self.sparse['platforms'])
+            self.sparse['platforms'].clear()
+            replicate(
+                self.sparse['platforms'],
+                expanded_platforms,
             )
 
     def platform_dump(


### PR DESCRIPTION
We are currently replacing the `[platforms]` part of the "sparse" configuration.

This means that the platforms dictionary is being replaced, introducing the potential for some part of the system to retain a reference to the stale dictionary.

This PR uses the parsec replicate method as used elsewhere to decant the new platform entries into the existing dictionary.

Attempted whilst investigating #6244, however, this does not fix that issue, at least, not by itself.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
