### PR TITLE
Lint: Tell users that backslashes are no longer necessary after => & |

### DIFF
--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,1 +1,1 @@
-Cylc lint now checks for unecessary continuation characters in graph section.
+`cylc lint` now checks for unecessary continuation characters in graph section.

--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,1 +1,1 @@
-`cylc lint` now checks for unecessary continuation characters in graph section.
+`cylc lint` now checks for unnecessary continuation characters in the graph section.

--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,0 +1,1 @@
+Cylc lint now checks for unecessary continuation characters in graph section.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -550,7 +550,7 @@ STYLE_CHECKS = {
     },
     'S014': {
         'short': (
-            '`=>` is a line continuation without `\\`'
+            '`=>` implies line continuation without `\\`'
         ),
         FUNCTION: re.compile(r'=>\s*\\').findall
     },
@@ -723,7 +723,7 @@ MANUAL_DEPRECATIONS = {
     },
     'U017': {
         'short': (
-            '`&` and `|` are line continuations without `\\`'
+            '`&` and `|` imply line continuation without `\\`'
         ),
         FUNCTION: re.compile(r'[&|]\s*\\').findall
     },

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -547,7 +547,13 @@ STYLE_CHECKS = {
     'S013': {
         'short': 'Items should be indented in 4 space blocks.',
         FUNCTION: check_indentation
-    }
+    },
+    'S014': {
+        'short': (
+            '`=>` is a line continuation without `\\`'
+        ),
+        FUNCTION: re.compile(r'=>\s*\\').findall
+    },
 }
 # Subset of deprecations which are tricky (impossible?) to scrape from the
 # upgrader.
@@ -714,6 +720,12 @@ MANUAL_DEPRECATIONS = {
         ),
         FUNCTION: functools.partial(
             list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
+    },
+    'U017': {
+        'short': (
+            '`&` and `|` are line continuations without `\\`'
+        ),
+        FUNCTION: re.compile(r'[&|]\s*\\').findall
     },
 }
 ALL_RULESETS = ['728', 'style', 'all']

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -44,7 +44,7 @@ from cylc.flow.exceptions import CylcError
 STYLE_CHECKS = parse_checks(['style'])
 UPG_CHECKS = parse_checks(['728'])
 
-TEST_FILE = """
+TEST_FILE = '''
 [visualization]
 
 [cylc]
@@ -97,7 +97,13 @@ TEST_FILE = """
     hold after point = 20220101T0000Z
     [[dependencies]]
         [[[R1]]]
-            graph = MyFaM:finish-all => remote => !mash_theme
+            graph = """
+                MyFaM:finish-all => remote => !mash_theme
+                a & \\
+                b => c
+                c | \\
+                d => e
+            """
 
 [runtime]
     [[root]]
@@ -154,10 +160,10 @@ TEST_FILE = """
             host = `rose host-select thingy`
 
 %include foo.cylc
-"""
+'''
 
 
-LINT_TEST_FILE = """
+LINT_TEST_FILE = '''
 \t[scheduler]
 
  [scheduler]
@@ -167,6 +173,11 @@ LINT_TEST_FILE = """
 {% foo %}
 {{foo}}
 # {{quix}}
+    R1 = """
+        foo & \\
+        bar => \\
+        baz
+    """
 
 [runtime]
     [[this_is_ok]]
@@ -180,7 +191,7 @@ something\t
         platform = $(some-script foo)
     [[baz]]
         platform = `no backticks`
-""" + (
+''' + (
     '\nscript = the quick brown fox jumps over the lazy dog until it becomes '
     'clear that this line is longer than the default 130 character limit.'
 )


### PR DESCRIPTION
Closes #6456 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] This is a feature, but a lint feature, so suitable to be added to a maintainance release.
