### PR TITLE
Fix.simulation mode started bug

### DIFF
--- a/changes.d/6351.fix.md
+++ b/changes.d/6351.fix.md
@@ -1,0 +1,1 @@
+Fix a bug where simulation mode tasks were not spawning children of task:started.

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -776,6 +776,9 @@ class TaskEventsManager():
                 )
                 self.data_store_mgr.delta_job_attr(
                     job_tokens, 'job_id', itask.summary['submit_method_id'])
+            else:
+                # In simulation mode submitted implies started:
+                self.spawn_children(itask, TASK_OUTPUT_STARTED)
 
         elif message.startswith(FAIL_MESSAGE_PREFIX):
             # Task received signal.

--- a/tests/integration/run_modes/test_simulation.py
+++ b/tests/integration/run_modes/test_simulation.py
@@ -1,0 +1,34 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test the workings of simulation mode"""
+
+
+async def test_started_trigger(flow, reftest, scheduler):
+    """Does the started task output trigger downstream tasks
+    in sim mode?
+
+    Long standing Bug discovered in Skip Mode work.
+    https://github.com/cylc/cylc-flow/pull/6039#issuecomment-2321147445
+    """
+    schd = scheduler(flow({
+        'scheduler': {'events': {'stall timeout': 'PT0S', 'abort on stall timeout': True}},
+        'scheduling': {'graph': {'R1': 'a:started => b'}}
+    }), paused_start=False)
+    assert await reftest(schd) == {
+        ('1/a', None),
+        ('1/b', ('1/a',))
+    }


### PR DESCRIPTION
Fixes a bug discovered by @oliver-sanders in the process of reviewing skip mode work (https://github.com/cylc/cylc-flow/pull/6039#issuecomment-2321147445). The bug however, is long-standing (it goes back at least as far as Cylc 8.0.0.

### Summary

In simulation mode, job starting is done by the job submission pathway as a side-effect (because in sim mode the two might as well be identical). However, the pathway is not currently spawning children of started.

### Example

Run this

```flow.cylc
# flow.cylc
[scheduling]
    [[graph]]
        R1 = a? & a:started => b

[runtime]
  [[root]]
    run mode  = skip
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
