### PR TITLE
Fix rst output from cylc lint

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -620,7 +620,7 @@ STYLE_CHECKS = {
     },
     'S015': {
         'short': (
-            '`=>` implies line continuation without `\\`.'
+            '``=>`` implies line continuation without ``\\``.'
         ),
         FUNCTION: re.compile(r'=>\s*\\').findall
     },
@@ -793,7 +793,7 @@ MANUAL_DEPRECATIONS = {
     },
     'U017': {
         'short': (
-            '`&` and `|` imply line continuation without `\\`'
+            '``&`` and ``|`` imply line continuation without ``\\``'
         ),
         FUNCTION: re.compile(r'[&|]\s*\\').findall
     },


### PR DESCRIPTION
Cylc Docs build was broken by the single backtick in https://github.com/cylc/cylc-flow/pull/6493