### PR TITLE
task_events_mgr: handle missing job config

### DIFF
--- a/changes.d/6326.fix.md
+++ b/changes.d/6326.fix.md
@@ -1,0 +1,1 @@
+Fix a rare issue where missing job records could cause tasks to become stuck in active states.


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/6314
* There are niche situations where the job is not stored in "TaskProxy.jobs".
* This handles the situation as gracefully as we are able to.

The solution is far from ideal, the job config info has been lost for starters, however, I think that is non-functional at this stage?

@hjoliver, any better ideas?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.