### PR TITLE
GH actions: re-run failed Tui tests

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -66,9 +66,15 @@ jobs:
           pytest cylc/flow tests/unit
 
       - name: Integration Tests
-        timeout-minutes: 6
+        timeout-minutes: 5
         run: |
-          pytest tests/integration
+          pytest tests/integration --ignore tests/integration/tui/
+
+      - name: Tui Integration Tests
+        timeout-minutes: 5
+        # Re-run failed Tui tests as they can be flaky
+        run: |
+          pytest tests/integration/tui || pytest tests/integration/tui --last-failed
 
       - name: Upload failed tests artifact
         if: failure()


### PR DESCRIPTION
The Tui integration tests are flakily failing quite a lot on GH Actions, so I've made it so that they re-run any failures.

Tried re-triggering several times, couldn't get it to fail 🤷‍♂️. Perhaps splitting it off from the other integration test run was enough.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] CI changes so none of the usual stuff
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
