### PR TITLE
Expand comma separated lists in `global.cylc:[install][symlink dirs]`

### DIFF
--- a/changes.d/6475.feat.md
+++ b/changes.d/6475.feat.md
@@ -1,0 +1,1 @@
+Allow definition of `install targets` in `global.cylc` using comma separated lists.

--- a/changes.d/6475.feat.md
+++ b/changes.d/6475.feat.md
@@ -1,1 +1,1 @@
-Allow definition of `install targets` in `global.cylc` using comma separated lists.
+Allow easy definition of multiple install targets in `global.cylc[install][symlink dirs]` using comma separated lists.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -18,7 +18,7 @@
 import os
 from pathlib import Path
 from sys import stderr
-from textwrap import dedent
+from textwrap import dedent, indent
 from typing import List, Optional, Tuple, Any, Union
 
 from contextlib import suppress
@@ -1165,10 +1165,9 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
         """):
-            with Conf('<install target>', desc=f"""
+            with Conf('<install target>', desc="""
                 :ref:`Host <Install targets>` on which to create the symlinks.
-                {COMMA_SEPARATED_SECTION_NOTE}
-            """):
+            """ + COMMA_SEPARATED_SECTION_NOTE):
                 Conf('run', VDR.V_STRING, None, desc="""
                     Alternative location for the run dir.
 
@@ -1290,8 +1289,7 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
 
-            {COMMA_SEPARATED_SECTION_NOTE}
-        ''') as Platform:
+        ''' + indent(COMMA_SEPARATED_SECTION_NOTE, '   ' * 3)) as Platform:
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -587,6 +587,40 @@ task_event_handling.template_variables`.
     '''
 }
 
+COMMA_SEPARATED_SECTION_NOTE = '''
+
+
+    .. note::
+
+       This section can be a comma separated list.
+
+        .. spoiler:: Example
+
+            For example:
+
+            .. code-block:: cylc
+
+                [a, b]
+                    setting = x
+                [a]
+                    another_setting = y
+
+            Will become:
+
+            .. code-block:: cylc
+
+                [a]
+                    setting = x
+                [b]
+                    setting = x
+                [a]
+                    another_setting = y
+
+            Which will then be combined according to
+            :ref:`the rules for Cylc config syntax<syntax>`.
+
+'''
+
 # ----------------------------------------------------------------------------
 
 
@@ -1131,8 +1165,9 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
         """):
-            with Conf('<install target>', desc="""
+            with Conf('<install target>', desc=f"""
                 :ref:`Host <Install targets>` on which to create the symlinks.
+                {COMMA_SEPARATED_SECTION_NOTE}
             """):
                 Conf('run', VDR.V_STRING, None, desc="""
                     Alternative location for the run dir.
@@ -1209,7 +1244,7 @@ with Conf('global.cylc', desc='''
 
         .. versionadded:: 8.0.0
     '''):
-        with Conf('<platform name>', desc='''
+        with Conf('<platform name>', desc=f'''
             Configuration defining a platform.
 
             Many of these settings have replaced those of the same name from
@@ -1219,7 +1254,7 @@ with Conf('global.cylc', desc='''
             Platform names can be regular expressions: If you have a set of
             compute resources such as ``bigmachine1, bigmachine2`` or
             ``desktop0000, .., desktop9999`` one would define platforms with
-            names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{4}]]``.
+            names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{{4}}]]``.
 
             Cylc searches for a matching platform in the reverse
             of the definition order to allow user defined platforms
@@ -1254,6 +1289,8 @@ with Conf('global.cylc', desc='''
                  platform configurations.
 
             .. versionadded:: 8.0.0
+
+            {COMMA_SEPARATED_SECTION_NOTE}
         ''') as Platform:
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -18,7 +18,7 @@
 import os
 from pathlib import Path
 from sys import stderr
-from textwrap import dedent, indent
+from textwrap import dedent
 from typing import List, Optional, Tuple, Any, Union
 
 from contextlib import suppress
@@ -590,34 +590,34 @@ task_event_handling.template_variables`.
 COMMA_SEPARATED_SECTION_NOTE = '''
 
 
-    .. note::
+.. note::
 
-       This section can be a comma separated list.
+   This section can be a comma separated list.
 
-        .. spoiler:: Example
+   .. spoiler:: Example
 
-            For example:
+      For example:
 
-            .. code-block:: cylc
+      .. code-block:: cylc
 
-                [a, b]
-                    setting = x
-                [a]
-                    another_setting = y
+         [a, b]
+             setting = x
+         [a]
+             another_setting = y
 
-            Will become:
+      Will become:
 
-            .. code-block:: cylc
+      .. code-block:: cylc
 
-                [a]
-                    setting = x
-                [b]
-                    setting = x
-                [a]
-                    another_setting = y
+         [a]
+             setting = x
+         [b]
+             setting = x
+         [a]
+             another_setting = y
 
-            Which will then be combined according to
-            :ref:`the rules for Cylc config syntax<syntax>`.
+      Which will then be combined according to
+      :ref:`the rules for Cylc config syntax<syntax>`.
 
 '''
 
@@ -1165,9 +1165,9 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
         """):
-            with Conf('<install target>', desc="""
+            with Conf('<install target>', desc=dedent("""
                 :ref:`Host <Install targets>` on which to create the symlinks.
-            """ + COMMA_SEPARATED_SECTION_NOTE):
+            """) + COMMA_SEPARATED_SECTION_NOTE):
                 Conf('run', VDR.V_STRING, None, desc="""
                     Alternative location for the run dir.
 
@@ -1243,7 +1243,7 @@ with Conf('global.cylc', desc='''
 
         .. versionadded:: 8.0.0
     '''):
-        with Conf('<platform name>', desc=f'''
+        with Conf('<platform name>', desc=dedent('''
             Configuration defining a platform.
 
             Many of these settings have replaced those of the same name from
@@ -1253,7 +1253,7 @@ with Conf('global.cylc', desc='''
             Platform names can be regular expressions: If you have a set of
             compute resources such as ``bigmachine1, bigmachine2`` or
             ``desktop0000, .., desktop9999`` one would define platforms with
-            names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{{4}}]]``.
+            names ``[[bigmachine[12]]]`` and ``[[desktop[0-9]{4}]]``.
 
             Cylc searches for a matching platform in the reverse
             of the definition order to allow user defined platforms
@@ -1289,7 +1289,7 @@ with Conf('global.cylc', desc='''
 
             .. versionadded:: 8.0.0
 
-        ''' + indent(COMMA_SEPARATED_SECTION_NOTE, '   ' * 3)) as Platform:
+        ''') + COMMA_SEPARATED_SECTION_NOTE) as Platform:
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -2018,6 +2018,7 @@ class GlobalConfig(ParsecConfig):
         self.dense.clear()
         LOG.debug("Loading site/user config files")
         conf_path_str = os.getenv("CYLC_CONF_PATH")
+
         if conf_path_str:
             # Explicit config file override.
             fname = os.path.join(conf_path_str, self.CONF_BASENAME)
@@ -2030,7 +2031,7 @@ class GlobalConfig(ParsecConfig):
 
         # Expand platforms needs to be performed first because it
         # manipulates the sparse config.
-        self._expand_platforms()
+        self._expand_commas()
 
         # Flesh out with defaults
         self.expand()
@@ -2074,8 +2075,8 @@ class GlobalConfig(ParsecConfig):
                     msg += f'\n * {name}'
                 raise GlobalConfigError(msg)
 
-    def _expand_platforms(self):
-        """Expand comma separated platform names.
+    def _expand_commas(self):
+        """Expand comma separated section headers.
 
         E.G. turn [platforms][foo, bar] into [platforms][foo] and
         platforms[bar].
@@ -2083,6 +2084,13 @@ class GlobalConfig(ParsecConfig):
         if self.sparse.get('platforms'):
             self.sparse['platforms'] = expand_many_section(
                 self.sparse['platforms']
+            )
+        if (
+            self.sparse.get("install")
+            and self.sparse["install"].get("symlink dirs")
+        ):
+            self.sparse["install"]["symlink dirs"] = expand_many_section(
+                self.sparse["install"]["symlink dirs"]
             )
 
     def platform_dump(

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -2123,8 +2123,7 @@ class GlobalConfig(ParsecConfig):
                 self.sparse['platforms']
             )
         if (
-            self.sparse.get("install")
-            and self.sparse["install"].get("symlink dirs")
+            self.sparse.get("install", {}).get("symlink dirs")
         ):
             self.sparse["install"]["symlink dirs"] = expand_many_section(
                 self.sparse["install"]["symlink dirs"]

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -18,7 +18,7 @@
 import os
 from pathlib import Path
 from sys import stderr
-from textwrap import dedent
+from textwrap import dedent, indent
 from typing import List, Optional, Tuple, Any, Union
 
 from contextlib import suppress
@@ -587,39 +587,46 @@ task_event_handling.template_variables`.
     '''
 }
 
-COMMA_SEPARATED_SECTION_NOTE = '''
 
+def comma_sep_section_note(version_changed: str = '') -> str:
+    note_text = "This section can be a comma separated list."
+    if version_changed:
+        note_text = (
+            f".. versionchanged:: {version_changed}\n\n" +
+            indent(note_text, 3 * ' ')
+        )
 
-.. note::
+    example = dedent('''
 
-   This section can be a comma separated list.
+    .. spoiler:: Example
 
-   .. spoiler:: Example
+       For example:
 
-      For example:
+       .. code-block:: cylc
 
-      .. code-block:: cylc
+          [a, b]
+              setting = x
+          [a]
+              another_setting = y
 
-         [a, b]
-             setting = x
-         [a]
-             another_setting = y
+       Will become:
 
-      Will become:
+       .. code-block:: cylc
 
-      .. code-block:: cylc
+          [a]
+              setting = x
+          [b]
+              setting = x
+          [a]
+              another_setting = y
 
-         [a]
-             setting = x
-         [b]
-             setting = x
-         [a]
-             another_setting = y
+       Which will then be combined according to
+       :ref:`the rules for Cylc config syntax<syntax>`.
 
-      Which will then be combined according to
-      :ref:`the rules for Cylc config syntax<syntax>`.
+    ''')
 
-'''
+    return "\n\n.. note::\n\n" + indent(note_text + example, 3 * ' ')
+
 
 # ----------------------------------------------------------------------------
 
@@ -1167,7 +1174,10 @@ with Conf('global.cylc', desc='''
         """):
             with Conf('<install target>', desc=dedent("""
                 :ref:`Host <Install targets>` on which to create the symlinks.
-            """) + COMMA_SEPARATED_SECTION_NOTE):
+
+                .. versionadded:: 8.0.0
+
+            """) + comma_sep_section_note(version_changed='8.4.0')):
                 Conf('run', VDR.V_STRING, None, desc="""
                     Alternative location for the run dir.
 
@@ -1243,7 +1253,9 @@ with Conf('global.cylc', desc='''
 
         .. versionadded:: 8.0.0
     '''):
-        with Conf('<platform name>', desc=dedent('''
+        with Conf(
+            '<platform name>',
+            desc=dedent('''
             Configuration defining a platform.
 
             Many of these settings have replaced those of the same name from
@@ -1287,9 +1299,10 @@ with Conf('global.cylc', desc='''
                - :ref:`AdminGuide.PlatformConfigs`, an administrator's guide to
                  platform configurations.
 
-            .. versionadded:: 8.0.0
-
-        ''') + COMMA_SEPARATED_SECTION_NOTE) as Platform:
+        ''')
+            + comma_sep_section_note()
+            + ".. versionadded:: 8.0.0",
+        ) as Platform:
             with Conf('meta', desc=PLATFORM_META_DESCR):
                 Conf('<custom metadata>', VDR.V_STRING, '', desc='''
                     Any user-defined metadata item.

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -797,7 +797,6 @@ class TaskEventsSettings(ObjectType):
     handlers = String(default_value=None)
     foo = String(default_value=None)
 
-
 class Runtime(ObjectType):
     class Meta:
         description = sstrip("""
@@ -809,8 +808,6 @@ class Runtime(ObjectType):
               of the definition)
             - Job (a record of what was run for a particular submit)
         """)
-    events = Field(TaskEventsSettings)
-
     platform = String(default_value=None)
     script = String(default_value=None)
     completion = String(default_value=None)

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -792,6 +792,12 @@ class RuntimeSetting(ObjectType):
     value = String(default_value=None)
 
 
+class TaskEventsSettings(ObjectType):
+    """Key = value setting for a `[runtime][<namespace>]` configuration."""
+    handlers = String(default_value=None)
+    foo = String(default_value=None)
+
+
 class Runtime(ObjectType):
     class Meta:
         description = sstrip("""
@@ -803,6 +809,8 @@ class Runtime(ObjectType):
               of the definition)
             - Job (a record of what was run for a particular submit)
         """)
+    events = Field(TaskEventsSettings)
+
     platform = String(default_value=None)
     script = String(default_value=None)
     completion = String(default_value=None)

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -792,11 +792,6 @@ class RuntimeSetting(ObjectType):
     value = String(default_value=None)
 
 
-class TaskEventsSettings(ObjectType):
-    """Key = value setting for a `[runtime][<namespace>]` configuration."""
-    handlers = String(default_value=None)
-    foo = String(default_value=None)
-
 class Runtime(ObjectType):
     class Meta:
         description = sstrip("""

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -74,9 +74,19 @@ def test_dump_platform_details(capsys, mock_global_config):
     assert expected == out
 
 
-def test_expand_platforms(tmp_path: Path, mock_global_config: Callable):
-    """It should expand comma separated platform definitions."""
+def test_expand_commas(tmp_path: Path, mock_global_config: Callable):
+    """It should expand comma separated platform and install target
+    definitions."""
     glblcfg: GlobalConfig = mock_global_config('''
+    [install]
+        [[symlink dirs]]
+            [[[foo, bar]]]
+                run = /x
+            [[[foo]]]
+                share = /y
+            [[[bar]]]
+                share = /z
+
     [platforms]
         [[foo]]
             [[[meta]]]
@@ -91,7 +101,7 @@ def test_expand_platforms(tmp_path: Path, mock_global_config: Callable):
             [[[meta]]]
                 x = 4
     ''')
-    glblcfg._expand_platforms()
+    glblcfg._expand_commas()
 
     # ensure the definition order is preserved
     assert glblcfg.get(['platforms']).keys() == [
@@ -102,11 +112,17 @@ def test_expand_platforms(tmp_path: Path, mock_global_config: Callable):
         'pub',
     ]
 
-    # ensure sections are correctly deep-merged
+    # ensure platform sections are correctly deep-merged
     assert glblcfg.get(['platforms', 'foo', 'meta', 'x']) == '1'
     assert glblcfg.get(['platforms', 'bar', 'meta', 'x']) == '3'
     assert glblcfg.get(['platforms', 'baz', 'meta', 'x']) == '3'
     assert glblcfg.get(['platforms', 'pub', 'meta', 'x']) == '4'
+
+    # ensure install target sections are correctly merged:
+    assert glblcfg.get(["install", "symlink dirs", "foo", "run"]) == "/x"
+    assert glblcfg.get(["install", "symlink dirs", "foo", "share"]) == "/y"
+    assert glblcfg.get(["install", "symlink dirs", "bar", "run"]) == "/x"
+    assert glblcfg.get(["install", "symlink dirs", "bar", "share"]) == "/z"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
From an issue raised by @dpmatthews 

Allow comma separated lists of install targets in  `global.cylc:[install][symlink dirs][__MANY__]`

@oliver-sanders tagged for code review, @dpmatthews for concept review.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
