### PR TITLE
coverage: fill some coverage holes

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -80,7 +80,6 @@ from cylc.flow.pathutil import (
     get_cylc_run_dir,
     is_relative_to,
 )
-from cylc.flow.print_tree import print_tree
 from cylc.flow.task_qualifiers import ALT_QUALIFIERS
 from cylc.flow.simulation import configure_sim_modes
 from cylc.flow.subprocctx import SubFuncContext
@@ -1604,18 +1603,6 @@ class WorkflowConfig:
     def get_first_parent_descendants(self):
         return self.runtime['first-parent descendants']
 
-    @staticmethod
-    def define_inheritance_tree(tree, hierarchy):
-        """Combine inheritance hierarchies into a tree structure."""
-        for rt_ in hierarchy:
-            hier = copy(hierarchy[rt_])
-            hier.reverse()
-            cur_tree = tree
-            for item in hier:
-                if item not in cur_tree:
-                    cur_tree[item] = {}
-                cur_tree = cur_tree[item]
-
     def add_tree_titles(self, tree):
         for key, val in tree.items():
             if val == {}:
@@ -1650,34 +1637,6 @@ class WorkflowConfig:
         except KeyError:
             mro = ["no such namespace: " + ns]
         return mro
-
-    def print_first_parent_tree(self, pretty=False, titles=False):
-        # find task namespaces (no descendants)
-        tasks = []
-        for ns in self.cfg['runtime']:
-            if ns not in self.runtime['descendants']:
-                tasks.append(ns)
-
-        pruned_ancestors = self.get_first_parent_ancestors(pruned=True)
-        tree = {}
-        self.define_inheritance_tree(tree, pruned_ancestors)
-        padding = ''
-        if titles:
-            self.add_tree_titles(tree)
-            # compute pre-title padding
-            maxlen = 0
-            for namespace in pruned_ancestors:
-                items = copy(pruned_ancestors[namespace])
-                items.reverse()
-                for itt, item in enumerate(items):
-                    tmp = 2 * itt + 1 + len(item)
-                    if itt == 0:
-                        tmp -= 1
-                    if tmp > maxlen:
-                        maxlen = tmp
-            padding = maxlen * ' '
-
-        print_tree(tree, padding=padding, use_unicode=pretty)
 
     def process_workflow_env(self):
         """Export Workflow context to the local environment.

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -254,9 +254,6 @@ class IntervalBase(metaclass=ABCMeta):
         """Subtract other (interval) from self; return an interval."""
         pass
 
-    def is_null(self):
-        return (self == self.get_null())
-
     def __str__(self) -> str:
         # Stringify.
         return self.value

--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -100,7 +100,7 @@ class PointBase(metaclass=ABCMeta):
                missing off the front) will be tollerated, if False, truncated
                points will cause an exception to be raised.
         """
-        return self
+        raise NotImplementedError
 
     @abstractmethod
     def sub(self, other):

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -31,12 +31,14 @@ To visualize the full multiple inheritance hierarchy use:
 """
 
 import asyncio
+from copy import copy
 import os
 from pathlib import Path
 import sys
 from typing import TYPE_CHECKING
 
 from cylc.flow.config import WorkflowConfig
+from cylc.flow.exceptions import InputError
 from cylc.flow.id_cli import parse_id_async
 from cylc.flow.option_parsers import (
     AGAINST_SOURCE_OPTION,
@@ -44,6 +46,7 @@ from cylc.flow.option_parsers import (
     CylcOptionParser as COP,
     icp_option,
 )
+from cylc.flow.print_tree import print_tree
 from cylc.flow.workflow_files import get_workflow_run_dir
 from cylc.flow.templatevars import get_template_vars
 from cylc.flow.terminal import cli_function
@@ -109,10 +112,51 @@ def get_option_parser():
 
 @cli_function(get_option_parser)
 def main(parser: COP, options: 'Values', workflow_id: str) -> None:
-    asyncio.run(_main(parser, options, workflow_id))
+    asyncio.run(_main(options, workflow_id))
 
 
-async def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
+def define_inheritance_tree(tree, hierarchy):
+    """Combine inheritance hierarchies into a tree structure."""
+    for rt_ in hierarchy:
+        hier = copy(hierarchy[rt_])
+        hier.reverse()
+        cur_tree = tree
+        for item in hier:
+            if item not in cur_tree:
+                cur_tree[item] = {}
+            cur_tree = cur_tree[item]
+
+
+def print_first_parent_tree(config, pretty=False, titles=False):
+    # find task namespaces (no descendants)
+    tasks = []
+    for ns in config.cfg['runtime']:
+        if ns not in config.runtime['descendants']:
+            tasks.append(ns)
+
+    pruned_ancestors = config.get_first_parent_ancestors(pruned=True)
+    tree = {}
+    define_inheritance_tree(tree, pruned_ancestors)
+    padding = ''
+    if titles:
+        config.add_tree_titles(tree)
+        # compute pre-title padding
+        maxlen = 0
+        for namespace in pruned_ancestors:
+            items = copy(pruned_ancestors[namespace])
+            items.reverse()
+            for itt, item in enumerate(items):
+                tmp = 2 * itt + 1 + len(item)
+                if itt == 0:
+                    tmp -= 1
+                if tmp > maxlen:
+                    maxlen = tmp
+        padding = maxlen * ' '
+
+    print_tree(tree, padding=padding, use_unicode=pretty)
+
+
+async def _main(options: 'Values', workflow_id: str) -> None:
     workflow_id, _, flow_file = await parse_id_async(
         workflow_id,
         src=True,
@@ -121,7 +165,14 @@ async def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
     template_vars = get_template_vars(options)
 
     if options.all_tasks and options.all_namespaces:
-        parser.error("Choose either -a or -n")
+        raise InputError("Choose either -a or -n")
+    if (options.all_tasks or options.all_namespaces) and options.prange:
+        raise InputError(
+            '--points cannot be used with --all-tasks or --all-namespaces'
+        )
+    if options.box and not options.tree:
+        options.tree = True
+
     if options.all_tasks:
         which = "all tasks"
     elif options.all_namespaces:
@@ -147,7 +198,7 @@ async def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
         options.tree = False
 
     if options.titles and options.mro:
-        parser.error("Please choose --mro or --title, not both")
+        raise InputError("Please choose --mro or --title, not both")
 
     if options.tree and any(
             [options.all_tasks, options.all_namespaces, options.mro]):
@@ -166,8 +217,11 @@ async def _main(parser: COP, options: 'Values', workflow_id: str) -> None:
         template_vars
     )
     if options.tree:
-        config.print_first_parent_tree(
-            pretty=options.box, titles=options.titles)
+        print_first_parent_tree(
+            config,
+            pretty=options.box,
+            titles=options.titles,
+        )
     elif options.prange:
         for node in sorted(config.get_node_labels(tr_start, tr_stop)):
             print(node)

--- a/tests/functional/cylc-config/09-platforms.t
+++ b/tests/functional/cylc-config/09-platforms.t
@@ -18,7 +18,7 @@
 # Test cylc config --platform-names and --platforms
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 5
+set_test_number 7
 #-------------------------------------------------------------------------------
 cat > "global.cylc" <<__HEREDOC__
 [platforms]
@@ -62,5 +62,17 @@ TEST_NAME="${TEST_NAME_BASE}-s"
 head -n 10 > just_platforms < global.cylc
 run_ok "${TEST_NAME}" cylc config --platforms
 cmp_ok "${TEST_NAME}.stdout" "just_platforms"
+
+#-------------------------------------------------------------------------------
+# test with no platforms or platform groups defined
+rm "global.cylc"
+touch "global.cylc"
+
+TEST_NAME="${TEST_NAME_BASE}-names"
+run_ok "${TEST_NAME}" cylc config --platform-names
+cmp_ok "${TEST_NAME}.stdout" <<__HEREDOC__
+localhost
+
+__HEREDOC__
 
 exit

--- a/tests/functional/rnd/08-cylc-list.t
+++ b/tests/functional/rnd/08-cylc-list.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Functional test of the cylc-list command
+# (see integration tests for more comprehensive tests)
+
+. "$(dirname "$0")/test_header"
+set_test_number 4
+
+
+cat > flow.cylc <<__FLOW__
+[scheduling]
+    [[graph]]
+        R1 = c
+[runtime]
+    [[A]]
+        [[[meta]]]
+            title = Aaa
+    [[B]]
+        inherit = A
+        [[[meta]]]
+            title = Bbb
+    [[c]]
+        inherit = B
+        [[[meta]]]
+            title = Ccc
+__FLOW__
+
+
+# test signals on a detached scheduler
+TEST_NAME="${TEST_NAME_BASE}-list"
+run_ok "$TEST_NAME" cylc list '.' --all-namespaces --with-titles
+cmp_ok "${TEST_NAME}.stdout" << __HERE__
+A     Aaa
+B     Bbb
+c     Ccc
+root  
+__HERE__
+
+TEST_NAME="${TEST_NAME_BASE}-tree"
+run_ok "$TEST_NAME" cylc list '.' --tree --with-titles
+cmp_ok "${TEST_NAME}.stdout" << '__HERE__'
+root     
+ `-A     
+   `-B   
+     `-c Ccc
+__HERE__

--- a/tests/integration/scripts/test_list.py
+++ b/tests/integration/scripts/test_list.py
@@ -116,7 +116,7 @@ async def test_plain(cylc_list, supports_utf8, capsys):
 
 
 async def test_mro(cylc_list, supports_utf8, capsys):
-    """Test the --mro option."""
+    """Test the --mro (method resolution order) option."""
     assert await cylc_list(capsys, mro=True) == [
         'a111  a111 A11 A1 A root',
         'a112  a112 A11 A1 A root',

--- a/tests/integration/scripts/test_list.py
+++ b/tests/integration/scripts/test_list.py
@@ -1,0 +1,340 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test the "cylc list" command."""
+
+import pytest
+
+from cylc.flow.exceptions import InputError
+from cylc.flow.option_parsers import Options
+from cylc.flow.scripts.list import (
+    get_option_parser,
+    _main,
+)
+
+
+ListOptions = Options(get_option_parser())
+
+
+@pytest.fixture(scope='module')
+async def cylc_list(mod_flow, mod_scheduler, mod_start):
+    id_ = mod_flow(
+        {
+            'scheduling': {
+                # NOTE: all "a*" tasks are in the graph, but not "b*" tasks
+                'initial cycle point': 1,
+                'cycling mode': 'integer',
+                'graph': {'P1': 'a12 & a111 & a112 & a121 & a2'},
+            },
+            'runtime': {
+                'A': {'meta': {'title': 'Title For A'}},
+                'A1': {'inherit': 'A'},
+                'A11': {'inherit': 'A1', 'meta': {'title': 'Title For A11'}},
+                'A12': {'inherit': 'A1'},
+                'a2': {'inherit': 'A'},
+                'a12': {'inherit': 'A1'},
+                'a111': {'inherit': 'A11'},
+                'a112': {'inherit': 'A11'},
+                'a121': {'inherit': 'A12'},
+                'B': {},
+                'b1': {'inherit': 'B'},
+            },
+        }
+    )
+    schd = mod_scheduler(id_)
+
+    async def _list(capsys, **kwargs):
+        nonlocal schd
+        capsys.readouterr()
+        await _main(ListOptions(**kwargs), schd.workflow)
+        out, err = capsys.readouterr()
+        return out.splitlines()
+
+    async with mod_start(schd):
+        yield _list
+
+
+@pytest.fixture
+def supports_utf8(monkeypatch):
+    monkeypatch.setenv('LANG', 'C.utf-8')
+
+
+@pytest.fixture
+def does_not_support_utf8(monkeypatch):
+    monkeypatch.setenv('LANG', 'C')
+
+
+async def test_plain(cylc_list, supports_utf8, capsys):
+    """Test the default output format."""
+    assert await cylc_list(capsys) == [
+        'a111',
+        'a112',
+        'a12',
+        'a121',
+        'a2',
+    ]
+
+    assert await cylc_list(capsys, all_tasks=True) == [
+        'a111',
+        'a112',
+        'a12',
+        'a121',
+        'a2',
+        'b1',  # <= in the runtime but not in the graph
+    ]
+
+    assert await cylc_list(capsys, all_namespaces=True) == [
+        'A',
+        'A1',
+        'A11',
+        'A12',
+        'B',
+        'a111',
+        'a112',
+        'a12',
+        'a121',
+        'a2',
+        'b1',
+        'root',
+    ]
+
+    with pytest.raises(InputError):
+        await cylc_list(capsys, all_tasks=True, all_namespaces=True)
+
+
+async def test_mro(cylc_list, supports_utf8, capsys):
+    """Test the --mro option."""
+    assert await cylc_list(capsys, mro=True) == [
+        'a111  a111 A11 A1 A root',
+        'a112  a112 A11 A1 A root',
+        'a12   a12 A1 A root',
+        'a121  a121 A12 A1 A root',
+        'a2    a2 A root',
+    ]
+
+    assert await cylc_list(capsys, mro=True, all_tasks=True) == [
+        'a111  a111 A11 A1 A root',
+        'a112  a112 A11 A1 A root',
+        'a12   a12 A1 A root',
+        'a121  a121 A12 A1 A root',
+        'a2    a2 A root',
+        'b1    b1 B root',
+    ]
+
+    assert await cylc_list(capsys, mro=True, all_namespaces=True) == [
+        'A     A root',
+        'A1    A1 A root',
+        'A11   A11 A1 A root',
+        'A12   A12 A1 A root',
+        'B     B root',
+        'a111  a111 A11 A1 A root',
+        'a112  a112 A11 A1 A root',
+        'a12   a12 A1 A root',
+        'a121  a121 A12 A1 A root',
+        'a2    a2 A root',
+        'b1    b1 B root',
+        'root  root',
+    ]
+
+    with pytest.raises(InputError):
+        await cylc_list(capsys, titles=True, mro=True)
+
+
+
+async def test_tree(cylc_list, supports_utf8, capsys):
+    """Test the --tree option."""
+    assert (
+        await cylc_list(capsys, tree=True)
+        # NOTE: the --all-tasks and --all-namespaces opts should be ignored
+        == await cylc_list(capsys, tree=True, all_tasks=True)
+        == await cylc_list(capsys, tree=True, all_namespaces=True)
+        == [
+            'root ',
+            ' `-A ',
+            '   |-A1 ',
+            '   | |-A11 ',
+            '   | | |-a111 ',
+            '   | | `-a112 ',
+            '   | |-A12 ',
+            '   | | `-a121 ',
+            '   | `-a12 ',
+            '   `-a2 ',
+        ]
+    )
+
+    assert (
+        await cylc_list(capsys, tree=True, box=True)
+        == await cylc_list(capsys, box=True)  # --tree implicit with --box
+        == [
+            'root ',
+            ' └─A ',
+            '   ├─A1 ',
+            '   │ ├─A11 ',
+            '   │ │ ├─a111 ',
+            '   │ │ └─a112 ',
+            '   │ ├─A12 ',
+            '   │ │ └─a121 ',
+            '   │ └─a12 ',
+            '   └─a2 ',
+        ]
+    )
+
+    assert await cylc_list(capsys, tree=True, titles=True) == [
+        'root          ',
+        ' `-A          ',
+        '   |-A1       ',
+        '   | |-A11    ',
+        '   | | |-a111 Title For A11',
+        '   | | `-a112 Title For A11',
+        '   | |-A12    ',
+        '   | | `-a121 Title For A',
+        '   | `-a12    Title For A',
+        '   `-a2       Title For A',
+    ]
+
+    assert await cylc_list(capsys, tree=True, box=True, titles=True) == [
+        'root          ',
+        ' └─A          ',
+        '   ├─A1       ',
+        '   │ ├─A11    ',
+        '   │ │ ├─a111 Title For A11',
+        '   │ │ └─a112 Title For A11',
+        '   │ ├─A12    ',
+        '   │ │ └─a121 Title For A',
+        '   │ └─a12    Title For A',
+        '   └─a2       Title For A',
+    ]
+
+
+async def test_box_with_lang_c(cylc_list, does_not_support_utf8, capsys):
+    """It falls back to plain output if unicode support isn't there."""
+    assert await cylc_list(capsys, tree=True, box=True) == [
+        'a111',
+        'a112',
+        'a12',
+        'a121',
+        'a2',
+    ]
+
+
+async def test_titles(cylc_list, supports_utf8, capsys):
+    """Test the --titles option."""
+    assert await cylc_list(capsys, titles=True) == [
+        'a111  Title For A11',
+        'a112  Title For A11',
+        'a12   Title For A',
+        'a121  Title For A',
+        'a2    Title For A',
+    ]
+
+    assert await cylc_list(capsys, titles=True, all_tasks=True) == [
+        'a111  Title For A11',
+        'a112  Title For A11',
+        'a12   Title For A',
+        'a121  Title For A',
+        'a2    Title For A',
+        'b1    ',
+    ]
+
+    assert await cylc_list(capsys, titles=True, all_namespaces=True) == [
+        'A     Title For A',
+        'A1    Title For A',
+        'A11   Title For A11',
+        'A12   Title For A',
+        'B     ',
+        'a111  Title For A11',
+        'a112  Title For A11',
+        'a12   Title For A',
+        'a121  Title For A',
+        'a2    Title For A',
+        'b1    ',
+        'root  ',
+    ]
+
+
+async def test_points(cylc_list, supports_utf8, capsys):
+    """Test the --points option."""
+    # specify start and stop points
+    assert await cylc_list(capsys, prange='1,2') == [
+        '1/a111',
+        '1/a112',
+        '1/a12',
+        '1/a121',
+        '1/a2',
+        '2/a111',
+        '2/a112',
+        '2/a12',
+        '2/a121',
+        '2/a2',
+    ]
+
+    # leave start and stop points implicit
+    assert await cylc_list(capsys, prange=',') == [
+        '1/a111',
+        '1/a112',
+        '1/a12',
+        '1/a121',
+        '1/a2',
+        '2/a111',
+        '2/a112',
+        '2/a12',
+        '2/a121',
+        '2/a2',
+        '3/a111',
+        '3/a112',
+        '3/a12',
+        '3/a121',
+        '3/a2',
+    ]
+
+    # leave start point implicit
+    assert await cylc_list(capsys, prange=',2') == [
+        '1/a111',
+        '1/a112',
+        '1/a12',
+        '1/a121',
+        '1/a2',
+        '2/a111',
+        '2/a112',
+        '2/a12',
+        '2/a121',
+        '2/a2',
+    ]
+
+    # leave stop point implicit
+    assert await cylc_list(capsys, prange='4,') == [
+        '4/a111',
+        '4/a112',
+        '4/a12',
+        '4/a121',
+        '4/a2',
+        '5/a111',
+        '5/a112',
+        '5/a12',
+        '5/a121',
+        '5/a2',
+        '6/a111',
+        '6/a112',
+        '6/a12',
+        '6/a121',
+        '6/a2',
+    ]
+
+    with pytest.raises(InputError):
+        await cylc_list(capsys, prange='1,2', all_tasks=True)
+
+    with pytest.raises(InputError):
+        await cylc_list(capsys, prange='1,2', all_namespaces=True)

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -23,6 +23,7 @@ import pytest
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.cfgspec.globalcfg import GlobalConfig
 from cylc.flow.exceptions import (
+    InputError,
     PointParsingError,
     ServiceFileError,
     WorkflowConfigError,
@@ -618,3 +619,12 @@ def test_validate_run_mode(flow: Fixture, validate: Fixture):
     # It fails with run mode dummy:
     with pytest.raises(PointParsingError, match='Incompatible value'):
         validate(wid, run_mode='dummy')
+
+
+async def test_invalid_starttask(one_conf, flow, scheduler, start):
+    """It should reject invalid starttask arguments."""
+    id_ = flow(one_conf)
+    schd = scheduler(id_, starttask=['a///b'])
+    with pytest.raises(InputError, match='a///b'):
+        async with start(schd):
+            pass

--- a/tests/integration/test_get_old_tvars.py
+++ b/tests/integration/test_get_old_tvars.py
@@ -85,7 +85,7 @@ async def test_validate_with_old_tvars(
         opts.reference = True
 
     async with mod_start(_setup):
-        if function == view:
+        if function in {view, cylclist}:
             await function(opts, _setup.workflow_name)
         else:
             await function(parser, opts, _setup.workflow_name)

--- a/tests/unit/cycling/test_integer.py
+++ b/tests/unit/cycling/test_integer.py
@@ -258,7 +258,7 @@ def test_point_comparisons():
     assert IntegerInterval('P2') >= IntegerInterval('P1')
     assert IntegerInterval('P1') != IntegerInterval('P2')
 
-    # None comparisons work counter intuatively
+    # None comparisons work counter intuitively
     # (reason unknown)
     assert IntegerPoint(1) < None
     assert None > IntegerPoint(1)

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -498,6 +498,15 @@ def test_advanced_exclusions_sequences_implied_start_point(set_cycling_type):
     ]
 
 
+def test_point_init():
+    """It should error if inited with anything other than a string."""
+    ISO8601Point('1000')
+    with pytest.raises(TypeError):
+        ISO8601Point(1000)
+    with pytest.raises(TypeError):
+        ISO8601Interval(1000)
+
+
 def test_exclusions_sequences_points(set_cycling_type):
     """Test ISO8601Sequence methods for sequences with exclusions"""
     set_cycling_type(ISO8601_CYCLING_TYPE, "Z")


### PR DESCRIPTION
Had a go at filling in some coverage holes whilst ill last week and struggling to work on anything else:

* [refactor] Move "cylc list" specific functions out of the config module and into the script module.
* [test] Test the "cylc list" command.
* [fix] Fix some uncaught "cylc list" option combinations.
* [refactor] Make the unused PointBase.standardise method raise NotImplementedError (both implementations override this method).
* [test] Add test for invalid start task detection in the config module.
* [test] Address some coverage holes in the cycling modules.
* [refactor] Remove unused `is_null` interface (separate commit).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.