### PR TITLE
Allow 'cylc reload' to reload global configuration

### DIFF
--- a/changes.d/6509.feat.md
+++ b/changes.d/6509.feat.md
@@ -1,1 +1,1 @@
-Added --global flag to 'cylc reload'
+Added --global flag to 'cylc reload' which also reloads the Cylc global config.

--- a/changes.d/6509.feat.md
+++ b/changes.d/6509.feat.md
@@ -1,0 +1,1 @@
+Added --global flag to 'cylc reload'

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -108,13 +108,6 @@ Settings for the scheduler.
 
    Not to be confused with :cylc:conf:`flow.cylc[scheduling]`.
 
-.. note::
-
-   The majority of scheduler settings affect the server and cannot be reloaded
-   with ``cylc reload --global``, the server must be stopped and restarted for
-   changes to take effect except for the sections `[mail]` and `[events]` which
-   provide workflow defaults.
-
 .. versionchanged:: 8.0.0
 
    {REPLACES}``[cylc]``
@@ -717,6 +710,20 @@ with Conf('global.cylc', desc='''
 
        The ``global.cylc`` file can be templated using Jinja2 variables.
        See :ref:`Jinja`.
+
+    .. note::
+
+       Most of the global settings can be changed while a workflow is running
+       using ``cylc reload --global``. Exceptions are:
+       
+       `[scheduler]`: The majority of these settings affect the server and
+       cannot be reloaded while the server is running. The server must be
+       stopped and restarted for changes to take effect except for the sections
+       `[scheduler][mail]` and `[scheduler][events]` which provide workflow
+       defaults.
+
+       `[install][symlink dirs]`: These settings create files on disk, once a
+       task has started on a remote host these can't be changed for that host.
 
     .. versionchanged:: 8.0.0
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -110,8 +110,10 @@ Settings for the scheduler.
 
 .. note::
 
-   Scheduler settings cannot be reloaded, the server must be stopped and
-   restarted for changes to take effect
+   The majority of scheduler settings affect the server and cannot be reloaded
+   with ``cylc reload --global``, the server must be stopped and restarted for
+   changes to take effect except for the sections [mail] and [events] which
+   provide workflow defaults.
 
 .. versionchanged:: 8.0.0
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -112,7 +112,7 @@ Settings for the scheduler.
 
    The majority of scheduler settings affect the server and cannot be reloaded
    with ``cylc reload --global``, the server must be stopped and restarted for
-   changes to take effect except for the sections [mail] and [events] which
+   changes to take effect except for the sections `[mail]` and `[events]` which
    provide workflow defaults.
 
 .. versionchanged:: 8.0.0

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -715,7 +715,7 @@ with Conf('global.cylc', desc='''
 
        Most of the global settings can be changed while a workflow is running
        using ``cylc reload --global``. Exceptions are:
-       
+
        `[scheduler]`: The majority of these settings affect the server and
        cannot be reloaded while the server is running. The server must be
        stopped and restarted for changes to take effect except for the sections

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -2087,6 +2087,11 @@ class GlobalConfig(ParsecConfig):
             LOG.error(f'bad {conf_type} {fname}')
             raise
 
+    @classmethod
+    def set_cache(cls, cfg: "GlobalConfig") -> None:
+        """Set the cached config"""
+        cls._DEFAULT = cfg
+
     def load(self) -> None:
         """Load configuration from files."""
         self.sparse.clear()

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -108,6 +108,11 @@ Settings for the scheduler.
 
    Not to be confused with :cylc:conf:`flow.cylc[scheduling]`.
 
+.. note::
+
+   Scheduler settings cannot be reloaded, the server must be stopped and
+   restarted for changes to take effect
+
 .. versionchanged:: 8.0.0
 
    {REPLACES}``[cylc]``
@@ -1216,6 +1221,11 @@ with Conf('global.cylc', desc='''
 
             Symlinks from the the standard ``$HOME/cylc-run`` locations will be
             created.
+
+            .. note::
+
+               Once a platform has been installed and symlinks created they
+               cannot be modified for that run.
 
             .. versionadded:: 8.0.0
         """):

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -364,7 +364,6 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
         # give commands time to complete
         sleep(1)  # give any remove-init's time to complete
 
-
     if reload_global:
         # Reload global config if requested
         LOG.info("Reloading the global configuration.")
@@ -383,7 +382,6 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
                 '\nOtherwise, fix the configuration and attempt to reload'
                 ' again.'
             )
-
 
     # reload the workflow definition
     schd.reload_pending = 'loading the workflow definition'

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -365,6 +365,9 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
         sleep(1)  # give any remove-init's time to complete
 
     try:
+        # Back up the current config in case workflow reload errors
+        global_cfg_old = glbl_cfg()
+
         if reload_global:
             # Reload global config if requested
             schd.reload_pending = 'reloading the global configuration'
@@ -372,8 +375,6 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
             await schd.update_data_structure()
             LOG.info("Reloading the global configuration.")
 
-            # Back up the current config in case workflow reload errors
-            global_cfg_old = glbl_cfg()
             glbl_cfg(reload=True)
 
         # reload the workflow definition

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -330,7 +330,7 @@ async def remove_tasks(
 
 
 @_command('reload_workflow')
-async def reload_workflow(schd: 'Scheduler', reload_global: bool):
+async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
     """Reload workflow configuration."""
     yield
     # pause the workflow if not already

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -367,6 +367,9 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
     if reload_global:
         # Reload global config if requested
         LOG.info("Reloading the global configuration.")
+        schd.reload_pending = 'reloading the global configuration'
+        schd.update_data_store()  # update workflow status msg
+        await schd.update_data_structure()
         try:
             glbl_cfg(reload=True)
         except (ParsecError, CylcConfigError) as exc:

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -85,10 +85,7 @@ from cylc.flow.network.schema import WorkflowStopMode
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.run_modes import RunMode
 from cylc.flow.task_id import TaskID
-from cylc.flow.workflow_status import (
-    RunMode,
-    StopMode,
-)
+from cylc.flow.workflow_status import StopMode
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1938,7 +1938,8 @@ class Reload(Mutation):
 
         reload_global = Boolean(
             default_value=False,
-            description="Also reload global config")
+            required=False,
+            description="Reload global config as well as the workflow config")
 
     result = GenericScalar()
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1936,6 +1936,10 @@ class Reload(Mutation):
     class Arguments:
         workflows = graphene.List(WorkflowID, required=True)
 
+        reload_global = Boolean(
+                default_value=False,
+                description="Also reload global config")
+
     result = GenericScalar()
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1937,8 +1937,8 @@ class Reload(Mutation):
         workflows = graphene.List(WorkflowID, required=True)
 
         reload_global = Boolean(
-                default_value=False,
-                description="Also reload global config")
+            default_value=False,
+            description="Also reload global config")
 
     result = GenericScalar()
 

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -60,11 +60,24 @@ from cylc.flow.network.multi import call_multi
 from cylc.flow.option_parsers import (
     WORKFLOW_ID_MULTI_ARG_DOC,
     CylcOptionParser as COP,
+    OptionSettings,
 )
 from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
     from optparse import Values
+
+
+RELOAD_OPTIONS = [
+    OptionSettings(
+        ['-g', '--global'],
+        help='also reload global configuration.',
+        action="store_true",
+        default=False,
+        dest="reload_global",
+        sources={'reload'}
+    ),
+]
 
 
 MUTATION = '''
@@ -89,11 +102,8 @@ def get_option_parser():
         multiworkflow=True,
         argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
-
-    parser.add_option(
-        "-g", "--global",
-        help="also reload global configuration.",
-        action="store_true", default=False, dest="reload_global")
+    for option in RELOAD_OPTIONS:
+        parser.add_option(*option.args, **option.kwargs)
 
     return parser
 

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -91,9 +91,9 @@ def get_option_parser():
     )
 
     parser.add_option(
-            "-g", "--global",
-            help="also reload global configuration.",
-            action="store_true", default=False, dest="reload_global")
+        "-g", "--global",
+        help="also reload global configuration.",
+        action="store_true", default=False, dest="reload_global")
 
     return parser
 

--- a/cylc/flow/scripts/reload.py
+++ b/cylc/flow/scripts/reload.py
@@ -69,10 +69,12 @@ if TYPE_CHECKING:
 
 MUTATION = '''
 mutation (
-  $wFlows: [WorkflowID]!
+  $wFlows: [WorkflowID]!,
+  $reloadGlobal: Boolean,
 ) {
   reload (
     workflows: $wFlows
+    reloadGlobal: $reloadGlobal
   ) {
     result
   }
@@ -87,6 +89,12 @@ def get_option_parser():
         multiworkflow=True,
         argdoc=[WORKFLOW_ID_MULTI_ARG_DOC],
     )
+
+    parser.add_option(
+            "-g", "--global",
+            help="also reload global configuration.",
+            action="store_true", default=False, dest="reload_global")
+
     return parser
 
 
@@ -97,6 +105,7 @@ async def run(options: 'Values', workflow_id: str):
         'request_string': MUTATION,
         'variables': {
             'wFlows': [workflow_id],
+            'reloadGlobal': options.reload_global,
         }
     }
 

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -73,6 +73,7 @@ from cylc.flow.scripts.reinstall import (
     reinstall_cli as cylc_reinstall,
 )
 from cylc.flow.scripts.reload import (
+    RELOAD_OPTIONS,
     run as cylc_reload
 )
 from cylc.flow.terminal import cli_function
@@ -86,6 +87,7 @@ VR_OPTIONS = combine_options(
     VALIDATE_OPTIONS,
     REINSTALL_OPTIONS,
     REINSTALL_CYLC_ROSE_OPTIONS,
+    RELOAD_OPTIONS,
     PLAY_OPTIONS,
     CYLC_ROSE_OPTIONS,
     modify={'cylc-rose': 'validate, install'}
@@ -102,6 +104,7 @@ def get_option_parser() -> COP:
     for option in VR_OPTIONS:
         parser.add_option(*option.args, **option.kwargs)
     parser.set_defaults(is_validate=True)
+
     return parser
 
 

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -347,6 +347,7 @@ class TaskProxy:
         reload_successor.summary = self.summary
         reload_successor.local_job_file_path = self.local_job_file_path
         reload_successor.try_timers = self.try_timers
+        reload_successor.platform = self.platform
         reload_successor.job_vacated = self.job_vacated
         reload_successor.poll_timer = self.poll_timer
         reload_successor.timeout = self.timeout

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -347,7 +347,6 @@ class TaskProxy:
         reload_successor.summary = self.summary
         reload_successor.local_job_file_path = self.local_job_file_path
         reload_successor.try_timers = self.try_timers
-        reload_successor.platform = self.platform
         reload_successor.job_vacated = self.job_vacated
         reload_successor.poll_timer = self.poll_timer
         reload_successor.timeout = self.timeout

--- a/tests/functional/reload/29-global.t
+++ b/tests/functional/reload/29-global.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test reloading global configuration
+. "$(dirname "$0")/test_header"
+set_test_number 9
+
+create_test_global_config "" ""
+
+TEST_NAME="${TEST_NAME_BASE}"
+install_workflow "${TEST_NAME}" "${TEST_NAME_BASE}"
+
+# Validate the config
+run_ok "${TEST_NAME}-validate" cylc validate "${WORKFLOW_NAME}"
+
+# Run the workflow
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach -v
+
+# Reload happened
+grep_ok "Reloading the global configuration" "${WORKFLOW_RUN_DIR}/log/scheduler/01-start-01.log"
+
+# Reload hasn't happened in job a, has happened in b and c
+grep_fail "global init-script reloaded!" "${WORKFLOW_RUN_DIR}/log/job/1/a/01/job.out"
+grep_ok "global init-script reloaded!" "${WORKFLOW_RUN_DIR}/log/job/1/b/01/job.out"
+grep_ok "global init-script reloaded!" "${WORKFLOW_RUN_DIR}/log/job/1/c/01/job.out"
+
+# Events are original in job a, updated in b and c
+grep_fail "!!EVENT!! succeeded 1/a" "${WORKFLOW_RUN_DIR}/log/scheduler/01-start-01.log"
+grep_ok "!!EVENT!! succeeded 1/b" "${WORKFLOW_RUN_DIR}/log/scheduler/01-start-01.log"
+grep_ok "!!EVENT!! succeeded 1/c" "${WORKFLOW_RUN_DIR}/log/scheduler/01-start-01.log"
+
+purge
+exit

--- a/tests/functional/reload/29-global/flow.cylc
+++ b/tests/functional/reload/29-global/flow.cylc
@@ -1,0 +1,30 @@
+[scheduling]
+    cycling mode = integer
+    [[graph]]
+        R1 = a => reload-global => b & c
+[runtime]
+    [[root]]
+        script = true
+    [[a,b]]
+        platform = localhost
+    [[c]]
+        platform = $CYLC_TEST_PLATFORM
+    [[reload-global]]
+        platform = localhost
+        script = """
+            # Append to global config
+            cat >> "$CYLC_CONF_PATH/global.cylc" <<EOF 
+                [platforms]
+                    [[localhost,${CYLC_TEST_PLATFORM}]]
+                        global init-script = echo "global init-script reloaded!"
+                [task events]
+                    handlers = echo "!!EVENT!! %(event)s %(id)s"
+                    handler events = succeeded
+EOF
+
+            # Log the new config
+            cylc config
+
+            # Reload the global config
+            cylc reload --global "${CYLC_WORKFLOW_ID}"
+            """

--- a/tests/functional/reload/30-global-rollback.t
+++ b/tests/functional/reload/30-global-rollback.t
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test reloading global configuration
+. "$(dirname "$0")/test_header"
+set_test_number 6
+
+create_test_global_config "" ""
+
+TEST_NAME="${TEST_NAME_BASE}"
+install_workflow "${TEST_NAME}" "${TEST_NAME_BASE}"
+
+# Validate the config
+run_ok "${TEST_NAME}-validate" cylc validate "${WORKFLOW_NAME}"
+
+# Run the workflow
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}" --no-detach -v
+
+# Reload happened
+grep_ok "Reloading the global configuration" "${WORKFLOW_RUN_DIR}/log/scheduler/01-start-01.log"
+
+# But there was an error in the workflow config, so the change rolled back
+grep_ok "Reload failed - IllegalItemError: garbage" "${WORKFLOW_RUN_DIR}/log/scheduler/log"
+
+# Reload has rolled back in all tasks
+grep_fail "global init-script reloaded!" "${WORKFLOW_RUN_DIR}/log/job/1/b/01/job.out"
+grep_fail "global init-script reloaded!" "${WORKFLOW_RUN_DIR}/log/job/1/c/01/job.out"
+
+purge
+exit

--- a/tests/functional/reload/30-global-rollback/flow.cylc
+++ b/tests/functional/reload/30-global-rollback/flow.cylc
@@ -1,0 +1,31 @@
+[scheduling]
+    cycling mode = integer
+    [[graph]]
+        R1 = """
+            a => reload-global-error-workflow? => b & c
+            """
+[runtime]
+    [[root]]
+        script = true
+    [[a,b]]
+        platform = localhost
+    [[c]]
+        platform = $CYLC_TEST_PLATFORM
+    [[reload-global-error-workflow]]
+        platform = localhost
+        script = """
+            # Append to global config
+            cat >> "$CYLC_CONF_PATH/global.cylc" <<EOF 
+                [platforms]
+                    [[localhost,${CYLC_TEST_PLATFORM}]]
+                        global init-script = echo "global init-script reloaded!"
+EOF
+
+            # Append to workflow config, with an error
+            cat >> "$CYLC_WORKFLOW_RUN_DIR/flow.cylc" <<EOF
+                [garbage-workflow]
+EOF
+
+            # Reload the global config - should fail reloading the workflow and roll back
+            cylc reload --global "${CYLC_WORKFLOW_ID}"
+            """

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -173,7 +173,7 @@ async def test_reload_global(
 
     id_ = flow(one_conf)
     schd = scheduler(id_)
-    async with start(schd) as log:
+    async with start(schd):
 
         # Modify the global config file
         global_config_path.write_text("""
@@ -184,11 +184,10 @@ async def test_reload_global(
         """)
 
         # reload the workflow and global config
-        await commands.run_cmd(commands.reload_workflow, schd, reload_global=True)
+        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
 
         # Global config should have been reloaded
         assert log_filter(
-            log,
             contains=(
                 'Reloading the global configuration.'
             )
@@ -206,11 +205,10 @@ async def test_reload_global(
         """)
 
         # reload the workflow and global config
-        await commands.run_cmd(commands.reload_workflow, schd, reload_global=True)
+        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
 
         # Error is noted in the log
         assert log_filter(
-            log,
             contains=(
                 'This is probably due to an issue with the new configuration.'
             )

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -159,8 +159,7 @@ async def test_reload_global_platform(
     log_filter,
     tmp_path,
     monkeypatch,
-    ):
-
+):
     global_config_path = tmp_path / 'global.cylc'
     monkeypatch.setenv("CYLC_CONF_PATH", str(global_config_path.parent))
 
@@ -172,13 +171,15 @@ async def test_reload_global_platform(
                 x = 1
     """)
     glbl_cfg(reload=True)
-    assert glbl_cfg().get(['platforms','localhost','meta','x']) == '1'
+    assert glbl_cfg().get(['platforms', 'localhost', 'meta', 'x']) == '1'
 
     id_ = flow(one_conf)
     schd = scheduler(id_)
     async with start(schd):
         # Task platforms reflect the original config
-        rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
+        rtconf = schd.broadcast_mgr.get_updated_rtconfig(
+            schd.pool.get_tasks()[0]
+        )
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '1'
 
@@ -191,17 +192,17 @@ async def test_reload_global_platform(
         """)
 
         # reload the workflow and global config
-        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
-
-        # Global config should have been reloaded
-        assert log_filter(
-            contains=(
-                'Reloading the global configuration.'
-            )
+        await commands.run_cmd(
+            commands.reload_workflow(schd, reload_global=True)
         )
 
+        # Global config should have been reloaded
+        assert log_filter(contains=('Reloading the global configuration.'))
+
         # Task platforms reflect the new config
-        rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
+        rtconf = schd.broadcast_mgr.get_updated_rtconfig(
+            schd.pool.get_tasks()[0]
+        )
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '2'
 
@@ -215,7 +216,9 @@ async def test_reload_global_platform(
         """)
 
         # reload the workflow and global config
-        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
+        await commands.run_cmd(
+            commands.reload_workflow(schd, reload_global=True)
+        )
 
         # Error is noted in the log
         assert log_filter(
@@ -225,18 +228,21 @@ async def test_reload_global_platform(
         )
 
         # Task platforms should be the last valid value
-        rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
+        rtconf = schd.broadcast_mgr.get_updated_rtconfig(
+            schd.pool.get_tasks()[0]
+        )
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '2'
 
         # reload the workflow in verbose mode
         flags.verbosity = 2
-        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
-
-        # Traceback is shown in the log (match for ERROR, trace is not captured)
-        assert log_filter(
-            exact_match = 'ERROR'
+        await commands.run_cmd(
+            commands.reload_workflow(schd, reload_global=True)
         )
+
+        # Traceback is shown in the log
+        # (match for ERROR, trace is not captured)
+        assert log_filter(exact_match='ERROR')
 
 
 async def test_reload_global_platform_group(
@@ -246,8 +252,7 @@ async def test_reload_global_platform_group(
     log_filter,
     tmp_path,
     monkeypatch,
-    ):
-
+):
     global_config_path = tmp_path / 'global.cylc'
     monkeypatch.setenv("CYLC_CONF_PATH", str(global_config_path.parent))
 
@@ -265,14 +270,8 @@ async def test_reload_global_platform_group(
 
     # Task using the platform group
     conf = {
-        'scheduler': {
-            'allow implicit tasks': True
-        },
-        'scheduling': {
-            'graph': {
-                'R1': 'one'
-            }
-        },
+        'scheduler': {'allow implicit tasks': True},
+        'scheduling': {'graph': {'R1': 'one'}},
         'runtime': {
             'one': {
                 'platform': 'pg',
@@ -284,7 +283,9 @@ async def test_reload_global_platform_group(
     schd = scheduler(id_)
     async with start(schd):
         # Task platforms reflect the original config
-        rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
+        rtconf = schd.broadcast_mgr.get_updated_rtconfig(
+            schd.pool.get_tasks()[0]
+        )
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '1'
 
@@ -300,16 +301,16 @@ async def test_reload_global_platform_group(
         """)
 
         # reload the workflow and global config
-        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
-
-        # Global config should have been reloaded
-        assert log_filter(
-            contains=(
-                'Reloading the global configuration.'
-            )
+        await commands.run_cmd(
+            commands.reload_workflow(schd, reload_global=True)
         )
 
+        # Global config should have been reloaded
+        assert log_filter(contains=('Reloading the global configuration.'))
+
         # Task platforms reflect the new config
-        rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
+        rtconf = schd.broadcast_mgr.get_updated_rtconfig(
+            schd.pool.get_tasks()[0]
+        )
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '2'

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -26,6 +26,7 @@ from cylc.flow.task_state import (
 )
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.platforms import get_platform
+from cylc.flow import flags
 
 
 async def test_reload_waits_for_pending_tasks(
@@ -226,3 +227,12 @@ async def test_reload_global(
         rtconf = schd.broadcast_mgr.get_updated_rtconfig(schd.pool.get_tasks()[0])
         platform = get_platform(rtconf)
         assert platform['meta']['x'] == '2'
+
+        # reload the workflow in verbose mode
+        flags.verbosity = 2
+        await commands.run_cmd(commands.reload_workflow(schd, reload_global=True))
+
+        # Traceback is shown in the log (match for ERROR, trace is not captured)
+        assert log_filter(
+            exact_match = 'ERROR'
+        )

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -169,7 +169,7 @@ async def test_reload_global(
             [[[meta]]]
                 x = 1
     """)
-    assert glbl_cfg().get(['platforms','localhost','meta','x']) == '1'
+    assert glbl_cfg(reload=True).get(['platforms','localhost','meta','x']) == '1'
 
     # Modify the global config file
     global_config_path.write_text("""

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -181,9 +181,10 @@ def test_platform_ssh_forward_variables(mock_global_config):
         ['platforms', 'foo', 'ssh forward environment variables']
     ) == ["FOO", "BAR"]
 
+
 def test_reload(mock_global_config, tmp_path):
     # Load a config
-    glblcfg: GlobalConfig = mock_global_config(f'''
+    glblcfg: GlobalConfig = mock_global_config('''
     [platforms]
         [[foo]]
             [[[meta]]]
@@ -200,9 +201,10 @@ def test_reload(mock_global_config, tmp_path):
     ''')
     glblcfg.load()
 
-    assert glblcfg.get(['platforms','foo','meta','x']) == '2'
+    assert glblcfg.get(['platforms', 'foo', 'meta', 'x']) == '2'
 
     from cylc.flow.platforms import get_platform
+
     platform = get_platform("foo")
 
     assert platform['meta']['x'] == "2"

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -180,3 +180,29 @@ def test_platform_ssh_forward_variables(mock_global_config):
     assert glblcfg.get(
         ['platforms', 'foo', 'ssh forward environment variables']
     ) == ["FOO", "BAR"]
+
+def test_reload(mock_global_config, tmp_path):
+    # Load a config
+    glblcfg: GlobalConfig = mock_global_config(f'''
+    [platforms]
+        [[foo]]
+            [[[meta]]]
+                x = 1
+    ''')
+
+    # Update the global config file and reload
+    conf_path = tmp_path / GlobalConfig.CONF_BASENAME
+    conf_path.write_text('''
+    [platforms]
+        [[foo]]
+            [[[meta]]]
+                x = 2
+    ''')
+    glblcfg.load()
+
+    assert glblcfg.get(['platforms','foo','meta','x']) == '2'
+
+    from cylc.flow.platforms import get_platform
+    platform = get_platform("foo")
+
+    assert platform['meta']['x'] == "2"

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -22,7 +22,6 @@ import pytest
 from cylc.flow.cfgspec.globalcfg import GlobalConfig, SPEC
 from cylc.flow.parsec.exceptions import ValidationError
 from cylc.flow.parsec.validate import cylc_config_validate
-from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
 
 if TYPE_CHECKING:
@@ -183,7 +182,9 @@ def test_platform_ssh_forward_variables(mock_global_config):
     ) == ["FOO", "BAR"]
 
 
-def test_reload(mock_global_config, tmp_path: 'Path', monkeypatch: pytest.MonkeyPatch):
+def test_reload(
+    mock_global_config, tmp_path: 'Path', monkeypatch: pytest.MonkeyPatch
+):
     # Load a config
     glblcfg: GlobalConfig = mock_global_config('''
     [platforms]
@@ -203,7 +204,7 @@ def test_reload(mock_global_config, tmp_path: 'Path', monkeypatch: pytest.Monkey
     glblcfg.load()
 
     # Mock the global config singleton
-    monkeypatch.setattr(glbl_cfg, "__call__", lambda *a,**kw: glblcfg)
+    monkeypatch.setattr(GlobalConfig, "get_inst", lambda *a, **k: glblcfg)
 
     assert glblcfg.get(['platforms', 'foo', 'meta', 'x']) == '2'
 

--- a/tests/unit/cfgspec/test_globalcfg.py
+++ b/tests/unit/cfgspec/test_globalcfg.py
@@ -22,6 +22,7 @@ import pytest
 from cylc.flow.cfgspec.globalcfg import GlobalConfig, SPEC
 from cylc.flow.parsec.exceptions import ValidationError
 from cylc.flow.parsec.validate import cylc_config_validate
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
 
 if TYPE_CHECKING:
@@ -182,7 +183,7 @@ def test_platform_ssh_forward_variables(mock_global_config):
     ) == ["FOO", "BAR"]
 
 
-def test_reload(mock_global_config, tmp_path):
+def test_reload(mock_global_config, tmp_path: 'Path', monkeypatch: pytest.MonkeyPatch):
     # Load a config
     glblcfg: GlobalConfig = mock_global_config('''
     [platforms]
@@ -200,6 +201,9 @@ def test_reload(mock_global_config, tmp_path):
                 x = 2
     ''')
     glblcfg.load()
+
+    # Mock the global config singleton
+    monkeypatch.setattr(glbl_cfg, "__call__", lambda *a,**kw: glblcfg)
 
     assert glblcfg.get(['platforms', 'foo', 'meta', 'x']) == '2'
 


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

Add a `--global` flag to `cylc reload` that will reload the server's global configuration when set. This can be used to update platform definitions while a workflow is running.

Note that:
* Most changes to the `[scheduler]` section (ports, process pool size, etc.) require a server restart to take effect.
* Already installed platforms cannot have their symlink paths changed.
* Some changes to platforms (such as changing the hosts) may prevent Cylc from communicating with existing jobs (through polls, kill etc.).

Closes #3762

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/815
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
