### PR TITLE
Pass pre-install plugins the value of workflow rundir

### DIFF
--- a/changes.d/6404.fix.md
+++ b/changes.d/6404.fix.md
@@ -1,1 +1,0 @@
-Use opts.against_source to pass rundir to plugins

--- a/changes.d/6404.fix.md
+++ b/changes.d/6404.fix.md
@@ -1,0 +1,1 @@
+Use opts.against_source to pass rundir to plugins

--- a/cylc/flow/scripts/config.py
+++ b/cylc/flow/scripts/config.py
@@ -52,6 +52,7 @@ Examples:
 import asyncio
 
 import os.path
+from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
@@ -201,6 +202,11 @@ async def _main(
     if options.print_hierarchy:
         print("\n".join(get_config_file_hierarchy(workflow_id)))
         return
+
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    if options.against_source:
+        options.against_source = Path(get_workflow_run_dir(workflow_id))
 
     config = WorkflowConfig(
         workflow_id,

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -37,6 +37,7 @@ Examples:
 
 import asyncio
 from difflib import unified_diff
+from pathlib import Path
 from shutil import which
 from subprocess import Popen, PIPE
 import sys
@@ -53,6 +54,7 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     icp_option,
 )
+from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -557,6 +559,11 @@ async def _main(
         src=True,
         constraint='workflows',
     )
+
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    if opts.against_source:
+        opts.against_source = Path(get_workflow_run_dir(workflow_id))
 
     if opts.diff:
         return await graph_diff(

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -32,6 +32,7 @@ To visualize the full multiple inheritance hierarchy use:
 
 import asyncio
 import os
+from pathlib import Path
 import sys
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,7 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     icp_option,
 )
+from cylc.flow.workflow_files import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 
@@ -151,6 +153,12 @@ async def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
             [options.all_tasks, options.all_namespaces, options.mro]):
         print("WARNING: -t chosen, ignoring non-tree options.",
               file=sys.stderr)
+
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    if options.against_source:
+        options.against_source = Path(get_workflow_run_dir(workflow_id))
+
     config = WorkflowConfig(
         workflow_id,
         flow_file,

--- a/cylc/flow/scripts/validate.py
+++ b/cylc/flow/scripts/validate.py
@@ -28,6 +28,7 @@ use 'cylc view -i,--inline WORKFLOW' for comparison.
 import asyncio
 from ansimarkup import parse as cparse
 from copy import deepcopy
+from pathlib import Path
 import sys
 from typing import TYPE_CHECKING
 
@@ -55,6 +56,7 @@ from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
 from cylc.flow.scheduler_cli import RUN_MODE
+from cylc.flow.workflow_files import get_workflow_run_dir
 from cylc.flow.workflow_status import RunMode
 
 if TYPE_CHECKING:
@@ -153,6 +155,12 @@ async def run(
         src=True,
         constraint='workflows',
     )
+
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    if getattr(options, 'against_source', False):
+        options.against_source = Path(get_workflow_run_dir(workflow_id))
+
     cfg = WorkflowConfig(
         workflow_id,
         flow_file,

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -40,6 +40,7 @@ Note:
 """
 
 import asyncio
+from pathlib import Path
 import sys
 from typing import TYPE_CHECKING, Union
 
@@ -75,7 +76,10 @@ from cylc.flow.scripts.reload import (
     run as cylc_reload
 )
 from cylc.flow.terminal import cli_function
-from cylc.flow.workflow_files import detect_old_contact_file
+from cylc.flow.workflow_files import (
+    detect_old_contact_file,
+    get_workflow_run_dir,
+)
 
 CYLC_ROSE_OPTIONS = COP.get_cylc_rose_options()
 VR_OPTIONS = combine_options(
@@ -186,8 +190,9 @@ async def vr_cli(
     ):
         return False
 
-    # Force on the against_source option:
-    options.against_source = True
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    options.against_source = Path(get_workflow_run_dir(workflow_id))
 
     # Run cylc validate
     log_subcommand('validate --against-source', workflow_id)

--- a/cylc/flow/scripts/view.py
+++ b/cylc/flow/scripts/view.py
@@ -34,6 +34,7 @@ See also `cylc config`, which displays the fully parsed configuration.
 """
 
 import asyncio
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from cylc.flow.id_cli import parse_id_async
@@ -42,6 +43,7 @@ from cylc.flow.option_parsers import (
     WORKFLOW_ID_OR_PATH_ARG_DOC,
     CylcOptionParser as COP,
 )
+from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.parsec.fileparse import read_and_proc
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
@@ -122,6 +124,12 @@ async def _main(options: 'Values', workflow_id: str) -> None:
         src=True,
         constraint='workflows',
     )
+
+    # Save the location of the existing workflow run dir in the
+    # against source option:
+    if options.against_source:
+        options.against_source = Path(get_workflow_run_dir(workflow_id))
+
     # read in the flow.cylc file
     for line in read_and_proc(
         flow_file,


### PR DESCRIPTION
Closes #6286 

Set `options.against_source` to the rundir of the workflow, allowing re-install and validate against source to access previous CLI opts as stored in rose-suite-cylc-install.conf

Paired with https://github.com/cylc/cylc-rose/pull/345

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
