### PR TITLE
`cylc play` (restart): fix bug affecting run host reinvocation after interactive upgrade

### DIFF
--- a/changes.d/6267.fix.md
+++ b/changes.d/6267.fix.md
@@ -1,0 +1,1 @@
+Fixed bug in `cylc play` affecting run host reinvocation after interactively upgrading the workflow to a new Cylc version.


### PR DESCRIPTION
Fixes a bug not recorded in an issue. I think this bug has been present since the introduction of the interactive upgrade mechanism (#5074)

TL;DR - remote reinvocation would not work after interactively upgrading a workflow to a new Cylc version on the CLI.

#### Steps to reproduce

With `run hosts` configured in `global.cylc`

```cylc
[scheduler]
    [[run hosts]]
        available = <server1>, ...
```

Start a workflow and stop it, then fiddle the workflow DB to make it look like it was run with an older version:

```
sqlite3 wflow/.service/db 'UPDATE workflow_params SET value="8.1.7" WHERE key="cylc_version"'
```

Now restart it with `cylc play`, and type 'y' at the interactive upgrade prompt. When it re-invokes on the run host, you should see an error

```
This workflow was previously run with 8.1.7.
This version of Cylc is 8.3.4.dev
Use "--upgrade" to upgrade the workflow.
ERROR: ERROR: command terminated by signal 1: ssh ...
```

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs entry needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
