### PR TITLE
pool: update DB after removing a task

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -870,6 +870,11 @@ class TaskPool:
                 msg += " - active job orphaned"
 
             LOG.log(level, f"[{itask}] {msg}")
+
+            # ensure this task is written to the DB before moving on
+            # https://github.com/cylc/cylc-flow/issues/6315
+            self.workflow_db_mgr.process_queued_ops()
+
             del itask
 
     def get_tasks(self) -> List[TaskProxy]:


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/6315
* If the DB is not updated after a task is removed, then it can be respawned in its previous state as the result of upstream output completion.

This fixes the "running(runahead) => running" bug that could cause tasks to get stuck in the running state indefinitely.

Performing a DB write every time a task completes is going to be a performance hit since this is performed per-task not per-main-loop-cycle (i.e. there is no batching efficiency gain). I'm not sure what we can do about this without changes to the task_pool data model. Any ideas?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.