### PR TITLE
Functional tests: fix unbound env var failure

### DIFF
--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -784,7 +784,7 @@ skip_all() {
 
 skip_macos_gh_actions() {
     # https://github.com/cylc/cylc-flow/issues/6276
-    if [[ "$CI" && "$OSTYPE" == "darwin"* ]]; then
+    if [[ "${CI:-}" && "$OSTYPE" == "darwin"* ]]; then
         skip_all "Skipped due to performance issues on GH Actions MacOS runner"
     fi
 }


### PR DESCRIPTION
Fix tests failing locally due to unbound `$CI` variable, while still [running](https://github.com/cylc/cylc-flow/actions/runs/10372770706/job/28716276626?pr=6300#step:16:142) or [skipping](https://github.com/cylc/cylc-flow/actions/runs/10372770706/job/28716278817?pr=6300#step:16:32) as appropriate on GH Actions