### PR TITLE
cat-log: list out/err files when available via tailer

### DIFF
--- a/changes.d/6480.fix.md
+++ b/changes.d/6480.fix.md
@@ -1,0 +1,1 @@
+`cat-log`: List log files which are available via a configured tailer/viewer command.

--- a/tests/functional/cylc-cat-log/13-remote-out-err-tailer.t
+++ b/tests/functional/cylc-cat-log/13-remote-out-err-tailer.t
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc cat-log" with custom out/err tailers
+export REQUIRE_PLATFORM='loc:remote runner:background fs:indep comms:tcp'
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 12
+#-------------------------------------------------------------------------------
+# run the workflow
+TEST_NAME="${TEST_NAME_BASE}-validate"
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play -N "${WORKFLOW_NAME}"
+#-------------------------------------------------------------------------------
+# change the platform the task ran on to the remote platform
+sqlite3 "${HOME}/cylc-run/${WORKFLOW_NAME}/log/db" "
+  UPDATE
+    task_jobs
+  SET
+    platform_name = '${CYLC_TEST_PLATFORM}',
+    run_status = null
+  WHERE
+    name = 'foo'
+    AND cycle = '1'
+;"
+#-------------------------------------------------------------------------------
+# test cylc cat-log --mode=list-dir will not list job.out / err
+# (no tailer / viewer configured)
+create_test_global_config "" "
+[platforms]
+   [[$CYLC_TEST_PLATFORM]]
+      out tailer =
+      err tailer =
+      out viewer =
+      err viewer =
+  "
+TEST_NAME="${TEST_NAME_BASE}-list-dir-no-tailers"
+# NOTE: command will fail due to missing remote directory (this tests remote
+# error code is preserved)
+run_fail "${TEST_NAME}" cylc cat-log "${WORKFLOW_NAME}//1/foo" -m 'list-dir'
+# the job.out and job.err filees
+grep_fail "job.out" "${TEST_NAME}.stdout"
+grep_fail "job.err" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+# test cylc cat-log --mode=list-dir lists the tailed files
+# (both tailer and viewer configured)
+create_test_global_config "" "
+[platforms]
+   [[$CYLC_TEST_PLATFORM]]
+      out tailer = echo OUT
+      err tailer = echo ERR
+      out viewer = echo OUT
+      err viewer = echo ERR
+  "
+# test cylc cat-log --mode=list-dir lists the tailed files
+TEST_NAME="${TEST_NAME_BASE}-list-dir-with-tailers"
+# NOTE: command will fail due to missing remote directory (this tests remote
+# error code is preserved)
+run_fail "${TEST_NAME}" cylc cat-log "${WORKFLOW_NAME}//1/foo" -m 'list-dir'
+# the job.out and job.err filees
+grep_ok "job.out" "${TEST_NAME}.stdout"
+grep_ok "job.err" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+# test cylc cat-log runs the custom tailers
+TEST_NAME="${TEST_NAME_BASE}-cat-out"
+run_ok "${TEST_NAME}" cylc cat-log "${WORKFLOW_NAME}//1/foo" -f o -m t
+grep_ok "OUT" "${TEST_NAME}.stdout"
+run_ok "${TEST_NAME}" cylc cat-log "${WORKFLOW_NAME}//1/foo" -f e -m t
+grep_ok "ERR" "${TEST_NAME}.stdout"
+#-------------------------------------------------------------------------------
+purge
+exit

--- a/tests/functional/cylc-cat-log/13-remote-out-err-tailer/flow.cylc
+++ b/tests/functional/cylc-cat-log/13-remote-out-err-tailer/flow.cylc
@@ -1,0 +1,25 @@
+[scheduler]
+   [[events]]
+       abort on stall timeout = True
+       stall timeout = PT2M
+
+[scheduling]
+    [[graph]]
+        R1 = foo
+
+[runtime]
+    [[foo]]
+        script = """
+            # wait for the started message to be received
+            cylc__job__poll_grep_workflow_log -E 'foo.*running'
+
+            # remove the out/err files
+            rm "${CYLC_TASK_LOG_DIR}/job.out"
+            rm "${CYLC_TASK_LOG_DIR}/job.err"
+
+            # stop the workflow, orphaning this job
+            cylc stop --now --now "${CYLC_WORKFLOW_ID}" 2>/dev/null >/dev/null
+
+            # suppress any subsequent messages
+            rm "${CYLC_WORKFLOW_RUN_DIR}/.service/contact"
+        """


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/5802

List log files that are not present on disk but which are available via a tailer.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.