### PR TITLE
GH Actions: automatically use latest `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/2_auto_publish_release.yml
+++ b/.github/workflows/2_auto_publish_release.yml
@@ -38,7 +38,7 @@ jobs:
       uses: cylc/release-actions/build-python-package@v1
 
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__ # uses the API token feature of PyPI - least permissions possible
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository_owner == 'cylc' || github.event_name != 'schedule'
     uses: cylc/release-actions/.github/workflows/branch-sync.yml@v1
     with:
       head_branch: ${{ inputs.head_branch }}

--- a/.github/workflows/test_conda-build.yml
+++ b/.github/workflows/test_conda-build.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test_conda_install:
+    if: github.repository_owner == 'cylc' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This will avoid the need for dependabot PRs