### PR TITLE
Make `cylc remove` flow-aware and extend to historical tasks

### DIFF
--- a/changes.d/6370.feat.md
+++ b/changes.d/6370.feat.md
@@ -1,0 +1,4 @@
+`cylc remove` improvements:
+- It can now remove tasks that are no longer active, making it look like they never ran.
+- Added the `--flow` option.
+- Removed tasks are now demoted to `flow=none`.

--- a/cylc/flow/command_validation.py
+++ b/cylc/flow/command_validation.py
@@ -24,12 +24,22 @@ from typing import (
 )
 
 from cylc.flow.exceptions import InputError
-from cylc.flow.id import IDTokens, Tokens
+from cylc.flow.flow_mgr import (
+    FLOW_ALL,
+    FLOW_NEW,
+    FLOW_NONE,
+)
+from cylc.flow.id import (
+    IDTokens,
+    Tokens,
+)
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
-from cylc.flow.flow_mgr import FLOW_ALL, FLOW_NEW, FLOW_NONE
 
 
-ERR_OPT_FLOW_VAL = "Flow values must be an integer, or 'all', 'new', or 'none'"
+ERR_OPT_FLOW_VAL = (
+    f"Flow values must be an integer, or '{FLOW_ALL}', '{FLOW_NEW}', "
+    f"or '{FLOW_NONE}'"
+)
 ERR_OPT_FLOW_COMBINE = "Cannot combine --flow={0} with other flow values"
 ERR_OPT_FLOW_WAIT = (
     f"--wait is not compatible with --flow={FLOW_NEW} or --flow={FLOW_NONE}"

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -80,7 +80,6 @@ from cylc.flow.exceptions import (
 )
 import cylc.flow.flags
 from cylc.flow.flow_mgr import get_flow_nums_set
-from cylc.flow.id import tokenise
 from cylc.flow.log_level import log_level_to_verbosity
 from cylc.flow.network.schema import WorkflowStopMode
 from cylc.flow.parsec.exceptions import ParsecError
@@ -333,14 +332,7 @@ async def remove_tasks(
     validate.flow_opts(flow, flow_wait=False, allow_new_or_none=False)
     yield
     flow_nums = get_flow_nums_set(flow)
-    schd.pool.remove_tasks(tasks)
-    for task in tasks:
-        task_id = tokenise(task, relative=True)
-        schd.workflow_db_mgr.remove_task_from_flows(
-            point=task_id['cycle'],
-            name=task_id['task'],
-            flow_nums=flow_nums
-        )
+    schd.pool.remove_tasks(tasks, flow_nums)
 
 
 @_command('reload_workflow')

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -2369,22 +2369,42 @@ class DataStoreMgr:
         self.updates_pending = True
 
     def delta_task_flow_nums(self, itask: TaskProxy) -> None:
-        """Create delta for change in task proxy flow_nums.
+        """Create delta for change in task proxy flow numbers.
 
         Args:
-            itask (cylc.flow.task_proxy.TaskProxy):
-                Update task-node from corresponding task proxy
-                objects from the workflow task pool.
-
+            itask: TaskProxy with updated flow numbers.
         """
         tproxy: Optional[PbTaskProxy]
         tp_id, tproxy = self.store_node_fetcher(itask.tokens)
         if not tproxy:
             return
-        tp_delta = self.updated[TASK_PROXIES].setdefault(
-            tp_id, PbTaskProxy(id=tp_id))
+        self._delta_task_flow_nums(tp_id, itask.flow_nums)
+
+    def delta_remove_task_flow_nums(
+        self, task: str, removed: 'FlowNums'
+    ) -> None:
+        """Create delta for removal of flow numbers from a task proxy.
+
+        Args:
+            task: Relative ID of task.
+            removed: Flow numbers to remove from the task proxy in the
+                data store.
+        """
+        tproxy: Optional[PbTaskProxy]
+        tp_id, tproxy = self.store_node_fetcher(
+            Tokens(task, relative=True).duplicate(**self.id_)
+        )
+        if not tproxy:
+            return
+        new_flow_nums = deserialise_set(tproxy.flow_nums).difference(removed)
+        self._delta_task_flow_nums(tp_id, new_flow_nums)
+
+    def _delta_task_flow_nums(self, tp_id: str, flow_nums: 'FlowNums') -> None:
+        tp_delta: PbTaskProxy = self.updated[TASK_PROXIES].setdefault(
+            tp_id, PbTaskProxy(id=tp_id)
+        )
         tp_delta.stamp = f'{tp_id}@{time()}'
-        tp_delta.flow_nums = serialise_set(itask.flow_nums)
+        tp_delta.flow_nums = serialise_set(flow_nums)
         self.updates_pending = True
 
     def delta_task_runahead(self, itask: TaskProxy) -> None:

--- a/cylc/flow/dbstatecheck.py
+++ b/cylc/flow/dbstatecheck.py
@@ -28,7 +28,7 @@ from cylc.flow.cycling.integer import (
     IntegerPoint,
     IntegerInterval
 )
-from cylc.flow.flow_mgr import stringify_flow_nums
+from cylc.flow.flow_mgr import repr_flow_nums
 from cylc.flow.pathutil import expand_path
 from cylc.flow.rundb import CylcWorkflowDAO
 from cylc.flow.task_outputs import (
@@ -318,7 +318,7 @@ class CylcWorkflowDBChecker:
                 if flow_num is not None and flow_num not in flow_nums:
                     # skip result, wrong flow
                     continue
-                fstr = stringify_flow_nums(flow_nums)
+                fstr = repr_flow_nums(flow_nums)
                 if fstr:
                     res.append(fstr)
             db_res.append(res)

--- a/cylc/flow/id.py
+++ b/cylc/flow/id.py
@@ -22,6 +22,7 @@ This module contains the abstract ID tokenising/detokenising code.
 from enum import Enum
 import re
 from typing import (
+    TYPE_CHECKING,
     Iterable,
     List,
     Optional,
@@ -31,6 +32,10 @@ from typing import (
 )
 
 from cylc.flow import LOG
+
+
+if TYPE_CHECKING:
+    from cylc.flow.cycling import PointBase
 
 
 class IDTokens(Enum):
@@ -524,14 +529,14 @@ LEGACY_CYCLE_SLASH_TASK = re.compile(
 )
 
 
-def quick_relative_detokenise(cycle, task):
+def quick_relative_id(cycle: Union[str, int, 'PointBase'], task: str) -> str:
     """Generate a relative ID for a task.
 
     This is a more efficient solution to `Tokens` for cases where
     you only want the ID string and don't have any use for a Tokens object.
 
     Example:
-        >>> q = quick_relative_detokenise
+        >>> q = quick_relative_id
         >>> q('1', 'a') == Tokens(cycle='1', task='a').relative_id
         True
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -22,8 +22,8 @@ import json
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
-    AsyncGenerator,
     Any,
+    AsyncGenerator,
     Dict,
     List,
     Optional,
@@ -34,44 +34,68 @@ from typing import (
 
 import graphene
 from graphene import (
-    Boolean, Field, Float, ID, InputObjectType, Int,
-    Mutation, ObjectType, Schema, String, Argument, Interface
+    ID,
+    Argument,
+    Boolean,
+    Field,
+    Float,
+    InputObjectType,
+    Int,
+    Interface,
+    Mutation,
+    ObjectType,
+    Schema,
+    String,
 )
 from graphene.types.generic import GenericScalar
 from graphene.utils.str_converters import to_snake_case
 from graphql.type.definition import get_named_type
 
 from cylc.flow import LOG_LEVELS
-from cylc.flow.broadcast_mgr import ALL_CYCLE_POINTS_STRS, addict
-from cylc.flow.data_store_mgr import (
-    FAMILIES, FAMILY_PROXIES, JOBS, TASKS, TASK_PROXIES,
-    DELTA_ADDED, DELTA_UPDATED
+from cylc.flow.broadcast_mgr import (
+    ALL_CYCLE_POINTS_STRS,
+    addict,
 )
-from cylc.flow.flow_mgr import FLOW_ALL, FLOW_NEW, FLOW_NONE
+from cylc.flow.data_store_mgr import (
+    DELTA_ADDED,
+    DELTA_UPDATED,
+    FAMILIES,
+    FAMILY_PROXIES,
+    JOBS,
+    TASK_PROXIES,
+    TASKS,
+)
+from cylc.flow.flow_mgr import (
+    FLOW_ALL,
+    FLOW_NEW,
+    FLOW_NONE,
+)
 from cylc.flow.id import Tokens
 from cylc.flow.task_outputs import SORT_ORDERS
 from cylc.flow.task_state import (
-    TASK_STATUSES_ORDERED,
     TASK_STATUS_DESC,
-    TASK_STATUS_WAITING,
     TASK_STATUS_EXPIRED,
+    TASK_STATUS_FAILED,
     TASK_STATUS_PREPARING,
+    TASK_STATUS_RUNNING,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_SUBMITTED,
-    TASK_STATUS_RUNNING,
-    TASK_STATUS_FAILED,
-    TASK_STATUS_SUCCEEDED
+    TASK_STATUS_SUCCEEDED,
+    TASK_STATUS_WAITING,
+    TASK_STATUSES_ORDERED,
 )
 from cylc.flow.util import sstrip
 from cylc.flow.workflow_status import StopMode
 
+
 if TYPE_CHECKING:
     from graphql import ResolveInfo
     from graphql.type.definition import (
-        GraphQLNamedType,
         GraphQLList,
+        GraphQLNamedType,
         GraphQLNonNull,
     )
+
     from cylc.flow.network.resolvers import BaseResolvers
 
 
@@ -2107,6 +2131,19 @@ class Remove(Mutation, TaskMutation):
             Valid for: paused, running workflows.
         ''')
         resolver = partial(mutator, command='remove_tasks')
+
+    class Arguments(TaskMutation.Arguments):
+        flow = graphene.List(
+            graphene.NonNull(Flow),
+            default_value=[FLOW_ALL],
+            description=sstrip(f'''
+                "Remove the task(s) from the specified flows. "
+
+                This should be a list of flow numbers, or '{FLOW_ALL}'
+                to remove the task(s) from all flows they belong to
+                (which is the default).
+            ''')
+        )
 
 
 class SetPrereqsAndOutputs(Mutation, TaskMutation):

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -354,10 +354,12 @@ class Prerequisite:
             if satisfied
         ]
 
-    def naturally_satisfied_dependencies(self) -> List[PrereqMessage]:
-        """Return naturally satisfied dependencies."""
-        return [
-            msg
-            for msg, sat in self._satisfied.items()
-            if sat and sat != 'force satisfied'
-        ]
+    def unset_naturally_satisfied_dependency(self, id_: str) -> bool:
+        """Set the matching dependency to unsatisfied and return True only if
+        it was naturally satisfied."""
+        changed = False
+        for msg, sat in self._satisfied.items():
+            if msg.get_id() == id_ and sat and sat != 'force satisfied':
+                self[msg] = False
+                changed = True
+        return changed

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -603,7 +603,7 @@ class CylcWorkflowDAO:
                 key, value
             FROM
                 {self.TABLE_WORKFLOW_PARAMS}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         return self.connect().execute(stmt)
 
     def select_workflow_flows(self, flow_nums: Iterable[int]):
@@ -615,7 +615,7 @@ class CylcWorkflowDAO:
                 {self.TABLE_WORKFLOW_FLOWS}
             WHERE
                 flow_num in ({stringify_flow_nums(flow_nums)})
-        '''  # nosec (table name is code constant, flow_nums just integers)
+        '''  # nosec B608 (table name is code constant, flow_nums just ints)
         flows = {}
         for flow_num, start_time, descr in self.connect().execute(stmt):
             flows[flow_num] = {
@@ -631,7 +631,7 @@ class CylcWorkflowDAO:
                 MAX(flow_num)
             FROM
                 {self.TABLE_WORKFLOW_FLOWS}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         return self.connect().execute(stmt).fetchone()[0]
 
     def select_workflow_params_restart_count(self):
@@ -643,7 +643,7 @@ class CylcWorkflowDAO:
                 {self.TABLE_WORKFLOW_PARAMS}
             WHERE
                 key == 'n_restart'
-        """  # nosec (table name is code constant)
+        """  # nosec B608 (table name is code constant)
         result = self.connect().execute(stmt).fetchone()
         return int(result[0]) if result else 0
 
@@ -659,7 +659,7 @@ class CylcWorkflowDAO:
                         key, value
                     FROM
                         {self.TABLE_WORKFLOW_TEMPLATE_VARS}
-                '''  # nosec (table name is code constant)
+                '''  # nosec B608 (table name is code constant)
         )):
             callback(row_idx, list(row))
 
@@ -676,7 +676,7 @@ class CylcWorkflowDAO:
                 {",".join(attrs)}
             FROM
                 {self.TABLE_TASK_ACTION_TIMERS}
-        '''  # nosec
+        '''  # nosec B608
         # * table name is code constant
         # * attrs are code constants
         for row_idx, row in enumerate(self.connect().execute(stmt)):
@@ -702,7 +702,7 @@ class CylcWorkflowDAO:
                     AND name==?
                 ORDER BY
                     submit_num DESC LIMIT 1
-            '''  # nosec
+            '''  # nosec B608
             # * table name is code constant
             # * keys are code constants
             stmt_args = [cycle, name]
@@ -716,7 +716,7 @@ class CylcWorkflowDAO:
                     cycle==?
                     AND name==?
                     AND submit_num==?
-            '''  # nosec
+            '''  # nosec B608
             # * table name is code constant
             # * keys are code constants
             stmt_args = [cycle, name, submit_num]
@@ -799,7 +799,7 @@ class CylcWorkflowDAO:
                 platform_name
             FROM
                 {self.TABLE_TASK_JOBS}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         return {i[0] for i in self.connect().execute(stmt)}
 
     def select_prev_instances(
@@ -812,7 +812,7 @@ class CylcWorkflowDAO:
         # Ignore bandit false positive: B608: hardcoded_sql_expressions
         # Not an injection, simply putting the table name in the SQL query
         # expression as a string constant local to this module.
-        stmt = (  # nosec
+        stmt = (  # nosec B608
             r"SELECT flow_nums,submit_num,flow_wait,status FROM %(name)s"
             r" WHERE name==? AND cycle==?"
         ) % {"name": self.TABLE_TASK_STATES}
@@ -860,7 +860,7 @@ class CylcWorkflowDAO:
                {self.TABLE_TASK_OUTPUTS}
             WHERE
                 name==? AND cycle==?
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         return {
             outputs: deserialise_set(flow_nums)
             for flow_nums, outputs in self.connect().execute(
@@ -874,7 +874,7 @@ class CylcWorkflowDAO:
                 signature, results
             FROM
                 {self.TABLE_XTRIGGERS}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         for row_idx, row in enumerate(self.connect().execute(stmt, [])):
             callback(row_idx, list(row))
 
@@ -884,7 +884,7 @@ class CylcWorkflowDAO:
                 cycle, name, output
             FROM
                 {self.TABLE_ABS_OUTPUTS}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         for row_idx, row in enumerate(self.connect().execute(stmt, [])):
             callback(row_idx, list(row))
 
@@ -997,7 +997,7 @@ class CylcWorkflowDAO:
                 cycle == ? AND
                 name == ? AND
                 flow_nums == ?
-        """  # nosec (table name is code constant)
+        """  # nosec B608 (table name is code constant)
         stmt_args = [cycle, name, flow_nums]
         return list(self.connect().execute(stmt, stmt_args))
 
@@ -1008,7 +1008,7 @@ class CylcWorkflowDAO:
                 name, cycle
             FROM
                 {self.TABLE_TASKS_TO_HOLD}
-        '''  # nosec (table name is code constant)
+        '''  # nosec B608 (table name is code constant)
         return list(self.connect().execute(stmt))
 
     def select_task_times(self):
@@ -1030,7 +1030,7 @@ class CylcWorkflowDAO:
                 {self.TABLE_TASK_JOBS}
             WHERE
                 run_status = 0
-        """  # nosec (table name is code constant)
+        """  # nosec B608 (table name is code constant)
         columns = (
             'name', 'cycle', 'host', 'job_runner',
             'submit_time', 'start_time', 'succeed_time'

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Provide data access object for the workflow runtime database."""
 
+from collections import defaultdict
 from contextlib import suppress
 from dataclasses import dataclass
 from os.path import expandvars
@@ -23,6 +24,8 @@ import sqlite3
 import traceback
 from typing import (
     TYPE_CHECKING,
+    Any,
+    DefaultDict,
     Dict,
     Iterable,
     List,
@@ -30,11 +33,13 @@ from typing import (
     Set,
     Tuple,
     Union,
+    cast,
 )
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import PlatformLookupError
 import cylc.flow.flags
+from cylc.flow.flow_mgr import stringify_flow_nums
 from cylc.flow.util import (
     deserialise_set,
     serialise_set,
@@ -45,6 +50,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from cylc.flow.flow_mgr import FlowNums
+
+
+DbArgDict = Dict[str, Any]
+DbUpdateTuple = Union[
+    Tuple[DbArgDict, DbArgDict],
+    Tuple[str, list]
+]
 
 
 @dataclass
@@ -69,7 +81,7 @@ class CylcWorkflowDAOTable:
 
     def __init__(self, name, column_items):
         self.name = name
-        self.columns = []
+        self.columns: List[CylcWorkflowDAOTableColumn] = []
         for column_item in column_items:
             name = column_item[0]
             attrs = {}
@@ -81,7 +93,7 @@ class CylcWorkflowDAOTable:
                 attrs.get("is_primary_key", False)))
         self.delete_queues = {}
         self.insert_queue = []
-        self.update_queues = {}
+        self.update_queues: DefaultDict[str, list] = defaultdict(list)
 
     def get_create_stmt(self):
         """Return an SQL statement to create this table."""
@@ -150,14 +162,23 @@ class CylcWorkflowDAOTable:
                 args.get(column.name, None) for column in self.columns]
         self.insert_queue.append(stmt_args)
 
-    def add_update_item(self, set_args, where_args):
+    def add_update_item(self, item: DbUpdateTuple) -> None:
         """Queue an UPDATE item.
 
+        If stmt is not a string, it should be a tuple (set_args, where_args) -
         set_args should be a dict, with column keys and values to be set.
         where_args should be a dict, update will only apply to rows matching
         all these items.
 
         """
+        if isinstance(item[0], str):
+            stmt = item[0]
+            params = cast('list', item[1])
+            self.update_queues[stmt].extend(params)
+            return
+
+        set_args = item[0]
+        where_args = cast('DbArgDict', item[1])
         set_strs = []
         stmt_args = []
         for column in self.columns:
@@ -177,9 +198,8 @@ class CylcWorkflowDAOTable:
         stmt = self.FMT_UPDATE % {
             "name": self.name,
             "set_str": set_str,
-            "where_str": where_str}
-        if stmt not in self.update_queues:
-            self.update_queues[stmt] = []
+            "where_str": where_str
+        }
         self.update_queues[stmt].append(stmt_args)
 
 
@@ -407,15 +427,18 @@ class CylcWorkflowDAO:
         """
         self.tables[table_name].add_insert_item(args)
 
-    def add_update_item(self, table_name, set_args, where_args=None):
+    def add_update_item(
+        self, table_name: str, item: DbUpdateTuple
+    ) -> None:
         """Queue an UPDATE item for a given table.
 
+        If stmt is not a string, it should be a tuple (set_args, where_args) -
         set_args should be a dict, with column keys and values to be set.
         where_args should be a dict, update will only apply to rows matching
         all these items.
 
         """
-        self.tables[table_name].add_update_item(set_args, where_args)
+        self.tables[table_name].add_update_item(item)
 
     def close(self) -> None:
         """Explicitly close the connection."""
@@ -583,7 +606,7 @@ class CylcWorkflowDAO:
         '''  # nosec (table name is code constant)
         return self.connect().execute(stmt)
 
-    def select_workflow_flows(self, flow_nums):
+    def select_workflow_flows(self, flow_nums: Iterable[int]):
         """Return flow data for selected flows."""
         stmt = rf'''
             SELECT
@@ -591,7 +614,7 @@ class CylcWorkflowDAO:
             FROM
                 {self.TABLE_WORKFLOW_FLOWS}
             WHERE
-                flow_num in ({','.join(str(f) for f in flow_nums)})
+                flow_num in ({stringify_flow_nums(flow_nums)})
         '''  # nosec (table name is code constant, flow_nums just integers)
         flows = {}
         for flow_num, start_time, descr in self.connect().execute(stmt):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -543,7 +543,7 @@ class Scheduler:
         elif self.config.cfg['scheduling']['hold after cycle point']:
             holdcp = self.config.cfg['scheduling']['hold after cycle point']
         if holdcp is not None:
-            await commands.run_cmd(commands.set_hold_point, self, holdcp)
+            await commands.run_cmd(commands.set_hold_point(self, holdcp))
 
         if self.options.paused_start:
             self.pause_workflow('Paused on start up')
@@ -633,7 +633,7 @@ class Scheduler:
                 if self.pool.get_tasks():
                     # (If we're not restarting a finished workflow)
                     self.restart_remote_init()
-                    await commands.run_cmd(commands.poll_tasks, self, ['*/*'])
+                    await commands.run_cmd(commands.poll_tasks(self, ['*/*']))
 
             self.run_event_handlers(self.EVENT_STARTUP, 'workflow starting')
             await asyncio.gather(
@@ -1386,8 +1386,8 @@ class Scheduler:
             self.time_next_kill is not None
             and time() > self.time_next_kill
         ):
-            await commands.run_cmd(commands.poll_tasks, self, ['*/*'])
-            await commands.run_cmd(commands.kill_tasks, self, ['*/*'])
+            await commands.run_cmd(commands.poll_tasks(self, ['*/*']))
+            await commands.run_cmd(commands.kill_tasks(self, ['*/*']))
             self.time_next_kill = time() + self.INTERVAL_STOP_KILL
 
         # Is the workflow set to auto stop [+restart] now ...

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -32,7 +32,6 @@ import traceback
 from typing import (
     Any,
     AsyncGenerator,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -948,10 +947,6 @@ class Scheduler:
             for _, msg in tms:
                 warn += f'\n  {msg.job_id}: {msg.severity} - "{msg.message}"'
             LOG.warning(warn)
-
-    def get_command_method(self, command_name: str) -> Callable:
-        """Return a command processing method or raise AttributeError."""
-        return getattr(self, f'command_{command_name}')
 
     async def process_command_queue(self) -> None:
         """Process queued commands."""

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1529,7 +1529,7 @@ class Scheduler:
                 self.broadcast_mgr.check_ext_triggers(
                     itask, self.ext_trigger_queue)
 
-            if all(itask.is_ready_to_run()):
+            if itask.is_ready_to_run():
                 self.pool.queue_task(itask)
 
         if self.xtrigger_mgr.sequential_spawn_next:

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -18,7 +18,26 @@
 
 """cylc remove [OPTIONS] ARGS
 
-Remove one or more task instances from a running workflow.
+Remove task instances from a running workflow and the workflow's history.
+
+This removes the task(s) from any specified flows. The task will still exist,
+just not in the specified flows, so will not influence the evolution of
+the workflow in those flows.
+
+If a task is removed from all flows, it and its outputs will be left in the
+`None` flow. This preserves a record that the task ran, but it will not
+influence any flows in any way.
+
+Examples:
+  # remove a task which has already run
+  # (any tasks downstream of this task which have already run or are currently
+  # running will be left alone The task and its outputs will be left in the
+  # None flow)
+  $ cylc remove <id>
+
+  # remove a task from a specified flow
+  # (the task may remain in other flows)
+  $ cylc remove <id> --flow=1
 """
 
 from functools import partial
@@ -33,6 +52,7 @@ from cylc.flow.option_parsers import (
 )
 from cylc.flow.terminal import cli_function
 
+
 if TYPE_CHECKING:
     from optparse import Values
 
@@ -41,10 +61,12 @@ MUTATION = '''
 mutation (
   $wFlows: [WorkflowID]!,
   $tasks: [NamespaceIDGlob]!,
+  $flow: [Flow!],
 ) {
   remove (
     workflows: $wFlows,
     tasks: $tasks,
+    flow: $flow
   ) {
     result
   }
@@ -61,6 +83,19 @@ def get_option_parser() -> COP:
         argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
 
+    parser.add_option(
+        '--flow',
+        action='append',
+        dest='flow',
+        metavar='FLOW',
+        help=(
+            "Remove the task(s) from the specified flow number. "
+            "Reuse the option to remove the task(s) from multiple flows. "
+            "If the option is not used at all, the task(s) will be removed "
+            "from all flows."
+        ),
+    )
+
     return parser
 
 
@@ -75,6 +110,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
                 tokens.relative_id_with_selectors
                 for tokens in tokens_list
             ],
+            'flow': options.flow,
         }
     }
 

--- a/cylc/flow/scripts/show.py
+++ b/cylc/flow/scripts/show.py
@@ -60,6 +60,7 @@ from cylc.flow.task_state import (
 from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     ID_MULTI_ARG_DOC,
+    Options,
 )
 from cylc.flow.terminal import cli_function
 from cylc.flow.util import BOOL_SYMBOLS
@@ -244,6 +245,9 @@ def get_option_parser():
     )
 
     return parser
+
+
+ShowOptions = Options(get_option_parser())
 
 
 async def workflow_meta_query(workflow_id, pclient, options, json_filter):

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -26,19 +26,26 @@ This module provides logic to:
 
 from contextlib import suppress
 import json
-import os
 from logging import (
     CRITICAL,
     DEBUG,
     INFO,
-    WARNING
+    WARNING,
 )
+import os
 from shutil import rmtree
 from time import time
-from typing import TYPE_CHECKING, Any, Union, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 
 from cylc.flow import LOG
-from cylc.flow.job_runner_mgr import JobPollContext
+from cylc.flow.cfgspec.globalcfg import SYSPATH
 from cylc.flow.exceptions import (
     NoHostsError,
     NoPlatformsError,
@@ -48,9 +55,10 @@ from cylc.flow.exceptions import (
 )
 from cylc.flow.hostuserutil import (
     get_host,
-    is_remote_platform
+    is_remote_platform,
 )
 from cylc.flow.job_file import JobFileWriter
+from cylc.flow.job_runner_mgr import JobPollContext
 from cylc.flow.pathutil import get_remote_workflow_run_job_dir
 from cylc.flow.platforms import (
     get_host_from_platform,
@@ -64,50 +72,51 @@ from cylc.flow.subprocctx import SubProcContext
 from cylc.flow.subprocpool import SubProcPool
 from cylc.flow.task_action_timer import (
     TaskActionTimer,
-    TimerFlags
+    TimerFlags,
 )
 from cylc.flow.task_events_mgr import (
     TaskEventsManager,
-    log_task_job_activity
+    log_task_job_activity,
 )
 from cylc.flow.task_job_logs import (
     JOB_LOG_JOB,
     NN,
     get_task_job_activity_log,
     get_task_job_job_log,
-    get_task_job_log
+    get_task_job_log,
 )
 from cylc.flow.task_message import FAIL_MESSAGE_PREFIX
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_FAILED,
     TASK_OUTPUT_STARTED,
     TASK_OUTPUT_SUBMITTED,
-    TASK_OUTPUT_SUCCEEDED
+    TASK_OUTPUT_SUCCEEDED,
 )
 from cylc.flow.task_remote_mgr import (
+    REMOTE_FILE_INSTALL_255,
     REMOTE_FILE_INSTALL_DONE,
     REMOTE_FILE_INSTALL_FAILED,
     REMOTE_FILE_INSTALL_IN_PROGRESS,
-    REMOTE_INIT_IN_PROGRESS,
     REMOTE_INIT_255,
-    REMOTE_FILE_INSTALL_255,
-    REMOTE_INIT_DONE, REMOTE_INIT_FAILED,
-    TaskRemoteMgr
+    REMOTE_INIT_DONE,
+    REMOTE_INIT_FAILED,
+    REMOTE_INIT_IN_PROGRESS,
+    TaskRemoteMgr,
 )
 from cylc.flow.task_state import (
     TASK_STATUS_PREPARING,
-    TASK_STATUS_SUBMITTED,
     TASK_STATUS_RUNNING,
+    TASK_STATUS_SUBMITTED,
     TASK_STATUS_WAITING,
-    TASK_STATUSES_ACTIVE
+    TASK_STATUSES_ACTIVE,
 )
+from cylc.flow.util import serialise_set
 from cylc.flow.wallclock import (
     get_current_time_string,
     get_time_string_from_unix_time,
-    get_utc_mode
+    get_utc_mode,
 )
-from cylc.flow.cfgspec.globalcfg import SYSPATH
-from cylc.flow.util import serialise_set
+
 
 if TYPE_CHECKING:
     from cylc.flow.task_proxy import TaskProxy
@@ -271,12 +280,10 @@ class TaskJobManager:
         if not prepared_tasks:
             return bad_tasks
 
-        auth_itasks = {}  # {platform: [itask, ...], ...}
-
+        # Mapping of platforms to task proxies:
+        auth_itasks: Dict[str, List[TaskProxy]] = {}
         for itask in prepared_tasks:
-            platform_name = itask.platform['name']
-            auth_itasks.setdefault(platform_name, [])
-            auth_itasks[platform_name].append(itask)
+            auth_itasks.setdefault(itask.platform['name'], []).append(itask)
         # Submit task jobs for each platform
         # Non-prepared tasks can be considered done for now:
         done_tasks = bad_tasks

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -54,6 +54,7 @@ from cylc.flow.flow_mgr import (
 from cylc.flow.id import (
     Tokens,
     detokenise,
+    quick_relative_id,
 )
 from cylc.flow.id_cli import contains_fnmatch
 from cylc.flow.id_match import filter_ids
@@ -459,13 +460,24 @@ class TaskPool:
         output_msg: str,
         flow_nums: 'FlowNums',
     ) -> 'SatisfiedState':
-        """Returns truthy if the specified output is satisfied in the DB."""
+        """Returns truthy if the specified output is satisfied in the DB.
+
+        Args:
+            cycle: Cycle point of the task whose output is being checked.
+            task: Name of the task whose output is being checked.
+            output_msg: The output message to check for.
+            flow_nums: Flow numbers of the task whose output is being
+                checked. If this is empty it means 'none'; will return False.
+        """
+        if not flow_nums:
+            return False
+
         for task_outputs, task_flow_nums in (
             self.workflow_db_mgr.pri_dao.select_task_outputs(task, cycle)
         ).items():
             # loop through matching tasks
+            # (if task_flow_nums is empty, it means the 'none' flow)
             if flow_nums.intersection(task_flow_nums):
-                # this task is in the right flow
                 # BACK COMPAT: In Cylc >8.0.0,<8.3.0, only the task
                 #   messages were stored in the DB as a list.
                 # from: 8.0.0
@@ -1316,8 +1328,8 @@ class TaskPool:
         # Hold active tasks:
         itasks, inactive_tasks, unmatched = self.filter_task_proxies(
             items,
-            warn=False,
-            future=True,
+            warn_no_active=False,
+            inactive=True,
         )
         for itask in itasks:
             self.hold_active_task(itask)
@@ -1334,8 +1346,8 @@ class TaskPool:
         # Release active tasks:
         itasks, inactive_tasks, unmatched = self.filter_task_proxies(
             items,
-            warn=False,
-            future=True,
+            warn_no_active=False,
+            inactive=True,
         )
         for itask in itasks:
             self.release_held_active_task(itask)
@@ -1436,7 +1448,7 @@ class TaskPool:
                 if is_abs:
                     tasks, *_ = self.filter_task_proxies(
                         [f'*/{c_name}'],
-                        warn=False,
+                        warn_no_active=False,
                     )
                     if c_task not in tasks:
                         tasks.append(c_task)
@@ -1664,6 +1676,7 @@ class TaskPool:
         else:
             flow_seen = False
             for outputs_str, fnums in info.items():
+                # (if fnums is empty, it means the 'none' flow)
                 if itask.flow_nums.intersection(fnums):
                     # DB row has overlap with itask's flows
                     flow_seen = True
@@ -1943,8 +1956,8 @@ class TaskPool:
         # Get matching pool tasks and inactive task definitions.
         itasks, inactive_tasks, unmatched = self.filter_task_proxies(
             items,
-            future=True,
-            warn=False,
+            inactive=True,
+            warn_no_active=False,
         )
 
         flow_nums = self._get_flow_nums(flow, flow_descr)
@@ -2034,7 +2047,7 @@ class TaskPool:
             # Attempt to set the given presrequisites.
             # Log any that aren't valid for the task.
             presus = self._standardise_prereqs(prereqs)
-            unmatched = itask.satisfy_me(presus.keys())
+            unmatched = itask.satisfy_me(presus.keys(), forced=True)
             for task_msg in unmatched:
                 LOG.warning(
                     f"{itask.identity} does not depend on"
@@ -2079,28 +2092,108 @@ class TaskPool:
             or {1}
         )
 
-    def remove_tasks(self, items: Iterable[str]) -> None:
-        """Remove tasks from the pool (forced by command)."""
-        itasks, _, _unmatched = self.filter_task_proxies(items, warn=False)
-        for itask in itasks:
-            # Spawn next occurrence of xtrigger sequential task.
-            if (
-                itask.is_xtrigger_sequential
-                and (
-                    itask.identity not in
-                    self.xtrigger_mgr.sequential_has_spawned_next
-                )
+    def remove_tasks(
+        self, items: Iterable[str], flow_nums: Optional['FlowNums'] = None
+    ) -> None:
+        """Remove tasks from the pool (forced by command).
+
+        Args:
+            items: Relative IDs or globs.
+            flow_nums: Flows to remove the tasks from. If empty or None, it
+                means 'all'.
+        """
+        active, inactive, _unmatched = self.filter_task_proxies(
+            items, warn_no_active=False, inactive=True
+        )
+        if not (active or inactive):
+            return
+
+        if flow_nums is None:
+            flow_nums = set()
+        # Mapping of task IDs to removed flow numbers:
+        removed: Dict[str, FlowNums] = {}
+        not_removed: Set[str] = set()
+
+        for itask in active:
+            fnums_to_remove = itask.match_flows(flow_nums)
+            if not fnums_to_remove:
+                not_removed.add(itask.identity)
+                continue
+            removed[itask.identity] = fnums_to_remove
+            if fnums_to_remove == itask.flow_nums:
+                # Need to remove the task from the pool.
+                # Spawn next occurrence of xtrigger sequential task (otherwise
+                # this would not happen after removing this occurrence):
+                if (
+                    itask.is_xtrigger_sequential
+                    and (
+                        itask.identity not in
+                        self.xtrigger_mgr.sequential_has_spawned_next
+                    )
+                ):
+                    self.xtrigger_mgr.sequential_has_spawned_next.add(
+                        itask.identity
+                    )
+                    self.spawn_to_rh_limit(
+                        itask.tdef,
+                        itask.tdef.next_point(itask.point),
+                        itask.flow_nums
+                    )
+                self.remove(itask, 'request')
+            else:
+                itask.flow_nums.difference_update(fnums_to_remove)
+
+        matched_task_ids = {
+            *removed.keys(),
+            *(quick_relative_id(cycle, task) for task, cycle in inactive),
+        }
+
+        # Unset any prereqs naturally satisfied by these tasks
+        # (do not unset those satisfied by `cylc set --pre`):
+        for itask in self.get_tasks():
+            fnums_to_remove = itask.match_flows(flow_nums)
+            if not fnums_to_remove:
+                continue
+            for prereq in (
+                *itask.state.prerequisites,
+                *itask.state.suicide_prerequisites,
             ):
-                self.xtrigger_mgr.sequential_has_spawned_next.add(
-                    itask.identity
+                for msg in prereq.naturally_satisfied_dependencies():
+                    id_ = msg.get_id()
+                    if id_ in matched_task_ids:
+                        prereq[msg] = False
+                        if id_ not in removed:
+                            removed[id_] = fnums_to_remove
+
+        # Remove from DB tables:
+        for id_ in matched_task_ids:
+            point, name = id_.split('/', 1)
+            db_removed_fnums = self.workflow_db_mgr.remove_task_from_flows(
+                point, name, flow_nums
+            )
+            if db_removed_fnums:
+                removed.setdefault(id_, set()).update(db_removed_fnums)
+
+        if removed:
+            tasks_str = ', '.join(
+                sorted(
+                    f"{task} {repr_flow_nums(fnums, full=True)}"
+                    for task, fnums in removed.items()
                 )
-                self.spawn_to_rh_limit(
-                    itask.tdef,
-                    itask.tdef.next_point(itask.point),
-                    itask.flow_nums
-                )
-            self.remove(itask, 'request')
-        if self.compute_runahead():
+            )
+            LOG.info(f"Removed task(s): {tasks_str}")
+
+        not_removed.update(matched_task_ids.difference(removed))
+        if not_removed:
+            fnums_str = (
+                repr_flow_nums(flow_nums, full=True) if flow_nums else ''
+            )
+            LOG.warning(
+                "Task(s) not removable: "
+                f"{', '.join(sorted(not_removed))} {fnums_str}"
+            )
+
+        if removed and self.compute_runahead():
             self.release_runahead_tasks()
 
     def _get_flow_nums(
@@ -2191,8 +2284,8 @@ class TaskPool:
 
         """
         # Get matching tasks proxies, and matching inactive task IDs.
-        existing_tasks, future_ids, unmatched = self.filter_task_proxies(
-            items, future=True, warn=False,
+        existing_tasks, inactive_ids, unmatched = self.filter_task_proxies(
+            items, inactive=True, warn_no_active=False,
         )
 
         flow_nums = self._get_flow_nums(flow, flow_descr)
@@ -2215,7 +2308,7 @@ class TaskPool:
         if not flow:
             # default: assign to all active flows
             flow_nums = self._get_active_flow_nums()
-        for name, point in future_ids:
+        for name, point in inactive_ids:
             if not self.can_be_spawned(name, point):
                 continue
             submit_num, _, prev_fwait = (
@@ -2328,41 +2421,41 @@ class TaskPool:
     def filter_task_proxies(
         self,
         ids: Iterable[str],
-        warn: bool = True,
-        future: bool = False,
+        warn_no_active: bool = True,
+        inactive: bool = False,
     ) -> 'Tuple[List[TaskProxy], Set[Tuple[str, PointBase]], List[str]]':
         """Return task proxies that match names, points, states in items.
 
         Args:
             ids:
                 ID strings.
-            warn:
-                Whether to log a warning if no matching tasks are found.
-            future:
+            warn_no_active:
+                Whether to log a warning if no matching active tasks are found.
+            inactive:
                 If True, unmatched IDs will be checked against taskdefs
-                and cycle, task pairs will be provided in the future_matched
-                argument providing the ID
+                and cycle, and any matches will be returned in the second
+                return value, provided that the ID:
 
                 * Specifies a cycle point.
                 * Is not a pattern. (e.g. `*/foo`).
                 * Does not contain a state selector (e.g. `:failed`).
 
         Returns:
-            (matched, future_matched, unmatched)
+            (matched, inactive_matched, unmatched)
 
         """
         matched, unmatched = filter_ids(
             self.active_tasks,
             ids,
-            warn=warn,
+            warn=warn_no_active,
         )
-        future_matched: 'Set[Tuple[str, PointBase]]' = set()
-        if future and unmatched:
-            future_matched, unmatched = self.match_inactive_tasks(
+        inactive_matched: 'Set[Tuple[str, PointBase]]' = set()
+        if inactive and unmatched:
+            inactive_matched, unmatched = self.match_inactive_tasks(
                 unmatched
             )
 
-        return matched, future_matched, unmatched
+        return matched, inactive_matched, unmatched
 
     def match_inactive_tasks(
         self,

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2148,13 +2148,13 @@ class TaskPool:
                 removed.setdefault(id_, set()).update(db_removed_fnums)
 
         if removed:
-            tasks_str = ', '.join(
-                sorted(
+            tasks_str_list = []
+            for task, fnums in removed.items():
+                self.data_store_mgr.delta_remove_task_flow_nums(task, fnums)
+                tasks_str_list.append(
                     f"{task} {repr_flow_nums(fnums, full=True)}"
-                    for task, fnums in removed.items()
                 )
-            )
-            LOG.info(f"Removed task(s): {tasks_str}")
+            LOG.info(f"Removed task(s): {', '.join(sorted(tasks_str_list))}")
 
         not_removed.update(matched_task_ids.difference(removed))
         if not_removed:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -90,11 +90,7 @@ from cylc.flow.task_state import (
     TASK_STATUSES_FINAL,
 )
 from cylc.flow.task_trigger import TaskTrigger
-from cylc.flow.util import (
-    deserialise_set,
-    serialise_set,
-)
-from cylc.flow.wallclock import get_current_time_string
+from cylc.flow.util import deserialise_set
 from cylc.flow.workflow_status import StopMode
 
 
@@ -222,18 +218,7 @@ class TaskPool:
         Call when a new task is spawned or a flow merge occurs.
         """
         # Add row to task_states table.
-        now = get_current_time_string()
-        self.workflow_db_mgr.put_insert_task_states(
-            itask,
-            {
-                "time_created": now,
-                "time_updated": now,
-                "status": itask.state.status,
-                "flow_nums": serialise_set(itask.flow_nums),
-                "flow_wait": itask.flow_wait,
-                "is_manual_submit": itask.is_manual_submit
-            }
-        )
+        self.workflow_db_mgr.put_insert_task_states(itask)
         # Add row to task_outputs table:
         self.workflow_db_mgr.put_insert_task_outputs(itask)
 
@@ -739,7 +724,7 @@ class TaskPool:
         """
         if itask.state_reset(is_runahead=False):
             self.data_store_mgr.delta_task_runahead(itask)
-        if all(itask.is_ready_to_run()):
+        if itask.is_ready_to_run():
             # (otherwise waiting on xtriggers etc.)
             self.queue_task(itask)
 
@@ -766,9 +751,7 @@ class TaskPool:
 
         It does not add a spawned task proxy to the pool.
         """
-        ntask = self._get_task_by_id(
-            Tokens(cycle=str(point), task=tdef.name).relative_id
-        )
+        ntask = self.get_task(point, tdef.name)
         is_in_pool = False
         is_xtrig_sequential = False
         if ntask is None:
@@ -913,31 +896,32 @@ class TaskPool:
         # Cached list only for use internally in this method.
         if self.active_tasks_changed:
             self.active_tasks_changed = False
-            self._active_tasks_list = []
-            for itask_id_map in self.active_tasks.values():
-                for itask in itask_id_map.values():
-                    self._active_tasks_list.append(itask)
+            self._active_tasks_list = [
+                itask
+                for itask_id_map in self.active_tasks.values()
+                for itask in itask_id_map.values()
+            ]
         return self._active_tasks_list
 
     def get_tasks_by_point(self) -> 'Dict[PointBase, List[TaskProxy]]':
         """Return a map of task proxies by cycle point."""
-        point_itasks = {}
-        for point, itask_id_map in self.active_tasks.items():
-            point_itasks[point] = list(itask_id_map.values())
-        return point_itasks
+        return {
+            point: list(itask_id_map.values())
+            for point, itask_id_map in self.active_tasks.items()
+        }
 
     def get_task(self, point: 'PointBase', name: str) -> Optional[TaskProxy]:
         """Retrieve a task from the pool."""
         rel_id = f'{point}/{name}'
         tasks = self.active_tasks.get(point)
-        if tasks and rel_id in tasks:
-            return tasks[rel_id]
+        if tasks:
+            return tasks.get(rel_id)
         return None
 
     def _get_task_by_id(self, id_: str) -> Optional[TaskProxy]:
         """Return pool task by ID if it exists, or None."""
         for itask_ids in self.active_tasks.values():
-            with suppress(KeyError):
+            if id_ in itask_ids:
                 return itask_ids[id_]
         return None
 
@@ -1126,8 +1110,7 @@ class TaskPool:
             if itask.state.is_queued:
                 # Already queued
                 continue
-            ready_check_items = itask.is_ready_to_run()
-            if all(ready_check_items) and not itask.state.is_runahead:
+            if itask.is_ready_to_run() and not itask.state.is_runahead:
                 self.queue_task(itask)
 
     def set_stop_point(self, stop_point: 'PointBase') -> bool:
@@ -1292,7 +1275,7 @@ class TaskPool:
                 itask.state(TASK_STATUS_WAITING)
                 and not itask.state.is_runahead
                 # (avoid waiting pre-spawned absolute-triggered tasks:)
-                and not itask.is_task_prereqs_not_done()
+                and itask.prereqs_are_satisfied()
             ) for itask in self.get_tasks()
         ):
             return False
@@ -1310,7 +1293,7 @@ class TaskPool:
     def release_held_active_task(self, itask: TaskProxy) -> None:
         if itask.state_reset(is_held=False):
             self.data_store_mgr.delta_task_held(itask)
-            if (not itask.state.is_runahead) and all(itask.is_ready_to_run()):
+            if (not itask.state.is_runahead) and itask.is_ready_to_run():
                 self.queue_task(itask)
         self.tasks_to_hold.discard((itask.tdef.name, itask.point))
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
@@ -1426,12 +1409,7 @@ class TaskPool:
                     str(itask.point), itask.tdef.name, output)
                 self.workflow_db_mgr.process_queued_ops()
 
-            c_taskid = Tokens(
-                cycle=str(c_point),
-                task=c_name,
-            ).relative_id
-
-            c_task = self._get_task_by_id(c_taskid)
+            c_task = self._get_task_by_id(quick_relative_id(c_point, c_name))
             in_pool = c_task is not None
 
             if c_task is not None and c_task != itask:
@@ -1849,9 +1827,6 @@ class TaskPool:
                 self.xtrigger_mgr.xtriggers.sequential_xtrigger_labels
             ),
         )
-        if itask is None:
-            return None
-
         # Update it with outputs that were already completed.
         self._load_historical_outputs(itask)
         return itask

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1266,7 +1266,7 @@ class TaskPool:
             LOG.warning(
                 "Partially satisfied prerequisites:\n"
                 + "\n".join(
-                    f"  * {id_} is waiting on {others}"
+                    f"  * {id_} is waiting on {sorted(others)}"
                     for id_, others in unsat.items()
                 )
             )
@@ -2138,27 +2138,54 @@ class TaskPool:
         for id_ in matched_task_ids:
             point_str, name = id_.split('/', 1)
             tdef = self.config.taskdefs[name]
-            # Unset any prereqs naturally satisfied by these tasks
-            # (do not unset those satisfied by `cylc set --pre`):
-            for child in itertools.chain.from_iterable(
+            # Go through downstream tasks to see if any need to stand down
+            # as a result of this task being removed:
+            for child in set(itertools.chain.from_iterable(
                 generate_graph_children(tdef, get_point(point_str)).values()
-            ):
+            )):
                 child_itask = self.get_task(child.point, child.name)
                 if not child_itask:
                     continue
                 fnums_to_remove = child_itask.match_flows(flow_nums)
                 if not fnums_to_remove:
                     continue
+                prereqs_changed = False
                 for prereq in (
                     *child_itask.state.prerequisites,
                     *child_itask.state.suicide_prerequisites,
                 ):
-                    for msg in prereq.naturally_satisfied_dependencies():
-                        if msg.get_id() == id_:
-                            prereq[msg] = False
-                            self.unqueue_task(child_itask)
-                            if id_ not in removed:
-                                removed[id_] = fnums_to_remove
+                    # Unset any prereqs naturally satisfied by these tasks
+                    # (do not unset those satisfied by `cylc set --pre`):
+                    if prereq.unset_naturally_satisfied_dependency(id_):
+                        prereqs_changed = True
+                        removed.setdefault(id_, set()).update(fnums_to_remove)
+                if not prereqs_changed:
+                    continue
+                self.data_store_mgr.delta_task_prerequisite(child_itask)
+                # Check if downstream task is still ready to run:
+                if (
+                    child_itask.state.is_gte(TASK_STATUS_PREPARING)
+                    # Still ready if the task exists in other flows:
+                    or child_itask.flow_nums != fnums_to_remove
+                    or child_itask.state.prerequisites_all_satisfied()
+                ):
+                    continue
+                # No longer ready to run
+                self.unqueue_task(child_itask)
+                # Check if downstream task should remain spawned:
+                if (
+                    # Ignoring tasks we are already dealing with:
+                    child_itask.identity in matched_task_ids
+                    or child_itask.state.any_satisfied_prerequisite_tasks()
+                ):
+                    continue
+                # No longer has reason to be in pool:
+                self.remove(child_itask, 'upstream task(s) removed')
+                # Remove from DB tables to ensure it is not skipped if it
+                # respawns in future:
+                self.workflow_db_mgr.remove_task_from_flows(
+                    str(child.point), child.name, fnums_to_remove
+                )
 
             # Remove from DB tables:
             db_removed_fnums = self.workflow_db_mgr.remove_task_from_flows(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -931,6 +931,12 @@ class TaskPool:
             self.data_store_mgr.delta_task_queued(itask)
             self.task_queue_mgr.push_task(itask)
 
+    def unqueue_task(self, itask: TaskProxy) -> None:
+        """Un-queue a task that is no longer ready to run."""
+        if itask.state_reset(is_queued=False):
+            self.data_store_mgr.delta_task_queued(itask)
+            self.task_queue_mgr.remove_task(itask)
+
     def release_queued_tasks(self):
         """Return list of queue-released tasks awaiting job prep.
 
@@ -2137,6 +2143,8 @@ class TaskPool:
                         prereq[msg] = False
                         if id_ not in removed:
                             removed[id_] = fnums_to_remove
+            if not itask.prereqs_are_satisfied():
+                self.unqueue_task(itask)
 
         # Remove from DB tables:
         for id_ in matched_task_ids:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1722,12 +1722,10 @@ class TaskPool:
             and not itask.state.outputs.get_completed_outputs()
         ):
             # If itask has any history in this flow but no completed outputs
-            # we can infer it was deliberately removed, so don't respawn it.
+            # we can infer it has just been deliberately removed (N.B. not
+            # by `cylc remove`), so don't immediately respawn it.
             # TODO (follow-up work):
             # - this logic fails if task removed after some outputs completed
-            # - this is does not conform to future "cylc remove" flow-erasure
-            #   behaviour which would result in respawning of the removed task
-            # See github.com/cylc/cylc-flow/pull/6186/#discussion_r1669727292
             LOG.debug(f"Not respawning {point}/{name} - task was removed")
             return None
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -829,11 +829,7 @@ class TaskPool:
                 itask.flow_nums
             )
 
-        msg = "removed from active task pool"
-        if reason is None:
-            msg += ": completed"
-        else:
-            msg += f": {reason}"
+        msg = f"removed from active task pool: {reason or 'completed'}"
 
         if itask.is_xtrigger_sequential:
             self.xtrigger_mgr.sequential_spawn_next.discard(itask.identity)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -18,6 +18,7 @@
 
 from collections import Counter
 from contextlib import suppress
+import itertools
 import json
 import logging
 from textwrap import indent
@@ -90,6 +91,7 @@ from cylc.flow.task_state import (
     TASK_STATUSES_FINAL,
 )
 from cylc.flow.task_trigger import TaskTrigger
+from cylc.flow.taskdef import generate_graph_children
 from cylc.flow.util import deserialise_set
 from cylc.flow.workflow_status import StopMode
 
@@ -926,13 +928,19 @@ class TaskPool:
         return None
 
     def queue_task(self, itask: TaskProxy) -> None:
-        """Queue a task that is ready to run."""
+        """Queue a task that is ready to run.
+
+        If it is already queued, do nothing.
+        """
         if itask.state_reset(is_queued=True):
             self.data_store_mgr.delta_task_queued(itask)
             self.task_queue_mgr.push_task(itask)
 
     def unqueue_task(self, itask: TaskProxy) -> None:
-        """Un-queue a task that is no longer ready to run."""
+        """Un-queue a task that is no longer ready to run.
+
+        If it is not queued, do nothing.
+        """
         if itask.state_reset(is_queued=False):
             self.data_store_mgr.delta_task_queued(itask)
             self.task_queue_mgr.remove_task(itask)
@@ -2127,30 +2135,34 @@ class TaskPool:
             *(quick_relative_id(cycle, task) for task, cycle in inactive),
         }
 
-        # Unset any prereqs naturally satisfied by these tasks
-        # (do not unset those satisfied by `cylc set --pre`):
-        for itask in self.get_tasks():
-            fnums_to_remove = itask.match_flows(flow_nums)
-            if not fnums_to_remove:
-                continue
-            for prereq in (
-                *itask.state.prerequisites,
-                *itask.state.suicide_prerequisites,
-            ):
-                for msg in prereq.naturally_satisfied_dependencies():
-                    id_ = msg.get_id()
-                    if id_ in matched_task_ids:
-                        prereq[msg] = False
-                        if id_ not in removed:
-                            removed[id_] = fnums_to_remove
-            if not itask.prereqs_are_satisfied():
-                self.unqueue_task(itask)
-
-        # Remove from DB tables:
         for id_ in matched_task_ids:
-            point, name = id_.split('/', 1)
+            point_str, name = id_.split('/', 1)
+            tdef = self.config.taskdefs[name]
+            # Unset any prereqs naturally satisfied by these tasks
+            # (do not unset those satisfied by `cylc set --pre`):
+            for child in itertools.chain.from_iterable(
+                generate_graph_children(tdef, get_point(point_str)).values()
+            ):
+                child_itask = self.get_task(child.point, child.name)
+                if not child_itask:
+                    continue
+                fnums_to_remove = child_itask.match_flows(flow_nums)
+                if not fnums_to_remove:
+                    continue
+                for prereq in (
+                    *child_itask.state.prerequisites,
+                    *child_itask.state.suicide_prerequisites,
+                ):
+                    for msg in prereq.naturally_satisfied_dependencies():
+                        if msg.get_id() == id_:
+                            prereq[msg] = False
+                            self.unqueue_task(child_itask)
+                            if id_ not in removed:
+                                removed[id_] = fnums_to_remove
+
+            # Remove from DB tables:
             db_removed_fnums = self.workflow_db_mgr.remove_task_from_flows(
-                point, name, flow_nums
+                point_str, name, flow_nums
             )
             if db_removed_fnums:
                 removed.setdefault(id_, set()).update(db_removed_fnums)

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -309,7 +309,7 @@ class TaskProxy:
             )
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} '{self.tokens}'>"
+        return f"<{self.__class__.__name__} {self.identity}>"
 
     def __str__(self) -> str:
         """Stringify with tokens, state, submit_num, and flow_nums.

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -36,26 +36,30 @@ from typing import (
 from metomi.isodatetime.timezone import get_local_time_zone
 
 from cylc.flow import LOG
-from cylc.flow.flow_mgr import stringify_flow_nums
+from cylc.flow.cycling.iso8601 import (
+    interval_parse,
+    point_parse,
+)
+from cylc.flow.flow_mgr import repr_flow_nums
 from cylc.flow.platforms import get_platform
 from cylc.flow.task_action_timer import TimerFlags
 from cylc.flow.task_state import (
-    TaskState,
-    TASK_STATUS_WAITING,
     TASK_STATUS_EXPIRED,
+    TASK_STATUS_WAITING,
+    TaskState,
 )
 from cylc.flow.taskdef import generate_graph_children
 from cylc.flow.wallclock import get_unix_time_from_time_string as str2time
-from cylc.flow.cycling.iso8601 import (
-    point_parse,
-    interval_parse,
-)
+
 
 if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.flow_mgr import FlowNums
     from cylc.flow.id import Tokens
-    from cylc.flow.prerequisite import PrereqMessage, SatisfiedState
+    from cylc.flow.prerequisite import (
+        PrereqMessage,
+        SatisfiedState,
+    )
     from cylc.flow.simulation import ModeSettings
     from cylc.flow.task_action_timer import TaskActionTimer
     from cylc.flow.taskdef import TaskDef
@@ -317,11 +321,11 @@ class TaskProxy:
         """
         id_ = self.identity
         if self.transient:
-            return f"{id_}{stringify_flow_nums(self.flow_nums)}"
+            return f"{id_}{repr_flow_nums(self.flow_nums)}"
         if not self.state(TASK_STATUS_WAITING, TASK_STATUS_EXPIRED):
             id_ += f"/{self.submit_num:02d}"
         return (
-            f"{id_}{stringify_flow_nums(self.flow_nums)}:{self.state}"
+            f"{id_}{repr_flow_nums(self.flow_nums)}:{self.state}"
         )
 
     def copy_to_reload_successor(

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -528,3 +528,12 @@ class TaskState:
             for prereq in self.prerequisites if not prereq.is_satisfied()
             for key, satisfied in prereq.items() if not satisfied
         ]
+
+    def any_satisfied_prerequisite_tasks(self) -> bool:
+        """Return True if any of this task's prerequisite tasks are
+        satisfied."""
+        return any(
+            satisfied
+            for prereq in self.prerequisites
+            for satisfied in prereq._satisfied.values()
+        )

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -324,7 +324,8 @@ class TaskState:
 
     def satisfy_me(
         self,
-        outputs: Iterable['Tokens']
+        outputs: Iterable['Tokens'],
+        forced: bool = False,
     ) -> Set['Tokens']:
         """Try to satisfy my prerequisites with given outputs.
 
@@ -333,7 +334,7 @@ class TaskState:
         valid: Set[Tokens] = set()
         for prereq in (*self.prerequisites, *self.suicide_prerequisites):
             valid.update(
-                prereq.satisfy_me(outputs)
+                prereq.satisfy_me(outputs, forced)
             )
         return valid
 
@@ -393,7 +394,7 @@ class TaskState:
         return sorted(
             dep
             for prereq in self.prerequisites
-            for dep in prereq.get_resolved_dependencies()
+            for dep in prereq.get_satisfied_dependencies()
         )
 
     def reset(

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -17,7 +17,10 @@
 
 import ast
 from contextlib import suppress
-from functools import partial
+from functools import (
+    lru_cache,
+    partial,
+)
 import json
 import re
 from textwrap import dedent
@@ -30,6 +33,7 @@ from typing import (
     Sequence,
     Tuple,
 )
+
 
 BOOL_SYMBOLS: Dict[bool, str] = {
     # U+2A2F (vector cross product)
@@ -163,15 +167,23 @@ def serialise_set(flow_nums: Optional[set] = None) -> str:
         '[]'
 
     """
-    return json.dumps(sorted(flow_nums or ()))
+    return _serialise_set(tuple(sorted(flow_nums or ())))
 
 
+@lru_cache(maxsize=100)
+def _serialise_set(flow_nums: tuple) -> str:
+    return json.dumps(flow_nums)
+
+
+@lru_cache(maxsize=100)
 def deserialise_set(flow_num_str: str) -> set:
     """Convert json string to set.
 
     Example:
-    >>> sorted(deserialise_set('[2, 3]'))
-    [2, 3]
+    >>> deserialise_set('[2, 3]') == {2, 3}
+    True
+    >>> deserialise_set('[]')
+    set()
 
     """
     return set(json.loads(flow_num_str))

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -718,7 +718,7 @@ class WorkflowDatabaseManager:
                 WHERE
                     cycle = ?
                     AND name = ?
-            '''
+            '''  # nosec B608 (table name is a code constant)
             fnums_select_cursor = self.pri_dao.connect().execute(
                 fnums_select_stmt, (point, name)
             )
@@ -731,12 +731,12 @@ class WorkflowDatabaseManager:
                     UPDATE OR REPLACE
                         {table}
                     SET
-                        flow_nums = "{serialise_set()}"
+                        flow_nums = ?
                     WHERE
                         cycle = ?
                         AND name = ?
-                '''
-                params: List[tuple] = [(point, name)]
+                '''  # nosec B608 (table name is a code constant)
+                params: List[tuple] = [(serialise_set(), point, name)]
             else:
                 # Mapping of existing flow nums to what should be left after
                 # removing the specified flow nums:
@@ -759,7 +759,7 @@ class WorkflowDatabaseManager:
                         cycle = ?
                         AND name = ?
                         AND flow_nums = ?
-                '''
+                '''  # nosec B608 (table name is a code constant)
                 params = [
                     (serialise_set(new), point, name, old)
                     for old, new in flow_nums_map.items()
@@ -811,7 +811,7 @@ class WorkflowDatabaseManager:
                         {cls.TABLE_WORKFLOW_PARAMS}
                     WHERE
                         key == ?
-                ''',  # nosec (table name is a code constant)
+                ''',  # nosec B608 (table name is a code constant)
                 [cls.KEY_CYLC_VERSION]
             ).fetchone()[0]
         except (TypeError, OperationalError) as exc:

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -25,30 +25,55 @@ This module provides the logic to:
 
 import json
 import os
-from shutil import copy, rmtree
+from shutil import (
+    copy,
+    rmtree,
+)
 from sqlite3 import OperationalError
 from tempfile import mkstemp
 from typing import (
-    Any, AnyStr, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
+    TYPE_CHECKING,
+    Any,
+    AnyStr,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
 )
 
 from packaging.version import parse as parse_version
 
-from cylc.flow import LOG
+from cylc.flow import (
+    LOG,
+    __version__ as CYLC_VERSION,
+)
 from cylc.flow.broadcast_report import get_broadcast_change_iter
+from cylc.flow.exceptions import (
+    CylcError,
+    ServiceFileError,
+)
 from cylc.flow.rundb import CylcWorkflowDAO
-from cylc.flow import __version__ as CYLC_VERSION
-from cylc.flow.wallclock import get_current_time_string, get_utc_mode
-from cylc.flow.exceptions import CylcError, ServiceFileError
-from cylc.flow.util import serialise_set, deserialise_set
+from cylc.flow.util import (
+    deserialise_set,
+    serialise_set,
+)
+from cylc.flow.wallclock import (
+    get_current_time_string,
+    get_utc_mode,
+)
+
 
 if TYPE_CHECKING:
     from pathlib import Path
+
     from cylc.flow.cycling import PointBase
     from cylc.flow.scheduler import Scheduler
-    from cylc.flow.task_pool import TaskPool
     from cylc.flow.task_events_mgr import EventKey
+    from cylc.flow.task_pool import TaskPool
     from cylc.flow.task_proxy import TaskProxy
+
 
 Version = Any
 # TODO: narrow down Any (should be str | int) after implementing type
@@ -422,7 +447,7 @@ class WorkflowDatabaseManager:
                     "signature": sig,
                     "results": json.dumps(res)})
 
-    def put_update_task_state(self, itask):
+    def put_update_task_state(self, itask: 'TaskProxy') -> None:
         """Update task_states table for current state of itask.
 
         NOTE the task_states table is normally updated along with the task pool
@@ -443,9 +468,9 @@ class WorkflowDatabaseManager:
             "name": itask.tdef.name,
             "flow_nums": serialise_set(itask.flow_nums),
         }
-        self.db_updates_map.setdefault(self.TABLE_TASK_STATES, [])
-        self.db_updates_map[self.TABLE_TASK_STATES].append(
-            (set_args, where_args))
+        self.db_updates_map.setdefault(self.TABLE_TASK_STATES, []).append(
+            (set_args, where_args)
+        )
 
     def put_update_task_flow_wait(self, itask):
         """Update flow_wait status of a task, in the task_states table.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,31 +99,30 @@ def mock_glbl_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def log_filter():
-    """Filter caplog record_tuples.
+def log_filter(caplog: pytest.LogCaptureFixture):
+    """Filter caplog record_tuples (also discarding the log name entry).
 
     Args:
-        log: The caplog instance.
-        name: Filter out records if they don't match this logger name.
         level: Filter out records if they aren't at this logging level.
         contains: Filter out records if this string is not in the message.
         regex: Filter out records if the message doesn't match this regex.
         exact_match: Filter out records if the message does not exactly match
             this string.
+        log: A caplog instance.
     """
     def _log_filter(
-        log: pytest.LogCaptureFixture,
-        name: Optional[str] = None,
         level: Optional[int] = None,
         contains: Optional[str] = None,
         regex: Optional[str] = None,
         exact_match: Optional[str] = None,
-    ) -> List[Tuple[str, int, str]]:
+        log: Optional[pytest.LogCaptureFixture] = None
+    ) -> List[Tuple[int, str]]:
+        if log is None:
+            log = caplog
         return [
-            (log_name, log_level, log_message)
-            for log_name, log_level, log_message in log.record_tuples
-            if (name is None or name == log_name)
-            and (level is None or level == log_level)
+            (log_level, log_message)
+            for _, log_level, log_message in log.record_tuples
+            if (level is None or level == log_level)
             and (contains is None or contains in log_message)
             and (regex is None or re.search(regex, log_message))
             and (exact_match is None or exact_match == log_message)

--- a/tests/functional/cylc-remove/00-simple/flow.cylc
+++ b/tests/functional/cylc-remove/00-simple/flow.cylc
@@ -1,13 +1,15 @@
 # Abort on stall timeout unless we remove unhandled failed and waiting task.
 [scheduler]
     [[events]]
-        stall timeout = PT20S
+        stall timeout = PT30S
         abort on stall timeout = True
         expected task failures = 1/b
 [scheduling]
     [[graph]]
-        R1 = """a => b => c
-                cleaner"""
+        R1 = """
+            a => b => c
+            cleaner
+        """
 [runtime]
     [[a,c]]
         script = true
@@ -15,10 +17,10 @@
         script = false
     [[cleaner]]
         script = """
-cylc__job__poll_grep_workflow_log -E '1/b/01:running.* \(received\)failed'
-# Remove the unhandled failed task
-cylc remove "$CYLC_WORKFLOW_ID//1/b"
-# Remove waiting 1/c
-# (not auto-removed because parent 1/b, an unhandled fail, is not finished.)
-cylc remove "$CYLC_WORKFLOW_ID//1/c:waiting"
-"""
+            cylc__job__poll_grep_workflow_log -E '1/b/01:running.* \(received\)failed'
+            # Remove the unhandled failed task
+            cylc remove "$CYLC_WORKFLOW_ID//1/b"
+            # Remove waiting 1/c
+            # (not auto-removed because parent 1/b, an unhandled fail, is not finished.)
+            cylc remove "$CYLC_WORKFLOW_ID//1/c:waiting"
+        """

--- a/tests/functional/cylc-remove/02-cycling/flow.cylc
+++ b/tests/functional/cylc-remove/02-cycling/flow.cylc
@@ -28,18 +28,6 @@
     [[foo, waz]]
         script = true
     [[bar]]
-        script = """
-            if [[ $CYLC_TASK_CYCLE_POINT == 2020 ]]; then
-               false
-            else
-                true
-            fi
-        """
+        script = [[ $CYLC_TASK_CYCLE_POINT != 2020 ]]
     [[baz]]
-        script = """
-            if [[ $CYLC_TASK_CYCLE_POINT == 2021 ]]; then
-               false
-            else
-                true
-            fi
-        """
+        script = [[ $CYLC_TASK_CYCLE_POINT != 2021 ]]

--- a/tests/integration/events/test_task_events.py
+++ b/tests/integration/events/test_task_events.py
@@ -52,7 +52,7 @@ async def test_mail_footer_template(
     # start the workflow and get it to send an email
     ctx = SimpleNamespace(mail_to=None, mail_from=None)
     id_keys = [EventKey('none', 'failed', 'failed', Tokens('//1/a'))]
-    async with start(mod_one) as one_log:
+    async with start(mod_one):
         mod_one.task_events_mgr._process_event_email(mod_one, ctx, id_keys)
 
     # warnings should appear only when the template is invalid
@@ -60,11 +60,9 @@ async def test_mail_footer_template(
 
     # check that template issues are handled correctly
     assert bool(log_filter(
-        one_log,
         contains='Ignoring bad mail footer template',
     )) == should_log
     assert bool(log_filter(
-        one_log,
         contains=template,
     )) == should_log
 

--- a/tests/integration/events/test_workflow_events.py
+++ b/tests/integration/events/test_workflow_events.py
@@ -69,11 +69,9 @@ async def test_mail_footer_template(
 
     # check that template issues are handled correctly
     assert bool(log_filter(
-        one_log,
         contains='Ignoring bad mail footer template',
     )) == should_log
     assert bool(log_filter(
-        one_log,
         contains=template,
     )) == should_log
 
@@ -114,10 +112,8 @@ async def test_custom_event_handler_template(
 
     # check that template issues are handled correctly
     assert bool(log_filter(
-        one_log,
         contains='bad template',
     )) == should_log
     assert bool(log_filter(
-        one_log,
         contains=template,
     )) == should_log

--- a/tests/integration/main_loop/test_auto_restart.py
+++ b/tests/integration/main_loop/test_auto_restart.py
@@ -45,6 +45,6 @@ async def test_no_detach(
     id_: str = flow(one_conf)
     schd: Scheduler = scheduler(id_, paused_start=True, no_detach=True)
     with pytest.raises(MainLoopPluginException) as exc:
-        async with run(schd) as log:
+        async with run(schd):
             await asyncio.sleep(2)
-    assert log_filter(log, contains=f"Workflow shutting down - {exc.value}")
+    assert log_filter(contains=f"Workflow shutting down - {exc.value}")

--- a/tests/integration/scripts/test_set.py
+++ b/tests/integration/scripts/test_set.py
@@ -149,9 +149,9 @@ async def test_incomplete_detection(
 ):
     """It should detect and log finished tasks left with incomplete outputs."""
     schd = scheduler(flow(one_conf))
-    async with start(schd) as log:
+    async with start(schd):
         schd.pool.set_prereqs_and_outputs(['1/one'], ['failed'], None, ['1'])
-    assert log_filter(log, contains='1/one did not complete')
+    assert log_filter(contains='1/one did not complete')
 
 
 async def test_pre_all(flow, scheduler, run):

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -151,7 +151,6 @@ def test_validate_param_env_templ(
     one_conf,
     validate,
     env_val,
-    caplog,
     log_filter,
 ):
     """It should validate parameter environment templates."""
@@ -166,8 +165,8 @@ def test_validate_param_env_templ(
         }
     })
     validate(id_)
-    assert log_filter(caplog, contains='bad parameter environment template')
-    assert log_filter(caplog, contains=env_val)
+    assert log_filter(contains='bad parameter environment template')
+    assert log_filter(contains=env_val)
 
 
 def test_no_graph(flow, validate):

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -331,9 +331,8 @@ def test_delta_task_prerequisite(harness):
     for itask in schd.pool.get_tasks():
         # set prereqs as not-satisfied
         for prereq in itask.state.prerequisites:
-            prereq._all_satisfied = False
             for key in prereq:
-                prereq._satisfied[key] = False
+                prereq[key] = False
         schd.data_store_mgr.delta_task_prerequisite(itask)
     assert not any(p.satisfied for p in get_pb_prereqs(schd))
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -62,9 +62,9 @@ async def test_logging(flow, scheduler, start, one_conf, log_filter):
     # Ensure that the cylc version is logged on startup.
     id_ = flow(one_conf)
     schd = scheduler(id_)
-    async with start(schd) as log:
+    async with start(schd):
         # this returns a list of log records containing __version__
-        assert log_filter(log, contains=__version__)
+        assert log_filter(contains=__version__)
 
 
 async def test_scheduler_arguments(flow, scheduler, start, one_conf):
@@ -159,16 +159,12 @@ async def test_exception(one, run, log_filter):
 
     # make sure that this error causes the flow to shutdown
     with pytest.raises(MyException):
-        async with run(one) as log:
+        async with run(one):
             # The `run` fixture's shutdown logic waits for the main loop to run
             pass
 
     # make sure the exception was logged
-    assert len(log_filter(
-        log,
-        level=logging.CRITICAL,
-        contains='mess'
-    )) == 1
+    assert len(log_filter(logging.CRITICAL, contains='mess')) == 1
 
     # make sure the server socket has closed - a good indication of a
     # successful clean shutdown

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -23,9 +23,11 @@ useful testing in the process 😀.)
 import asyncio
 import logging
 from pathlib import Path
+
 import pytest
 
 from cylc.flow import __version__
+from cylc.flow.scheduler import Scheduler
 
 
 async def test_create_flow(flow, run_dir):
@@ -286,3 +288,11 @@ async def test_reftest(flow, scheduler, reftest):
         ('1/a', None),
         ('1/b', ('1/a',)),
     }
+
+
+async def test_show(one: Scheduler, start, cylc_show):
+    """Demonstrate the `cylc_show` fixture"""
+    async with start(one):
+        out = await cylc_show(one, '1/one')
+    assert list(out.keys()) == ['1/one']
+    assert out['1/one']['state'] == 'waiting'

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -27,7 +27,7 @@ from cylc.flow.flow_mgr import (
     FLOW_ALL,
     FLOW_NEW,
     FLOW_NONE,
-    stringify_flow_nums
+    repr_flow_nums
 )
 from cylc.flow.scheduler import Scheduler
 
@@ -139,7 +139,7 @@ async def test_flow_assignment(
         assert log_filter(
             contains=(
                 f'[{active_a}] ignoring \'flow=none\' {command}: '
-                f'task already has {stringify_flow_nums(active_a.flow_nums)}'
+                f'task already has {repr_flow_nums(active_a.flow_nums)}'
             ),
             level=logging.ERROR
         )

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -110,7 +110,7 @@ async def test_flow_assignment(
     }
     id_ = flow(conf)
     schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
-    async with start(schd) as log:
+    async with start(schd):
         if command == 'set':
             do_command: Callable = functools.partial(
                 schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
@@ -137,7 +137,6 @@ async def test_flow_assignment(
         do_command([active_a.identity], flow=[FLOW_NONE])
         assert active_a.flow_nums == {1, 2}
         assert log_filter(
-            log,
             contains=(
                 f'[{active_a}] ignoring \'flow=none\' {command}: '
                 f'task already has {stringify_flow_nums(active_a.flow_nums)}'

--- a/tests/integration/test_queues.py
+++ b/tests/integration/test_queues.py
@@ -120,7 +120,7 @@ async def test_queue_held_tasks(
 
         # hold all tasks and resume the workflow
         # (nothing should have run yet because the workflow started paused)
-        await commands.run_cmd(commands.hold, schd, ['*/*'])
+        await commands.run_cmd(commands.hold(schd, ['*/*']))
         schd.resume_workflow()
 
         # release queued tasks
@@ -129,7 +129,7 @@ async def test_queue_held_tasks(
         assert len(submitted_tasks) == 0
 
         # un-hold tasks
-        await commands.run_cmd(commands.release, schd, ['*/*'])
+        await commands.run_cmd(commands.release(schd, ['*/*']))
 
         # release queued tasks
         # (tasks should now be released from the queues)

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -89,7 +89,7 @@ async def test_reload_waits_for_pending_tasks(
         change_state()
 
         # reload the workflow
-        await commands.run_cmd(commands.reload_workflow, schd)
+        await commands.run_cmd(commands.reload_workflow(schd))
 
         # the task should end in the submitted state
         assert foo.state(TASK_STATUS_SUBMITTED)
@@ -133,7 +133,7 @@ async def test_reload_failure(
         flow(two_conf, id_=id_)
 
         # reload the workflow
-        await commands.run_cmd(commands.reload_workflow, schd)
+        await commands.run_cmd(commands.reload_workflow(schd))
 
         # the reload should have failed but the workflow should still be
         # running

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -127,7 +127,7 @@ async def test_reload_failure(
     """
     id_ = flow(one_conf)
     schd = scheduler(id_)
-    async with start(schd) as log:
+    async with start(schd):
         # corrupt the config by removing the scheduling section
         two_conf = {**one_conf, 'scheduling': {}}
         flow(two_conf, id_=id_)
@@ -138,7 +138,6 @@ async def test_reload_failure(
         # the reload should have failed but the workflow should still be
         # running
         assert log_filter(
-            log,
             contains=(
                 'Reload failed - WorkflowConfigError:'
                 ' missing [scheduling][[graph]] section'

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -1,0 +1,284 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+
+import pytest
+
+from cylc.flow.commands import force_trigger_tasks, remove_tasks, run_cmd
+from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.flow_mgr import FLOW_ALL
+from cylc.flow.scheduler import Scheduler
+from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
+
+
+@pytest.fixture
+def example_workflow(flow):
+    return flow({
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    a1 & a2 => b
+                    a3 => b
+                ''',
+            },
+        },
+    })
+
+
+async def test_basic(
+    example_workflow, scheduler, start, db_select
+):
+    """Test removing a task from all flows."""
+    schd: Scheduler = scheduler(example_workflow)
+    async with start(schd):
+        a1 = schd.pool._get_task_by_id('1/a1')
+        schd.pool.spawn_on_output(a1, TASK_OUTPUT_SUCCEEDED)
+        await schd.update_data_structure()
+
+        assert a1 in schd.pool.get_tasks()
+        for table in ('task_states', 'task_outputs'):
+            assert db_select(schd, True, table, 'flow_nums', name='a1') == [
+                ('[1]',),
+            ]
+        assert db_select(
+            schd, True, 'task_prerequisites', 'satisfied', prereq_name='a1'
+        ) == [
+            ('satisfied naturally',),
+        ]
+
+        await run_cmd(remove_tasks(schd, ['1/a1'], [FLOW_ALL]))
+        await schd.update_data_structure()
+
+        assert a1 not in schd.pool.get_tasks()  # removed from pool
+        for table in ('task_states', 'task_outputs'):
+            assert db_select(schd, True, table, 'flow_nums', name='a1') == [
+                ('[]',),  # removed from all flows
+            ]
+        assert db_select(
+            schd, True, 'task_prerequisites', 'satisfied', prereq_name='a1'
+        ) == [
+            ('0',),  # prereq is now unsatisfied
+        ]
+
+
+async def test_specific_flow(
+    example_workflow, scheduler, start, db_select
+):
+    """Test removing a task from a specific flow."""
+    schd: Scheduler = scheduler(example_workflow)
+
+    def select_prereqs():
+        return db_select(
+            schd,
+            True,
+            'task_prerequisites',
+            'flow_nums',
+            'satisfied',
+            prereq_name='a1',
+        )
+
+    async with start(schd):
+        a1 = schd.pool._get_task_by_id('1/a1')
+        schd.pool.force_trigger_tasks(['1/a1'], ['1', '2'])
+        schd.pool.spawn_on_output(a1, TASK_OUTPUT_SUCCEEDED)
+        await schd.update_data_structure()
+
+        assert a1 in schd.pool.get_tasks()
+        assert a1.flow_nums == {1, 2}
+        for table in ('task_states', 'task_outputs'):
+            assert sorted(
+                db_select(schd, True, table, 'flow_nums', name='a1')
+            ) == [
+                ('[1, 2]',),  # triggered task
+                ('[1]',),  # original spawned task
+            ]
+        assert select_prereqs() == [
+            ('[1, 2]', 'satisfied naturally'),
+        ]
+
+        await run_cmd(remove_tasks(schd, ['1/a1'], ['1']))
+        await schd.update_data_structure()
+
+        assert a1 in schd.pool.get_tasks()  # still in pool
+        assert a1.flow_nums == {2}
+        for table in ('task_states', 'task_outputs'):
+            assert sorted(
+                db_select(schd, True, table, 'flow_nums', name='a1')
+            ) == [
+                ('[2]',),
+                ('[]',),
+            ]
+        assert select_prereqs() == [
+            ('[1, 2]', '0'),
+        ]
+
+
+async def test_unset_prereq(example_workflow, scheduler, start):
+    """Test removing a task unsets any prerequisites it satisfied."""
+    schd: Scheduler = scheduler(example_workflow)
+    async with start(schd):
+        for task in ('a1', 'a2', 'a3'):
+            schd.pool.spawn_on_output(
+                schd.pool.get_task(IntegerPoint('1'), task),
+                TASK_OUTPUT_SUCCEEDED,
+            )
+        b = schd.pool.get_task(IntegerPoint('1'), 'b')
+        assert b.prereqs_are_satisfied()
+
+        await run_cmd(remove_tasks(schd, ['1/a1'], [FLOW_ALL]))
+
+        assert not b.prereqs_are_satisfied()
+
+
+async def test_not_unset_prereq(
+    example_workflow, scheduler, start, db_select
+):
+    """Test removing a task does not unset a force-satisfied prerequisite
+    (one that was satisfied by `cylc set --pre`)."""
+    schd: Scheduler = scheduler(example_workflow)
+    async with start(schd):
+        # This set prereq should not be unset by removing a1:
+        schd.pool.set_prereqs_and_outputs(
+            ['1/b'], outputs=[], prereqs=['1/a1'], flow=[FLOW_ALL]
+        )
+        # Whereas the prereq satisfied by this set output *should* be unset
+        # by removing a2:
+        schd.pool.set_prereqs_and_outputs(
+            ['1/a2'], outputs=['succeeded'], prereqs=[], flow=[FLOW_ALL]
+        )
+        await schd.update_data_structure()
+
+        assert sorted(
+            db_select(
+                schd, True, 'task_prerequisites', 'prereq_name', 'satisfied'
+            )
+        ) == [
+            ('a1', 'force satisfied'),
+            ('a2', 'satisfied naturally'),
+            ('a3', '0'),
+        ]
+
+        await run_cmd(remove_tasks(schd, ['1/a1', '1/a2'], [FLOW_ALL]))
+        await schd.update_data_structure()
+
+        assert sorted(
+            db_select(
+                schd, True, 'task_prerequisites', 'prereq_name', 'satisfied'
+            )
+        ) == [
+            ('a1', 'force satisfied'),
+            ('a2', '0'),
+            ('a3', '0'),
+        ]
+
+
+async def test_logging(flow, scheduler, start, log_filter):
+    """Test logging of a mixture of valid and invalid task removals."""
+    schd: Scheduler = scheduler(
+        flow({
+            'scheduler': {
+                'cycle point format': 'CCYY',
+            },
+            'scheduling': {
+                'initial cycle point': '2000',
+                'graph': {
+                    'R3//P1Y': 'b[-P1Y] => a & b',
+                },
+            },
+        })
+    )
+    tasks_to_remove = [
+        # Active, removable tasks:
+        '2000/*',
+        # Future, non-removable tasks:
+        '2001/a', '2001/b',
+        # Glob that doesn't match any active tasks:
+        '2002/*',
+        # Invalid tasks:
+        '2005/a', '2000/doh',
+    ]
+    async with start(schd):
+        await run_cmd(remove_tasks(schd, tasks_to_remove, [FLOW_ALL]))
+
+    assert log_filter(
+        logging.INFO, "Removed task(s): 2000/a (flows=1), 2000/b (flows=1)"
+    )
+
+    assert log_filter(logging.WARNING, "Task(s) not removable: 2001/a, 2001/b")
+    assert log_filter(logging.WARNING, "No active tasks matching: 2002/*")
+    assert log_filter(logging.WARNING, "Invalid cycle point for task: a, 2005")
+    assert log_filter(logging.WARNING, "No matching tasks found: doh")
+
+
+async def test_logging_flow_nums(
+    example_workflow, scheduler, start, log_filter
+):
+    """Test logging of task removals involving flow numbers."""
+    schd: Scheduler = scheduler(example_workflow)
+    async with start(schd):
+        schd.pool.force_trigger_tasks(['1/a1'], ['1', '2'])
+        # Removing from flow that doesn't exist doesn't work:
+        await run_cmd(remove_tasks(schd, ['1/a1'], ['3']))
+        assert log_filter(
+            logging.WARNING, "Task(s) not removable: 1/a1 (flows=3)"
+        )
+
+        # But if a valid flow is included, it will be removed from that flow:
+        await run_cmd(remove_tasks(schd, ['1/a1'], ['2', '3']))
+        assert log_filter(logging.INFO, "Removed task(s): 1/a1 (flows=2)")
+        assert schd.pool._get_task_by_id('1/a1').flow_nums == {1}
+
+
+async def test_ref1(flow, scheduler, run, reflog, complete, log_filter):
+    """Test prereqs/stall & re-run behaviour when removing tasks."""
+    schd: Scheduler = scheduler(
+        flow({
+            'scheduling': {
+                'graph': {
+                    'R1': 'a => b => c',
+                },
+            },
+        }),
+        paused_start=False,
+    )
+    async with run(schd):
+        reflog_triggers: set = reflog(schd)
+        schd.pool.tasks_to_hold.add(('c', IntegerPoint('1')))
+        await complete(schd, '1/b')
+        assert not schd.pool.is_stalled()
+
+        await run_cmd(remove_tasks(schd, ['1/a', '1/b'], [FLOW_ALL]))
+        schd.process_workflow_db_queue()
+        # Removing 1/b should cause stall because it is prereq of 1/c:
+        assert schd.pool.is_stalled()
+        assert log_filter(
+            logging.WARNING, "1/c is waiting on ['1/b:succeeded']"
+        )
+        assert reflog_triggers == {
+            ('1/a', None),
+            ('1/b', ('1/a',)),
+        }
+        reflog_triggers.clear()
+
+        await run_cmd(force_trigger_tasks(schd, ['1/a'], [FLOW_ALL]))
+        await complete(schd, '1/b')
+        assert not schd.pool.is_stalled()
+        assert reflog_triggers == {
+            ('1/a', None),
+            # 1/b should have run again after 1/a on the re-trigger in flow 1:
+            ('1/b', ('1/a',)),
+        }

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -381,3 +381,28 @@ async def test_downstream_preparing(flow, scheduler, start):
         schd.pool._get_task_by_id('1/y').state_reset('preparing')
         await run_cmd(remove_tasks(schd, ['1/a'], [FLOW_ALL]))
         assert get_pool_tasks(schd) == {'1/y'}
+
+
+async def test_suicide(flow, scheduler, run, reflog, complete):
+    """Test that suicide prereqs are unset by `cylc remove`."""
+    schd: Scheduler = scheduler(
+        flow('''
+            a => b => c => d => x
+            a & c => !x
+        '''),
+        paused_start=False,
+    )
+    async with run(schd):
+        reflog_triggers: set = reflog(schd)
+        await complete(schd, '1/b')
+        await run_cmd(remove_tasks(schd, ['1/a'], [FLOW_ALL]))
+        await complete(schd)
+
+    assert reflog_triggers == {
+        ('1/a', None),
+        ('1/b', ('1/a',)),
+        ('1/c', ('1/b',)),
+        ('1/d', ('1/c',)),
+        # 1/x not suicided as 1/a was removed:
+        ('1/x', ('1/d',)),
+    }

--- a/tests/integration/test_resolvers.py
+++ b/tests/integration/test_resolvers.py
@@ -234,7 +234,7 @@ async def test_command_logging(mock_flow, caplog, log_filter):
         {'mode': StopMode.REQUEST_CLEAN.value},
         meta,
     )
-    assert log_filter(caplog, contains='Command "stop" received')
+    assert log_filter(contains='Command "stop" received')
 
     # put_messages: only log for owner
     kwargs = {
@@ -244,12 +244,11 @@ async def test_command_logging(mock_flow, caplog, log_filter):
     }
     meta["auth_user"] = mock_flow.owner
     await mock_flow.resolvers._mutation_mapper("put_messages", kwargs, meta)
-    assert not log_filter(caplog, contains='Command "put_messages" received:')
+    assert not log_filter(contains='Command "put_messages" received:')
 
     meta["auth_user"] = "Dr Spock"
     await mock_flow.resolvers._mutation_mapper("put_messages", kwargs, meta)
-    assert log_filter(
-        caplog, contains='Command "put_messages" received from Dr Spock')
+    assert log_filter(contains='Command "put_messages" received from Dr Spock')
 
 
 async def test_command_validation_failure(

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -267,7 +267,7 @@ async def test_unexpected_ParsecError(
             pass
 
     assert log_filter(
-        log, level=logging.CRITICAL,
+        logging.CRITICAL,
         exact_match="Workflow shutting down - Mock error"
     )
     assert TRACEBACK_MSG in log.text
@@ -295,7 +295,7 @@ async def test_error_during_auto_restart(
         async with run(one) as log:
             pass
 
-    assert log_filter(log, level=logging.ERROR, contains=err_msg)
+    assert log_filter(logging.ERROR, err_msg)
     assert TRACEBACK_MSG in log.text
 
 
@@ -361,20 +361,19 @@ async def test_restart_timeout(
 
     # restart the completed workflow
     schd = scheduler(id_)
-    async with run(schd) as log:
+    async with run(schd):
         # it should detect that the workflow has completed and alert the user
         assert log_filter(
-            log,
             contains='This workflow already ran to completion.'
         )
 
         # it should activate a timeout
-        assert log_filter(log, contains='restart timer starts NOW')
+        assert log_filter(contains='restart timer starts NOW')
 
         # when we trigger tasks the timeout should be cleared
         schd.pool.force_trigger_tasks(['1/one'], {1})
         await asyncio.sleep(0)  # yield control to the main loop
-        assert log_filter(log, contains='restart timer stopped')
+        assert log_filter(contains='restart timer stopped')
 
 
 @pytest.mark.parametrize("signal", ((SIGHUP), (SIGINT), (SIGTERM)))
@@ -387,14 +386,14 @@ async def test_signal_escallation(one, start, signal, log_filter):
 
     See https://github.com/cylc/cylc-flow/pull/6444
     """
-    async with start(one) as log:
+    async with start(one):
         # put the workflow in the stopping state
         one._set_stop(StopMode.REQUEST_CLEAN)
         assert one.stop_mode.name == 'REQUEST_CLEAN'
 
         # one signal should escalate this from CLEAN to NOW
         one._handle_signal(signal, None)
-        assert log_filter(log, contains=signal.name)
+        assert log_filter(contains=signal.name)
         assert one.stop_mode.name == 'REQUEST_NOW'
 
         # two signals should escalate this from NOW to NOW_NOW

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -174,7 +174,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
         assert submitted_tasks == set()
 
         # hold all tasks & resume the workflow
-        await commands.run_cmd(commands.hold, one, ['*/*'])
+        await commands.run_cmd(commands.hold(one, ['*/*']))
         one.resume_workflow()
 
         # release queued tasks
@@ -183,7 +183,7 @@ async def test_holding_tasks_whilst_scheduler_paused(
         assert submitted_tasks == set()
 
         # release all tasks
-        await commands.run_cmd(commands.release, one, ['*/*'])
+        await commands.run_cmd(commands.release(one, ['*/*']))
 
         # release queued tasks
         # (the task should be submitted)
@@ -219,12 +219,12 @@ async def test_no_poll_waiting_tasks(
         polled_tasks = capture_polling(one)
 
         # Waiting tasks should not be polled.
-        await commands.run_cmd(commands.poll_tasks, one, ['*/*'])
+        await commands.run_cmd(commands.poll_tasks(one, ['*/*']))
         assert polled_tasks == set()
 
         # Even if they have a submit number.
         task.submit_num = 1
-        await commands.run_cmd(commands.poll_tasks, one, ['*/*'])
+        await commands.run_cmd(commands.poll_tasks(one, ['*/*']))
         assert len(polled_tasks) == 0
 
         # But these states should be:
@@ -235,7 +235,7 @@ async def test_no_poll_waiting_tasks(
             TASK_STATUS_RUNNING
         ]:
             task.state.status = state
-            await commands.run_cmd(commands.poll_tasks, one, ['*/*'])
+            await commands.run_cmd(commands.poll_tasks(one, ['*/*']))
             assert len(polled_tasks) == 1
             polled_tasks.clear()
 

--- a/tests/integration/test_simulation.py
+++ b/tests/integration/test_simulation.py
@@ -344,7 +344,7 @@ async def test_settings_reload(
             conf_file.read_text().replace('False', 'True'))
 
         # Reload Workflow:
-        await commands.run_cmd(commands.reload_workflow, schd)
+        await commands.run_cmd(commands.reload_workflow(schd))
 
         # Submit second psuedo-job and "run" to success:
         itask = run_simjob(schd, one_1066.point, 'one')

--- a/tests/integration/test_stop_after_cycle_point.py
+++ b/tests/integration/test_stop_after_cycle_point.py
@@ -119,10 +119,11 @@ async def test_stop_after_cycle_point(
 
         # override this value whilst the workflow is running
         await commands.run_cmd(
-            commands.stop,
-            schd,
-            cycle_point=IntegerPoint('4'),
-            mode=StopMode.REQUEST_CLEAN,
+            commands.stop(
+                schd,
+                cycle_point=IntegerPoint('4'),
+                mode=StopMode.REQUEST_CLEAN,
+            )
         )
         assert schd.config.stop_point == IntegerPoint('4')
 

--- a/tests/integration/test_subprocctx.py
+++ b/tests/integration/test_subprocctx.py
@@ -47,7 +47,7 @@ async def test_log_xtrigger_stdout(
             return True, {}
     """))
     schd = scheduler(id_)
-    async with start(schd, level=DEBUG) as log:
+    async with start(schd, level=DEBUG):
         # Set off check for x-trigger:
         task = schd.pool.get_tasks()[0]
         schd.xtrigger_mgr.call_xtriggers_async(task)
@@ -59,4 +59,4 @@ async def test_log_xtrigger_stdout(
         # Assert that both stderr and out from the print statement
         # in our xtrigger appear in the log.
         for expected in ['Hello World', 'Hello Hades']:
-            assert log_filter(log, contains=expected, level=DEBUG)
+            assert log_filter(DEBUG, expected)

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -23,7 +23,6 @@ from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_state import TASK_STATUS_RUNNING
 
 
-
 async def test_run_job_cmd_no_hosts_error(
     flow,
     scheduler,
@@ -92,7 +91,6 @@ async def test_run_job_cmd_no_hosts_error(
 
         # ...but the failure should be logged
         assert log_filter(
-            log,
             contains='No available hosts for no-host-platform',
         )
         log.clear()
@@ -105,7 +103,6 @@ async def test_run_job_cmd_no_hosts_error(
 
         # ...but the failure should be logged
         assert log_filter(
-            log,
             contains='No available hosts for no-host-platform',
         )
 
@@ -217,7 +214,7 @@ async def test_broadcast_platform_change(
 
     schd = scheduler(id_, run_mode='live')
 
-    async with start(schd) as log:
+    async with start(schd):
         # Change the task platform with broadcast:
         schd.broadcast_mgr.put_broadcast(
             ['1'], ['mytask'], [{'platform': 'foo'}])
@@ -235,4 +232,4 @@ async def test_broadcast_platform_change(
         # Check that task platform hasn't become "localhost":
         assert schd.pool.get_tasks()[0].platform['name'] == 'foo'
         # ... and that remote init failed because all hosts bad:
-        assert log_filter(log, contains="(no hosts were reachable)")
+        assert log_filter(regex=r"platform: foo .*\(no hosts were reachable\)")

--- a/tests/integration/test_workflow_db_mgr.py
+++ b/tests/integration/test_workflow_db_mgr.py
@@ -34,12 +34,12 @@ async def test_restart_number(
         """(Re)start the workflow and check the restart number is as expected.
         """
         schd: 'Scheduler' = scheduler(id_, paused_start=True)
-        async with start(schd) as log:
+        async with start(schd):
             if do_reload:
                 await commands.run_cmd(commands.reload_workflow(schd))
             assert schd.workflow_db_mgr.n_restart == expected_restart_num
             assert log_filter(
-                log, contains=f"(re)start number={expected_restart_num + 1}"
+                contains=f"(re)start number={expected_restart_num + 1}"
                 # (In the log, it's 1 higher than backend value)
             )
         assert ('n_restart', f'{expected_restart_num}') in db_select(

--- a/tests/integration/test_workflow_db_mgr.py
+++ b/tests/integration/test_workflow_db_mgr.py
@@ -36,7 +36,7 @@ async def test_restart_number(
         schd: 'Scheduler' = scheduler(id_, paused_start=True)
         async with start(schd) as log:
             if do_reload:
-                await commands.run_cmd(commands.reload_workflow, schd)
+                await commands.run_cmd(commands.reload_workflow(schd))
             assert schd.workflow_db_mgr.n_restart == expected_restart_num
             assert log_filter(
                 log, contains=f"(re)start number={expected_restart_num + 1}"

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -151,7 +151,7 @@ def test_detect_old_contact_file_old_run(workflow, caplog, log_filter):
 
     # as a side effect the contact file should have been removed
     assert not workflow.contact_file.exists()
-    assert log_filter(caplog, contains='Removed contact file')
+    assert log_filter(contains='Removed contact file')
 
 
 def test_detect_old_contact_file_none(workflow):
@@ -260,11 +260,9 @@ def test_detect_old_contact_file_removal_errors(
 
     # check the appropriate messages were logged
     assert bool(log_filter(
-        caplog,
         contains='Removed contact file',
     )) is remove_succeeded
     assert bool(log_filter(
-        caplog,
         contains=(
             f'Failed to remove contact file for {workflow.id_}:'
             '\nmocked-os-error'

--- a/tests/integration/tui/conftest.py
+++ b/tests/integration/tui/conftest.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import re
 from time import sleep
-from uuid import uuid1
+from secrets import token_hex
 
 import pytest
 from urwid.display import html_fragment
@@ -211,7 +211,7 @@ class RakiuraSession:
             )
             if exc:
                 msg += f'\n{exc}'
-            self.compare_screenshot(f'fail-{uuid1()}', msg, 1)
+            self.compare_screenshot(f'fail-{token_hex(4)}', msg, 1)
 
 
 @pytest.fixture

--- a/tests/integration/tui/test_mutations.py
+++ b/tests/integration/tui/test_mutations.py
@@ -59,7 +59,7 @@ async def test_online_mutation(
     id_ = flow(one_conf, name='one')
     schd = scheduler(id_)
     with rakiura(size='80,15') as rk:
-        async with start(schd) as schd_log:
+        async with start(schd):
             await schd.update_data_structure()
             assert schd.command_queue.empty()
 
@@ -91,7 +91,7 @@ async def test_online_mutation(
 
             # the mutation should be in the scheduler's command_queue
             await asyncio.sleep(0)
-            assert log_filter(schd_log, contains="hold(tasks=['1/one'])")
+            assert log_filter(contains="hold(tasks=['1/one'])")
 
         # close the dialogue and re-run the hold mutation
         rk.user_input('q', 'q', 'enter')
@@ -127,7 +127,7 @@ def standardise_cli_cmds(monkeypatch):
     """This remove the variable bit of the workflow ID from CLI commands.
 
     The workflow ID changes from run to run. In order to make screenshots
-    stable, this 
+    stable, this
     """
     from cylc.flow.tui.data import extract_context
     def _extract_context(selection):

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -28,7 +28,7 @@ from contextlib import asynccontextmanager, contextmanager
 import logging
 import pytest
 from typing import Any, Optional, Union
-from uuid import uuid1
+from secrets import token_hex
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.workflow_files import WorkflowFiles
@@ -41,7 +41,7 @@ from .flow_writer import flow_config_str
 
 def _make_src_flow(src_path, conf, filename=WorkflowFiles.FLOW_FILE):
     """Construct a workflow on the filesystem"""
-    flow_src_dir = (src_path / str(uuid1()))
+    flow_src_dir = (src_path / token_hex(4))
     flow_src_dir.mkdir(parents=True, exist_ok=True)
     if isinstance(conf, dict):
         conf = flow_config_str(conf)
@@ -71,7 +71,7 @@ def _make_flow(
         flow_run_dir = (cylc_run_dir / id_)
     else:
         if name is None:
-            name = str(uuid1())
+            name = token_hex(4)
         flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
     id_ = str(flow_run_dir.relative_to(cylc_run_dir))

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -53,7 +53,7 @@ def _make_src_flow(src_path, conf, filename=WorkflowFiles.FLOW_FILE):
 def _make_flow(
     cylc_run_dir: Union[Path, str],
     test_dir: Path,
-    conf: dict,
+    conf: Union[dict, str],
     name: Optional[str] = None,
     id_: Optional[str] = None,
     defaults: Optional[bool] = True,
@@ -62,6 +62,8 @@ def _make_flow(
     """Construct a workflow on the filesystem.
 
     Args:
+        conf: Either a workflow config dictionary, or a graph string to be
+            used as the R1 graph in the workflow config.
         defaults: Set up a common defaults.
             * [scheduling]allow implicit tasks = true
 
@@ -75,6 +77,14 @@ def _make_flow(
         flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
     id_ = str(flow_run_dir.relative_to(cylc_run_dir))
+    if isinstance(conf, str):
+        conf = {
+            'scheduling': {
+                'graph': {
+                    'R1': conf
+                }
+            }
+        }
     if defaults:
         # set the default simulation runtime to zero (can be overridden)
         (

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -601,12 +601,12 @@ def test_exclusion_zero_duration_warning(set_cycling_type, caplog, log_filter):
     set_cycling_type(ISO8601_CYCLING_TYPE, "+05")
     with pytest.raises(Exception):
         ISO8601Sequence('3000', '2999')
-    assert log_filter(caplog, contains='zero-duration')
+    assert log_filter(contains='zero-duration')
 
     # parsing a point in an exclusion should not
     caplog.clear()
     ISO8601Sequence('P1Y ! 3000', '2999')
-    assert not log_filter(caplog, contains='zero-duration')
+    assert not log_filter(contains='zero-duration')
 
 
 def test_simple(set_cycling_type):

--- a/tests/unit/post_install/test_log_vc_info.py
+++ b/tests/unit/post_install/test_log_vc_info.py
@@ -279,13 +279,13 @@ def test_no_base_commit_git(tmp_path: Path):
 
 @require_svn
 def test_untracked_svn_subdir(
-    svn_source_repo: Tuple[str, str, str], caplog, log_filter
+    svn_source_repo: Tuple[str, str, str], log_filter
 ):
     repo_dir, *_ = svn_source_repo
     source_dir = Path(repo_dir, 'jar_jar_binks')
     source_dir.mkdir()
     assert get_vc_info(source_dir) is None
-    assert log_filter(caplog, level=logging.WARNING, contains="$ svn info")
+    assert log_filter(logging.WARNING, contains="$ svn info")
 
 
 def test_not_installed(
@@ -306,7 +306,6 @@ def test_not_installed(
     caplog.set_level(logging.DEBUG)
     assert get_vc_info(tmp_path) is None
     assert log_filter(
-        caplog,
-        level=logging.DEBUG,
+        logging.DEBUG,
         contains=f"{fake_vcs} does not appear to be installed",
     )

--- a/tests/unit/test_clean.py
+++ b/tests/unit/test_clean.py
@@ -945,7 +945,7 @@ def test_remote_clean(
             id_, platform_names, timeout='irrelevant', rm_dirs=rm_dirs
         )
     for msg in expected_err_msgs:
-        assert log_filter(caplog, level=logging.ERROR, contains=msg)
+        assert log_filter(logging.ERROR, msg)
     if expected_platforms:
         for p_name in expected_platforms:
             mocked_remote_clean_cmd.assert_any_call(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1400,7 +1400,7 @@ def test_implicit_tasks(
 
 @pytest.mark.parametrize('workflow_meta', [True, False])
 @pytest.mark.parametrize('url_type', ['good', 'bad', 'ugly', 'broken'])
-def test_process_urls(caplog, log_filter, workflow_meta, url_type):
+def test_process_urls(log_filter, workflow_meta, url_type):
 
     if url_type == 'good':
         # valid cylc 8 syntax
@@ -1436,7 +1436,6 @@ def test_process_urls(caplog, log_filter, workflow_meta, url_type):
     elif url_type == 'ugly':
         WorkflowConfig.process_metadata_urls(config)
         assert log_filter(
-            caplog,
             contains='Detected deprecated template variables',
         )
 
@@ -1464,7 +1463,6 @@ def test_zero_interval(
     should_warn: bool,
     opts: Values,
     tmp_flow_config: Callable,
-    caplog: pytest.LogCaptureFixture,
     log_filter: Callable,
 ):
     """Test that a zero-duration recurrence with >1 repetition gets an
@@ -1482,7 +1480,6 @@ def test_zero_interval(
     """)
     WorkflowConfig(id_, flow_file, options=opts)
     logged = log_filter(
-        caplog,
         level=logging.WARNING,
         contains="Cannot have more than 1 repetition for zero-duration"
     )

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -17,12 +17,15 @@
 
 import pytest
 
+from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.cycling.iso8601 import ISO8601Point
 from cylc.flow.id import (
     LEGACY_CYCLE_SLASH_TASK,
     LEGACY_TASK_DOT_CYCLE,
     RELATIVE_ID,
-    Tokens,
     UNIVERSAL_ID,
+    Tokens,
+    quick_relative_id,
 )
 
 
@@ -392,3 +395,14 @@ def test_task_property():
     ) == (
         Tokens('//c:cs/t:ts/j:js', relative=True)
     )
+
+
+@pytest.mark.parametrize('cycle, expected', [
+    ('2000', '2000/foo'),
+    (2001, '2001/foo'),
+    (IntegerPoint('3'), '3/foo'),
+    # NOTE: ISO8601Points are not standardised by this function:
+    (ISO8601Point('2002'), '2002/foo'),
+])
+def test_quick_relative_id(cycle, expected):
+    assert quick_relative_id(cycle, 'foo') == expected

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -48,10 +48,10 @@ def test_satisfied(prereq: Prerequisite):
         ('2001', 'd', 'custom'): False,
     }
     # No cached satisfaction state yet:
-    assert prereq._all_satisfied is None
+    assert prereq._cached_satisfied is None
     # Calling self.is_satisfied() should cache the result:
     assert not prereq.is_satisfied()
-    assert prereq._all_satisfied is False
+    assert prereq._cached_satisfied is False
 
     # mark two prerequisites as satisfied
     prereq.satisfy_me([
@@ -68,7 +68,7 @@ def test_satisfied(prereq: Prerequisite):
         ('2001', 'd', 'custom'): False,
     }
     # Should have reset cached satisfaction state:
-    assert prereq._all_satisfied is None
+    assert prereq._cached_satisfied is None
     assert not prereq.is_satisfied()
 
     # mark all prereqs as satisfied
@@ -83,7 +83,7 @@ def test_satisfied(prereq: Prerequisite):
         ('2001', 'd', 'custom'): 'force satisfied',
     }
     # Should have set cached satisfaction state as must be true now:
-    assert prereq._all_satisfied is True
+    assert prereq._cached_satisfied is True
     assert prereq.is_satisfied()
 
 
@@ -176,7 +176,7 @@ def test_satisfy_me():
     for task_name in ('a', 'b', 'c'):
         prereq[('1', task_name, 'x')] = False
     assert not prereq.is_satisfied()
-    assert prereq._all_satisfied is False
+    assert prereq._cached_satisfied is False
 
     valid = prereq.satisfy_me(
         [Tokens('//1/a:x'), Tokens('//1/d:x'), Tokens('//1/c:y')],
@@ -188,7 +188,7 @@ def test_satisfy_me():
         ('1', 'c', 'x'): False,
     }
     # should have reset cached satisfaction state
-    assert prereq._all_satisfied is None
+    assert prereq._cached_satisfied is None
 
     valid = prereq.satisfy_me(
         [Tokens('//1/a:x'), Tokens('//1/b:x')],

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -14,12 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import partial
+
 import pytest
 
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.loader import ISO8601_CYCLING_TYPE, get_point
-from cylc.flow.prerequisite import Prerequisite
-from cylc.flow.id import Tokens
+from cylc.flow.id import Tokens, detokenise
+from cylc.flow.prerequisite import Prerequisite, SatisfiedState
+
+
+detok = partial(detokenise, selectors=True, relative=True)
 
 
 @pytest.fixture
@@ -138,14 +143,84 @@ def test_get_target_points(prereq):
     }
 
 
-def test_get_resolved_dependencies():
+@pytest.fixture
+def satisfied_states_prereq():
+    """Fixture for testing the full range of possible satisfied states."""
     prereq = Prerequisite(IntegerPoint('2'))
     prereq[('1', 'a', 'x')] = True
     prereq[('1', 'b', 'x')] = False
     prereq[('1', 'c', 'x')] = 'satisfied from database'
     prereq[('1', 'd', 'x')] = 'force satisfied'
-    assert prereq.get_resolved_dependencies() == [
+    return prereq
+
+
+def test_get_satisfied_dependencies(satisfied_states_prereq: Prerequisite):
+    assert satisfied_states_prereq.get_satisfied_dependencies() == [
         '1/a',
         '1/c',
         '1/d',
     ]
+
+
+def test_naturally_satisfied_dependencies(
+    satisfied_states_prereq: Prerequisite,
+):
+    assert satisfied_states_prereq.naturally_satisfied_dependencies() == [
+        ('1', 'a', 'x'),
+        ('1', 'c', 'x'),
+    ]
+
+
+def test_satisfy_me():
+    prereq = Prerequisite(IntegerPoint('2'))
+    for task_name in ('a', 'b', 'c'):
+        prereq[('1', task_name, 'x')] = False
+    assert not prereq.is_satisfied()
+    assert prereq._all_satisfied is False
+
+    valid = prereq.satisfy_me(
+        [Tokens('//1/a:x'), Tokens('//1/d:x'), Tokens('//1/c:y')],
+    )
+    assert {detok(tokens) for tokens in valid} == {'1/a:x'}
+    assert prereq._satisfied == {
+        ('1', 'a', 'x'): 'satisfied naturally',
+        ('1', 'b', 'x'): False,
+        ('1', 'c', 'x'): False,
+    }
+    # should have reset cached satisfaction state
+    assert prereq._all_satisfied is None
+
+    valid = prereq.satisfy_me(
+        [Tokens('//1/a:x'), Tokens('//1/b:x')],
+        forced=True,
+    )
+    assert {detok(tokens) for tokens in valid} == {'1/a:x', '1/b:x'}
+    assert prereq._satisfied == {
+        # 1/a:x unaffected as already satisfied
+        ('1', 'a', 'x'): 'satisfied naturally',
+        ('1', 'b', 'x'): 'force satisfied',
+        ('1', 'c', 'x'): False,
+    }
+
+
+@pytest.mark.parametrize('forced', [False, True])
+@pytest.mark.parametrize('existing, expected_when_forced', [
+    (False, 'force satisfied'),
+    ('satisfied from database', 'force satisfied'),
+    ('force satisfied', 'force satisfied'),
+    ('satisfied naturally', 'satisfied naturally'),
+])
+def test_satisfy_me__override(
+    forced: bool,
+    existing: SatisfiedState,
+    expected_when_forced: SatisfiedState,
+):
+    """Test that satisfying a prereq with a different state works as expected
+    with and without the `forced` arg."""
+    prereq = Prerequisite(IntegerPoint('2'))
+    prereq[('1', 'a', 'x')] = existing
+
+    prereq.satisfy_me([Tokens('//1/a:x')], forced)
+    assert prereq[('1', 'a', 'x')] == (
+        expected_when_forced if forced else 'satisfied naturally'
+    )

--- a/tests/unit/test_prerequisite.py
+++ b/tests/unit/test_prerequisite.py
@@ -162,13 +162,29 @@ def test_get_satisfied_dependencies(satisfied_states_prereq: Prerequisite):
     ]
 
 
-def test_naturally_satisfied_dependencies(
-    satisfied_states_prereq: Prerequisite,
+def test_unset_naturally_satisfied_dependency(
+    satisfied_states_prereq: Prerequisite
 ):
-    assert satisfied_states_prereq.naturally_satisfied_dependencies() == [
-        ('1', 'a', 'x'),
-        ('1', 'c', 'x'),
-    ]
+    satisfied_states_prereq[('1', 'a', 'y')] = True
+    satisfied_states_prereq[('1', 'a', 'z')] = 'force satisfied'
+    for id_, expected in [
+        ('1/a', True),
+        ('1/b', False),
+        ('1/c', True),
+        ('1/d', False),
+    ]:
+        assert (
+            satisfied_states_prereq.unset_naturally_satisfied_dependency(id_)
+            == expected
+        )
+    assert satisfied_states_prereq._satisfied == {
+        ('1', 'a', 'x'): False,
+        ('1', 'a', 'y'): False,
+        ('1', 'a', 'z'): 'force satisfied',
+        ('1', 'b', 'x'): False,
+        ('1', 'c', 'x'): False,
+        ('1', 'd', 'x'): 'force satisfied',
+    }
 
 
 def test_satisfy_me():

--- a/tests/unit/test_rundb.py
+++ b/tests/unit/test_rundb.py
@@ -112,7 +112,9 @@ def test_operational_error(tmp_path, caplog):
         # stage some stuff
         dao.add_delete_item(CylcWorkflowDAO.TABLE_TASK_JOBS)
         dao.add_insert_item(CylcWorkflowDAO.TABLE_TASK_JOBS, ['pub'])
-        dao.add_update_item(CylcWorkflowDAO.TABLE_TASK_JOBS, ['pub'])
+        dao.add_update_item(
+            CylcWorkflowDAO.TABLE_TASK_JOBS, ({'pub': None}, {})
+        )
 
         # connect the to DB
         dao.connect()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -133,7 +133,7 @@ def test_auto_restart_DNS_error(monkeypatch, caplog, log_filter):
     )
     caplog.set_level(logging.ERROR, CYLC_LOG)
     assert not Scheduler.workflow_auto_restart(schd, max_retries=2)
-    assert log_filter(caplog, contains='elephant')
+    assert log_filter(contains='elephant')
 
 
 def test_auto_restart_popen_error(monkeypatch, caplog, log_filter):
@@ -166,4 +166,4 @@ def test_auto_restart_popen_error(monkeypatch, caplog, log_filter):
     )
     caplog.set_level(logging.ERROR, CYLC_LOG)
     assert not Scheduler.workflow_auto_restart(schd, max_retries=2)
-    assert log_filter(caplog, contains='mystderr')
+    assert log_filter(contains='mystderr')

--- a/tests/unit/test_workflow_db_mgr.py
+++ b/tests/unit/test_workflow_db_mgr.py
@@ -1,0 +1,80 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pathlib import Path
+from typing import (
+    List,
+    Set,
+)
+from unittest.mock import Mock
+
+import pytest
+from pytest import param
+
+from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.flow_mgr import FlowNums
+from cylc.flow.id import Tokens
+from cylc.flow.task_proxy import TaskProxy
+from cylc.flow.taskdef import TaskDef
+from cylc.flow.util import serialise_set
+from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
+
+
+@pytest.mark.parametrize('flow_nums, expected_removed', [
+    param(set(), {1, 2, 5}, id='all'),
+    param({1}, {1}, id='subset'),
+    param({1, 2, 5}, {1, 2, 5}, id='complete-set'),
+    param({1, 3, 5}, {1, 5}, id='intersect'),
+    param({3, 4}, set(), id='disjoint'),
+])
+def test_remove_task_from_flows(
+    tmp_path: Path, flow_nums: FlowNums, expected_removed: FlowNums
+):
+    db_flows: List[FlowNums] = [
+        {1, 2},
+        {5},
+        set(),  # FLOW_NONE
+    ]
+    db_mgr = WorkflowDatabaseManager(tmp_path)
+    schd_tokens = Tokens('~asterix/gaul')
+    tdef = TaskDef('a', {}, None, None, None)
+    with db_mgr.get_pri_dao() as dao:
+        db_mgr.pri_dao = dao
+        db_mgr.pub_dao = Mock()
+        for flow in db_flows:
+            db_mgr.put_insert_task_states(
+                TaskProxy(
+                    schd_tokens,
+                    tdef,
+                    IntegerPoint('1'),
+                    flow_nums=flow,
+                ),
+            )
+        db_mgr.process_queued_ops()
+
+        removed_fnums = db_mgr.remove_task_from_flows('1', 'a', flow_nums)
+        assert removed_fnums == expected_removed
+
+        db_mgr.process_queued_ops()
+        remaining_fnums: Set[str] = {
+            fnums_str
+            for fnums_str, *_ in dao.connect().execute(
+                'SELECT flow_nums FROM task_states'
+            )
+        }
+        assert remaining_fnums == {
+            serialise_set(flow - expected_removed) for flow in db_flows
+        }

--- a/tests/unit/test_workflow_events.py
+++ b/tests/unit/test_workflow_events.py
@@ -83,13 +83,13 @@ def test_process_mail_footer(caplog, log_filter):
     assert process_mail_footer(
         '%(host)s|%(port)s|%(owner)s|%(suite)s|%(workflow)s', template_vars
     ) == 'myhost|42|me|my_workflow|my_workflow\n'
-    assert not log_filter(caplog, contains='Ignoring bad mail footer template')
+    assert not log_filter(contains='Ignoring bad mail footer template')
 
     # test invalid variable
     assert process_mail_footer('%(invalid)s', template_vars) == ''
-    assert log_filter(caplog, contains='Ignoring bad mail footer template')
+    assert log_filter(contains='Ignoring bad mail footer template')
 
     # test broken template
     caplog.clear()
     assert process_mail_footer('%(invalid)s', template_vars) == ''
-    assert log_filter(caplog, contains='Ignoring bad mail footer template')
+    assert log_filter(contains='Ignoring bad mail footer template')

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -196,7 +196,6 @@ def test_infer_latest_run(
 @pytest.mark.parametrize('warn_arg', [True, False])
 def test_infer_latest_run_warns_for_runN(
     warn_arg: bool,
-    caplog: pytest.LogCaptureFixture,
     log_filter: Callable,
     tmp_run_dir: Callable,
 ):
@@ -206,8 +205,7 @@ def test_infer_latest_run_warns_for_runN(
     runN_path.symlink_to('run1')
     infer_latest_run(runN_path, warn_runN=warn_arg)
     filtered_log = log_filter(
-        caplog, level=logging.WARNING,
-        contains="You do not need to include runN in the workflow ID"
+        logging.WARNING, "You do not need to include runN in the workflow ID"
     )
     assert filtered_log if warn_arg else not filtered_log
 


### PR DESCRIPTION
Partially addresses #5643

### Summary

This mostly implements [the "Cylc Remove Extension" proposal](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-remove.md).

#### Flow numbers

`cylc remove` now has a `--flow` option for removing a task from specific flows.

If not used, it will remove the task from all flows that it belongs to.

If the removed task is active/waiting, if it is removed from a subset of flows that it belongs to, it will remain in the task pool; if it is removed from all flows that it belongs to, it will be removed from the task pool (as is the current behaviour).

If a task is removed from all flows that it belongs to, it will become a no-flow task (`flow=None`).

For ease of reviewing, you can use my UI branch that displays flow numbers: https://github.com/MetRonnie/cylc-ui/tree/flow-nums [^c].

[^c]: Waiting tasks that are not yet in the pool have greyed out flow numbers at the moment.

#### Historical tasks

`cylc remove` now can remove tasks that are no longer active, making it look like they never ran. It does this by removing the task from the specified flows in the database (in the `task_states` and `task_outputs` tables)[^a], and un-setting any prerequisites of active tasks that the removed task had naturally satisfied[^b]. If a task is removed from all flows that it belongs to, a no-flow task is left in the DB for provenance.

The above also applies to active/waiting tasks that `cylc remove` is used on.

[^a]: If removing flows would result in two rows in the DB no longer being unique, the SQLite [`UPDATE OR REPLACE`](https://www.sqlite.org/lang_update.html) statement is used, so the first entry will be removed and the most recent entry will remain.
[^b]: Prerequisites manually satisfied by `cylc set --pre` are not affected by `cylc remove`.


### What's left to do

- [ ] When removing an active task from all its flows, kill the task.
- [ ] Should probably add a functional test with the `--flow` option.
- [x] Need to check this one:

  > If removing a task causes all of the prerequisites on a downstream task to be unset (i.e. if the downstream task was spawned as a result of outputs from this task alone) then the downstream task shall be removed from the pool.

### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
