### PR TITLE
Remove `UTC mode` from tutorial workflows

### DIFF
--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -1,7 +1,4 @@
 #!jinja2
-[scheduler]
-    UTC mode = True
-
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
     # * previous(T-00) takes the current time ignoring minutes and seconds.

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -1,6 +1,4 @@
 #!jinja2
-[scheduler]
-    UTC mode = True
 [task parameters]
     # A list of the weather stations we will be fetching observations from.
     station = camborne, heathrow, shetland, aldergrove

--- a/cylc/flow/etc/tutorial/retries-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/retries-tutorial/flow.cylc
@@ -1,6 +1,3 @@
-[scheduler]
-    UTC mode = True # Ignore DST
-
 [scheduling]
     [[graph]]
         R1 = start => roll_doubles => win

--- a/cylc/flow/etc/tutorial/runtime-introduction/flow.cylc
+++ b/cylc/flow/etc/tutorial/runtime-introduction/flow.cylc
@@ -1,6 +1,4 @@
 #!jinja2
-[scheduler]
-    UTC mode = True
 [scheduling]
     initial cycle point = 2000-01-01T00Z
     final cycle point = 2000-01-01T06Z

--- a/cylc/flow/etc/tutorial/runtime-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/runtime-tutorial/flow.cylc
@@ -1,6 +1,5 @@
 #!jinja2
 [scheduler]
-    UTC mode = True
     allow implicit tasks = True  # TODO: remove at end of exercise
 
 [scheduling]


### PR DESCRIPTION
`UTC mode` is a legacy setting which isn't required any-more for tutorial workflows.

Companion of https://github.com/cylc/cylc-doc/pull/769

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are **not** included should be tested by the validate script.
- [x] Changelog entry *not* included - very small change
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/0769.
- [x] PR raised against bug fix branch because this is a doc-fix and not a feature.
