### PR TITLE
Clarify trigger command help.

### DIFF
--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -27,7 +27,7 @@ Cylc queues restrict the number of jobs that can be active (submitted or
 running) at once. They release tasks to run when their active task count
 drops below the queue limit.
 
-Attempts to trigger active tasks will be ignored.
+Attempts to trigger active (submitted, running) tasks will be ignored.
 
 Examples:
   # trigger task foo in cycle 1234 in test
@@ -40,7 +40,7 @@ Examples:
   $ cylc trigger --flow=new test//1234/foo
 
 Flows:
-  Active tasks (in the n=0 window) already belong to a flow.
+  Waiting tasks in the active window (n=0) already belong to a flow.
   * by default, if triggered, they run in the same flow
   * or with --flow=all, they are assigned all active flows
   * or with --flow=INT or --flow=new, the original and new flows are merged

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -27,7 +27,8 @@ Cylc queues restrict the number of jobs that can be active (submitted or
 running) at once. They release tasks to run when their active task count
 drops below the queue limit.
 
-Attempts to trigger active (submitted, running) tasks will be ignored.
+Attempts to trigger active (preparing, submitted, running)
+tasks will be ignored.
 
 Examples:
   # trigger task foo in cycle 1234 in test


### PR DESCRIPTION
Currently, in `cylc trigger --help`:

```
...
Attempts to trigger active tasks will be ignored.
...
  Active tasks (in the n=0 window) already belong to a flow.
  * by default, if triggered, they run in the same flow
  *...
...
```

This seems inconsistent at first glance, so I've been a bit more explicit

As far as I'm aware, the terminology we've settled on is:
- "active tasks" are literally active (submitted, running)
  - (users will definitely assume this, so let's not mess with that terminology)
- the "active window of the workflow" (n=0) contains both active and waiting tasks
  - (this is not illogical or inconsistent, but we need to be careful not to call this "the active tasks")

One review will do.


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
