### PR TITLE
Revert "Lint: Tell users that backslashes are no longer necessary after => & |"

### DIFF
--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,1 +1,0 @@
-`cylc lint` now checks for unnecessary continuation characters in the graph section.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -547,13 +547,7 @@ STYLE_CHECKS = {
     'S013': {
         'short': 'Items should be indented in 4 space blocks.',
         FUNCTION: check_indentation
-    },
-    'S014': {
-        'short': (
-            '`=>` implies line continuation without `\\`'
-        ),
-        FUNCTION: re.compile(r'=>\s*\\').findall
-    },
+    }
 }
 # Subset of deprecations which are tricky (impossible?) to scrape from the
 # upgrader.
@@ -720,12 +714,6 @@ MANUAL_DEPRECATIONS = {
         ),
         FUNCTION: functools.partial(
             list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
-    },
-    'U017': {
-        'short': (
-            '`&` and `|` imply line continuation without `\\`'
-        ),
-        FUNCTION: re.compile(r'[&|]\s*\\').findall
     },
 }
 ALL_RULESETS = ['728', 'style', 'all']

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -44,7 +44,7 @@ from cylc.flow.exceptions import CylcError
 STYLE_CHECKS = parse_checks(['style'])
 UPG_CHECKS = parse_checks(['728'])
 
-TEST_FILE = '''
+TEST_FILE = """
 [visualization]
 
 [cylc]
@@ -97,13 +97,7 @@ TEST_FILE = '''
     hold after point = 20220101T0000Z
     [[dependencies]]
         [[[R1]]]
-            graph = """
-                MyFaM:finish-all => remote => !mash_theme
-                a & \\
-                b => c
-                c | \\
-                d => e
-            """
+            graph = MyFaM:finish-all => remote => !mash_theme
 
 [runtime]
     [[root]]
@@ -160,10 +154,10 @@ TEST_FILE = '''
             host = `rose host-select thingy`
 
 %include foo.cylc
-'''
+"""
 
 
-LINT_TEST_FILE = '''
+LINT_TEST_FILE = """
 \t[scheduler]
 
  [scheduler]
@@ -173,11 +167,6 @@ LINT_TEST_FILE = '''
 {% foo %}
 {{foo}}
 # {{quix}}
-    R1 = """
-        foo & \\
-        bar => \\
-        baz
-    """
 
 [runtime]
     [[this_is_ok]]
@@ -191,7 +180,7 @@ something\t
         platform = $(some-script foo)
     [[baz]]
         platform = `no backticks`
-''' + (
+""" + (
     '\nscript = the quick brown fox jumps over the lazy dog until it becomes '
     'clear that this line is longer than the default 130 character limit.'
 )


### PR DESCRIPTION
Reverts cylc/cylc-flow#6459 - Blocks Sync PR's Because Lint reference number already taken