### PR TITLE
`TaskState`: remove cached prereq satisfaction in preparation for `cylc remove`

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1990,7 +1990,7 @@ class TaskPool:
 
         """
         if prereqs == ["all"]:
-            itask.state.set_all_satisfied()
+            itask.state.set_prerequisites_all_satisfied()
         else:
             # Attempt to set the given presrequisites.
             # Log any that aren't valid for the task.

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -309,10 +309,9 @@ class TaskState:
         """
         valid: Set[Tokens] = set()
         for prereq in (*self.prerequisites, *self.suicide_prerequisites):
-            yep = prereq.satisfy_me(outputs)
-            if yep:
-                valid = valid.union(yep)
-                continue
+            valid.update(
+                prereq.satisfy_me(outputs)
+            )
         return valid
 
     def xtriggers_all_satisfied(self):
@@ -322,11 +321,6 @@ class TaskState:
     def external_triggers_all_satisfied(self):
         """Return True if all external triggers are satisfied."""
         return all(self.external_triggers.values())
-
-    def set_all_satisfied(self):
-        """Set all my prerequisites satisfied."""
-        for p in self.prerequisites:
-            p.set_satisfied()
 
     def prerequisites_all_satisfied(self):
         """Return True if (non-suicide) prerequisites are fully satisfied."""
@@ -349,9 +343,12 @@ class TaskState:
             for point in prerequisite.get_target_points()
         }
 
-    def prerequisites_eval_all(self):
-        """Set all prerequisites to satisfied."""
-        # (Validation: will abort on illegal trigger expressions.)
+    def prerequisites_eval_all(self) -> None:
+        """Evaluate satisifaction of all prerequisites and
+        suicide prerequisites.
+
+        Provides validation - will abort on illegal trigger expressions.
+        """
         for preqs in [self.prerequisites, self.suicide_prerequisites]:
             for preq in preqs:
                 preq.is_satisfied()

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -195,9 +195,6 @@ class TaskState:
             Time string of latest update time.
         .xtriggers (dict):
             xtriggers as {trigger (str): satisfied (boolean), ...}.
-        ._suicide_is_satisfied (boolean):
-            Are prerequisites to trigger suicide satisfied?
-            Reset None to force re-evaluation when a prereq gets satisfied.
     """
 
     # Memory optimization - constrain possible attributes to this list.
@@ -214,7 +211,6 @@ class TaskState:
         "suicide_prerequisites",
         "time_updated",
         "xtriggers",
-        "_suicide_is_satisfied",
     ]
 
     def __init__(self, tdef, point, status, is_held):
@@ -224,8 +220,6 @@ class TaskState:
         self.is_runahead = True
         self.is_updated = False
         self.time_updated = None
-
-        self._suicide_is_satisfied = None
 
         # Prerequisites.
         self.prerequisites: List[Prerequisite] = []
@@ -319,7 +313,6 @@ class TaskState:
             if yep:
                 valid = valid.union(yep)
                 continue
-            self._suicide_is_satisfied = None
         return valid
 
     def xtriggers_all_satisfied(self):
@@ -346,10 +339,7 @@ class TaskState:
 
     def suicide_prerequisites_all_satisfied(self):
         """Return True if all suicide prerequisites are satisfied."""
-        if self._suicide_is_satisfied is None:
-            self._suicide_is_satisfied = all(
-                preq.is_satisfied() for preq in self.suicide_prerequisites)
-        return self._suicide_is_satisfied
+        return all(preq.is_satisfied() for preq in self.suicide_prerequisites)
 
     def prerequisites_get_target_points(self):
         """Return a list of cycle points targeted by each prerequisite."""
@@ -456,7 +446,6 @@ class TaskState:
         """Add task prerequisites."""
         # Triggers for sequence_i only used if my cycle point is a
         # valid member of sequence_i's sequence of cycle points.
-        self._suicide_is_satisfied = None
 
         # Use dicts to avoid generating duplicate prerequisites from sequences
         # with coincident cycle points.

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -195,9 +195,6 @@ class TaskState:
             Time string of latest update time.
         .xtriggers (dict):
             xtriggers as {trigger (str): satisfied (boolean), ...}.
-        ._is_satisfied (boolean):
-            Are prerequisites satisfied?
-            Reset None to force re-evaluation when a prereq gets satisfied.
         ._suicide_is_satisfied (boolean):
             Are prerequisites to trigger suicide satisfied?
             Reset None to force re-evaluation when a prereq gets satisfied.
@@ -217,7 +214,6 @@ class TaskState:
         "suicide_prerequisites",
         "time_updated",
         "xtriggers",
-        "_is_satisfied",
         "_suicide_is_satisfied",
     ]
 
@@ -229,7 +225,6 @@ class TaskState:
         self.is_updated = False
         self.time_updated = None
 
-        self._is_satisfied = None
         self._suicide_is_satisfied = None
 
         # Prerequisites.
@@ -324,7 +319,6 @@ class TaskState:
             if yep:
                 valid = valid.union(yep)
                 continue
-            self._is_satisfied = None
             self._suicide_is_satisfied = None
         return valid
 
@@ -340,14 +334,10 @@ class TaskState:
         """Set all my prerequisites satisfied."""
         for p in self.prerequisites:
             p.set_satisfied()
-        self._is_satisfied = True
 
     def prerequisites_all_satisfied(self):
         """Return True if (non-suicide) prerequisites are fully satisfied."""
-        if self._is_satisfied is None:
-            self._is_satisfied = all(
-                preq.is_satisfied() for preq in self.prerequisites)
-        return self._is_satisfied
+        return all(preq.is_satisfied() for preq in self.prerequisites)
 
     def prerequisites_are_not_all_satisfied(self):
         """Return True if (any) prerequisites are not fully satisfied."""
@@ -380,7 +370,6 @@ class TaskState:
         """Set prerequisites to all satisfied."""
         for prereq in self.prerequisites:
             prereq.set_satisfied()
-        self._is_satisfied = None
 
     def get_resolved_dependencies(self):
         """Return a list of dependencies which have been met for this task.
@@ -467,7 +456,6 @@ class TaskState:
         """Add task prerequisites."""
         # Triggers for sequence_i only used if my cycle point is a
         # valid member of sequence_i's sequence of cycle points.
-        self._is_satisfied = None
         self._suicide_is_satisfied = None
 
         # Use dicts to avoid generating duplicate prerequisites from sequences


### PR DESCRIPTION
These manually cached satisfaction states have the possibility to drift out of sync with individual `Prerequisite` satisfaction states, especially with `cylc remove` work in progress #5643 (`cylc remove` will have to unset any satisfied prerequisites that the removed task provided).

It looks like they are barely used in the first place (at least not anymore):
- `_is_satisfied` only has any savings at this call to `TaskState.prerequisites_are_not_all_satisfied()`:
    https://github.com/cylc/cylc-flow/blob/80fa008e18a6feb8ecb21123bde16c048fd1b599/cylc/flow/task_pool.py#L1755-L1760

    which is the case for absolute triggers e.g. `foo[2001] => bar` which are not so common?

- `_suicide_is_satisfied` only has any savings at the call above and this call:
    https://github.com/cylc/cylc-flow/blob/80fa008e18a6feb8ecb21123bde16c048fd1b599/cylc/flow/task_pool.py#L1425-L1430

    suicide triggers are also not so common.

I am not sure this is strictly necessary for `cylc remove` (but not happy about the current situation), hence putting it up for review standalone first.

These cached values were first introduced in #1775. There was an issue #1857 mentioning it - looks like it was the cached states drifting out of sync that caused the problem in that case, which is why I am unhappy about it generally. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests needed
- [x] No changelog needed as not visible to users
- [x] No docs needed
- [x] On master branch as code refactor
