### PR TITLE
Fix KeyError when using `cylc remove` after a reload changed the graph

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1543,7 +1543,7 @@ class WorkflowConfig:
                         "script cannot be defined for automatic" +
                         " workflow polling task '%s':\n%s" % (l_task, cs))
         # Generate the automatic scripting.
-        for name, tdef in list(self.taskdefs.items()):
+        for name, tdef in self.taskdefs.items():
             if name not in self.workflow_polling_tasks:
                 continue
             rtc = tdef.rtconfig

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -70,7 +70,6 @@ from cylc.flow import (
 from cylc.flow.broadcast_mgr import BroadcastMgr
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.config import WorkflowConfig
-from cylc.flow.cycling.loader import get_point
 from cylc.flow.data_store_mgr import DataStoreMgr
 from cylc.flow.exceptions import (
     CommandFailedError,
@@ -93,9 +92,7 @@ from cylc.flow.hostuserutil import (
     get_user,
     is_remote_platform,
 )
-from cylc.flow.id import (
-    Tokens,
-)
+from cylc.flow.id import Tokens, quick_relative_id
 from cylc.flow.log_level import (
     verbosity_to_env,
     verbosity_to_opts,
@@ -1102,17 +1099,20 @@ class Scheduler:
 
         if flow_nums is None:
             flow_nums = set()
-        # Mapping of *relative* task IDs to removed flow numbers:
-        removed: Dict[Tokens, FlowNums] = {}
-        not_removed: Set[Tokens] = set()
+        # Mapping of relative task IDs to removed flow numbers:
+        removed: Dict[str, FlowNums] = {}
+        not_removed: Set[str] = set()
+        # All the matched tasks (will add applicable active tasks below):
+        matched_tasks = inactive.copy()
         to_kill: List[TaskProxy] = []
 
         for itask in active:
             fnums_to_remove = itask.match_flows(flow_nums)
             if not fnums_to_remove:
-                not_removed.add(itask.tokens.task)
+                not_removed.add(itask.identity)
                 continue
-            removed[itask.tokens.task] = fnums_to_remove
+            removed[itask.identity] = fnums_to_remove
+            matched_tasks.add((itask.tdef, itask.point))
             if fnums_to_remove == itask.flow_nums:
                 # Need to remove the task from the pool.
                 # Spawn next occurrence of xtrigger sequential task (otherwise
@@ -1123,21 +1123,13 @@ class Scheduler:
                 itask.removed = True
             itask.flow_nums.difference_update(fnums_to_remove)
 
-        # All the matched tasks (including inactive & applicable active tasks):
-        matched_tasks = {
-            *removed.keys(),
-            *(Tokens(cycle=str(cycle), task=task) for task, cycle in inactive),
-        }
-
-        for tokens in matched_tasks:
-            tdef = self.config.taskdefs[tokens['task']]
+        for tdef, point in matched_tasks:
+            task_id = quick_relative_id(point, tdef.name)
 
             # Go through any tasks downstream of this matched task to see if
             # any need to stand down as a result of this task being removed:
             for child in set(itertools.chain.from_iterable(
-                generate_graph_children(
-                    tdef, get_point(tokens['cycle'])
-                ).values()
+                generate_graph_children(tdef, point).values()
             )):
                 child_itask = self.pool.get_task(child.point, child.name)
                 if not child_itask:
@@ -1152,9 +1144,9 @@ class Scheduler:
                 ):
                     # Unset any prereqs naturally satisfied by these tasks
                     # (do not unset those satisfied by `cylc set --pre`):
-                    if prereq.unset_naturally_satisfied(tokens.relative_id):
+                    if prereq.unset_naturally_satisfied(task_id):
                         prereqs_changed = True
-                        removed.setdefault(tokens, set()).update(
+                        removed.setdefault(task_id, set()).update(
                             fnums_to_remove
                         )
                 if not prereqs_changed:
@@ -1173,7 +1165,7 @@ class Scheduler:
                 # Check if downstream task should remain spawned:
                 if (
                     # Ignoring tasks we are already dealing with:
-                    child_itask.tokens.task in matched_tasks
+                    (child_itask.tdef, child_itask.point) in matched_tasks
                     or child_itask.state.any_satisfied_prerequisite_outputs()
                 ):
                     continue
@@ -1187,10 +1179,13 @@ class Scheduler:
 
             # Remove the matched tasks from the flows in the DB tables:
             db_removed_fnums = self.workflow_db_mgr.remove_task_from_flows(
-                tokens['cycle'], tokens['task'], flow_nums,
+                str(point), tdef.name, flow_nums,
             )
             if db_removed_fnums:
-                removed.setdefault(tokens, set()).update(db_removed_fnums)
+                removed.setdefault(task_id, set()).update(db_removed_fnums)
+
+            if task_id not in removed:
+                not_removed.add(task_id)
 
         if to_kill:
             self.kill_tasks(to_kill, warn=False)
@@ -1198,22 +1193,17 @@ class Scheduler:
         if removed:
             tasks_str_list = []
             for task, fnums in removed.items():
-                self.data_store_mgr.delta_remove_task_flow_nums(
-                    task.relative_id, fnums
-                )
+                self.data_store_mgr.delta_remove_task_flow_nums(task, fnums)
                 tasks_str_list.append(
-                    f"{task.relative_id} {repr_flow_nums(fnums, full=True)}"
+                    f"{task} {repr_flow_nums(fnums, full=True)}"
                 )
             LOG.info(f"Removed task(s): {', '.join(sorted(tasks_str_list))}")
 
-        not_removed.update(matched_tasks.difference(removed))
         if not_removed:
             fnums_str = (
                 repr_flow_nums(flow_nums, full=True) if flow_nums else ''
             )
-            tasks_str = ', '.join(
-                sorted(tokens.relative_id for tokens in not_removed)
-            )
+            tasks_str = ', '.join(sorted(not_removed))
             LOG.warning(f"Task(s) not removable: {tasks_str} {fnums_str}")
 
         if removed and self.pool.compute_runahead():

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -165,7 +165,7 @@ class TaskDef:
     def __init__(self, name, rtcfg, start_point, initial_point):
         if not TaskID.is_valid_name(name):
             raise TaskDefError("Illegal task name: %s" % name)
-
+        self.name: str = name
         self.rtconfig = rtcfg
         self.start_point = start_point
         self.initial_point = initial_point
@@ -192,7 +192,6 @@ class TaskDef:
         self.external_triggers = []
         self.xtrig_labels = {}  # {sequence: [labels]}
 
-        self.name = name
         self.elapsed_times = deque(maxlen=self.MAX_LEN_ELAPSED_TIMES)
         self._add_std_outputs()
         self.has_abs_triggers = False

--- a/cylc/flow/workflow_db_mgr.py
+++ b/cylc/flow/workflow_db_mgr.py
@@ -698,7 +698,7 @@ class WorkflowDatabaseManager:
         self, table_name: str, itask: 'TaskProxy', set_args: 'DbArgDict'
     ) -> None:
         """Put UPDATE statement for a task_* table."""
-        where_args = {
+        where_args: Dict[str, Any] = {
             "cycle": str(itask.point),
             "name": itask.tdef.name,
         }

--- a/tests/integration/test_optional_outputs.py
+++ b/tests/integration/test_optional_outputs.py
@@ -41,7 +41,6 @@ from cylc.flow.task_outputs import (
     get_completion_expression,
 )
 from cylc.flow.task_state import (
-    TASK_STATUSES_ACTIVE,
     TASK_STATUS_EXPIRED,
     TASK_STATUS_PREPARING,
     TASK_STATUS_RUNNING,
@@ -484,7 +483,7 @@ async def test_removed_taskdef(
                 'R1': 'a'
             }
         }
-    }, id_=id_)
+    }, workflow_id=id_)
 
     # restart the workflow
     schd: 'Scheduler' = scheduler(id_)

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -130,7 +130,7 @@ async def test_reload_failure(
     async with start(schd):
         # corrupt the config by removing the scheduling section
         two_conf = {**one_conf, 'scheduling': {}}
-        flow(two_conf, id_=id_)
+        flow(two_conf, workflow_id=id_)
 
         # reload the workflow
         await commands.run_cmd(commands.reload_workflow(schd))

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -20,6 +20,7 @@ import pytest
 
 from cylc.flow.commands import (
     force_trigger_tasks,
+    reload_workflow,
     remove_tasks,
     run_cmd,
 )
@@ -478,3 +479,37 @@ async def test_kill_running(flow, scheduler, run, complete, reflog):
         ('1/c', ('1/b',)),
         # The a:failed output should not cause 1/q to run
     }
+
+
+async def test_reload_changed_config(flow, scheduler, run, complete):
+    """Test that a task is removed from the pool if its configuration changes
+    to make it no longer match the graph."""
+    wid = flow({
+        'scheduling': {
+            'graph': {
+                'R1': '''
+                    a => b
+                    a:started => s & b
+                ''',
+            },
+        },
+        'runtime': {
+            'a': {
+                'simulation': {
+                    # Ensure 1/a still in pool during reload
+                    'fail cycle points': 'all',
+                },
+            },
+        },
+    })
+    schd: Scheduler = scheduler(wid, paused_start=False)
+    async with run(schd):
+        await complete(schd, '1/s')
+        # Change graph then reload
+        flow('b', workflow_id=wid)
+        await run_cmd(reload_workflow(schd))
+        assert schd.config.cfg['scheduling']['graph']['R1'] == 'b'
+        assert schd.pool.get_task_ids() == {'1/a', '1/b'}
+
+        await run_cmd(remove_tasks(schd, ['1/a'], [FLOW_ALL]))
+        await complete(schd, '1/b')

--- a/tests/integration/test_stop_after_cycle_point.py
+++ b/tests/integration/test_stop_after_cycle_point.py
@@ -85,7 +85,7 @@ async def test_stop_after_cycle_point(
 
     # change the configured cycle point to "2"
     config['scheduling']['stop after cycle point'] = '2'
-    id_ = flow(config, id_=id_)
+    id_ = flow(config, workflow_id=id_)
     schd = scheduler(id_, paused_start=False)
     async with run(schd):
         # the cycle point should be reloaded from the workflow configuration

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -714,7 +714,7 @@ async def test_restart_prereqs(
 
     # Edit the workflow to add a new dependency on "z"
     conf['scheduling']['graph']['R1'] = graph_2
-    id_ = flow(conf, id_=id_)
+    id_ = flow(conf, workflow_id=id_)
 
     # Restart it
     schd = scheduler(id_, run_mode='simulation', paused_start=False)
@@ -834,7 +834,7 @@ async def test_reload_prereqs(
 
         # Modify flow.cylc to add a new dependency on "z"
         conf['scheduling']['graph']['R1'] = graph_2
-        flow(conf, id_=id_)
+        flow(conf, workflow_id=id_)
 
         # Reload the workflow config
         await commands.run_cmd(commands.reload_workflow(schd))
@@ -953,7 +953,7 @@ async def test_graph_change_prereq_satisfaction(
 
         # shutdown and change the workflow definiton
         conf['scheduling']['graph']['R1'] += '\nb => c'
-        flow(conf, id_=id_)
+        flow(conf, workflow_id=id_)
         schd = scheduler(id_, run_mode='simulation', paused_start=False)
 
         async with start(schd):
@@ -966,7 +966,7 @@ async def test_graph_change_prereq_satisfaction(
 
             # Modify flow.cylc to add a new dependency on "b"
             conf['scheduling']['graph']['R1'] += '\nb => c'
-            flow(conf, id_=id_)
+            flow(conf, workflow_id=id_)
 
             # Reload the workflow config
             await commands.run_cmd(commands.reload_workflow(schd))
@@ -2158,7 +2158,7 @@ async def test_reload_xtriggers(flow, scheduler, start):
         ].replace('@a', '@c')
 
         # reload
-        flow(config, id_=id_)
+        flow(config, workflow_id=id_)
         await commands.run_cmd(commands.reload_workflow(schd))
 
         # check xtrigs post-reload

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -31,7 +31,6 @@ from typing import Any, Optional, Union
 from secrets import token_hex
 
 from cylc.flow import CYLC_LOG
-from cylc.flow.run_modes import RunMode
 from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.scheduler import Scheduler, SchedulerStop
 from cylc.flow.scheduler_cli import RunOptions
@@ -56,7 +55,7 @@ def _make_flow(
     test_dir: Path,
     conf: Union[dict, str],
     name: Optional[str] = None,
-    id_: Optional[str] = None,
+    workflow_id: Optional[str] = None,
     defaults: Optional[bool] = True,
     filename: str = WorkflowFiles.FLOW_FILE,
 ) -> str:
@@ -70,14 +69,14 @@ def _make_flow(
 
             Set false for Cylc 7 upgrader tests.
     """
-    if id_:
-        flow_run_dir = (cylc_run_dir / id_)
+    if workflow_id:
+        flow_run_dir = (cylc_run_dir / workflow_id)
     else:
         if name is None:
             name = token_hex(4)
         flow_run_dir = (test_dir / name)
     flow_run_dir.mkdir(parents=True, exist_ok=True)
-    id_ = str(flow_run_dir.relative_to(cylc_run_dir))
+    workflow_id = str(flow_run_dir.relative_to(cylc_run_dir))
     if isinstance(conf, str):
         conf = {
             'scheduling': {
@@ -100,7 +99,7 @@ def _make_flow(
 
     with open((flow_run_dir / filename), 'w+') as flow_file:
         flow_file.write(flow_config_str(conf))
-    return id_
+    return workflow_id
 
 
 @contextmanager


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/6502

Unreleased bug. To reproduce:
1. Start a workflow `a & a:started => b` where `a` is either a long running task or is set to fail
2. Change the graph to just `b` and reload the workflow
3. Do `cylc remove a`
4. This results in a `KeyError` which crashes the scheduler

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] No changelog entry needed as unreleased bug
- [x] No docs needed
- [x] Master branch is correct
