### PR TITLE
Use `flake8-implicit-str-concat`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ tests =
     flake8-builtins>=1.5.0
     flake8-comprehensions>=3.5.0
     flake8-debugger>=4.0.0
+    flake8-implicit-str-concat>=0.4
     flake8-mutable>=1.2.0
     flake8-simplify>=0.14.0
     flake8-type-checking; python_version > "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ ignore=
     W504
     ; "experimental" SIM9xx rules (flake8-simplify)
     SIM9
+    ; explicitly concatenated strings (flake8-implicit-str-concat)
+    ISC003
 
 per-file-ignores=
     ; TYPE_CHECKING block suggestions


### PR DESCRIPTION
https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat

Use these 2 rules (better documented by ruff!):
- https://docs.astral.sh/ruff/rules/single-line-implicit-string-concatenation/
  - Prevents:
    ```
    z = "The quick " "brown fox."`
    ```
    (I spotted an example of this somewhere a while ago, can't remember where though)
- https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/
  - Prevents:
    ```
    z = "The quick brown fox jumps over the lazy "\
        "dog."
    ```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Dev dependency changes don't apply to `conda-environment.yml`
- [x] No tests, changelog etc needed as not user-facing
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
