### PR TITLE
Don't demote job failed messages to debug.

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -928,11 +928,12 @@ class TaskEventsManager():
             return False
 
         severity_lvl: int = LOG_LEVELS.get(severity, INFO)
-        # Demote log level to DEBUG if this is a message that duplicates what
-        # gets logged by itask state change anyway (and not manual poll)
+        # Demote log level to DEBUG if this duplicates task state change
+        # logging (and not manual poll). Failed messages are not demoted
+        # however - they are more important and have no obvious corresponding
+        # state change when there are retries lined up).
         if severity_lvl > DEBUG and flag != self.FLAG_POLLED and message in {
             self.EVENT_SUBMITTED, self.EVENT_STARTED, self.EVENT_SUCCEEDED,
-            self.EVENT_SUBMIT_FAILED, f'{FAIL_MESSAGE_PREFIX}ERR'
         }:
             severity_lvl = DEBUG
         LOG.log(severity_lvl, f"[{itask}] {flag}{message}{timestamp}")

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -934,6 +934,7 @@ class TaskEventsManager():
         # state change when there are retries lined up).
         if severity_lvl > DEBUG and flag != self.FLAG_POLLED and message in {
             self.EVENT_SUBMITTED, self.EVENT_STARTED, self.EVENT_SUCCEEDED,
+            self.EVENT_SUBMIT_FAILED
         }:
             severity_lvl = DEBUG
         LOG.log(severity_lvl, f"[{itask}] {flag}{message}{timestamp}")


### PR DESCRIPTION
Currently, we demote task messages to DEBUG level if they are more or less redundant with logged state changes.

However, this isn't ideal for job failure messages because,
- if there are any retries lined up, the state change straight to waiting, with no indication of failure, looks wrong
- job failures should really always be logged as critical (even if the graph is designed to handle it)
 
### Example:
```cylc
[scheduling]
    [[graph]]
        R1 = "a"
[runtime]
    [[a]]
        script = false
        execution retry delays = PT5S
```

### Current:
![Screenshot (12)](https://github.com/user-attachments/assets/59bde9f0-4040-4b48-bdb5-566d608ca558)

### This branch:
![Screenshot (11)](https://github.com/user-attachments/assets/f20aa38d-9ee7-468e-86ce-8dcf39360228)

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
