### PR TITLE
Remove `c` char from prereq API dump

### DIFF
--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -16,7 +16,6 @@
 
 """Functionality for expressing and evaluating logical triggers."""
 
-import math
 import re
 from typing import Iterable, Set, TYPE_CHECKING
 
@@ -232,11 +231,11 @@ class Prerequisite:
                 for s_msg in self.satisfied
             )
         conds = []
-        num_length = math.ceil(len(self.satisfied) / 10)
+        num_length = len(str(len(self.satisfied)))
         for ind, message_tuple in enumerate(sorted(self.satisfied)):
             point, name = message_tuple[0:2]
             t_id = quick_relative_detokenise(point, name)
-            char = 'c%.{0}d'.format(num_length) % ind
+            char = str(ind).zfill(num_length)
             c_msg = self.MESSAGE_TEMPLATE % message_tuple
             c_val = self.satisfied[message_tuple]
             c_bool = bool(c_val)

--- a/tests/flakyfunctional/cylc-show/00-simple.t
+++ b/tests/flakyfunctional/cylc-show/00-simple.t
@@ -112,10 +112,10 @@ cmp_json "${TEST_NAME}-taskinstance" "${TEST_NAME}-taskinstance" \
         "runtime": {"completion": "(started and succeeded)"},
         "prerequisites": [
             {
-                "expression": "c0",
+                "expression": "0",
                 "conditions": [
                     {
-                        "exprAlias": "c0",
+                        "exprAlias": "0",
                         "taskId": "20141106T0900Z/bar",
                         "reqState": "succeeded",
                         "message": "satisfied naturally",


### PR DESCRIPTION
https://github.com/cylc/cylc-ui/pull/1886#discussion_r1718434619

Not sure why "c" was ever included in the prerequisite alias. It is somewhat confusing when you have single-letter task names as we do in test workflows.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are updated.
- [x] No changelog or docs needed as not user-facing
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
