### PR TITLE
Fix unlinking old job out/err files.

### DIFF
--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -373,7 +373,7 @@ class JobRunnerManager():
 
     @classmethod
     def _create_nn(cls, job_file_path):
-        """Create NN symbolic link, or remove old job logs if they exist.
+        """Create NN symbolic link if necessary, and remove any old job logs.
 
         If NN => 01, remove numbered dirs with submit numbers greater than 01.
 

--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -568,8 +568,8 @@ class JobRunnerManager():
         # Create NN symbolic link, if necessary
         self._create_nn(job_file_path)
         for name in JOB_LOG_ERR, JOB_LOG_OUT:
-            with suppress(OSError):
-                os.unlink(os.path.join(job_file_path, name))
+            with suppress(FileNotFoundError):
+                os.unlink(os.path.join(os.path.dirname(job_file_path), name))
 
         # Start new status file
         with open(f"{job_file_path}.status", "w") as job_status_file:

--- a/tests/integration/test_job_runner_mgr.py
+++ b/tests/integration/test_job_runner_mgr.py
@@ -88,10 +88,9 @@ async def test_kill_error(one, start, test_dir, capsys, log_filter):
 async def test_create_nn_new(one, start, test_dir, capsys, log_filter):
     """Test _create_nn. 
 
-    It should the NN symlink.
+    It should create the NN symlink.
     """
     async with start(one):
-        # make it look like the task is running
         itask = one.pool.get_tasks()[0]
 
         workflow_job_log_dir = Path(get_workflow_run_job_dir(one.workflow))

--- a/tests/integration/test_job_runner_mgr.py
+++ b/tests/integration/test_job_runner_mgr.py
@@ -85,8 +85,8 @@ async def test_kill_error(one, start, test_dir, capsys, log_filter):
         assert itask.state(TASK_STATUS_RUNNING)
 
 
-async def test_create_nn_new(one, start, test_dir, capsys, log_filter):
-    """Test _create_nn. 
+async def test_create_nn_new(one, start):
+    """Test _create_nn.
 
     It should create the NN symlink.
     """
@@ -99,13 +99,13 @@ async def test_create_nn_new(one, start, test_dir, capsys, log_filter):
         job_log_dir.mkdir(parents=True)
 
         # call _create_nn
-        JobRunnerManager()._create_nn(job_log_dir / 'job.out')
+        JobRunnerManager()._create_nn(job_log_dir / 'job')
 
         # check the symlink exists
         assert (job_log_dir.parent / "NN").is_symlink()
 
 
-async def test_create_nn_old(one, start, test_dir, capsys, log_filter):
+async def test_create_nn_old(one, start):
     """Test _create_nn.
 
     It should remove existing job logs, if the dir already exists.
@@ -127,13 +127,8 @@ async def test_create_nn_old(one, start, test_dir, capsys, log_filter):
         for job_log in job_logs:
             job_log.touch()
 
-        # check they exist
-        for job_log in job_logs:
-            assert job_log.is_file()
-
         # call _create_nn
-        for job_log in job_logs:
-            JobRunnerManager()._create_nn(job_log)
+        JobRunnerManager()._create_nn(job_log_dir / 'job')
 
         # check they were removed
         for job_log in job_logs:

--- a/tests/integration/test_job_runner_mgr.py
+++ b/tests/integration/test_job_runner_mgr.py
@@ -24,6 +24,7 @@ from cylc.flow.job_runner_mgr import JobRunnerManager
 from cylc.flow.pathutil import get_workflow_run_job_dir
 from cylc.flow.task_state import TASK_STATUS_RUNNING
 from cylc.flow.subprocctx import SubProcContext
+from cylc.flow.task_job_logs import JOB_LOG_OUT, JOB_LOG_ERR
 
 
 async def test_kill_error(one, start, test_dir, capsys, log_filter):
@@ -82,3 +83,59 @@ async def test_kill_error(one, start, test_dir, capsys, log_filter):
             level=logging.WARNING,
         )
         assert itask.state(TASK_STATUS_RUNNING)
+
+
+async def test_create_nn_new(one, start, test_dir, capsys, log_filter):
+    """Test _create_nn. 
+
+    It should the NN symlink.
+    """
+    async with start(one):
+        # make it look like the task is running
+        itask = one.pool.get_tasks()[0]
+
+        workflow_job_log_dir = Path(get_workflow_run_job_dir(one.workflow))
+        job_id = itask.tokens.duplicate(job='01').relative_id
+        job_log_dir = Path(workflow_job_log_dir, job_id)
+        job_log_dir.mkdir(parents=True)
+
+        # call _create_nn
+        JobRunnerManager()._create_nn(job_log_dir / 'job.out')
+
+        # check the symlink exists
+        assert (job_log_dir.parent / "NN").is_symlink()
+
+
+async def test_create_nn_old(one, start, test_dir, capsys, log_filter):
+    """Test _create_nn.
+
+    It should remove existing job logs, if the dir already exists.
+    """
+    async with start(one):
+        itask = one.pool.get_tasks()[0]
+
+        # fake some old job logs
+        workflow_job_log_dir = Path(get_workflow_run_job_dir(one.workflow))
+        job_id = itask.tokens.duplicate(job='01').relative_id
+        job_log_dir = Path(workflow_job_log_dir, job_id)
+        job_log_dir.mkdir(parents=True)
+
+        job_logs = []
+        for name in JOB_LOG_OUT, JOB_LOG_ERR:
+            job_logs.append(job_log_dir / name)
+
+        # create the logs
+        for job_log in job_logs:
+            job_log.touch()
+
+        # check they exist
+        for job_log in job_logs:
+            assert job_log.is_file()
+
+        # call _create_nn
+        for job_log in job_logs:
+            JobRunnerManager()._create_nn(job_log)
+
+        # check they were removed
+        for job_log in job_logs:
+            assert not job_log.is_file()


### PR DESCRIPTION
Close #6529 

```diff
diff --git a/cylc/flow/job_runner_mgr.py b/cylc/flow/job_runner_mgr.py
index b8ddaaa05..de7817170 100644
--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -568,8 +568,8 @@ class JobRunnerManager():
         # Create NN symbolic link, if necessary
         self._create_nn(job_file_path)
         for name in JOB_LOG_ERR, JOB_LOG_OUT:
-            with suppress(OSError):
-                os.unlink(os.path.join(job_file_path, name))
+            with suppress(FileNotFoundError):
+                os.unlink(os.path.join(os.path.dirname(job_file_path), name))

         # Start new status file
```

Suppressing OSError here hid a bug:
```
    NotADirectoryError: [Errno 20] Not a directory: '/home/oliverh/cylc-run/bug/run32/log/job/1/a/01/job/job.err'
```

This fixes the path error and just suppresses FileNotFoundError.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
    - (there are no reports of users being affected by this)
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
   - (simple fix going directly for 8.4 for immediate release)

