### PR TITLE
`cylc clean`: fix bug where `--rm share` would not clean `share/cycle` symlink first

### DIFF
--- a/changes.d/6364.fix.md
+++ b/changes.d/6364.fix.md
@@ -1,0 +1,1 @@
+Fixed bug where `cylc clean <workflow> --rm share` would not take care of removing the target of the `share/cycle` symlink directory.

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -117,12 +117,8 @@ def _clean_check(opts: 'Values', id_: str, run_dir: Path) -> None:
     # Thing to clean must be a dir or broken symlink:
     if not run_dir.is_dir() and not run_dir.is_symlink():
         raise FileNotFoundError(f"No directory to clean at {run_dir}")
-    db_path = (
-        run_dir / WorkflowFiles.Service.DIRNAME / WorkflowFiles.Service.DB
-    )
-    if opts.local_only and not db_path.is_file():
-        # Will reach here if this is cylc clean re-invoked on remote host
-        # (workflow DB only exists on scheduler host); don't need to worry
+    if opts.no_scan:
+        # This is cylc clean re-invoked on remote host; don't need to worry
         # about contact file.
         return
     try:

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -259,7 +259,7 @@ def glob_in_run_dir(
     """Execute a (recursive) glob search in the given run directory.
 
     Returns list of any absolute paths that match the pattern. However:
-    * Does not follow symlinks (apart from the spcedified symlink dirs).
+    * Does not follow symlinks (apart from the specified symlink dirs).
     * Also does not return matching subpaths of matching directories (because
         that would be redundant).
 
@@ -281,6 +281,9 @@ def glob_in_run_dir(
     results: List[Path] = []
     subpath_excludes: Set[Path] = set()
     for path in matches:
+        # Iterate down through ancestors (starting at the run dir) to
+        # weed out redundant subpaths of matched directories and subpaths of
+        # non-standard symlinks
         for rel_ancestor in reversed(path.relative_to(run_dir).parents):
             ancestor = run_dir / rel_ancestor
             if ancestor in subpath_excludes:

--- a/cylc/flow/pathutil.py
+++ b/cylc/flow/pathutil.py
@@ -481,7 +481,8 @@ def parse_rm_dirs(rm_dirs: Iterable[str]) -> Set[str]:
 
 
 def is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
-    """Return whether or not path1 is relative to path2.
+    """Return whether or not path1 is relative to path2 (including if they are
+    the same path).
 
     Normalizes both paths to avoid trickery with paths containing `..`
     somewhere in them.

--- a/tests/unit/test_clean.py
+++ b/tests/unit/test_clean.py
@@ -34,8 +34,7 @@ from unittest import mock
 
 import pytest
 
-from cylc.flow import CYLC_LOG
-from cylc.flow import clean as cylc_clean
+from cylc.flow import CYLC_LOG, clean as cylc_clean
 from cylc.flow.clean import (
     _clean_using_glob,
     _remote_clean_cmd,
@@ -64,9 +63,11 @@ from .filetree import (
     FILETREE_2,
     FILETREE_3,
     FILETREE_4,
+    Symlink,
     create_filetree,
     get_filetree_as_list,
 )
+
 
 NonCallableFixture = Any
 
@@ -536,7 +537,7 @@ def filetree_for_testing_cylc_clean(tmp_path: Path):
                 'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
-                    'rincewind.txt': Path('whatever')
+                    'rincewind.txt': Symlink('whatever')
                 }}},
                 'sym': {'cylc-run': {'foo': {'bar': {}}}}
             }
@@ -548,12 +549,12 @@ def filetree_for_testing_cylc_clean(tmp_path: Path):
                 'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
-                    'log': Path('whatever'),
-                    'mirkwood': Path('whatever')
+                    'log': Symlink('whatever'),
+                    'mirkwood': Symlink('whatever')
                 }}},
                 'sym': {'cylc-run': {'foo': {'bar': {
                     'log': {
-                        'darmok': Path('whatever'),
+                        'darmok': Symlink('whatever'),
                         'bib': {}
                     }
                 }}}}
@@ -612,7 +613,7 @@ def test__clean_using_glob(
                 'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
-                    'rincewind.txt': Path('whatever')
+                    'rincewind.txt': Symlink('whatever')
                 }}},
                 'sym': {'cylc-run': {}}
             },
@@ -625,12 +626,12 @@ def test__clean_using_glob(
                 'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
-                    'log': Path('whatever'),
-                    'mirkwood': Path('whatever')
+                    'log': Symlink('whatever'),
+                    'mirkwood': Symlink('whatever')
                 }}},
                 'sym': {'cylc-run': {'foo': {'bar': {
                     'log': {
-                        'darmok': Path('whatever'),
+                        'darmok': Symlink('whatever'),
                         'bib': {}
                     }
                 }}}}
@@ -641,11 +642,13 @@ def test__clean_using_glob(
             {'**/cycle'},
             FILETREE_2,
             {
-                'cylc-run': {'foo': {'bar': Path('sym-run/cylc-run/foo/bar')}},
+                'cylc-run': {'foo': {
+                    'bar': Symlink('sym-run/cylc-run/foo/bar')
+                }},
                 'sym-run': {'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
-                    'share': Path('sym-share/cylc-run/foo/bar/share')
+                    'share': Symlink('sym-share/cylc-run/foo/bar/share')
                 }}}},
                 'sym-share': {'cylc-run': {'foo': {'bar': {
                     'share': {}
@@ -658,7 +661,9 @@ def test__clean_using_glob(
             {'share'},
             FILETREE_2,
             {
-                'cylc-run': {'foo': {'bar': Path('sym-run/cylc-run/foo/bar')}},
+                'cylc-run': {'foo': {
+                    'bar': Symlink('sym-run/cylc-run/foo/bar')
+                }},
                 'sym-run': {'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                     'flow.cylc': None,
@@ -689,7 +694,9 @@ def test__clean_using_glob(
             {'*'},
             FILETREE_2,
             {
-                'cylc-run': {'foo': {'bar': Path('sym-run/cylc-run/foo/bar')}},
+                'cylc-run': {'foo': {
+                    'bar': Symlink('sym-run/cylc-run/foo/bar')
+                }},
                 'sym-run': {'cylc-run': {'foo': {'bar': {
                     '.service': {'db': None},
                 }}}},
@@ -1087,6 +1094,12 @@ def test_clean_top_level(tmp_run_dir: Callable):
              'cylc-run/foo/bar/share',
              'cylc-run/foo/bar/share/cycle'],
             id="filetree2 **"
+        ),
+        pytest.param(
+            'share',
+            FILETREE_2,
+            ['cylc-run/foo/bar/share'],
+            id="filetree2 share"
         ),
         pytest.param(
             '**',

--- a/tests/unit/test_clean.py
+++ b/tests/unit/test_clean.py
@@ -669,13 +669,7 @@ def test__clean_using_glob(
                     'flow.cylc': None,
                 }}}},
                 'sym-share': {'cylc-run': {}},
-                'sym-cycle': {'cylc-run': {'foo': {'bar': {
-                    'share': {
-                        'cycle': {
-                            'macklunkey.txt': None
-                        }
-                    }
-                }}}}
+                'sym-cycle': {'cylc-run': {}},
             },
             id="filetree2 share"
         ),
@@ -701,13 +695,7 @@ def test__clean_using_glob(
                     '.service': {'db': None},
                 }}}},
                 'sym-share': {'cylc-run': {}},
-                'sym-cycle': {'cylc-run': {'foo': {'bar': {
-                    'share': {
-                        'cycle': {
-                            'macklunkey.txt': None
-                        }
-                    }
-                }}}}
+                'sym-cycle': {'cylc-run': {}},
             },
             id="filetree2 *"
         ),

--- a/tests/unit/test_pathutil.py
+++ b/tests/unit/test_pathutil.py
@@ -40,6 +40,7 @@ from cylc.flow.pathutil import (
     get_workflow_run_share_dir,
     get_workflow_run_work_dir,
     get_workflow_test_log_path,
+    is_relative_to,
     make_localhost_symlinks,
     make_workflow_run_tree,
     parse_rm_dirs,
@@ -576,3 +577,18 @@ def test_get_workflow_name_from_id(
 
     result = get_workflow_name_from_id(id_)
     assert result == name
+
+
+@pytest.mark.parametrize('abs_path', [True, False])
+@pytest.mark.parametrize('path1, path2, expected', [
+    param('/foo/bar/baz', '/foo/bar', True, id="child"),
+    param('/foo/bar', '/foo/bar/baz', False, id="parent"),
+    param('/foo/bar', '/foo/bar', True, id="same-path"),
+    param('/cat/dog', '/hat/bog', False, id="different"),
+    param('/a/b/c/../x/y', '/a/b/x', True, id="trickery"),
+])
+def test_is_relative_to(abs_path, path1, path2, expected):
+    if not abs_path:  # absolute & relative versions of same test
+        path1.lstrip('/')
+        path2.lstrip('/')
+    assert is_relative_to(path1, path2) == expected


### PR DESCRIPTION
Fixes a bug possibly (?) seen before by some users at the Met Office, but not tracked by an issue.

If `share/cycle` is a symlink directory, it must also be cleaned first when only specifying `--rm share`.

#### Reproduceable example

```cylc
# global.cylc
[install]
    [[symlink dirs]]
        [[[localhost]]]
            share = $HOME/sym-other
            share/cycle = $HOME/sym-cycle
```
```
$ cylc play <workflow>
$ cylc stop <workflow>
$ cylc clean <workflow> --rm share
# Restart:
$ cylc play <workflow>
WorkflowFilesError: Symlink dir target already exists: (~/cylc-run/<workflow>/share/cycle ->) ~/sym-cycle/cylc-run/<workflow>/share/cycle
Tip: in future, use 'cylc clean' instead of manually deleting workflow run dirs.
```


#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
