### PR TITLE
Fix duplicate job submissions.

### DIFF
--- a/changes.d/6337.fix.md
+++ b/changes.d/6337.fix.md
@@ -1,0 +1,1 @@
+Fix potential duplicate job submissions when manually triggering unqueued active tasks.

--- a/cylc/flow/task_queues/__init__.py
+++ b/cylc/flow/task_queues/__init__.py
@@ -53,8 +53,8 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def remove_task(self, itask: 'TaskProxy') -> None:
-        """Remove a task from the queueing system."""
+    def remove_task(self, itask: 'TaskProxy') -> bool:
+        """Try to remove a task from the queues. Return True if done."""
         pass
 
     @abstractmethod

--- a/cylc/flow/task_queues/independent.py
+++ b/cylc/flow/task_queues/independent.py
@@ -130,19 +130,17 @@ class IndepQueueManager(TaskQueueManagerBase):
             self.force_released = set()
         return released
 
-    def remove_task(self, itask: 'TaskProxy') -> None:
-        """Remove a task from whichever queue it belongs to."""
-        for queue in self.queues.values():
-            if queue.remove(itask):
-                break
+    def remove_task(self, itask: 'TaskProxy') -> bool:
+        """Try to remove a task from the queues. Return True if done."""
+        return any(queue.remove(itask) for queue in self.queues.values())
 
     def force_release_task(self, itask: 'TaskProxy') -> None:
         """Remove a task from whichever queue it belongs to.
 
         To be returned when release_tasks() is next called.
         """
-        self.remove_task(itask)
-        self.force_released.add(itask)
+        if self.remove_task(itask):
+            self.force_released.add(itask)
 
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt orphaned tasks to the default group."""


### PR DESCRIPTION
Close #6329 

In the example of 6329 an upstream failure generates a bunch of partially satisfied tasks - i.e. active (`n=0`) but not queued. Triggering them manually causes them to be added to a `forced_released` list - wrongly as they were not queued in the first place.

A bit later, the `forced_released` tasks top up the list of naturally released tasks. But by then there is some overlap between the two lists, so the queue limit matters (along with some task-state related race condition which I haven't fully understood, but that doesn't matter) as to how many of these tasks end up getting submitted again.


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
