### PR TITLE
gracefully handle SIGINT, SIGTERM and SIGHUP

### DIFF
--- a/changes.d/6444.feat.md
+++ b/changes.d/6444.feat.md
@@ -1,0 +1,1 @@
+The scheduler now traps the SIGINT, SIGTERM and SIGHUP signals and will respond by shutting down in --now mode. If the workflow is already shutting down in --now mode, it will escalate the shutdown to --now --now mode.

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -655,8 +655,6 @@ async def _run(scheduler: Scheduler) -> int:
     # stop cylc stop
     except SchedulerError:
         ret = 1
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        ret = 2
     except Exception:
         ret = 3
 

--- a/tests/functional/rnd/01-signals.t
+++ b/tests/functional/rnd/01-signals.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test scheduler signal handling
+# # See https://github.com/cylc/cylc-flow/issues/6438
+
+. "$(dirname "$0")/test_header"
+set_test_number 6
+
+
+init_workflow "${TEST_NAME_BASE}" <<__FLOW__
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+__FLOW__
+
+
+# test signals on a detached scheduler
+TEST_NAME="${TEST_NAME_BASE}-detatch"
+cylc play "${WORKFLOW_NAME}" --pause
+poll_workflow_running
+PID="$(sed -n 's/CYLC_WORKFLOW_PID=//p' "$HOME/cylc-run/$WORKFLOW_NAME/.service/contact")"
+kill -s SIGINT "$PID"
+poll_workflow_stopped
+log_scan "${TEST_NAME}" "$(cylc cat-log -m p "${WORKFLOW_NAME}")" 10 1 \
+    'Signal SIGINT received' \
+    'Workflow shutting down - REQUEST(NOW)' \
+    'DONE'
+
+
+# test signals on a non-detached scheduler
+TEST_NAME="${TEST_NAME_BASE}-no-detach"
+cylc play "${WORKFLOW_NAME}" --pause --no-detach 2>/dev/null &
+poll_workflow_running
+PID="$(sed -n 's/CYLC_WORKFLOW_PID=//p' "$HOME/cylc-run/$WORKFLOW_NAME/.service/contact")"
+kill -s SIGTERM "$PID"
+poll_workflow_stopped
+log_scan "${TEST_NAME}" "$(cylc cat-log -m p "${WORKFLOW_NAME}")" 10 1 \
+    'Signal SIGTERM received' \
+    'Workflow shutting down - REQUEST(NOW)' \
+    'DONE'
+
+
+purge


### PR DESCRIPTION
* Closes #4914
* Closes #6438
* If any of these signals are received, set the workflow to stop NOW.
* If the workflow is already stopping NOW, escalate that to NOW NOW (e.g. to handle stuck subprocpool processes)
* SIGINT is no longer handled as an exception (panic shutdown).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened - https://github.com/cylc/cylc-doc/pull/768
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.