### PR TITLE
GH Actions shortlog: check out head ref

### DIFF
--- a/.github/workflows/shortlog.yml
+++ b/.github/workflows/shortlog.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # need to fetch all commits to check contributors
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check CONTRIBUTING.md
         uses: cylc/release-actions/check-shortlog@v1


### PR DESCRIPTION
This avoids the action failing on PRs due to the merge commit checked out by default having different author details to the locally pushed changes by that contributor

