### PR TITLE
Support EmPy version 4

### DIFF
--- a/changes.d/6248.fix.md
+++ b/changes.d/6248.fix.md
@@ -1,0 +1,1 @@
+Upgrade to EmPy 4 to fix an issue with stdout in detaching mode.

--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - tomli >=2 # [py<3.11]
 
 # optional dependencies
-  #- empy >=3.3,<3.4
+  #- empy >=4.1
   #- pandas >=1.0,<2
   #- pympler
   #- matplotlib-base

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ include = cylc*
 
 [options.extras_require]
 empy =
-    EmPy==3.3.*
+    EmPy>=4.1
 graph =
     pillow
 main_loop-log_data_store =


### PR DESCRIPTION
A forum post has revealed that EmPy 3 doesn't play well with scheduler daemonization: 

https://cylc.discourse.group/t/empy-import-shell-environment-variables/985/1

If I simply add `#!EmPy` to a `flow.cylc`, the workflow runs fine but:
 - I get a traceback at start-up
- stdout does not end up in the log
- stdout still appears in the terminal

Something to do with EmPy replacing `sys.stdout`
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/oliverh/cylc/cylc-flow/cylc/flow/loggingutil.py", line 167, in emit
    self.do_rollover()
  File "/home/oliverh/cylc/cylc-flow/cylc/flow/loggingutil.py", line 234, in do_rollover
    os.dup2(self.stream.fileno(), sys.stdout.fileno())
AttributeError: 'ProxyFile' object has no attribute 'fileno'
```

The good news: EmPy 4.1 works fine, but it requires a small change to our code.

Anyone aware of any reason not to require EmPy > 4 ?

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
