### PR TITLE
Graph Parsing Incorrectly Validates if Cycle offset present

### DIFF
--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -543,7 +543,6 @@ class GraphParser:
 
         # Raise error for cycle point offsets at the end of chains
         if '[' in right and left and right in terminals:
-            # This right hand side is at the end of a chain:
             raise GraphParseError(
                 'Invalid cycle point offsets only on right hand '
                 'side of a dependency (must be on left hand side):'

--- a/tests/unit/test_graph_parser.py
+++ b/tests/unit/test_graph_parser.py
@@ -139,6 +139,36 @@ def test_graph_syntax_errors_2(seq, graph, expected_err):
             'Invalid cycle point offsets only on right',
             id='no-cycle-point-RHS'
         ),
+        # See https://github.com/cylc/cylc-flow/issues/6523
+        # For the next 4 tests:
+        param(
+            # Yes I know it's circular, but it's here to
+            # demonstrate that the test below is broken:
+            "foo:finished => foo",
+            'Output foo:succeeded can\'t be both required and'
+            ' optional',
+            id='finish-implies-success-optional'
+        ),
+        param(
+            "foo[-P1]:finish => foo",
+            'Output foo:succeeded can\'t be both required and'
+            ' optional',
+            id='finish-implies-success-optional-offset'
+        ),
+        param(
+            "foo[-P1]:succeeded | foo[-P1]:failed => bar",
+            (
+                # Truncated error because output parsing order not guaranteed.
+                ' must both be optional if both are used'
+            ),
+            id='succeed-or-failed-mustbe-optional'
+        ),
+        param(
+            "foo[-P1]:succeeded? | foo[-P1]:failed? => foo",
+            'Output foo:succeeded can\'t be both required and'
+            ' optional',
+            id='succeed-or-failed-implies-success-optional'
+        ),
     ]
 )
 def test_graph_syntax_errors(graph, expected_err):
@@ -385,15 +415,17 @@ b => c"""
             bar:succeed => baz
             """
         ],
-        [
+        param(
             """
             foo => bar[1649] => baz
+            bar
             """,
             """
             foo => bar[1649]
             bar[1649] => baz
-            """
-        ],
+            """,
+            id='it-continues-on-next-line'
+        ),
     ]
 )
 def test_trigger_equivalence(graph1, graph2):
@@ -945,11 +977,12 @@ def test_RHS_AND(graph: str, expected_triggers: Dict[str, List[str]]):
     'args, err',
     (
         # Error if offset in terminal RHS:
-        param((('a', 'b[-P42M]'), {'b[-P42M]'}), 'Invalid cycle point offset'),
+        param(
+            (('a', 'b[-P42M]'), {'b[-P42M]'}), 'Invalid cycle point offset',
+            id='invalid-cycle-point-offset'
+        ),
         # No error if offset in NON-terminal RHS:
-        param((('a', 'b[-P42M]'), {}), None),
-        # Don't check the left hand side if this has a non-terminal RHS:
-        param((('a &', 'b[-P42M]'), {}), None),
+        param((('a', 'b[-P42M]'), {}), None, id='no-offset-non-terminal-RHS'),
     )
 )
 def test_proc_dep_pair(args, err):


### PR DESCRIPTION
The following examples failed to fail validation.

* `foo[-P1]:finish => foo`
* `foo[-P1]:succeeded | foo[-P1]:failed`

Fixed by adding Cycle Offset to Regex for parsing RHS of graph pair

## Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
