### PR TITLE
`cylc lint`: S015/U017 line continuation chars

### DIFF
--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,1 +1,1 @@
-Cylc lint now checks for unecessary continuation characters in graph section.
+`cylc lint` now checks for unecessary continuation characters in graph section.

--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,1 +1,1 @@
-`cylc lint` now checks for unecessary continuation characters in graph section.
+`cylc lint` now checks for unnecessary continuation characters in the graph section.

--- a/changes.d/6459.feat.md
+++ b/changes.d/6459.feat.md
@@ -1,0 +1,1 @@
+Cylc lint now checks for unecessary continuation characters in graph section.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -617,7 +617,13 @@ STYLE_CHECKS = {
             for job_runner, directive in WALLCLOCK_DIRECTIVES.items()
         )),
         FUNCTION: check_wallclock_directives,
-    }
+    },
+    'S015': {
+        'short': (
+            '`=>` is a line continuation without `\\`.'
+        ),
+        FUNCTION: re.compile(r'=>\s*\\').findall
+    },
 }
 # Subset of deprecations which are tricky (impossible?) to scrape from the
 # upgrader.
@@ -784,6 +790,12 @@ MANUAL_DEPRECATIONS = {
         ),
         FUNCTION: functools.partial(
             list_wrapper, check=CHECK_FOR_OLD_VARS.findall),
+    },
+    'U017': {
+        'short': (
+            '`&` and `|` are line continuations without `\\`'
+        ),
+        FUNCTION: re.compile(r'[&|]\s*\\').findall
     },
 }
 ALL_RULESETS = ['728', 'style', 'all']

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -620,7 +620,7 @@ STYLE_CHECKS = {
     },
     'S015': {
         'short': (
-            '`=>` is a line continuation without `\\`.'
+            '`=>` implies line continuation without `\\`.'
         ),
         FUNCTION: re.compile(r'=>\s*\\').findall
     },

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -793,7 +793,7 @@ MANUAL_DEPRECATIONS = {
     },
     'U017': {
         'short': (
-            '`&` and `|` are line continuations without `\\`'
+            '`&` and `|` imply line continuation without `\\`'
         ),
         FUNCTION: re.compile(r'[&|]\s*\\').findall
     },

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -45,7 +45,7 @@ from cylc.flow.exceptions import CylcError
 STYLE_CHECKS = parse_checks(['style'])
 UPG_CHECKS = parse_checks(['728'])
 
-TEST_FILE = """
+TEST_FILE = '''
 [visualization]
 
 [cylc]
@@ -98,7 +98,13 @@ TEST_FILE = """
     hold after point = 20220101T0000Z
     [[dependencies]]
         [[[R1]]]
-            graph = MyFaM:finish-all => remote => !mash_theme
+            graph = """
+                MyFaM:finish-all => remote => !mash_theme
+                a & \\
+                b => c
+                c | \\
+                d => e
+            """
 
 [runtime]
     [[root]]
@@ -155,10 +161,10 @@ TEST_FILE = """
             host = `rose host-select thingy`
 
 %include foo.cylc
-"""
+'''
 
 
-LINT_TEST_FILE = """
+LINT_TEST_FILE = '''
 \t[scheduler]
 
  [scheduler]
@@ -168,6 +174,11 @@ LINT_TEST_FILE = """
 {% foo %}
 {{foo}}
 # {{quix}}
+    R1 = """
+        foo & \\
+        bar => \\
+        baz
+    """
 
 [runtime]
     [[this_is_ok]]
@@ -183,7 +194,7 @@ something\t
                 -l walltime = 666
     [[baz]]
         platform = `no backticks`
-""" + (
+''' + (
     '\nscript = the quick brown fox jumps over the lazy dog until it becomes '
     'clear that this line is longer than the default 130 character limit.'
 )


### PR DESCRIPTION
Replaces https://github.com/cylc/cylc-flow/pull/6459 which blocks sync PRs

Otherwise the same diff.

Seealso @MetRonnie's Comment on https://github.com/cylc/cylc-flow/pull/6459#issuecomment-2497686715

Probably OK to be a single review since it's a copy of an already accepted PR.

