### PR TITLE
Tweak handling of daemon exit to avoid macos traceback.

### DIFF
--- a/changes.d/6297.fix.md
+++ b/changes.d/6297.fix.md
@@ -1,0 +1,1 @@
+Prevent inconsequential traceback on startup and shutdown, since version 8.3.0, on macOS.


### PR DESCRIPTION

Close #6291 

Avoid inconsequential but frightening tracebacks at startup and shutdown on macOS, in detaching mode.

Uses `os._exit()`, which *I think* should be safe in this context:

```
Help on built-in function _exit in module posix:

_exit(status)
    Exit to the system with specified status, without normal exit processing.
```

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests NOT NEEDED (change is non functional)
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
