### PR TITLE
`cylc set`: log warning when no outputs specified and task has no required outputs

### DIFF
--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -98,7 +98,8 @@ def filter_ids(
             * If IDTokens.Cycle all CyclePoints with any matching tasks will
               be returned.
         warn:
-            Whether to log a warning if no matching tasks are found.
+            Whether to log a warning if no matching tasks are found in the
+            pool.
 
     TODO:
         Consider using wcmatch which would add support for


### PR DESCRIPTION
```
R1 = a? => b
```
```
$ cylc set workflow//1/a
```
does nothing and currently produces no warning.

This change makes it log a warning.

https://cylc.discourse.group/t/cylc-set-for-a-task-with-multiple-outputs-doesnt-seem-to-do-anything/1074

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry needed as minor 
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
