### PR TITLE
tui: sort workflows in natural order

### DIFF
--- a/cylc/flow/tui/updater.py
+++ b/cylc/flow/tui/updater.py
@@ -51,6 +51,7 @@ from cylc.flow.tui.data import (
     QUERY
 )
 from cylc.flow.tui.util import (
+    NaturalSort,
     compute_tree,
     suppress_logging,
 )
@@ -363,5 +364,5 @@ class Updater():
                 'stateTotals': {},
             })
 
-        data['workflows'].sort(key=lambda x: x['id'])
+        data['workflows'].sort(key=lambda x: NaturalSort(x['id']))
         return data


### PR DESCRIPTION
Tui uses a "natural" sort (similar to the UI) to make things sort more nicely, e.g:

Lex sort:

* 1
* 10
* 2

"Natural" sort:

* 1
* 2
* 10

This is already turned on for tasks, but it wasn't turned on for workflows.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.