### PR TITLE
Trigger now if workflow paused

### DIFF
--- a/changes.d/6499.feat.md
+++ b/changes.d/6499.feat.md
@@ -1,1 +1,1 @@
-Manual trigger: run tasks immediately even if the workflow is paused.
+Manually triggered tasks now run immediately even if the workflow is paused.

--- a/changes.d/6499.feat.md
+++ b/changes.d/6499.feat.md
@@ -1,0 +1,1 @@
+Manual trigger: run tasks immediately even if the workflow is paused.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -451,6 +451,11 @@ async def force_trigger_tasks(
     """Manual task trigger."""
     validate.is_tasks(tasks)
     validate.flow_opts(flow, flow_wait)
+    if on_resume:
+        LOG.warning(
+            "The --on-resume option is deprecated and will be removed "
+            "at Cylc 8.5."
+        )
     yield
     yield schd.pool.force_trigger_tasks(
         tasks, flow, flow_wait, flow_descr, on_resume

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -338,7 +338,7 @@ async def reload_workflow(schd: 'Scheduler'):
 
     # flush out preparing tasks before attempting reload
     schd.reload_pending = 'waiting for pending tasks to submit'
-    while schd.release_queued_tasks():
+    while schd.release_tasks_to_run():
         # Run the subset of main-loop functionality required to push
         # preparing through the submission pipeline and keep the workflow
         # responsive (e.g. to the `cylc stop` command).
@@ -446,9 +446,12 @@ async def force_trigger_tasks(
     flow: List[str],
     flow_wait: bool = False,
     flow_descr: Optional[str] = None,
+    on_resume: bool = False
 ):
     """Manual task trigger."""
     validate.is_tasks(tasks)
     validate.flow_opts(flow, flow_wait)
     yield
-    yield schd.pool.force_trigger_tasks(tasks, flow, flow_wait, flow_descr)
+    yield schd.pool.force_trigger_tasks(
+        tasks, flow, flow_wait, flow_descr, on_resume
+    )

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2216,12 +2216,16 @@ class Trigger(Mutation, TaskMutation):
             Manually trigger tasks, even in a paused workflow.
 
             Triggering a task that is not yet queued will queue it.
-               
+
             Triggering a queued task runs it immediately.
-                        
-            Queues release tasks to run when their active task count
-            drops below the queue limit. So, depending on the task count, you
-            may need to trigger a task twice to make it run immediately. 
+
+            Cylc queues restrict the number of jobs that can be active
+            (submitted or running) at once. They release tasks to run
+            when their active task count drops below the queue limit.
+            So, depending on the active task count, you may need to
+            trigger a task twice to make it run immediately.
+
+            Attempts to trigger active tasks will be ignored.
 
             Valid for: paused, running workflows.
         ''')

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2228,7 +2228,8 @@ class Trigger(Mutation, TaskMutation):
         on_resume = Boolean(
             default_value=False,
             description=sstrip('''
-                Run triggered tasks once the paused workflow is resumed.
+                If the workflow is paused, wait until it is resumed before
+                running the triggered task(s).
             ''')
         )
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2215,10 +2215,13 @@ class Trigger(Mutation, TaskMutation):
         description = sstrip('''
             Manually trigger tasks, even in a paused workflow.
 
-            Triggering an unqueued task queues it, to run when queue-released.
-            Triggering a queued task runs it now regardless of queue limiting.
-
-            The "on resume" option waits for a paused workflow to be resumed.
+            Triggering a task that is not yet queued will queue it.
+               
+            Triggering a queued task runs it immediately.
+                        
+            Queues release tasks to run when their active task count
+            drops below the queue limit. So, depending on the task count, you
+            may need to trigger a task twice to make it run immediately. 
 
             Valid for: paused, running workflows.
         ''')

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2213,20 +2213,24 @@ class SetPrereqsAndOutputs(Mutation, TaskMutation):
 class Trigger(Mutation, TaskMutation):
     class Meta:
         description = sstrip('''
-            Manually trigger tasks.
+            Manually trigger tasks, even in a paused workflow.
 
-            Warning: waiting tasks that are queue-limited will be queued if
-            triggered, to submit as normal when released by the queue; queued
-            tasks will submit immediately if triggered, even if that violates
-            the queue limit (so you may need to trigger a queue-limited task
-            twice to get it to submit immediately).
+            Triggering an unqueued task queues it, to run when queue-released.
+            Triggering a queued task runs it now regardless of queue limiting.
+
+            The "on resume" option waits for a paused workflow to be resumed.
 
             Valid for: paused, running workflows.
         ''')
         resolver = partial(mutator, command='force_trigger_tasks')
 
     class Arguments(TaskMutation.Arguments, FlowMutationArguments):
-        ...
+        on_resume = Boolean(
+            default_value=False,
+            description=sstrip('''
+                Run triggered tasks once the paused workflow is resumed.
+            ''')
+        )
 
 
 def _mut_field(cls):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -679,6 +679,9 @@ class Scheduler:
 
                     # If we shut down with manually triggered waiting tasks,
                     # submit them to run now.
+                    # NOTE: this will run tasks that were triggered with
+                    # the trigger "--on-resume" option, even if the workflow
+                    # is restarted as paused. Option to be removed at 8.5.0.
                     pre_prep_tasks = []
                     for itask in self.pool.get_tasks():
                         if (

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -18,9 +18,10 @@
 
 """cylc pause [OPTIONS] ARGS
 
-Suspend all automatic job submission until the workflow is resumed.
+Suspend automatic job submission.
 
-Manual triggering can still run tasks immediately, if the workflow is paused.
+Manual triggering can still run tasks immediately, even if the workflow is
+paused.
 
 Examples:
   # pause my_workflow

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -18,10 +18,9 @@
 
 """cylc pause [OPTIONS] ARGS
 
-Pause a workflow.
+Suspend all automatic job submission until the workflow is resumed.
 
-This suspends submission of all tasks until the workflow is resumed, except
-for tasks manually triggered "now" with `cylc trigger --now`.
+Manual triggering can still run tasks immediately, if the workflow is paused.
 
 Examples:
   # pause my_workflow

--- a/cylc/flow/scripts/pause.py
+++ b/cylc/flow/scripts/pause.py
@@ -20,7 +20,8 @@
 
 Pause a workflow.
 
-This suspends submission of all tasks in a workflow.
+This suspends submission of all tasks until the workflow is resumed, except
+for tasks manually triggered "now" with `cylc trigger --now`.
 
 Examples:
   # pause my_workflow

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -19,13 +19,13 @@
 
 Force task(s) to run regardless of prerequisites, even in a paused workflow.
 
-Triggering an unqueued task queues it, to run when released by the queue.
-Triggering a queued task runs it immediately regardless of queue limiting.
-So you may need to trigger tasks twice if queue limiting is in effect.
+Triggering a task that is not yet queued will queue it.
 
-If the workflow is paused queued waiting tasks will not run (unless manually
-triggered) until the workflow is resumed, even if the queue empties out. This
-includes tasks queued by manual triggering, when queue limits are in effect.
+Triggering a queued task runs it immediately.
+
+Queues release tasks to run when their active task count drops below the queue
+limit. So, depending on the task count, you may need to trigger a task twice to make
+it run immediately. 
 
 Attempts to trigger active tasks (submitted or running) will be ignored.
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -23,11 +23,11 @@ Triggering a task that is not yet queued will queue it.
 
 Triggering a queued task runs it immediately.
 
-Queues release tasks to run when their active task count drops below the queue
-limit. So, depending on the task count, you may need to trigger a task twice
-to make it run immediately.
+Cylc queues restrict the number of jobs that can be active (submitted or
+running) at once. They release tasks to run when their active task count
+drops below the queue limit.
 
-Attempts to trigger active tasks (submitted or running) will be ignored.
+Attempts to trigger active tasks will be ignored.
 
 Examples:
   # trigger task foo in cycle 1234 in test

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -21,7 +21,11 @@ Manually trigger tasks regardless of prerequisites, even in a paused workflow.
 
 Triggering an unqueued task queues it, to run when released by the queue.
 Triggering a queued task runs it immediately regardless of queue limiting.
-So you may need to trigger a task twice if queue limiting is in effect.
+So you may need to trigger tasks twice if queue limiting is in effect.
+
+If the workflow is paused queued waiting tasks will not run (unless manually
+triggered) until the workflow is resumed, even if the queue empties out. This
+includes tasks queued by manual triggering, when queue limits are in effect.
 
 Attempts to trigger active tasks (submitted or running) will be ignored.
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -24,8 +24,8 @@ Triggering a task that is not yet queued will queue it.
 Triggering a queued task runs it immediately.
 
 Queues release tasks to run when their active task count drops below the queue
-limit. So, depending on the task count, you may need to trigger a task twice to make
-it run immediately. 
+limit. So, depending on the task count, you may need to trigger a task twice
+to make it run immediately.
 
 Attempts to trigger active tasks (submitted or running) will be ignored.
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,7 +17,7 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-Manually trigger tasks regardless of prerequisites, even in a paused workflow.
+Force task(s) to run regardless of prerequisites, even in a paused workflow.
 
 Triggering an unqueued task queues it, to run when released by the queue.
 Triggering a queued task runs it immediately regardless of queue limiting.
@@ -109,7 +109,11 @@ def get_option_parser() -> COP:
 
     parser.add_option(
         "--on-resume",
-        help=r"Run triggered tasks once a paused workflow is resumed.",
+        help=(
+            "If the workflow is paused, wait until it is resumed before "
+            "running the triggered task(s). DEPRECATED - this will be "
+            "removed at Cylc 8.5."
+        ),
         action="store_true",
         default=False,
         dest="on_resume"

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2145,7 +2145,7 @@ class TaskPool:
         Triggering a queued task will:
           - run it, regardless of queue limiting
 
-        Triggering an unqueued task will:
+        Triggering an non-queued task will:
           - queue it, if the queue is limiting activity
           - run it, if the queue is not limiting activity
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2208,7 +2208,7 @@ class TaskPool:
         flow: List[str],
         flow_wait: bool = False,
         flow_descr: Optional[str] = None,
-        now: bool = False
+        on_resume: bool = False
     ):
         """Manually trigger tasks.
 
@@ -2244,7 +2244,7 @@ class TaskPool:
                 LOG.error(f"[{itask}] ignoring trigger - already active")
                 continue
             self.merge_flows(itask, flow_nums)
-            self._force_trigger(itask, now)
+            self._force_trigger(itask, on_resume)
 
         # Spawn and trigger inactive tasks.
         if not flow:
@@ -2279,7 +2279,7 @@ class TaskPool:
 
             # run it (or run it again for incomplete flow-wait)
             self.add_to_pool(itask)
-            self._force_trigger(itask, now)
+            self._force_trigger(itask, on_resume)
 
     def spawn_parentless_sequential_xtriggers(self):
         """Spawn successor(s) of parentless wall clock satisfied tasks."""

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2189,16 +2189,14 @@ class TaskPool:
             itask.waiting_on_job_prep = True
 
             if on_resume:
-                with suppress(KeyError):
-                    # In case previously triggered without --on-resume.
-                    # (It should have run already, but just in case).
-                    self.tasks_to_trigger_now.remove(itask)
                 self.tasks_to_trigger_on_resume.add(itask)
+                # In case previously triggered without --on-resume.
+                # (It should have run already, but just in case).
+                self.tasks_to_trigger_now.discard(itask)
             else:
-                with suppress(KeyError):
-                    # In case previously triggered with --on-resume.
-                    self.tasks_to_trigger_on_resume.remove(itask)
                 self.tasks_to_trigger_now.add(itask)
+                # In case previously triggered with --on-resume.
+                self.tasks_to_trigger_on_resume.discard(itask)
 
         # Task may be set running before xtrigger is satisfied,
         # if so check/spawn if xtrigger sequential.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2179,7 +2179,7 @@ class TaskPool:
                 itask.state_reset(is_queued=True)
                 self.data_store_mgr.delta_task_state(itask)
 
-        elif self.task_queue_mgr.force_release_task(itask):
+        elif self.task_queue_mgr.remove_task(itask):
             # else release it from the queue to run now
             itask.state_reset(is_queued=False)
             self.data_store_mgr.delta_task_state(itask)

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -467,13 +467,9 @@ class TaskProxy:
     def is_ready_to_run(self) -> bool:
         """Is this task ready to run?
 
-        Takes account of all dependence: on other tasks, xtriggers, and
-        old-style ext-triggers. Or, manual triggering.
+        Return True if not held, no active try timers, and prerequisites done.
 
         """
-        if self.is_manual_submit:
-            # Manually triggered, ignore unsatisfied prerequisites.
-            return True
         if self.state.is_held:
             # A held task is not ready to run.
             return False

--- a/cylc/flow/task_queues/__init__.py
+++ b/cylc/flow/task_queues/__init__.py
@@ -69,14 +69,6 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def force_release_task(self, itask: 'TaskProxy') -> bool:
-        """Remove a task from whichever queue it belongs to.
-
-        Return True if released, else False
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt tasks with defs removed by scheduler reload or restart."""
         raise NotImplementedError

--- a/cylc/flow/task_queues/__init__.py
+++ b/cylc/flow/task_queues/__init__.py
@@ -40,35 +40,46 @@ class TaskQueueManagerBase(metaclass=ABCMeta):
            * descendants: runtime family dict
 
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def push_task(self, itask: 'TaskProxy') -> None:
         """Queue the given task."""
-        pass
+        raise NotImplementedError
+
+    @abstractmethod
+    def push_task_if_limited(
+            self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Queue the task only if the queue limit is reached.
+
+        Requires current active task counts.
+        Return True if queued, else False.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def release_tasks(self, active: Counter[str]) -> 'List[TaskProxy]':
         """Release tasks, given current active task counts."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def remove_task(self, itask: 'TaskProxy') -> bool:
         """Try to remove a task from the queues. Return True if done."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
-    def force_release_task(self, itask: 'TaskProxy') -> None:
+    def force_release_task(self, itask: 'TaskProxy') -> bool:
         """Remove a task from whichever queue it belongs to.
 
-        To be returned when release_tasks() is next called.
+        Return True if released, else False
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt tasks with defs removed by scheduler reload or restart."""
-        pass
+        raise NotImplementedError
 
     def _expand_families(self,
                          qconfig: dict,

--- a/cylc/flow/task_queues/independent.py
+++ b/cylc/flow/task_queues/independent.py
@@ -44,9 +44,7 @@ class LimitedTaskQueue:
         self, itask: 'TaskProxy', active: Counter[str]
     ) -> bool:
         """Queue task if in my membership and the queue limit is reached."""
-        n_active: int = 0
-        for mem in self.members:
-            n_active += active[mem]
+        n_active = sum(active[mem] for mem in self.members)
         if (
             self.limit and n_active >= self.limit
             and itask.tdef.name in self.members

--- a/cylc/flow/task_queues/independent.py
+++ b/cylc/flow/task_queues/independent.py
@@ -40,6 +40,21 @@ class LimitedTaskQueue:
         if itask.tdef.name in self.members:
             self.deque.appendleft(itask)
 
+    def push_task_if_limited(
+        self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Queue task if in my membership and the queue limit is reached."""
+        n_active: int = 0
+        for mem in self.members:
+            n_active += active[mem]
+        if (
+            self.limit and n_active >= self.limit
+            and itask.tdef.name in self.members
+        ):
+            self.deque.appendleft(itask)
+            return True
+        return False
+
     def release(self, active: Counter[str]) -> List['TaskProxy']:
         """Release tasks if below the active limit."""
         # The "active" argument counts active tasks by name.
@@ -113,34 +128,37 @@ class IndepQueueManager(TaskQueueManagerBase):
                 config["limit"], config["members"]
             )
 
-        self.force_released: Set['TaskProxy'] = set()
-
     def push_task(self, itask: 'TaskProxy') -> None:
         """Push a task to the appropriate queue."""
         for queue in self.queues.values():
             queue.push_task(itask)
+
+    def push_task_if_limited(
+        self, itask: 'TaskProxy', active: Counter[str]
+    ) -> bool:
+        """Push a task to its queue only if the queue limit is reached."""
+        return any(
+            queue.push_task_if_limited(itask, active)
+            for queue in self.queues.values()
+        )
 
     def release_tasks(self, active: Counter[str]) -> List['TaskProxy']:
         """Release tasks up to the queue limits."""
         released: List['TaskProxy'] = []
         for queue in self.queues.values():
             released += queue.release(active)
-        if self.force_released:
-            released.extend(self.force_released)
-            self.force_released = set()
         return released
 
     def remove_task(self, itask: 'TaskProxy') -> bool:
         """Try to remove a task from the queues. Return True if done."""
         return any(queue.remove(itask) for queue in self.queues.values())
 
-    def force_release_task(self, itask: 'TaskProxy') -> None:
+    def force_release_task(self, itask: 'TaskProxy') -> bool:
         """Remove a task from whichever queue it belongs to.
 
-        To be returned when release_tasks() is next called.
+        Return True if released, else False.
         """
-        if self.remove_task(itask):
-            self.force_released.add(itask)
+        return self.remove_task(itask)
 
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt orphaned tasks to the default group."""

--- a/cylc/flow/task_queues/independent.py
+++ b/cylc/flow/task_queues/independent.py
@@ -151,13 +151,6 @@ class IndepQueueManager(TaskQueueManagerBase):
         """Try to remove a task from the queues. Return True if done."""
         return any(queue.remove(itask) for queue in self.queues.values())
 
-    def force_release_task(self, itask: 'TaskProxy') -> bool:
-        """Remove a task from whichever queue it belongs to.
-
-        Return True if released, else False.
-        """
-        return self.remove_task(itask)
-
     def adopt_tasks(self, orphans: List[str]) -> None:
         """Adopt orphaned tasks to the default group."""
         self.queues[self.Q_DEFAULT].adopt(orphans)

--- a/tests/functional/cylc-trigger/07-kill-trigger.t
+++ b/tests/functional/cylc-trigger/07-kill-trigger.t
@@ -27,6 +27,6 @@ install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 
 workflow_run_ok "${TEST_NAME_BASE}-run" \
-    cylc play --debug --no-detach "${WORKFLOW_NAME}"
+    cylc play --debug --no-detach --reference-test "${WORKFLOW_NAME}"
 
 purge

--- a/tests/functional/cylc-trigger/07-kill-trigger.t
+++ b/tests/functional/cylc-trigger/07-kill-trigger.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test killing a job, then re-triggering it whilst it is "held".
+# See https://github.com/cylc/cylc-flow/issues/6398
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 2
+
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+
+run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
+
+workflow_run_ok "${TEST_NAME_BASE}-run" \
+    cylc play --debug --no-detach "${WORKFLOW_NAME}"
+
+purge

--- a/tests/functional/cylc-trigger/07-kill-trigger/flow.cylc
+++ b/tests/functional/cylc-trigger/07-kill-trigger/flow.cylc
@@ -1,0 +1,22 @@
+[scheduler]
+    [[events]]
+        inactivity timeout = PT1M
+
+[scheduling]
+    [[graph]]
+        R1 = a
+
+[runtime]
+    [[a]]
+        script = """
+            if [[ $CYLC_TASK_SUBMIT_NUMBER == 1 ]]; then
+                # wait for the scheduler to receive the started message,
+                # then kill the job
+                cylc__job__poll_grep_workflow_log -E '1/a.*running'
+                cylc kill "${CYLC_WORKFLOW_ID}//1/a"
+            fi
+        """
+        [[[events]]]
+            # when the scheduler receives the failed message, trigger the task
+            # to run again, it should run instantly
+            failed handlers = cylc trigger "%(workflow)s//1/a"

--- a/tests/functional/cylc-trigger/07-kill-trigger/flow.cylc
+++ b/tests/functional/cylc-trigger/07-kill-trigger/flow.cylc
@@ -1,6 +1,7 @@
 [scheduler]
     [[events]]
         inactivity timeout = PT1M
+        expected task failures = "1/a"
 
 [scheduling]
     [[graph]]
@@ -14,6 +15,10 @@
                 # then kill the job
                 cylc__job__poll_grep_workflow_log -E '1/a.*running'
                 cylc kill "${CYLC_WORKFLOW_ID}//1/a"
+                # do not succeed immediately after issuing the kill command or the
+                # workflow may shut down as complete before registering task failure
+                # (This polling grep will never complete, but you know what I mean.)
+                cylc__job__poll_grep_workflow_log -E '1/a.*failed'
             fi
         """
         [[[events]]]

--- a/tests/functional/cylc-trigger/07-kill-trigger/reference.log
+++ b/tests/functional/cylc-trigger/07-kill-trigger/reference.log
@@ -1,0 +1,2 @@
+1/a -triggered off [] in flow 1
+1/a -triggered off [] in flow 1

--- a/tests/functional/restart/58-waiting-manual-triggered.t
+++ b/tests/functional/restart/58-waiting-manual-triggered.t
@@ -40,6 +40,7 @@ __EOF__
 
 # It should restart and shut down normally, not stall with 2/foo waiting on 1/foo.
 workflow_run_ok "${TEST_NAME_BASE}-restart" cylc play --no-detach "${WORKFLOW_NAME}"
+
 # Check that 2/foo job 02 did run before shutdown.
 grep_workflow_log_ok "${TEST_NAME_BASE}-grep" "\[2\/foo\/02:running\] => succeeded"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -55,6 +55,7 @@ from cylc.flow.util import serialise_set
 from cylc.flow.wallclock import get_current_time_string
 from cylc.flow.workflow_files import infer_latest_run_from_id
 from cylc.flow.workflow_status import StopMode
+from cylc.flow.task_state import TASK_STATUS_SUBMITTED
 
 from .utils import _rm_if_empty
 from .utils.flow_tools import (
@@ -425,6 +426,8 @@ def capture_submission():
 
         def _submit_task_jobs(_, itasks, *args, **kwargs):
             nonlocal submitted_tasks
+            for itask in itasks:
+                itask.state_reset(TASK_STATUS_SUBMITTED)
             submitted_tasks.update(itasks)
             return itasks
 

--- a/tests/integration/run_modes/test_skip.py
+++ b/tests/integration/run_modes/test_skip.py
@@ -185,14 +185,14 @@ async def test_doesnt_release_held_tasks(
         itask.state.is_held = True
 
         # Relinquish contol to the main loop.
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
 
         assert not log_filter(contains='=> running'), msg.format('run')
         assert not log_filter(contains='=> succeeded'), msg.format('succeed')
 
         # Release held task and assert that it now skips successfully:
         schd.pool.release_held_tasks(['1/one'])
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
 
         assert log_filter(contains='=> running'), msg.format('run')
         assert log_filter(contains='=> succeeded'), msg.format('succeed')

--- a/tests/integration/scripts/test_dump.py
+++ b/tests/integration/scripts/test_dump.py
@@ -46,7 +46,7 @@ async def test_dump_tasks(flow, scheduler, start):
     })
     schd = scheduler(id_)
     async with start(schd):
-        # schd.release_queued_tasks()
+        # schd.release_tasks_to_run()
         await schd.update_data_structure()
         ret = []
         await dump(

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -81,14 +81,11 @@ async def test_get_flow_nums(one: Scheduler, start):
         assert one.pool._get_flow_nums([FLOW_ALL]) == {1, 2}
 
 
-async def test_flow_assignment_set(
-    flow: 'Fixture',
-    scheduler: 'Fixture',
-    start: 'Fixture',
-    log_filter: Callable,
-    capture_submission: 'Fixture',
+@pytest.mark.parametrize('command', ['trigger', 'set'])
+async def test_flow_assignment(
+    flow, scheduler, start, command: str, log_filter: Callable
 ):
-    """Test flow assignment when setting tasks.
+    """Test flow assignment when triggering/setting tasks.
 
     Active tasks:
       By default keep existing flows, else merge with requested flows.
@@ -113,65 +110,53 @@ async def test_flow_assignment_set(
     }
     id_ = flow(conf)
     schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
-    async with start(schd) as log:
+    async with start(schd):
+        if command == 'set':
+            do_command: Callable = functools.partial(
+                schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
+            )
+        else:
+            do_command = schd.pool.force_trigger_tasks
 
-        # capture task submissions (prevents real submissions)
-        submitted_tasks = capture_submission(schd)
-
-        command = "set"
-        do_command = functools.partial(
-            schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
-        )
-  
-        # get active foo and bar (which is which doesn't matter)
-        # ("active" here means in the active task pool).
-        active_x, active_y = schd.pool.get_tasks()
-        schd.pool.merge_flows(active_y, schd.pool._get_flow_nums([FLOW_NEW]))
-        assert active_x.flow_nums == {1}
-        assert active_y.flow_nums == {1, 2}
+        active_a, active_b = schd.pool.get_tasks()
+        schd.pool.merge_flows(active_b, schd.pool._get_flow_nums([FLOW_NEW]))
+        assert active_a.flow_nums == {1}
+        assert active_b.flow_nums == {1, 2}
 
         # -----(1. Test active tasks)-----
 
-        # Note this also tests that setting prerequisites 
-
         # By default active tasks keep existing flow assignment.
-        do_command([active_x.identity], flow=[])
-        assert active_x.flow_nums == {1}
+        do_command([active_a.identity], flow=[])
+        assert active_a.flow_nums == {1}
 
         # Else merge existing flow with requested flows.
-        do_command([active_x.identity], flow=[FLOW_ALL])
-        assert active_x.flow_nums == {1, 2}
+        do_command([active_a.identity], flow=[FLOW_ALL])
+        assert active_a.flow_nums == {1, 2}
 
         # (no-flow is ignored for active tasks)
-        do_command([active_x.identity], flow=[FLOW_NONE])
-        assert active_x.flow_nums == {1, 2}
+        do_command([active_a.identity], flow=[FLOW_NONE])
+        assert active_a.flow_nums == {1, 2}
         assert log_filter(
             contains=(
-                f'[{active_x}] ignoring \'flow=none\' {command}: '
-                f'task already has {repr_flow_nums(active_x.flow_nums)}'
+                f'[{active_a}] ignoring \'flow=none\' {command}: '
+                f'task already has {repr_flow_nums(active_a.flow_nums)}'
             ),
             level=logging.ERROR
         )
 
-        do_command([active_x.identity], flow=[FLOW_NEW])
-        assert active_x.flow_nums == {1, 2, 3}
+        do_command([active_a.identity], flow=[FLOW_NEW])
+        assert active_a.flow_nums == {1, 2, 3}
 
         # -----(2. Test inactive tasks)-----
-        do_command = functools.partial(
-            schd.pool.set_prereqs_and_outputs, outputs=[], prereqs=['all']
-        )
+        if command == 'set':
+            do_command = functools.partial(
+                schd.pool.set_prereqs_and_outputs, outputs=[], prereqs=['all']
+            )
 
         # By default inactive tasks get all active flows.
         do_command(['1/a'], flow=[])
         assert schd.pool._get_task_by_id('1/a').flow_nums == {1, 2, 3}
 
-        # set --pre=all should not cause a task to submit in a paused workflow
-        assert len(submitted_tasks) == 0
-        # but triggering it should
-        schd.pool.force_trigger_tasks(['1/a'], [])
-        schd.release_tasks_to_run()
-        assert len(submitted_tasks) == 1
- 
         # Else assign requested flows.
         do_command(['1/b'], flow=[FLOW_NONE])
         assert schd.pool._get_task_by_id('1/b').flow_nums == set()
@@ -181,93 +166,5 @@ async def test_flow_assignment_set(
 
         do_command(['1/d'], flow=[FLOW_ALL])
         assert schd.pool._get_task_by_id('1/d').flow_nums == {1, 2, 3, 4}
-
         do_command(['1/e'], flow=[7])
-        assert schd.pool._get_task_by_id('1/e').flow_nums == {7}
-
-
-async def test_flow_assignment_trigger(
-    flow, scheduler, start, log_filter: Callable
-):
-    """Test flow assignment when triggering tasks.
-
-    Active tasks:
-      By default keep existing flows, else merge with requested flows.
-    Inactive tasks:
-      By default assign active flows; else assign requested flows.
-
-    Note this differs from the 'set' test above because triggering a
-    task once makes it active (even in a paused workflow) after which
-    additional triggers get ignored.
-
-    """
-    conf = {
-        'scheduler': {
-            'allow implicit tasks': 'True'
-        },
-        'scheduling': {
-            'graph': {
-                'R1': "foo & bar => a & b & c & d & e"
-            }
-        },
-        'runtime': {
-            'foo': {
-                'outputs': {'x': 'x'}
-            }
-        },
-    }
-    id_ = flow(conf)
-    schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
-    async with start(schd) as log:
-
-        command = 'trigger'
-        do_command = schd.pool.force_trigger_tasks
-
-        # get active foo and bar (which is which doesn't matter)
-        # ("active" here means in the active task pool).
-        active_x, active_y = schd.pool.get_tasks()
-        schd.pool.merge_flows(active_y, schd.pool._get_flow_nums([FLOW_NEW]))
-        assert active_x.flow_nums == {1}
-        assert active_y.flow_nums == {1, 2}
-
-        # -----(1. Test active tasks)-----
-
-        # By default active tasks keep existing flow assignment.
-        # This trigger makes the task literally active (submitted, running)
-        do_command([active_x.identity], flow=[])
-        schd.release_tasks_to_run()
-        assert active_x.flow_nums == {1}
-
-        # Triggering it again will be ignored (already active).
-        do_command([active_x.identity], flow=[FLOW_ALL])
-        schd.release_tasks_to_run()
-        assert active_x.flow_nums == {1}
-        assert log_filter(
-            contains=(
-                f'[{active_x}] ignoring trigger - already active'
-            ),
-            level=logging.ERROR
-        )
-
-        # -----(2. Test inactive tasks)-----
-        # By default inactive tasks get all active flows.
-        do_command(['1/a'], flow=[])
-        schd.release_tasks_to_run()
-        assert schd.pool._get_task_by_id('1/a').flow_nums == {1, 2}
-
-        # Else assign requested flows.
-        do_command(['1/b'], flow=[FLOW_NONE])
-        schd.release_tasks_to_run()
-        assert schd.pool._get_task_by_id('1/b').flow_nums == set()
-
-        do_command(['1/c'], flow=[FLOW_NEW])
-        schd.release_tasks_to_run()
-        assert schd.pool._get_task_by_id('1/c').flow_nums == {3}
-
-        do_command(['1/d'], flow=[FLOW_ALL])
-        schd.release_tasks_to_run()
-        assert schd.pool._get_task_by_id('1/d').flow_nums == {1, 2, 3}
-
-        do_command(['1/e'], flow=[7])
-        schd.release_tasks_to_run()
         assert schd.pool._get_task_by_id('1/e').flow_nums == {7}

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -81,11 +81,14 @@ async def test_get_flow_nums(one: Scheduler, start):
         assert one.pool._get_flow_nums([FLOW_ALL]) == {1, 2}
 
 
-@pytest.mark.parametrize('command', ['trigger', 'set'])
-async def test_flow_assignment(
-    flow, scheduler, start, command: str, log_filter: Callable
+async def test_flow_assignment_set(
+    flow: 'Fixture',
+    scheduler: 'Fixture',
+    start: 'Fixture',
+    log_filter: Callable,
+    capture_submission: 'Fixture',
 ):
-    """Test flow assignment when triggering/setting tasks.
+    """Test flow assignment when setting tasks.
 
     Active tasks:
       By default keep existing flows, else merge with requested flows.
@@ -110,53 +113,65 @@ async def test_flow_assignment(
     }
     id_ = flow(conf)
     schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
-    async with start(schd):
-        if command == 'set':
-            do_command: Callable = functools.partial(
-                schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
-            )
-        else:
-            do_command = schd.pool.force_trigger_tasks
+    async with start(schd) as log:
 
-        active_a, active_b = schd.pool.get_tasks()
-        schd.pool.merge_flows(active_b, schd.pool._get_flow_nums([FLOW_NEW]))
-        assert active_a.flow_nums == {1}
-        assert active_b.flow_nums == {1, 2}
+        # capture task submissions (prevents real submissions)
+        submitted_tasks = capture_submission(schd)
+
+        command = "set"
+        do_command = functools.partial(
+            schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
+        )
+  
+        # get active foo and bar (which is which doesn't matter)
+        # ("active" here means in the active task pool).
+        active_x, active_y = schd.pool.get_tasks()
+        schd.pool.merge_flows(active_y, schd.pool._get_flow_nums([FLOW_NEW]))
+        assert active_x.flow_nums == {1}
+        assert active_y.flow_nums == {1, 2}
 
         # -----(1. Test active tasks)-----
 
+        # Note this also tests that setting prerequisites 
+
         # By default active tasks keep existing flow assignment.
-        do_command([active_a.identity], flow=[])
-        assert active_a.flow_nums == {1}
+        do_command([active_x.identity], flow=[])
+        assert active_x.flow_nums == {1}
 
         # Else merge existing flow with requested flows.
-        do_command([active_a.identity], flow=[FLOW_ALL])
-        assert active_a.flow_nums == {1, 2}
+        do_command([active_x.identity], flow=[FLOW_ALL])
+        assert active_x.flow_nums == {1, 2}
 
         # (no-flow is ignored for active tasks)
-        do_command([active_a.identity], flow=[FLOW_NONE])
-        assert active_a.flow_nums == {1, 2}
+        do_command([active_x.identity], flow=[FLOW_NONE])
+        assert active_x.flow_nums == {1, 2}
         assert log_filter(
             contains=(
-                f'[{active_a}] ignoring \'flow=none\' {command}: '
-                f'task already has {repr_flow_nums(active_a.flow_nums)}'
+                f'[{active_x}] ignoring \'flow=none\' {command}: '
+                f'task already has {repr_flow_nums(active_x.flow_nums)}'
             ),
             level=logging.ERROR
         )
 
-        do_command([active_a.identity], flow=[FLOW_NEW])
-        assert active_a.flow_nums == {1, 2, 3}
+        do_command([active_x.identity], flow=[FLOW_NEW])
+        assert active_x.flow_nums == {1, 2, 3}
 
         # -----(2. Test inactive tasks)-----
-        if command == 'set':
-            do_command = functools.partial(
-                schd.pool.set_prereqs_and_outputs, outputs=[], prereqs=['all']
-            )
+        do_command = functools.partial(
+            schd.pool.set_prereqs_and_outputs, outputs=[], prereqs=['all']
+        )
 
         # By default inactive tasks get all active flows.
         do_command(['1/a'], flow=[])
         assert schd.pool._get_task_by_id('1/a').flow_nums == {1, 2, 3}
 
+        # set --pre=all should not cause a task to submit in a paused workflow
+        assert len(submitted_tasks) == 0
+        # but triggering it should
+        schd.pool.force_trigger_tasks(['1/a'], [])
+        schd.release_tasks_to_run()
+        assert len(submitted_tasks) == 1
+ 
         # Else assign requested flows.
         do_command(['1/b'], flow=[FLOW_NONE])
         assert schd.pool._get_task_by_id('1/b').flow_nums == set()
@@ -166,5 +181,93 @@ async def test_flow_assignment(
 
         do_command(['1/d'], flow=[FLOW_ALL])
         assert schd.pool._get_task_by_id('1/d').flow_nums == {1, 2, 3, 4}
+
         do_command(['1/e'], flow=[7])
+        assert schd.pool._get_task_by_id('1/e').flow_nums == {7}
+
+
+async def test_flow_assignment_trigger(
+    flow, scheduler, start, log_filter: Callable
+):
+    """Test flow assignment when triggering tasks.
+
+    Active tasks:
+      By default keep existing flows, else merge with requested flows.
+    Inactive tasks:
+      By default assign active flows; else assign requested flows.
+
+    Note this differs from the 'set' test above because triggering a
+    task once makes it active (even in a paused workflow) after which
+    additional triggers get ignored.
+
+    """
+    conf = {
+        'scheduler': {
+            'allow implicit tasks': 'True'
+        },
+        'scheduling': {
+            'graph': {
+                'R1': "foo & bar => a & b & c & d & e"
+            }
+        },
+        'runtime': {
+            'foo': {
+                'outputs': {'x': 'x'}
+            }
+        },
+    }
+    id_ = flow(conf)
+    schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
+    async with start(schd) as log:
+
+        command = 'trigger'
+        do_command = schd.pool.force_trigger_tasks
+
+        # get active foo and bar (which is which doesn't matter)
+        # ("active" here means in the active task pool).
+        active_x, active_y = schd.pool.get_tasks()
+        schd.pool.merge_flows(active_y, schd.pool._get_flow_nums([FLOW_NEW]))
+        assert active_x.flow_nums == {1}
+        assert active_y.flow_nums == {1, 2}
+
+        # -----(1. Test active tasks)-----
+
+        # By default active tasks keep existing flow assignment.
+        # This trigger makes the task literally active (submitted, running)
+        do_command([active_x.identity], flow=[])
+        schd.release_tasks_to_run()
+        assert active_x.flow_nums == {1}
+
+        # Triggering it again will be ignored (already active).
+        do_command([active_x.identity], flow=[FLOW_ALL])
+        schd.release_tasks_to_run()
+        assert active_x.flow_nums == {1}
+        assert log_filter(
+            contains=(
+                f'[{active_x}] ignoring trigger - already active'
+            ),
+            level=logging.ERROR
+        )
+
+        # -----(2. Test inactive tasks)-----
+        # By default inactive tasks get all active flows.
+        do_command(['1/a'], flow=[])
+        schd.release_tasks_to_run()
+        assert schd.pool._get_task_by_id('1/a').flow_nums == {1, 2}
+
+        # Else assign requested flows.
+        do_command(['1/b'], flow=[FLOW_NONE])
+        schd.release_tasks_to_run()
+        assert schd.pool._get_task_by_id('1/b').flow_nums == set()
+
+        do_command(['1/c'], flow=[FLOW_NEW])
+        schd.release_tasks_to_run()
+        assert schd.pool._get_task_by_id('1/c').flow_nums == {3}
+
+        do_command(['1/d'], flow=[FLOW_ALL])
+        schd.release_tasks_to_run()
+        assert schd.pool._get_task_by_id('1/d').flow_nums == {1, 2, 3}
+
+        do_command(['1/e'], flow=[7])
+        schd.release_tasks_to_run()
         assert schd.pool._get_task_by_id('1/e').flow_nums == {7}

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -37,9 +37,6 @@ async def test_trigger_workflow_paused(
 
     """
     id_ = flow({
-        'scheduler': {
-            'allow implicit tasks': True,
-        },
         'scheduling': {
             'queues': {
                 'default': {

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -1,0 +1,92 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import (
+    Any as Fixture,
+    Callable
+)
+
+import logging
+
+async def test_trigger_workflow_paused(
+    flow: 'Fixture',
+    scheduler: 'Fixture',
+    start: 'Fixture',
+    capture_submission: 'Fixture',
+    log_filter: Callable
+):
+    """
+    Test manual triggering when the workflow is paused.
+
+    The usual queue limiting behaviour is expected.
+
+    https://github.com/cylc/cylc-flow/issues/6192
+
+    """
+    id_ = flow({
+        'scheduler': {
+            'allow implicit tasks': True,
+        },
+        'scheduling': {
+            'queues': {
+                'default': {
+                    'limit': 1,
+                },
+            },
+            'graph': {
+                'R1': '''
+                    a => x & y & z
+                ''',
+            },
+        },
+    })
+    schd = scheduler(id_, paused_start=True)
+
+    # start the scheduler (but don't set the main loop running)
+    async with start(schd) as log:
+
+        # capture task submissions (prevents real submissions)
+        submitted_tasks = capture_submission(schd)
+
+        # paused at start-up so no tasks should be submitted
+        assert len(submitted_tasks) == 0
+
+        # manually trigger 1/x - it should be submitted
+        schd.pool.force_trigger_tasks(['1/x'], [1])
+        schd.release_tasks_to_run()
+        assert len(submitted_tasks) == 1
+
+        # manually trigger 1/y - it should not be queued but not submitted
+        # (queue limit reached)
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.release_tasks_to_run()
+        assert len(submitted_tasks) == 1
+
+        # manually trigger 1/y again - it should be submitted
+        # (triggering a queued task runs it)
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.release_tasks_to_run()
+        assert len(submitted_tasks) == 2
+
+        # manually trigger 1/y yet again - the trigger should be ignored
+        # (task already active)
+        schd.pool.force_trigger_tasks(['1/y'], [1])
+        schd.release_tasks_to_run()
+        assert len(submitted_tasks) == 2
+        assert log_filter(
+            level=logging.ERROR,
+            contains="ignoring trigger - already active"
+        )

--- a/tests/integration/test_optional_outputs.py
+++ b/tests/integration/test_optional_outputs.py
@@ -193,7 +193,7 @@ async def test_expire_orthogonality(flow, scheduler, start):
 
         # wait for the task to submit
         while not a_1.state(TASK_STATUS_WAITING, TASK_STATUS_PREPARING):
-            schd.release_queued_tasks()
+            schd.release_tasks_to_run()
 
         # NOTE: The submit number isn't presently incremented via this code
         # pathway so we have to hack it here. If the task messages in this test

--- a/tests/integration/test_queues.py
+++ b/tests/integration/test_queues.py
@@ -87,13 +87,13 @@ async def test_queue_release(
         # (if scheduler is paused we should not have any submissions)
         # (otherwise a number of tasks up to the limit should be released)
         schd.pool.release_runahead_tasks()
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == expected_submissions
 
         for _ in range(3):
             # release runahead/queued tasks
             # (no further tasks should be released)
-            schd.release_queued_tasks()
+            schd.release_tasks_to_run()
             assert len(submitted_tasks) == expected_submissions
 
 
@@ -125,7 +125,7 @@ async def test_queue_held_tasks(
 
         # release queued tasks
         # (no tasks should be released from the queues because they are held)
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 0
 
         # un-hold tasks
@@ -133,5 +133,5 @@ async def test_queue_held_tasks(
 
         # release queued tasks
         # (tasks should now be released from the queues)
-        schd.release_queued_tasks()
+        schd.release_tasks_to_run()
         assert len(submitted_tasks) == 1

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -91,8 +91,8 @@ def test_should_auto_restart_now(
     assert Scheduler.should_auto_restart_now(mock_schd) == expected
 
 
-def test_release_queued_tasks__auto_restart():
-    """Test that Scheduler.release_queued_tasks() works as expected
+def test_release_tasks_to_run__auto_restart():
+    """Test that Scheduler.release_tasks_to_run() works as expected
     during auto restart."""
     mock_schd = Mock(
         auto_restart_time=(time() - 100),
@@ -107,10 +107,12 @@ def test_release_queued_tasks__auto_restart():
         options=RunOptions(),
         task_job_mgr=MagicMock()
     )
-    Scheduler.release_queued_tasks(mock_schd)
+    Scheduler.release_tasks_to_run(mock_schd)
     # Should not actually release any more tasks, just submit the
     # preparing ones
     mock_schd.pool.release_queued_tasks.assert_not_called()
+
+    Scheduler.start_job_submission(mock_schd, mock_schd.pool.get_tasks())
     mock_schd.task_job_mgr.submit_task_jobs.assert_called()
 
 


### PR DESCRIPTION
Close #5963
Supesede #6192 (it was getting messy)
Close #6398

------

New behaviour for triggering when the workflow is paused

**DEFAULT: run triggered tasks NOW even if the workflow is paused**
  - supports the common use case *"I want to pause the workflow and just trigger individual tasks"*
  - (NIWA priority raised by both ops and research users in early Cylc 8 migration meetings)

**OPTION: `--on-resume` - run triggered tasks only when the paused workflow is resumed**
  - this supports [the broadcast-to-past-tasks workaround](https://github.com/cylc/cylc-flow/pull/6192#issuecomment-2486785465) until broadcast is fixed (prob. 8.5.0)
  - the option can be removed in the future, once broadcast is fixed, if there are no other use cases
  

-----

Implementation:
- separate start of job submission from queue release, in the scheduler
- manual trigger adds tasks to `tasks_to_trigger_(now|on_resume)` lists, after state reset and queue wrangling
- if these lists are populated, the scheduler will release tasks from them as appropriate
- (queues are not processed if the scheduler is paused)

-------

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/778
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
