### PR TITLE
Flake8: remove wrongly ignored error code

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ ignore=
     W504
     ; "experimental" SIM9xx rules (flake8-simplify)
     SIM9
-    ; suggests using f"{!r}" instead of manual quotes (flake8-bugbear)
-    ; Doesn't work at 3.7
-    B028
 
 per-file-ignores=
     ; TYPE_CHECKING block suggestions


### PR DESCRIPTION
Stop ignoring this flake8-bugbear rule:

> B028: No explicit stacklevel argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.

The code that was meant to be ignored according to the comment in `tox.ini` was:

> B907: Consider replacing f"'{foo}'" with f"{foo!r}" which is both easier to read and will escape quotes inside foo if that would appear. The check tries to filter out any format specs that are invalid together with !r. If you're using other conversion flags then e.g. f"'{foo!a}'" can be replaced with f"{ascii(foo)!r}". Not currently implemented for python<3.8 or str.format() calls.

This is an opinionated warning which is not enabled by default

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes, docs, tests, changelog entry needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
