### PR TITLE
remove: enable command for stopping workflows

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2161,7 +2161,7 @@ class Remove(Mutation, TaskMutation):
         description = sstrip('''
             Remove one or more task instances from a running workflow.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = partial(mutator, command='remove_tasks')
 


### PR DESCRIPTION
* A documented use case for `cylc remove` is "orphaning" stuck submissions, e.g. jobs that we can no longer poll or kill due to platform or network issues.
* It is conceivable that we might need to do this whilst a workflow is shutting down

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.