### PR TITLE
param expand: efficiency improvements

### DIFF
--- a/cylc/flow/param_expand.py
+++ b/cylc/flow/param_expand.py
@@ -62,7 +62,6 @@ from typing import List, Tuple
 
 from cylc.flow.exceptions import ParamExpandError
 from cylc.flow.task_id import TaskID
-from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 
 # To split runtime heading name lists.
 REC_NAMES = re.compile(r'(?:[^,<]|<[^>]*>)+')
@@ -398,7 +397,7 @@ class GraphExpander:
             # Inner loop.
             for p_group in set(REC_P_GROUP.findall(line)):
                 # Parameters must be expanded in the order found.
-                param_values = OrderedDictWithDefaults()
+                param_values = {}
                 tmpl = ''
                 for item in p_group.split(','):
                     pname, offs = REC_P_OFFS.match(item).groups()

--- a/cylc/flow/param_expand.py
+++ b/cylc/flow/param_expand.py
@@ -398,7 +398,6 @@ class GraphExpander:
             for p_group in set(REC_P_GROUP.findall(line)):
                 # Parameters must be expanded in the order found.
                 param_values = {}
-                tmpl = ''
                 for item in p_group.split(','):
                     pname, offs = REC_P_OFFS.match(item).groups()
                     if offs is None:
@@ -420,8 +419,10 @@ class GraphExpander:
                         else:
                             offval = self._REMOVE
                         param_values[pname] = offval
-                for pname in param_values:
-                    tmpl += self.param_tmpl_cfg[pname]
+                tmpl = ''.join(
+                    self.param_tmpl_cfg[pname]
+                    for pname in param_values
+                )
                 try:
                     repl = tmpl % param_values
                 except KeyError as exc:

--- a/cylc/flow/param_expand.py
+++ b/cylc/flow/param_expand.py
@@ -404,7 +404,7 @@ class GraphExpander:
                     pname, offs = REC_P_OFFS.match(item).groups()
                     if offs is None:
                         param_values[pname] = values[pname]
-                    elif offs.startswith('='):
+                    elif offs[0] == '=':
                         # Specific value.
                         try:
                             # Template may require an integer


### PR DESCRIPTION
Whils**t** investigating a bug, I found the workflow I was investigating loaded extremely slowly (~85-87s).

Over 90% of that time was down to the `_expand_graph` routine. We may be able to implement this more efficiently, but without getting too into it, there were three obvious improvements which bring it down to ~61s (~30% saving) without changing how the method works.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.