### PR TITLE
Rework `Prerequisite` class to ensure caching of satisfaction state is handled automatically

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -116,6 +116,7 @@ from cylc.flow.wallclock import (
 if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.flow_mgr import FlowNums
+    from cylc.flow.prerequisite import Prerequisite
 
 EDGES = 'edges'
 FAMILIES = 'families'
@@ -1444,7 +1445,7 @@ class DataStoreMgr:
             prereq_ids.add(f'{relative_id}/{flow_nums_str}')
 
         # Batch load prerequisites of tasks according to flow.
-        prereqs_map = {}
+        prereqs_map: Dict[str, dict] = {}
         for (
                 cycle, name, prereq_name,
                 prereq_cycle, prereq_output, satisfied
@@ -1458,16 +1459,14 @@ class DataStoreMgr:
             ] = satisfied if satisfied != '0' else False
 
         for ikey, prereqs in prereqs_map.items():
+            itask_prereq: Prerequisite
             for itask_prereq in (
-                    self.db_load_task_proxies[ikey][0].state.prerequisites
+                self.db_load_task_proxies[ikey][0].state.prerequisites
             ):
-                for key in itask_prereq.satisfied.keys():
-                    try:
-                        itask_prereq.satisfied[key] = prereqs[key]
-                    except KeyError:
-                        # This prereq is not in the DB: new dependencies
-                        # added to an already-spawned task before restart.
-                        itask_prereq.satisfied[key] = False
+                for key in itask_prereq:
+                    itask_prereq[key] = prereqs.get(key, False)
+                    # (False if prereq is not in the DB: new dependencies
+                    # added to an already-spawned task before restart.)
 
         # Extract info from itasks to data-store.
         for task_info in self.db_load_task_proxies.values():

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -295,4 +295,4 @@ class Prerequisite:
         """
         return [f'{point}/{name}' for
                 (point, name, _), satisfied in self.satisfied.items() if
-                satisfied == self.DEP_STATE_SATISFIED]
+                satisfied]

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -18,18 +18,64 @@
 
 import math
 import re
-from typing import Iterable, Set, TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    ItemsView,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+# BACK COMPAT: typing_extensions.Literal
+# FROM: Python 3.7
+# TO: Python 3.8
+from typing_extensions import Literal
 
 from cylc.flow.cycling.loader import get_point
+from cylc.flow.data_messages_pb2 import PbCondition, PbPrerequisite
 from cylc.flow.exceptions import TriggerExpressionError
-from cylc.flow.data_messages_pb2 import (
-    PbPrerequisite,
-    PbCondition,
-)
 from cylc.flow.id import quick_relative_detokenise
 
+
 if TYPE_CHECKING:
+    from cylc.flow.cycling import PointBase
     from cylc.flow.id import Tokens
+
+
+AnyPrereqMessage = Tuple[Union['PointBase', str, int], str, str]
+
+
+class PrereqMessage(NamedTuple):
+    """A message pertaining to a Prerequisite."""
+    point: str
+    task: str
+    output: str
+
+    def get_id(self) -> str:
+        """Get the relative ID of the task in this prereq message."""
+        return quick_relative_detokenise(self.point, self.task)
+
+    @staticmethod
+    def coerce(tuple_: AnyPrereqMessage) -> 'PrereqMessage':
+        """Coerce a tuple to a PrereqMessage."""
+        if isinstance(tuple_, PrereqMessage):
+            return tuple_
+        point, task, output = tuple_
+        return PrereqMessage(point=str(point), task=task, output=output)
+
+
+SatisfiedState = Literal[
+    'satisfied naturally',
+    'satisfied from database',
+    'force satisfied',
+    False
+]
 
 
 class Prerequisite:
@@ -46,70 +92,83 @@ class Prerequisite:
 
     # Memory optimization - constrain possible attributes to this list.
     __slots__ = (
-        "satisfied",
+        "_satisfied",
         "_all_satisfied",
         "conditional_expression",
         "point",
     )
 
     # Extracts T from "foo.T succeeded" etc.
-    SATISFIED_TEMPLATE = 'bool(self.satisfied[("%s", "%s", "%s")])'
+    SATISFIED_TEMPLATE = 'bool(self._satisfied[("%s", "%s", "%s")])'
     MESSAGE_TEMPLATE = r'%s/%s %s'
 
-    DEP_STATE_SATISFIED = 'satisfied naturally'
-    DEP_STATE_OVERRIDDEN = 'force satisfied'
-    DEP_STATE_UNSATISFIED = False
-
-    def __init__(self, point):
+    def __init__(self, point: 'PointBase'):
         # The cycle point to which this prerequisite belongs.
         # cylc.flow.cycling.PointBase
         self.point = point
 
         # Dictionary of messages pertaining to this prerequisite.
         # {('point string', 'task name', 'output'): DEP_STATE_X, ...}
-        self.satisfied = {}
+        self._satisfied: Dict[PrereqMessage, SatisfiedState] = {}
 
         # Expression present only when conditions are used.
         # '1/foo failed & 1/bar succeeded'
-        self.conditional_expression = None
+        self.conditional_expression: Optional[str] = None
 
         # The cached state of this prerequisite:
         # * `None` (no cached state)
         # * `True` (prerequisite satisfied)
         # * `False` (prerequisite unsatisfied).
-        self._all_satisfied = None
+        self._all_satisfied: Optional[bool] = None
 
-    def instantaneous_hash(self):
+    def instantaneous_hash(self) -> int:
         """Generate a hash of this prerequisite in its current state.
 
-        Note not using `__hash__` because Prerequisite objects are mutable.
+        NOTE: Is not affected by any change in satisfaction state.
+
+        (Not defining `self.__hash__()` because Prerequisite objects
+        are mutable.)
         """
         return hash((
             self.point,
             self.conditional_expression,
-            tuple(self.satisfied.keys()),
+            tuple(self._satisfied.keys()),
         ))
 
-    def add(self, name, point, output, pre_initial=False):
+    def __getitem__(self, key: AnyPrereqMessage) -> SatisfiedState:
+        """Return the satisfaction state of a dependency.
+
+        Args:
+            key: Tuple of (point, name, output) for a task.
+        """
+        return self._satisfied[PrereqMessage.coerce(key)]
+
+    def __setitem__(
+        self,
+        key: AnyPrereqMessage,
+        value: Union[SatisfiedState, bool] = False,
+    ) -> None:
         """Register an output with this prerequisite.
 
         Args:
-            name (str): The name of the task to which the output pertains.
-            point (str/cylc.flow.cycling.PointBase): The cycle point at which
-                this dependent output should appear.
-            output (str): String representing the output e.g. "succeeded".
-            pre_initial (bool): this is a pre-initial dependency.
+            key: Tuple of (point, name, output) for a prerequisite task.
+            value: Dependency satisfaction state (for pre-initial dependencies
+                this should be True).
 
         """
-        message = (str(point), name, output)
+        key = PrereqMessage.coerce(key)
+        if value is True:
+            value = 'satisfied naturally'
+        self._satisfied[key] = value
+        if not (self._all_satisfied and value):
+            # Force later recalculation of cached satisfaction state:
+            self._all_satisfied = None
 
-        # Add a new prerequisite as satisfied if pre-initial, else unsatisfied.
-        if pre_initial:
-            self.satisfied[message] = self.DEP_STATE_SATISFIED
-        else:
-            self.satisfied[message] = self.DEP_STATE_UNSATISFIED
-        if self._all_satisfied is not None:
-            self._all_satisfied = False
+    def __iter__(self) -> Iterator[PrereqMessage]:
+        return iter(self._satisfied)
+
+    def items(self) -> ItemsView[PrereqMessage, SatisfiedState]:
+        return self._satisfied.items()
 
     def get_raw_conditional_expression(self):
         """Return a representation of this prereq as a string.
@@ -120,7 +179,7 @@ class Prerequisite:
         expr = self.conditional_expression
         if not expr:
             return None
-        for message in self.satisfied:
+        for message in self._satisfied:
             expr = expr.replace(self.SATISFIED_TEMPLATE % message,
                                 self.MESSAGE_TEMPLATE % message)
         return expr
@@ -134,21 +193,19 @@ class Prerequisite:
             # is a substring of another: foo | xfoo => bar.
             # Add 'foo' to the 'satisfied' dict before 'xfoo'.
             >>> preq = Prerequisite(1)
-            >>> preq.satisfied = {
-            ...    ('1', 'foo', 'succeeded'): False,
-            ...    ('1', 'xfoo', 'succeeded'): False
-            ... }
+            >>> preq[(1, 'foo', 'succeeded')] = False
+            >>> preq[(1, 'xfoo', 'succeeded')] = False
             >>> preq.set_condition("1/foo succeeded|1/xfoo succeeded")
             >>> expr = preq.conditional_expression
             >>> expr.split('|')  # doctest: +NORMALIZE_WHITESPACE
-            ['bool(self.satisfied[("1", "foo", "succeeded")])',
-            'bool(self.satisfied[("1", "xfoo", "succeeded")])']
+            ['bool(self._satisfied[("1", "foo", "succeeded")])',
+            'bool(self._satisfied[("1", "xfoo", "succeeded")])']
 
         """
         self._all_satisfied = None
         if '|' in expr:
             # Make a Python expression so we can eval() the logic.
-            for message in self.satisfied:
+            for message in self._satisfied:
                 # Use '\b' in case one task name is a substring of another
                 # and escape special chars ('.', timezone '+') in task IDs.
                 expr = re.sub(
@@ -166,25 +223,23 @@ class Prerequisite:
 
         """
         if self._all_satisfied is not None:
+            # Cached value.
             return self._all_satisfied
-        else:
-            # No cached value.
-            if self.satisfied == {}:
-                # No prerequisites left after pre-initial simplification.
-                return True
-            if self.conditional_expression:
-                # Trigger expression with at least one '|': use eval.
-                self._all_satisfied = self._conditional_is_satisfied()
-            else:
-                self._all_satisfied = all(self.satisfied.values())
-            return self._all_satisfied
+        if self._satisfied == {}:
+            # No prerequisites left after pre-initial simplification.
+            return True
+        self._all_satisfied = self._eval_satisfied()
+        return self._all_satisfied
 
-    def _conditional_is_satisfied(self):
+    def _eval_satisfied(self) -> bool:
         """Evaluate the prerequisite's condition expression.
 
         Does not cache the result.
 
         """
+        if not self.conditional_expression:
+            return all(self._satisfied.values())
+
         try:
             res = eval(self.conditional_expression)  # nosec
             # * the expression is constructed internally
@@ -208,20 +263,18 @@ class Prerequisite:
         """
         valid = set()
         for output in outputs:
-            prereq = (output['cycle'], output['task'], output['task_sel'])
-            if prereq not in self.satisfied:
+            prereq = PrereqMessage(
+                output['cycle'], output['task'], output['task_sel']
+            )
+            if prereq not in self._satisfied:
                 continue
             valid.add(output)
-            self.satisfied[prereq] = self.DEP_STATE_SATISFIED
-            if self.conditional_expression is None:
-                self._all_satisfied = all(self.satisfied.values())
-            else:
-                self._all_satisfied = self._conditional_is_satisfied()
+            self[prereq] = 'satisfied naturally'
         return valid
 
-    def api_dump(self):
+    def api_dump(self) -> Optional[PbPrerequisite]:
         """Return list of populated Protobuf data objects."""
-        if not self.satisfied:
+        if not self._satisfied:
             return None
         if self.conditional_expression:
             expr = (
@@ -230,26 +283,22 @@ class Prerequisite:
         else:
             expr = ' & '.join(
                 self.MESSAGE_TEMPLATE % s_msg
-                for s_msg in self.satisfied
+                for s_msg in self._satisfied
             )
         conds = []
-        num_length = math.ceil(len(self.satisfied) / 10)
-        for ind, message_tuple in enumerate(sorted(self.satisfied)):
-            point, name = message_tuple[0:2]
-            t_id = quick_relative_detokenise(point, name)
+        num_length = math.ceil(len(self._satisfied) / 10)
+        for ind, message_tuple in enumerate(sorted(self._satisfied)):
+            t_id = message_tuple.get_id()
             char = 'c%.{0}d'.format(num_length) % ind
             c_msg = self.MESSAGE_TEMPLATE % message_tuple
-            c_val = self.satisfied[message_tuple]
-            c_bool = bool(c_val)
-            if c_bool is False:
-                c_val = "unsatisfied"
+            c_val = self._satisfied[message_tuple]
             conds.append(
                 PbCondition(
                     task_proxy=t_id,
                     expr_alias=char,
-                    req_state=message_tuple[2],
-                    satisfied=c_bool,
-                    message=c_val,
+                    req_state=message_tuple.output,
+                    satisfied=bool(c_val),
+                    message=(c_val or 'unsatisfied'),
                 )
             )
             expr = expr.replace(c_msg, char)
@@ -260,24 +309,23 @@ class Prerequisite:
             cycle_points=sorted(self.iter_target_point_strings()),
         )
 
-    def set_satisfied(self):
+    def set_satisfied(self) -> None:
         """Force this prerequisite into the satisfied state.
 
         State can be overridden by calling `self.satisfy_me`.
 
         """
-        for message in self.satisfied:
-            if not self.satisfied[message]:
-                self.satisfied[message] = self.DEP_STATE_OVERRIDDEN
-        if self.conditional_expression is None:
-            self._all_satisfied = True
+        for message in self._satisfied:
+            if not self._satisfied[message]:
+                self._satisfied[message] = 'force satisfied'
+        if self.conditional_expression:
+            self._all_satisfied = self._eval_satisfied()
         else:
-            self._all_satisfied = self._conditional_is_satisfied()
+            self._all_satisfied = True
 
     def iter_target_point_strings(self):
         yield from {
-            message[0]
-            for message in self.satisfied
+            message.point for message in self._satisfied
         }
 
     def get_target_points(self):
@@ -287,12 +335,14 @@ class Prerequisite:
             get_point(p) for p in self.iter_target_point_strings()
         ]
 
-    def get_resolved_dependencies(self):
+    def get_resolved_dependencies(self) -> List[str]:
         """Return a list of satisfied dependencies.
 
         E.G: ['1/foo', '2/bar']
 
         """
-        return [f'{point}/{name}' for
-                (point, name, _), satisfied in self.satisfied.items() if
-                satisfied]
+        return [
+            msg.get_id()
+            for msg, satisfied in self._satisfied.items()
+            if satisfied
+        ]

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1209,16 +1209,14 @@ class TaskPool:
             task_point = itask.point
             if self.stop_point and task_point > self.stop_point:
                 continue
-            for point, task, msg in (
-                itask.state.get_unsatisfied_prerequisites()
-            ):
-                if get_point(point) > self.stop_point:
+            for pr in itask.state.get_unsatisfied_prerequisites():
+                if self.stop_point and get_point(pr.point) > self.stop_point:
                     continue
                 if itask.identity not in unsat:
                     unsat[itask.identity] = []
                 unsat[itask.identity].append(
-                    f"{point}/{task}:"
-                    f"{self.config.get_taskdef(task).get_output(msg)}"
+                    f"{pr.get_id()}:"
+                    f"{self.config.get_taskdef(pr.task).get_output(pr.output)}"
                 )
         if unsat:
             LOG.warning(

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -17,20 +17,22 @@
 """Task definition."""
 
 from collections import deque
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 
 import cylc.flow.flags
 from cylc.flow.exceptions import TaskDefError
 from cylc.flow.task_id import TaskID
 from cylc.flow.task_outputs import (
+    SORT_ORDERS,
+    TASK_OUTPUT_FAILED,
     TASK_OUTPUT_SUBMITTED,
     TASK_OUTPUT_SUCCEEDED,
-    TASK_OUTPUT_FAILED,
-    SORT_ORDERS
 )
 
+
 if TYPE_CHECKING:
-    from cylc.flow.cycling import PointBase
+    from cylc.flow.cycling import PointBase, SequenceBase
+    from cylc.flow.task_trigger import Dependency
 
 
 def generate_graph_children(tdef, point):
@@ -145,7 +147,7 @@ class TaskDef:
         self.start_point = start_point
         self.initial_point = initial_point
 
-        self.sequences = []
+        self.sequences: List[SequenceBase] = []
         self.used_in_offset_trigger = False
 
         # some defaults
@@ -155,7 +157,7 @@ class TaskDef:
 
         self.expiration_offset = None
         self.namespace_hierarchy = []
-        self.dependencies = {}
+        self.dependencies: Dict[SequenceBase, List[Dependency]] = {}
         self.outputs = {}  # {output: (message, is_required)}
         self.graph_children = {}
         self.graph_parents = {}

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -479,7 +479,7 @@ class WorkflowDatabaseManager:
         for itask in pool.get_tasks():
             for prereq in itask.state.prerequisites:
                 for (p_cycle, p_name, p_output), satisfied_state in (
-                    prereq.satisfied.items()
+                    prereq.items()
                 ):
                     self.put_insert_task_prerequisites(itask, {
                         "flow_nums": serialise_set(itask.flow_nums),

--- a/tests/integration/scripts/test_set.py
+++ b/tests/integration/scripts/test_set.py
@@ -20,8 +20,10 @@ Note: see also functional tests
 """
 
 from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.data_messages_pb2 import PbTaskProxy
 from cylc.flow.data_store_mgr import TASK_PROXIES
-from cylc.flow.task_state import TASK_STATUS_WAITING, TASK_STATUS_SUCCEEDED
+from cylc.flow.scheduler import Scheduler
+from cylc.flow.task_state import TASK_STATUS_SUCCEEDED, TASK_STATUS_WAITING
 
 
 async def test_set_parentless_spawning(
@@ -106,11 +108,11 @@ async def test_data_store(
             'a': {'outputs': {'x': 'xyz'}},
         },
     })
-    schd = scheduler(id_)
+    schd: Scheduler = scheduler(id_)
     async with start(schd):
         await schd.update_data_structure()
         data = schd.data_store_mgr.data[schd.tokens.id]
-        task_a = data[TASK_PROXIES][
+        task_a: PbTaskProxy = data[TASK_PROXIES][
             schd.pool.get_task(IntegerPoint('1'), 'a').tokens.id
         ]
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -33,6 +33,7 @@ from cylc.flow import CYLC_LOG
 from cylc.flow import commands
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
+from cylc.flow.data_messages_pb2 import PbPrerequisite
 from cylc.flow.data_store_mgr import TASK_PROXIES
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
@@ -699,7 +700,7 @@ async def test_restart_prereqs(
         }
     }
     id_ = flow(conf)
-    schd = scheduler(id_, run_mode='simulation', paused_start=False)
+    schd: Scheduler = scheduler(id_, paused_start=False)
 
     async with start(schd):
         # Release tasks 1/a and 1/b
@@ -737,7 +738,7 @@ async def test_restart_prereqs(
         ][0]
         assert sorted(
             (
-                p.satisfied
+                p._satisfied
                 for p in task_z.state.prerequisites
             ),
             key=lambda d: tuple(d.keys())[0],
@@ -822,7 +823,7 @@ async def test_reload_prereqs(
         }
     }
     id_ = flow(conf)
-    schd = scheduler(id_, run_mode='simulation', paused_start=False)
+    schd: Scheduler = scheduler(id_, paused_start=False)
 
     async with start(schd):
         # Release tasks 1/a and 1/b
@@ -849,7 +850,7 @@ async def test_reload_prereqs(
         ][0]
         assert sorted(
             (
-                p.satisfied
+                p._satisfied
                 for p in task_z.state.prerequisites
             ),
             key=lambda d: tuple(d.keys())[0],
@@ -857,6 +858,7 @@ async def test_reload_prereqs(
 
 
 async def _test_restart_prereqs_sat():
+    schd: Scheduler
     # YIELD: the workflow has now started...
     schd = yield
     await schd.update_data_structure()
@@ -891,7 +893,7 @@ async def _test_restart_prereqs_sat():
     assert sorted(
         (*key, satisfied)
         for prereq in task_c.state.prerequisites
-        for key, satisfied in prereq.satisfied.items()
+        for key, satisfied in prereq.items()
     ) == [
         ('1', 'a', 'succeeded', 'satisfied naturally'),
         ('1', 'b', 'succeeded', 'satisfied from database')
@@ -902,7 +904,7 @@ async def _test_restart_prereqs_sat():
     tasks = (
         schd.data_store_mgr.data[schd.data_store_mgr.workflow_id][TASK_PROXIES]
     )
-    task_c_prereqs = tasks[
+    task_c_prereqs: List[PbPrerequisite] = tasks[
         schd.data_store_mgr.id_.duplicate(cycle='1', task='c').id
     ].prerequisites
     assert sorted(
@@ -1414,7 +1416,7 @@ async def test_set_bad_prereqs(
     async with start(schd) as log:
         # Invalid: task name wildcard:
         set_prereqs(["2040/*"])
-        assert log_filter(log, contains='Invalid prerequisite task name' )
+        assert log_filter(log, contains='Invalid prerequisite task name')
 
         # Invalid: cycle point wildcard.
         set_prereqs(["*/foo"])
@@ -2085,7 +2087,7 @@ async def test_set_future_flow(flow, scheduler, start, log_filter):
         # set b:succeeded in flow 2 and check downstream spawning
         schd.pool.set_prereqs_and_outputs(['1/b'], prereqs=[], outputs=[], flow=[2])
         assert schd.pool.get_task(IntegerPoint("1"), "c1") is None, '1/c1 (flow 2) should not be spawned after 1/b:succeeded'
-        assert schd.pool.get_task(IntegerPoint("1"), "c2") is not None, '1/c2 (flow 2) should be spawned after 1/b:succeeded' 
+        assert schd.pool.get_task(IntegerPoint("1"), "c2") is not None, '1/c2 (flow 2) should be spawned after 1/b:succeeded'
 
 
 async def test_trigger_queue(one, run, db_select, complete):

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.loader import ISO8601_CYCLING_TYPE, get_point
 from cylc.flow.prerequisite import Prerequisite
 from cylc.flow.id import Tokens
@@ -102,3 +103,16 @@ def test_get_target_points(prereq):
         get_point('2000'),
         get_point('2001'),
     }
+
+
+def test_get_resolved_dependencies():
+    prereq = Prerequisite(IntegerPoint('2'))
+    prereq.satisfied[('1', 'a', 'x')] = 'satisfied naturally'
+    prereq.satisfied[('1', 'b', 'x')] = False
+    prereq.satisfied[('1', 'c', 'x')] = 'satisfied from database'
+    prereq.satisfied[('1', 'd', 'x')] = 'force satisfied'
+    assert prereq.get_resolved_dependencies() == [
+        '1/a',
+        '1/c',
+        '1/d',
+    ]

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -26,35 +26,15 @@ from cylc.flow.id import Tokens
 def prereq(set_cycling_type):
     set_cycling_type(ISO8601_CYCLING_TYPE, "Z")
     prereq = Prerequisite(get_point('2000'))
-    prereq.add(
-        'a',
-        '1999',
-        'succeeded',
-        True
-    )
-    prereq.add(
-        'b',
-        '2000',
-        'succeeded',
-        False
-    )
-    prereq.add(
-        'c',
-        '2000',
-        'succeeded',
-        False
-    )
-    prereq.add(
-        'd',
-        '2001',
-        'custom',
-        False
-    )
+    prereq[(1999, 'a', 'succeeded')] = True
+    prereq[(2000, 'b', 'succeeded')] = False
+    prereq[(2000, 'c', 'succeeded')] = False
+    prereq[(2001, 'd', 'custom')] = False
     return prereq
 
 
-def test_satisfied(prereq):
-    assert prereq.satisfied == {
+def test_satisfied(prereq: Prerequisite):
+    assert prereq._satisfied == {
         # the pre-initial dependency should be marked as satisfied
         ('1999', 'a', 'succeeded'): 'satisfied naturally',
         # all others should not
@@ -62,12 +42,18 @@ def test_satisfied(prereq):
         ('2000', 'c', 'succeeded'): False,
         ('2001', 'd', 'custom'): False,
     }
+    # No cached satisfaction state yet:
+    assert prereq._all_satisfied is None
+    # Calling self.is_satisfied() should cache the result:
+    assert not prereq.is_satisfied()
+    assert prereq._all_satisfied is False
+
     # mark two prerequisites as satisfied
     prereq.satisfy_me([
         Tokens('2000/b:succeeded', relative=True),
         Tokens('2000/c:succeeded', relative=True),
     ])
-    assert prereq.satisfied == {
+    assert prereq._satisfied == {
         # the pre-initial dependency should be marked as satisfied
         ('1999', 'a', 'succeeded'): 'satisfied naturally',
         # the two newly-satisfied dependency should be satisfied
@@ -76,9 +62,13 @@ def test_satisfied(prereq):
         # the remaining dependency should not
         ('2001', 'd', 'custom'): False,
     }
+    # Should have reset cached satisfaction state:
+    assert prereq._all_satisfied is None
+    assert not prereq.is_satisfied()
+
     # mark all prereqs as satisfied
     prereq.set_satisfied()
-    assert prereq.satisfied == {
+    assert prereq._satisfied == {
         # the pre-initial dependency should be marked as satisfied
         ('1999', 'a', 'succeeded'): 'satisfied naturally',
         # the two newly-satisfied dependency should be satisfied
@@ -87,6 +77,49 @@ def test_satisfied(prereq):
         # the remaining dependency should be marked as forse-satisfied
         ('2001', 'd', 'custom'): 'force satisfied',
     }
+    # Should have set cached satisfaction state as must be true now:
+    assert prereq._all_satisfied is True
+    assert prereq.is_satisfied()
+
+
+def test_getitem_setitem(prereq: Prerequisite):
+    msg = ('2000', 'b', 'succeeded')
+    # __getitem__:
+    assert prereq[msg] is False
+
+    # __setitem__:
+    prereq[msg] = True
+    assert prereq[msg] == 'satisfied naturally'
+    prereq[msg] = 'force satisfied'
+    assert prereq[msg] == 'force satisfied'
+    # coercion of cycle point
+    assert prereq[(2000, 'b', 'succeeded')] == 'force satisfied'
+    assert prereq[(get_point('2000'), 'b', 'succeeded')] == 'force satisfied'
+
+
+def test_iter(prereq: Prerequisite):
+    assert list(prereq) == [
+        ('1999', 'a', 'succeeded'),
+        ('2000', 'b', 'succeeded'),
+        ('2000', 'c', 'succeeded'),
+        ('2001', 'd', 'custom'),
+    ]
+    assert [p.task for p in prereq] == ['a', 'b', 'c', 'd']
+
+
+def test_items(prereq: Prerequisite):
+    assert list(prereq.items()) == [
+        (('1999', 'a', 'succeeded'), 'satisfied naturally'),
+        (('2000', 'b', 'succeeded'), False),
+        (('2000', 'c', 'succeeded'), False),
+        (('2001', 'd', 'custom'), False),
+    ]
+
+
+def test_set_condition(prereq: Prerequisite):
+    assert not prereq.is_satisfied()
+    prereq.set_condition('1999/a succeeded | 2000/b succeeded')
+    assert prereq.is_satisfied()
 
 
 def test_iter_target_point_strings(prereq):
@@ -107,10 +140,10 @@ def test_get_target_points(prereq):
 
 def test_get_resolved_dependencies():
     prereq = Prerequisite(IntegerPoint('2'))
-    prereq.satisfied[('1', 'a', 'x')] = 'satisfied naturally'
-    prereq.satisfied[('1', 'b', 'x')] = False
-    prereq.satisfied[('1', 'c', 'x')] = 'satisfied from database'
-    prereq.satisfied[('1', 'd', 'x')] = 'force satisfied'
+    prereq[('1', 'a', 'x')] = True
+    prereq[('1', 'b', 'x')] = False
+    prereq[('1', 'c', 'x')] = 'satisfied from database'
+    prereq[('1', 'd', 'x')] = 'force satisfied'
     assert prereq.get_resolved_dependencies() == [
         '1/a',
         '1/c',

--- a/tests/unit/test_task_state.py
+++ b/tests/unit/test_task_state.py
@@ -100,7 +100,7 @@ def test_task_prereq_duplicates(set_cycling_type):
 
     tstate = TaskState(tdef, IntegerPoint("1"), TASK_STATUS_WAITING, False)
 
-    prereqs = [p.satisfied for p in tstate.prerequisites]
+    prereqs = [p._satisfied for p in tstate.prerequisites]
 
     assert prereqs == [{("1", "a", "succeeded"): False}]
 
@@ -118,4 +118,3 @@ def test_task_state_order():
     assert tstate.is_gte(TASK_STATUS_SUBMITTED)
     assert not tstate.is_gt(TASK_STATUS_RUNNING)
     assert not tstate.is_gte(TASK_STATUS_RUNNING)
-


### PR DESCRIPTION
Follow-up to #6287, split off from `cylc remove` work (#5643).

The caching of satisfaction state on a `Prerequisite` object is handled manually at the moment, which could have led to nasty bugs had I not spotted this, as `cylc remove` will unset any satisfied prerequisites that the removed task provided.

I have made the `Prerequisite.satisfied` dict private and exposed a `__setitem__ / __getitem__` API which automatically resets the cached satisfaction state.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry needed as not user-facing
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
