### PR TITLE
Demote "timer stopped" warning to info & fix functional tests `contains_ok` function

### DIFF
--- a/cylc/flow/timer.py
+++ b/cylc/flow/timer.py
@@ -52,7 +52,7 @@ class Timer:
         if self.timeout is None:
             return
         self.timeout = None
-        LOG.warning(f"{self.name} stopped")
+        LOG.info(f"{self.name} stopped")
 
     def timed_out(self) -> bool:
         """Return whether timed out yet."""

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -386,7 +386,7 @@ contains_ok() {
     local FILE_CONTROL="${2:--}"
     local TEST_NAME
     TEST_NAME="$(basename "${FILE_TEST}")-contains-ok"
-    LANG=C comm -13 <(sort "${FILE_TEST}") <(sort "${FILE_CONTROL}") \
+    LANG=C comm -13 <(LANG=C sort "${FILE_TEST}") <(LANG=C sort "${FILE_CONTROL}") \
         1>"${TEST_NAME}.stdout" 2>"${TEST_NAME}.stderr"
     if [[ -s "${TEST_NAME}.stdout" ]]; then
         mkdir -p "${TEST_LOG_DIR}"

--- a/tests/unit/test_timer.py
+++ b/tests/unit/test_timer.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from time import sleep
 
 import pytest
@@ -23,7 +24,7 @@ from cylc.flow.timer import Timer
 
 def test_Timer(caplog: pytest.LogCaptureFixture):
     """Test the Timer class."""
-    caplog.set_level('WARNING')
+    caplog.set_level(logging.INFO)
     timer = Timer("bob timeout", 1.0)
 
     # timer attributes


### PR DESCRIPTION
```
WARNING - stall timer stopped
```

is a bit noisy, demoted it to `INFO`

---
Functional tests: `contains_ok`

Setting `LANG=C` at the start of
```bash
LANG=C comm <(sort $FILE1) <(sort FILE2)
```
only applies to `comm` and not the `sort`s in the process substitutions

---

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No changelog, tests or docs needed as minor
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
