### PR TITLE
GH actions: Ubuntu 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,10 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
         include:
+          - os: 'ubuntu-22.04'
+            python: '3.7'
           - os: 'macos-latest'
             python: '3.8'
     steps:

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -20,9 +20,10 @@ jobs:
       fail-fast: false # don't stop on first failure
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.10', '3.11', '3']
+        python-version: ['3.8', '3.10', '3.11', '3']
         include:
-          # mac os test
+          - os: 'ubuntu-22.04'
+            python-version: '3.7'
           - os: 'macos-latest'
             python-version: '3.9'  # oldest supported version
           # non-utc timezone test

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-22.04']
         python-version: ['3.7']
         test-base: ['tests/f']
         chunk: ['1/4', '2/4', '3/4', '4/4']
@@ -56,20 +56,20 @@ jobs:
             platform: '_local_background*'
           # tests/k
           - name: 'flaky'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-22.04'
             python-version: '3.7'
             test-base: 'tests/k'
             chunk: '1/1'
             platform: '_local_background* _local_at*'
           # remote platforms
           - name: '_remote_background_indep_poll'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-22.04'
             python-version: '3.7'
             test-base: 'tests/f tests/k'
             chunk: '1/1'
             platform: '_remote_background_indep_poll _remote_at_indep_poll'
           - name: '_remote_background_indep_tcp'
-            os: 'ubuntu-latest'
+            os: 'ubuntu-22.04'
             test-base: 'tests/f tests/k'
             python-version: '3.7'
             chunk: '1/1'

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -21,8 +21,12 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ['3.7', '3']
-    runs-on: ubuntu-latest
+        include:
+          - os: 'ubuntu-latest'
+            python-version: '3'
+          - os: 'ubuntu-22.04'
+            python-version: '3.7'
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - name: configure python

--- a/etc/bin/swarm
+++ b/etc/bin/swarm
@@ -145,11 +145,9 @@ prompt () {
         case $USR in
             [Yy])
                 return 0
-                break
                 ;;
             [Nn])
                 return 1
-                break
                 ;;
         esac
     done

--- a/tests/flakyfunctional/cylc-poll/16-execution-time-limit.t
+++ b/tests/flakyfunctional/cylc-poll/16-execution-time-limit.t
@@ -33,6 +33,7 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --reference-test -v --no-detach "${WORKFLOW_NAME}" --timestamp
 #-------------------------------------------------------------------------------
+# shellcheck disable=SC2317
 cmp_times () {
     # Test if the times $1 and $2 are within $3 seconds of each other.
     python3 -u - "$@" <<'__PYTHON__'

--- a/tests/flakyfunctional/xtriggers/00-wall_clock.t
+++ b/tests/flakyfunctional/xtriggers/00-wall_clock.t
@@ -18,6 +18,7 @@
 # Test clock xtriggers
 . "$(dirname "$0")/test_header"
 
+# shellcheck disable=SC2317
 run_workflow() {
   cylc play --no-detach --debug "$1" \
     -s "START='$2'" -s "HOUR='$3'" -s "OFFSET='$4'"

--- a/tests/functional/lib/bash/test_header
+++ b/tests/functional/lib/bash/test_header
@@ -1160,7 +1160,6 @@ for SKIP in ${CYLC_TEST_SKIP}; do
         # Deliberately print variable substitution syntax unexpanded
         # shellcheck disable=SC2016
         skip_all 'this test is in $CYLC_TEST_SKIP.'
-        break
     fi
 done
 

--- a/tests/functional/reload/17-graphing-change.t
+++ b/tests/functional/reload/17-graphing-change.t
@@ -20,6 +20,7 @@
 #-------------------------------------------------------------------------------
 set_test_number 12
 
+# shellcheck disable=SC2317
 grep_workflow_log_n_times() {
     TEXT="$1"
     N_TIMES="$2"


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10636 - Ubuntu 24 is rolling out as `ubuntu-latest`, dropping Python 3.7 and bringing a new version of shellcheck.

We can keep using `ubuntu-22.04` for Python 3.7

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes, tests, docs etc.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
