### PR TITLE
Made jinja2 subsitution regex less greedy in gedit syntax highlighter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ requests_).
  - Mark Dawson
  - Diquan Jabbour
  - Shixian Sheng
+ - Paul Earnshaw
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/flow/etc/syntax/cylc.lang
+++ b/cylc/flow/etc/syntax/cylc.lang
@@ -219,7 +219,7 @@
       <end>#\}</end>
     </context>
     <context id="jinja2-substitution" style-ref="template">
-      <match>\{\{.*\}\}</match>
+      <match>\{\{.*?\}\}</match>
     </context>
     <context id="jinja2-block" style-ref="template" end-at-line-end="false">
       <start>\{%</start>


### PR DESCRIPTION
The regex for jinja2 subsitution in gedit syntax highlighter is too greedy, for example if you have two variables on a single line then all the text between the two variables gets highlighted as jinja2 instead of just the variables. e.g.

> {{VAR1}} extra text {{VAR2}}

would have the "extra text" syntax highlighted as jinja2, where as with the change only the {{VAR1}} and {{VAR2}} would be syntax highlighted as jinja2.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
