### PR TITLE
Correctly reset log level when temporarily changing it

### DIFF
--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -90,8 +90,7 @@ def _get_logger(rund, log_name, open_file=True):
 
     """
     logger = logging.getLogger(log_name)
-    if logger.getEffectiveLevel != logging.INFO:
-        logger.setLevel(logging.INFO)
+    logger.setLevel(logging.INFO)
     if open_file and not logger.hasHandlers():
         _open_install_log(rund, logger)
     return logger

--- a/cylc/flow/loggingutil.py
+++ b/cylc/flow/loggingutil.py
@@ -430,7 +430,7 @@ def patch_log_level(logger: logging.Logger, level: int = logging.INFO):
 
     Defaults to INFO.
     """
-    orig_level = logger.getEffectiveLevel()
+    orig_level = logger.level
     if level < orig_level:
         logger.setLevel(level)
         yield

--- a/cylc/flow/tui/util.py
+++ b/cylc/flow/tui/util.py
@@ -51,10 +51,10 @@ def suppress_logging():
     silly for the duration of this context manager then set it back again
     afterwards.
     """
-    level = LOG.getEffectiveLevel()
+    orig_level = LOG.level
     LOG.setLevel(99999)
     yield
-    LOG.setLevel(level)
+    LOG.setLevel(orig_level)
 
 
 def get_task_icon(

--- a/tests/unit/test_loggingutil.py
+++ b/tests/unit/test_loggingutil.py
@@ -34,6 +34,7 @@ from cylc.flow.loggingutil import (
     RotatingLogFileHandler,
     get_reload_start_number,
     get_sorted_logs_by_time,
+    patch_log_level,
     set_timestamps,
 )
 
@@ -245,3 +246,32 @@ def test_log_emit_and_glbl_cfg(
     # Check log emit does not access global config object:
     LOG.debug("Entering zero gravity")
     assert mock_cfg.get.call_args_list == []
+
+
+def test_patch_log_level(caplog: pytest.LogCaptureFixture):
+    """Test patch_log_level temporarily changes the log level."""
+    caplog.set_level(logging.DEBUG)
+    logger = logging.getLogger("forest")
+    assert logger.level == logging.NOTSET
+    logger.setLevel(logging.ERROR)
+    logger.info("nope")
+    assert not caplog.records
+    with patch_log_level(logger, logging.INFO):
+        LOG.info("yep")
+        assert len(caplog.records) == 1
+    logger.info("nope")
+    assert len(caplog.records) == 1
+
+
+def test_patch_log_level__reset(caplog: pytest.LogCaptureFixture):
+    """Test patch_log_level resets the log level correctly after use."""
+    caplog.set_level(logging.ERROR)
+    logger = logging.getLogger("woods")
+    assert logger.level == logging.NOTSET
+    with patch_log_level(logger, logging.INFO):
+        logger.info("emitted but not captured, as caplog is at ERROR level")
+        assert not caplog.records
+    caplog.set_level(logging.INFO)
+    logger.info("yep")
+    assert len(caplog.records) == 1
+    assert logger.level == logging.NOTSET


### PR DESCRIPTION
Fixes tests that were failing on my `cylc remove` branch due to a change in order

#### Context

Running these 2 tests in this order would guarantee `test_Timer` would fail.
```
pytest -n 0 \
  tests/integration/scripts/test_show.py::test_workflow_meta_query \
  tests/unit/test_timer.py::test_Timer
```

This is due to the way we were temporarily changing the Cylc logger level during `Scheduler.start()`

https://github.com/cylc/cylc-flow/blob/cadf1ef057145873f869092ffcab9784ad7c082e/cylc/flow/loggingutil.py#L426-L437

`Logger.getEffectiveLevel()` will return the root logger level if `Logger.level` is `NOTSET`.

In pytest the root logger level is `WARNING`, so in the tests, there were cases where the Cylc logger was being incorrectly reset to `WARNING` instead of `NOTSET`

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] No changelog entry needed as not affecting users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
