### PR TITLE
fix.more helpful insert deprecation msg

### DIFF
--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -283,7 +283,8 @@ DEAD_ENDS = {
     'gscan':
         'cylc gscan has been removed, use the web UI',
     'insert':
-        'inserting tasks is now done automatically',
+        'Insertion is now automatic: Use `cylc set` or `cylc trigger`'
+        ' to re-run old tasks.',
     'jobscript':
         'cylc jobscript has been removed',
     'nudge':


### PR DESCRIPTION
Very small documentation change to deprecation notice for `cylc insert`.

Make it clearer to the user what to do _instead_ of `cylc insert`.

Reviewers with access may view trigger at https://engage.cloud.microsoft/main/org/metoffice.gov.uk/threads/eyJfdHlwZSI6IlRocmVhZCIsImlkIjoiMzA4MjQyNDM2NjIzNTY0OCJ9?trk_copy_link=V2