### PR TITLE
Reconstruct xtriggers at reload time.

### DIFF
--- a/changes.d/6263.fix.md
+++ b/changes.d/6263.fix.md
@@ -1,1 +1,1 @@
-Fix bug preventing changes to user-defined xtriggers taking effect after a reload.
+Fix bug that prevented changes to user-defined xtriggers taking effect after a reload.

--- a/changes.d/6263.fix.md
+++ b/changes.d/6263.fix.md
@@ -1,0 +1,1 @@
+Fix bug preventing changes to user-defined xtriggers taking effect after a reload.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -413,7 +413,7 @@ async def reload_workflow(schd: 'Scheduler'):
         # Reset the remote init map to trigger fresh file installation
         schd.task_job_mgr.task_remote_mgr.remote_init_map.clear()
         schd.task_job_mgr.task_remote_mgr.is_reload = True
-        schd.pool.reload_taskdefs(config)
+        schd.pool.reload(config)
         # Load jobs from DB
         schd.workflow_db_mgr.pri_dao.select_jobs_for_restart(
             schd.data_store_mgr.insert_db_job

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -368,11 +368,14 @@ class TaskProxy:
                     )
 
         reload_successor.state.xtriggers.update({
-            # copy across any special "_cylc" xtriggers which were added
-            # dynamically at runtime (i.e. execution retry xtriggers)
+            # Copy across any auto-defined "_cylc" xtriggers runtime (retries),
+            # but avoid "_cylc_wallclock" xtriggers which are user-defined.
             key: value
             for key, value in self.state.xtriggers.items()
-            if key.startswith('_cylc')
+            if (
+                key.startswith('_cylc') and not
+                key.startswith('_cylc_wallclock')
+            )
         })
         reload_successor.jobs = self.jobs
 

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -207,6 +207,7 @@ class XtriggerCollator:
             del self.functx_map[label]
             with suppress(KeyError):
                 self.wall_clock_labels.remove(label)
+            with suppress(KeyError):
                 self.sequential_xtrigger_labels.remove(label)
 
     def add_trig(self, label: str, fctx: 'SubFuncContext', fdir: str) -> None:

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -116,7 +116,7 @@ async def test_reload(sequential, start):
         assert pre_reload.is_xtrigger_sequential is True
 
         # reload the workflow
-        sequential.pool.reload_taskdefs(sequential.config)
+        sequential.pool.reload(sequential.config)
 
         # the original task proxy should have been replaced
         post_reload = sequential.pool.get_task(ISO8601Point('2000'), 'foo')

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2322,4 +2322,3 @@ async def test_downstream_complete_before_upstream(
         # 1/a should be removed from the pool (completed)
         # 1/b should not be re-spawned by the success of 1/a
         assert schd.pool.get_tasks() == []
-

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2100,7 +2100,86 @@ async def test_trigger_queue(one, run, db_select, complete):
         await complete(one, timeout=2)
         assert db_select(one, False, 'task_outputs', 'flow_nums') == [('[1, 2]',), ('[1]',)]
 
+async def test_reload_xtriggers(flow, scheduler, start):
+    """It should rebuild xtriggers when the workflow is reloaded.
 
+    See https://github.com/cylc/cylc-flow/pull/6263
+    """
+    config = {
+        'scheduling': {
+            'initial cycle point': '2000',
+            'graph': {
+                'R1': '''
+                    @a => foo
+                    @b => foo
+                '''
+            },
+            'xtriggers': {
+                'a': 'wall_clock(offset="P0D")',
+                'b': 'wall_clock(offset="P5D")',
+            },
+        }
+    }
+    id_ = flow(config)
+    schd: Scheduler = scheduler(id_)
+
+    def list_xtrig_mgr():
+        """List xtrigs from the xtrigger_mgr."""
+        nonlocal schd
+        return {
+            key: repr(value)
+            for key, value in schd.xtrigger_mgr.xtriggers.functx_map.items()
+        }
+
+    async def list_data_store():
+        """List xtrigs from the data_store_mgr."""
+        nonlocal schd
+        await schd.update_data_structure()
+        return {
+            value.label: key
+            for key, value in schd.data_store_mgr.data[schd.tokens.id][
+                TASK_PROXIES
+            ][
+                schd.tokens.duplicate(cycle='20000101T0000Z', task='foo').id
+            ].xtriggers.items()
+        }
+
+    async with start(schd):
+        # check xtrigs on startup
+        assert list_xtrig_mgr() == {
+            'a': '<SubFuncContext wall_clock(offset=P0D):10.0>',
+            'b': '<SubFuncContext wall_clock(offset=P5D):10.0>',
+        }
+        assert await list_data_store() == {
+            'a': 'wall_clock(trigger_time=946684800)',
+            'b': 'wall_clock(trigger_time=947116800)',
+        }
+
+        # remove @a
+        config['scheduling']['xtriggers'].pop('a')
+        # modify @b
+        config['scheduling']['xtriggers']['b'] = 'wall_clock(offset="PT12H")'
+        # add @c
+        config['scheduling']['xtriggers']['c'] = 'wall_clock(offset="PT1H")'
+        config['scheduling']['graph']['R1'] = config['scheduling']['graph'][
+            'R1'
+        ].replace('@a', '@c')
+
+        # reload
+        flow(config, id_=id_)
+        await commands.run_cmd(commands.reload_workflow, schd)
+
+        # check xtrigs post-reload
+        assert list_xtrig_mgr() == {
+            'b': '<SubFuncContext wall_clock(offset=PT12H):10.0>',
+            'c': '<SubFuncContext wall_clock(offset=PT1H):10.0>',
+        }
+        assert await list_data_store() == {
+            'b': 'wall_clock(trigger_time=946728000)',
+            'c': 'wall_clock(trigger_time=946688400)',
+        }
+
+        
 async def test_trigger_unqueued(flow, scheduler, start):
     """Test triggering an unqueued active task.
 
@@ -2243,3 +2322,4 @@ async def test_downstream_complete_before_upstream(
         # 1/a should be removed from the pool (completed)
         # 1/b should not be re-spawned by the success of 1/a
         assert schd.pool.get_tasks() == []
+


### PR DESCRIPTION
Close #6259 
Close #6260

User-defined xtriggers (including wall-clock) need to be reconstructed after reload (to pick up changes), but auto-defined ones (retries) must be retained.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
