### PR TITLE
Tweak 'cylc play' resume help.

### DIFF
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -344,12 +344,11 @@ CONTACT_FILE_EXISTS_MSG = r"""workflow contact file exists: %(fname)s
 
 Workflow "%(workflow)s" is already running, listening at "%(host)s:%(port)s".
 
-To start a new run, stop the old one first with one or more of these:
+If you like, you can stop it with one or more of the following commands:
 * cylc stop %(workflow)s              # wait for active tasks/event handlers
 * cylc stop --kill %(workflow)s       # kill active tasks and wait
-
 * cylc stop --now %(workflow)s        # don't wait for active tasks
-* cylc stop --now --now %(workflow)s  # don't wait
+* cylc stop --now --now %(workflow)s  # don't wait for tasks or handlers
 * ssh -n "%(host)s" kill %(pid)s      # final brute force!
 """
 


### PR DESCRIPTION
If you use `cylc play` to resume a paused workflow, currently its says:
```
Workflow "bug/run101" is already running, listening at "<host>:<port>".

To start a new run, stop the old one first with one or more of these:
* cylc stop bug/run101              # wait for active tasks/event handlers
* cylc stop --kill bug/run101       # kill active tasks and wait

* cylc stop --now bug/run101        # don't wait for active tasks
* cylc stop --now --now bug/run101  # don't wait
* ssh -n "<host>" kill <pid>      # final brute force!
```

Two minor annoyances with the above advice:
- you don't have to, and may not want to, stop this run before starting another
- there's a blank line in the middle for no apparent reason

On this branch:
```
Workflow "bug/run101" is already running, listening at "<host>:<port>".

If you like, you can stop it with one or more of the following commands:
* cylc stop bug/run101              # wait for active tasks/event handlers
* cylc stop --kill bug/run101       # kill active tasks and wait
* cylc stop --now bug/run101        # don't wait for active tasks
* cylc stop --now --now bug/run101  # don't wait for tasks or handlers
* ssh -n "<host>" kill <pid>      # final brute force!
```

This is a trivial change - one review will do.