### PR TITLE
Lint S014: Only warn about `-W` when used for LSF

### DIFF
--- a/changes.d/6551.fix.md
+++ b/changes.d/6551.fix.md
@@ -1,0 +1,1 @@
+Lint: Fix bug where lint warned about use of legitimate -W directive for PBS.

--- a/changes.d/6551.fix.md
+++ b/changes.d/6551.fix.md
@@ -1,1 +1,1 @@
-Lint: Fix bug where lint warned about use of legitimate -W directive for PBS.
+Fix bug in `cylc lint` S014 where it warned about use of legitimate `-W` directive for PBS.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -192,7 +192,7 @@ def get_wallclock_directives():
         if directive and directive == '-W':
             # LSF directive -W needs to have a particular form to
             # avoid matching PBS directive -W:
-            directives[module.name] = re.compile(r'^-W\s*=?\s*(\d+:)?\d+$')
+            directives[module.name] = re.compile(r'^-W\s*=?\s*(\d+:)?\d+[^/]*$')
         elif directive:
             directives[module.name] = re.compile(rf'^{directive}.*')
     return directives

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -194,7 +194,7 @@ def get_wallclock_directives():
             # avoid matching PBS directive -W:
             directives[module.name] = re.compile(r'^-W\s+(\d+:)?\d+$')
         elif directive:
-            directives[module.name] = re.compile(rf'^{directive}')
+            directives[module.name] = re.compile(rf'^{directive}.*')
     return directives
 
 
@@ -221,6 +221,8 @@ def check_wallclock_directives(line: str) -> Union[Dict[str, str], bool]:
         False
         >>> this('    -W foo="Hello World"')  # Legit PBS use case.
         False
+        >>> this('    -l walltime whatever')
+        {'directive': '-l walltime whatever'}
     """
     for directive in set(WALLCLOCK_DIRECTIVES.values()):
         if directive.findall(line.strip()):

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -192,7 +192,8 @@ def get_wallclock_directives():
         if directive and directive == '-W':
             # LSF directive -W needs to have a particular form to
             # avoid matching PBS directive -W:
-            directives[module.name] = re.compile(r'^-W\s*=?\s*(\d+:)?\d+[^/]*$')
+            directives[module.name] = re.compile(
+                r'^-W\s*=?\s*(\d+:)?\d+[^/]*$')
         elif directive:
             directives[module.name] = re.compile(rf'^{directive}.*')
     return directives

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -201,7 +201,7 @@ def get_wallclock_directives():
 WALLCLOCK_DIRECTIVES = get_wallclock_directives()
 
 
-def check_wallclock_directives(line: str) -> Union[Dict[str, str], bool]:
+def check_wallclock_directives(line: str) -> Dict[str, str]:
     """Check for job runner specific directives
     equivalent to exection time limit.
 
@@ -214,20 +214,20 @@ def check_wallclock_directives(line: str) -> Union[Dict[str, str], bool]:
         >>> this('    -W 42:22')
         {'directive': '-W 42:22'}
         >>> this('    -W 42:22/hostname')  # Legit LSF use case
-        False
+        {}
         >>> this('    -W 422')
         {'directive': '-W 422'}
         >>> this('    -W foo=42')  # Legit PBS use case.
-        False
+        {}
         >>> this('    -W foo="Hello World"')  # Legit PBS use case.
-        False
+        {}
         >>> this('    -l walltime whatever')
         {'directive': '-l walltime whatever'}
     """
     for directive in set(WALLCLOCK_DIRECTIVES.values()):
         if directive.findall(line.strip()):
             return {'directive': line.strip()}
-    return False
+    return {}
 
 
 def check_jinja2_no_shebang(

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -192,7 +192,7 @@ def get_wallclock_directives():
         if directive and directive == '-W':
             # LSF directive -W needs to have a particular form to
             # avoid matching PBS directive -W:
-            directives[module.name] = re.compile(r'^-W\s+(\d+:)?\d+$')
+            directives[module.name] = re.compile(r'^-W\s*=?\s*(\d+:)?\d+$')
         elif directive:
             directives[module.name] = re.compile(rf'^{directive}.*')
     return directives


### PR DESCRIPTION
Closes #6550 

`-W` should only be highlighted by Cylc lint when being used in a way which indicates use of LSF.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] Very small, self documenting.
- [x] Raised against 8.4.x, bugfix