### PR TITLE
glbl_cfg: reload without mutating the original

### DIFF
--- a/changes.d/6249.fix.md
+++ b/changes.d/6249.fix.md
@@ -1,0 +1,1 @@
+Fix a race condition between global config reload and debug logging that caused "platform not defined" errors when running workflows that contained a "rose-suite.conf" file in vebose or debug mode.

--- a/changes.d/6249.fix.md
+++ b/changes.d/6249.fix.md
@@ -1,1 +1,1 @@
-Fix a race condition between global config reload and debug logging that caused "platform not defined" errors when running workflows that contained a "rose-suite.conf" file in vebose or debug mode.
+Fix a race condition between global config reload and debug logging that caused "platform not defined" errors when running workflows that contained a "rose-suite.conf" file in verbose or debug mode.

--- a/cylc/flow/cfgspec/glbl_cfg.py
+++ b/cylc/flow/cfgspec/glbl_cfg.py
@@ -16,7 +16,7 @@
 """Allow lazy loading of `cylc.flow.cfgspec.globalcfg`."""
 
 
-def glbl_cfg(cached=True):
+def glbl_cfg(**kwargs):
     """Load and return the global configuration singleton instance."""
     from cylc.flow.cfgspec.globalcfg import GlobalConfig
-    return GlobalConfig.get_inst(cached=cached)
+    return GlobalConfig.get_inst(**kwargs)

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -529,7 +529,7 @@ async def test_glbl_cfg(monkeypatch, tmp_path, caplog):
 
     def get_platforms(cfg_obj):
         """Return the platforms defined in the provided config instance."""
-        return {p for p in cfg_obj.get(['platforms']).keys()}
+        return set(cfg_obj.get(['platforms']).keys())
 
     def expect_platforms_during_reload(platforms):
         """Test the platforms defined in glbl_cfg() during reload.

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -14,11 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from pathlib import Path
 import sqlite3
 from typing import Any
 import pytest
 
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
+from cylc.flow.cfgspec.globalcfg import GlobalConfig
 from cylc.flow.exceptions import (
     ServiceFileError,
     WorkflowConfigError,
@@ -503,3 +506,90 @@ def test_special_task_non_word_names(flow: Fixture, validate: Fixture):
         },
     })
     validate(wid)
+
+
+async def test_glbl_cfg(monkeypatch, tmp_path, caplog):
+    """Test accessing the global config via the glbl_cfg wrapper.
+
+    Test the "cached" and "reload" kwargs to glbl_cfg.
+
+    Also assert that accessing the global config during a reload operation does
+    not cause issues. See https://github.com/cylc/cylc-flow/issues/6244
+    """
+    # wipe any previously cached config
+    monkeypatch.setattr(
+        'cylc.flow.cfgspec.globalcfg.GlobalConfig._DEFAULT', None
+    )
+    # load the global config from the test tmp directory
+    monkeypatch.setenv('CYLC_CONF_PATH', str(tmp_path))
+
+    def write_global_config(cfg_str):
+        """Write the global.cylc file."""
+        Path(tmp_path, 'global.cylc').write_text(cfg_str)
+
+    def get_platforms(cfg_obj):
+        """Return the platforms defined in the provided config instance."""
+        return {p for p in cfg_obj.get(['platforms']).keys()}
+
+    def expect_platforms_during_reload(platforms):
+        """Test the platforms defined in glbl_cfg() during reload.
+
+        Assert that the platforms defined in glbl_cfg() match the expected
+        value, whilst the global config is in the process of being reloaded.
+
+        In other words, this tests that the cached instance is not changed
+        until after the reload has completed.
+
+        See https://github.com/cylc/cylc-flow/issues/6244
+        """
+        caplog.set_level(logging.INFO)
+
+        def _capture(fcn):
+            def _inner(*args, **kwargs):
+                cfg = glbl_cfg()
+                assert get_platforms(cfg) == platforms
+                logging.getLogger('test').info(
+                    'ran expect_platforms_during_reload test'
+                )
+                return fcn(*args, **kwargs)
+            return _inner
+
+        monkeypatch.setattr(
+            'cylc.flow.cfgspec.globalcfg.GlobalConfig._load',
+            _capture(GlobalConfig._load)
+        )
+
+    # write a global config
+    write_global_config('''
+        [platforms]
+            [[foo]]
+    ''')
+
+    # test the platforms defined in it
+    assert get_platforms(glbl_cfg()) == {'localhost', 'foo'}
+
+    # add a new platform the config
+    write_global_config('''
+        [platforms]
+            [[foo]]
+            [[bar]]
+    ''')
+
+    # the new platform should not appear (due to the cached instance)
+    assert get_platforms(glbl_cfg()) == {'localhost', 'foo'}
+
+    # if we request an uncached instance, the new platform should appear
+    assert get_platforms(glbl_cfg(cached=False)) == {'localhost', 'foo', 'bar'}
+
+    # however, this should not affect the cached instance
+    assert get_platforms(glbl_cfg()) == {'localhost', 'foo'}
+
+    # * if we reload the cached instance, the new platform should appear
+    # * but during the reload itself, the old config should persist
+    #   see https://github.com/cylc/cylc-flow/issues/6244
+    expect_platforms_during_reload({'localhost', 'foo'})
+    assert get_platforms(glbl_cfg(reload=True)) == {'localhost', 'foo', 'bar'}
+    assert 'ran expect_platforms_during_reload test' in caplog.messages
+
+    # the cache should have been updated by the reload
+    assert get_platforms(glbl_cfg()) == {'localhost', 'foo', 'bar'}


### PR DESCRIPTION
Sibling: https://github.com/cylc/cylc-rose/pull/336

* Use the new `reload` kwarg rather than calling the `.load()` method.
* Fixes https://github.com/cylc/cylc-flow/issues/6244
* The `.load()` method mutates the existing config, due to the use of logging within (and outside of) this routine and the use of `glbl_cfg` in the logging, this created a race condition.
* The new `reload` kwarg creates a new config instance, then sets this as the default.

To assert that the test captures the issue, try applying this diff to test the old reload method:

```diff
diff --git a/tests/integration/test_config.py b/tests/integration/test_config.py
index 231fb12f8..eb56ed5cb 100644
--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -588,7 +588,9 @@ async def test_glbl_cfg(monkeypatch, tmp_path, caplog):
     # * but during the reload itself, the old config should persist
     #   see https://github.com/cylc/cylc-flow/issues/6244
     expect_platforms_during_reload({'localhost', 'foo'})
-    assert get_platforms(glbl_cfg(reload=True)) == {'localhost', 'foo', 'bar'}
+    cfg = glbl_cfg()
+    cfg.load()
+    assert get_platforms(cfg) == {'localhost', 'foo', 'bar'}
     assert 'ran expect_platforms_during_reload test' in caplog.messages
 
     # the cache should have been updated by the reload
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.