### PR TITLE
Upgrade towncrier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ template = "changes.d/changelog-template.jinja"
 underlines = ["", "", ""]
 title_format = "## __cylc-{version} (Released {project_date})__"
 issue_format = "[#{issue}](https://github.com/cylc/cylc-flow/pull/{issue})"
+ignore = ["changelog-template.jinja"]
 
 # These changelog sections will be shown in the defined order:
 [[tool.towncrier.type]]

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,7 @@ tests =
     pytest-mock>=3.7
     pytest>=6
     testfixtures>=6.11.0
-    towncrier>=23
+    towncrier>=24.7.0; python_version > "3.7"
     # Type annotation stubs
     # http://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
     types-Jinja2>=0.1.3


### PR DESCRIPTION
Supersedes https://github.com/cylc/cylc-flow/pull/6216

`towncrier build` will now fail as part of CI if you create a file in `changes.d/` with an invalid fragment file name, thanks to my PR https://github.com/twisted/towncrier/pull/622 (needs the `ignore` setting added to the towncrier config).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Dev dependency change does not apply to conda
- [x] Tests are not needed
- [x] No changelog entry needed
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
