### PR TITLE
Housekeep broadcasts on task completion

### DIFF
--- a/changes.d/6359.feat.md
+++ b/changes.d/6359.feat.md
@@ -1,0 +1,1 @@
+Clear broadcasts once on task completion, not on every main loop cycle.

--- a/cylc/flow/broadcast_report.py
+++ b/cylc/flow/broadcast_report.py
@@ -24,6 +24,8 @@ CHANGE_FMT = "\n%(change)s [%(point)s/%(namespace)s] %(key)s=%(value)s"
 CHANGE_PREFIX_CANCEL = "-"
 CHANGE_PREFIX_SET = "+"
 CHANGE_TITLE_CANCEL = "Broadcast cancelled:"
+CHANGE_TITLE_CANCEL_ON_COMPLETION = (
+    "Broadcast cancelled (housekept on task completion):")
 CHANGE_TITLE_SET = "Broadcast set:"
 
 
@@ -85,11 +87,19 @@ def get_broadcast_change_iter(modified_settings, is_cancel=False):
                     "value": str(value)}
 
 
-def get_broadcast_change_report(modified_settings, is_cancel=False):
-    """Return a string for reporting modification to broadcast settings."""
+def get_broadcast_change_report(
+    modified_settings, is_cancel=False, is_housekeeping=False
+):
+    """Return a string for reporting modification to broadcast settings.
+
+    Args:
+        is_housekeeping: Note that this is an automatic cancellation.
+    """
     if not modified_settings:
         return ""
-    if is_cancel:
+    if is_housekeeping:
+        msg = CHANGE_TITLE_CANCEL_ON_COMPLETION
+    elif is_cancel:
         msg = CHANGE_TITLE_CANCEL
     else:
         msg = CHANGE_TITLE_SET

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1531,7 +1531,6 @@ class Scheduler:
             # A simulated task state change occurred.
             self.reset_inactivity_timer()
 
-        self.broadcast_mgr.expire_broadcast(self.pool.get_min_point())
         self.late_tasks_check()
 
         self.process_queued_task_messages()

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1441,6 +1441,18 @@ class TaskPool:
     def remove_if_complete(
         self, itask: TaskProxy, output: Optional[str] = None
     ) -> bool:
+        """Wraps _remove_if_complete, clears broadcasts targeted
+        at this task if it's complete.
+        """
+        complete = self._remove_if_complete(itask, output)
+        if complete:
+            self.task_events_mgr.broadcast_mgr.housekeep(
+                **itask.tokens.task)
+        return complete
+
+    def _remove_if_complete(
+        self, itask: TaskProxy, output: Optional[str] = None
+    ) -> bool:
         """Remove a finished task if required outputs are complete.
 
         Return True if removed else False.

--- a/tests/flakyfunctional/database/01-broadcast.t
+++ b/tests/flakyfunctional/database/01-broadcast.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Workflow database content, broadcast + manual trigger to recover a failure.
 . "$(dirname "$0")/test_header"
-set_test_number 5
+set_test_number 4
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
@@ -37,13 +37,7 @@ sqlite3 "${DB_FILE}" \
     'SELECT change, point, namespace, key, value FROM broadcast_events' >"${NAME}"
 cmp_ok "${NAME}" <<'__SELECT__'
 +|1|t1|[environment]HELLO|Hello
-__SELECT__
-
-NAME='select-broadcast-states.out'
-sqlite3 "${DB_FILE}" \
-    'SELECT point, namespace, key, value FROM broadcast_states' >"${NAME}"
-cmp_ok "${NAME}" <<'__SELECT__'
-1|t1|[environment]HELLO|Hello
+-|1|t1|[environment]HELLO|Hello
 __SELECT__
 
 NAME='select-task-jobs.out'

--- a/tests/functional/broadcast/00-simple.t
+++ b/tests/functional/broadcast/00-simple.t
@@ -48,6 +48,8 @@ cmp_ok "${NAME}" <<'__SELECT__'
 +|*|m8|[environment]BCAST|M8
 +|*|m9|[environment]BCAST|M9
 -|20100808T00|foo|[environment]BCAST|FOO
+-|20100809T00|baz|[environment]BCAST|BAZ
+-|20100809T00|m2|[environment]BCAST|M2
 __SELECT__
 
 NAME='select-broadcast-states.out'
@@ -62,8 +64,6 @@ cmp_ok "${NAME}" <<'__SELECT__'
 *|m8|[environment]BCAST|M8
 *|m9|[environment]BCAST|M9
 *|root|[environment]BCAST|ROOT
-20100809T00|baz|[environment]BCAST|BAZ
-20100809T00|m2|[environment]BCAST|M2
 __SELECT__
 
 purge

--- a/tests/functional/restart/01-broadcast.t
+++ b/tests/functional/restart/01-broadcast.t
@@ -20,7 +20,7 @@ if [[ -z ${TEST_DIR:-} ]]; then
     . "$(dirname "$0")/test_header"
 fi
 #-------------------------------------------------------------------------------
-set_test_number 8
+set_test_number 7
 #-------------------------------------------------------------------------------
 install_workflow "${TEST_NAME_BASE}" 'broadcast'
 cp "$TEST_SOURCE_DIR/lib/flow-runtime-restart.cylc" "${WORKFLOW_RUN_DIR}/"
@@ -50,14 +50,6 @@ output_states|20130923T0000Z|1|1|succeeded
 send_a_broadcast_task|20130923T0000Z|1|1|succeeded
 shutdown|20130923T0000Z|1|1|succeeded
 __DB_DUMP__
-sqlite3 "${WORKFLOW_RUN_DIR}/log/db" '
-    SELECT
-        point,namespace,key,value
-    FROM
-        broadcast_states
-    ORDER BY
-        point,namespace,key' >'select-broadcast-states.out'
-cmp_ok 'select-broadcast-states.out' \
-    <<<"20130923T0000Z|broadcast_task|[environment]MY_VALUE|'something'"
+
 #-------------------------------------------------------------------------------
 purge


### PR DESCRIPTION
Closes #6308 

> [!NOTE]
> This is a moderate change in behaviour, so I've targeted 8.4.

Previously broadcasts have been housekept when they refer to a Cycle point the scheduler has moved on from. This probably doesn't make sense in a multi-flow system.

This PR moves the housekeeping to the point of completion, and doesn't attempt to re-expire broadcasts with every cycle of the main-loop. This allows users to broadcast a task from the past and trigger it without the broadcast being deleted before the trigger.

I've left the interface to expire broadcasts alone, so that users can still use if if they like.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
