### PR TITLE
subprocpool: populate missing 255 callback arguments

### DIFF
--- a/changes.d/6376.fix.md
+++ b/changes.d/6376.fix.md
@@ -1,0 +1,1 @@
+Fixes an issue that could cause Cylc to ignore the remaining hosts in a platform in response to an `ssh` error in some niche circumstances.

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -291,8 +291,17 @@ class SubProcPool:
                 )
                 continue
             # Command still running, see if STDOUT/STDERR are readable or not
-            runnings.append([
-                proc, ctx, bad_hosts, callback, callback_args, None, None])
+            runnings.append(
+                [
+                    proc,
+                    ctx,
+                    bad_hosts,
+                    callback,
+                    callback_args,
+                    callback_255,
+                    callback_255_args,
+                ]
+            )
             # Unblock proc's STDOUT/STDERR if necessary. Otherwise, a full
             # STDOUT or STDERR may stop command from proceeding.
             self._poll_proc_pipes(proc, ctx)


### PR DESCRIPTION
In some situations, these missing arguments could cause tasks to submit fail as the result of a host outage rather than moving onto the next host for the platform.

The bug is as old as the 255 callback - https://github.com/cylc/cylc-flow/pull/4184/files#diff-577155476a8501cbb774dad9dfc50a2ed7b846d577835e58d9bb4dfdb5d56b34R243-R244


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.