### PR TITLE
Tidy `TaskJobManager`: remove unecessary `workflow` arg from many methods

### DIFF
--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -254,7 +254,7 @@ async def poll_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     if schd.get_run_mode() == RunMode.SIMULATION:
         yield 0
     itasks, _, bad_items = schd.pool.filter_task_proxies(tasks)
-    schd.task_job_mgr.poll_task_jobs(schd.workflow, itasks)
+    schd.task_job_mgr.poll_task_jobs(itasks)
     yield len(bad_items)
 
 

--- a/cylc/flow/run_modes/__init__.py
+++ b/cylc/flow/run_modes/__init__.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
             'TaskProxy',
             # the task's runtime config (with broadcasts applied)
             Dict[str, Any],
-            # the workflow ID
-            str,
             # the current time as (float_unix_time, str_ISO8601)
             Tuple[float, str]
         ],

--- a/cylc/flow/run_modes/dummy.py
+++ b/cylc/flow/run_modes/dummy.py
@@ -50,7 +50,6 @@ def submit_task_job(
     task_job_mgr: 'TaskJobManager',
     itask: 'TaskProxy',
     rtconfig: Dict[str, Any],
-    workflow: str,
     now: Tuple[float, str]
 ) -> 'Literal[False]':
     """Submit a task in dummy mode.
@@ -77,7 +76,7 @@ def submit_task_job(
     itask.summary[task_job_mgr.KEY_EXECUTE_TIME_LIMIT] = (
         itask.mode_settings.simulated_run_length)
     itask.jobs.append(
-        task_job_mgr.get_simulation_job_conf(itask, workflow))
+        task_job_mgr.get_simulation_job_conf(itask))
     task_job_mgr.workflow_db_mgr.put_insert_task_jobs(
         itask, {
             'time_submit': now[1],

--- a/cylc/flow/run_modes/simulation.py
+++ b/cylc/flow/run_modes/simulation.py
@@ -51,7 +51,6 @@ def submit_task_job(
     task_job_mgr: 'TaskJobManager',
     itask: 'TaskProxy',
     rtconfig: Dict[str, Any],
-    workflow: str,
     now: Tuple[float, str]
 ) -> 'Literal[True]':
     """Submit a task in simulation mode.
@@ -84,7 +83,7 @@ def submit_task_job(
         itask.mode_settings.simulated_run_length
     )
     itask.jobs.append(
-        task_job_mgr.get_simulation_job_conf(itask, workflow)
+        task_job_mgr.get_simulation_job_conf(itask)
     )
     task_job_mgr.task_events_mgr.process_message(
         itask, INFO, TASK_OUTPUT_SUBMITTED,

--- a/cylc/flow/run_modes/skip.py
+++ b/cylc/flow/run_modes/skip.py
@@ -40,7 +40,6 @@ def submit_task_job(
     task_job_mgr: 'TaskJobManager',
     itask: 'TaskProxy',
     rtconfig: Dict,
-    _workflow: str,
     now: Tuple[float, str]
 ) -> 'Literal[True]':
     """Submit a task in skip mode.
@@ -65,7 +64,7 @@ def submit_task_job(
     }
     itask.summary['job_runner_name'] = RunMode.SKIP.value
     itask.jobs.append(
-        task_job_mgr.get_simulation_job_conf(itask, _workflow)
+        task_job_mgr.get_simulation_job_conf(itask)
     )
     itask.run_mode = RunMode.SKIP
     task_job_mgr.workflow_db_mgr.put_insert_task_jobs(

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -995,7 +995,7 @@ class Scheduler:
             if should_poll:
                 to_poll_tasks.append(itask)
         if to_poll_tasks:
-            self.task_job_mgr.poll_task_jobs(self.workflow, to_poll_tasks)
+            self.task_job_mgr.poll_task_jobs(to_poll_tasks)
 
         # Remaining unprocessed messages have no corresponding task proxy.
         # For example, if I manually set a running task to succeeded, the
@@ -1096,7 +1096,7 @@ class Scheduler:
                 f"{', '.join(sorted(t.identity for t in unkillable))}"
             )
         if not jobless:
-            self.task_job_mgr.kill_task_jobs(self.workflow, to_kill)
+            self.task_job_mgr.kill_task_jobs(to_kill)
 
         return len(unkillable)
 
@@ -1536,7 +1536,6 @@ class Scheduler:
             log = LOG.info
 
         for itask in self.task_job_mgr.submit_task_jobs(
-            self.workflow,
             itasks,
             self.server.curve_auth,
             self.server.client_pub_key_dir,
@@ -1592,7 +1591,7 @@ class Scheduler:
         self.check_workflow_timers()
         # check submission and execution timeout and polling timers
         if self.get_run_mode() != RunMode.SIMULATION:
-            self.task_job_mgr.check_task_jobs(self.workflow, self.pool)
+            self.task_job_mgr.check_task_jobs(self.pool)
 
     async def workflow_shutdown(self):
         """Determines if the workflow can be shutdown yet."""

--- a/tests/integration/run_modes/test_mode_overrides.py
+++ b/tests/integration/run_modes/test_mode_overrides.py
@@ -96,7 +96,6 @@ async def test_force_trigger_does_not_override_run_mode(
 
         # ... but job submission will always change this to the correct mode:
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             [foo],
             schd.server.curve_auth,
             schd.server.client_pub_key_dir)
@@ -158,7 +157,6 @@ async def test_run_mode_override_from_broadcast(
         foo_1001 = schd.pool.get_task(ISO8601Point('1001'), 'foo')
 
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             [foo_1000, foo_1001],
             schd.server.curve_auth,
             schd.server.client_pub_key_dir)

--- a/tests/integration/run_modes/test_nonlive.py
+++ b/tests/integration/run_modes/test_nonlive.py
@@ -60,7 +60,6 @@ def submit_and_check_db():
     def _inner(schd):
         # Submit task jobs:
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             schd.server.curve_auth,
             schd.server.client_pub_key_dir
@@ -125,7 +124,6 @@ async def test_db_task_states(
     schd = scheduler(flow(conf))
     async with start(schd):
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             schd.server.curve_auth,
             schd.server.client_pub_key_dir
@@ -166,7 +164,6 @@ async def test_mean_task_time(
 
         # Submit two tasks:
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             [itask],
             schd.server.curve_auth,
             schd.server.client_pub_key_dir

--- a/tests/integration/run_modes/test_simulation.py
+++ b/tests/integration/run_modes/test_simulation.py
@@ -63,8 +63,7 @@ def run_simjob(monkeytime):
         itask = schd.pool.get_task(point, task)
         itask.state.is_queued = False
         monkeytime(0)
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         monkeytime(itask.mode_settings.timeout + 1)
 
         # Run Time Check
@@ -171,8 +170,7 @@ def test_fail_once(sim_time_check_setup, itask, point, results, monkeypatch):
 
     for i, result in enumerate(results):
         itask.try_timers['execution-retry'].num = i
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert itask.mode_settings.sim_task_fails is result
 
 
@@ -192,7 +190,8 @@ def test_task_finishes(sim_time_check_setup, monkeytime, caplog):
     fail_all_1066.state.status = 'running'
     fail_all_1066.state.is_queued = False
     schd.task_job_mgr.submit_nonlive_task_jobs(
-        schd.workflow, [fail_all_1066], RunMode.SIMULATION)
+        [fail_all_1066], RunMode.SIMULATION
+    )
 
     # For the purpose of the test delete the started time set by
     # submit_nonlive_task_jobs.
@@ -222,7 +221,8 @@ def test_task_sped_up(sim_time_check_setup, monkeytime):
     # Run the job submission method:
     monkeytime(0)
     schd.task_job_mgr.submit_nonlive_task_jobs(
-        schd.workflow, [fast_forward_1066], RunMode.SIMULATION)
+        [fast_forward_1066], RunMode.SIMULATION
+    )
     fast_forward_1066.state.is_queued = False
 
     result = sim_time_check(schd.task_events_mgr, [fast_forward_1066], '')
@@ -273,7 +273,8 @@ async def test_settings_restart(monkeytime, flow, scheduler, start):
         og_timeouts = {}
         for itask in schd.pool.get_tasks():
             schd.task_job_mgr.submit_nonlive_task_jobs(
-                schd.workflow, [itask], RunMode.SIMULATION)
+                [itask], RunMode.SIMULATION
+            )
 
             og_timeouts[itask.identity] = itask.mode_settings.timeout
 
@@ -391,8 +392,7 @@ async def test_settings_broadcast(
         itask.state.is_queued = False
 
         # Submit the first - the sim task will fail:
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert itask.mode_settings.sim_task_fails is True
 
         # Let task finish.
@@ -410,14 +410,12 @@ async def test_settings_broadcast(
                 'simulation': {'fail cycle points': ''}
             }])
         # Submit again - result is different:
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert itask.mode_settings.sim_task_fails is False
 
         # Assert Clearing the broadcast works
         schd.broadcast_mgr.clear_broadcast()
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert itask.mode_settings.sim_task_fails is True
 
         # Assert that list of broadcasts doesn't change if we submit
@@ -427,8 +425,7 @@ async def test_settings_broadcast(
             ['1066'], ['one'], [{
                 'simulation': {'fail cycle points': 'higadfuhasgiurguj'}
             }])
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert (
             'Invalid ISO 8601 date representation: higadfuhasgiurguj'
             in log.messages[-1])
@@ -441,8 +438,7 @@ async def test_settings_broadcast(
             ['1066'], ['one'], [{
                 'simulation': {'fail cycle points': '1'}
             }])
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert (
             'Invalid ISO 8601 date representation: 1'
             in log.messages[-1])
@@ -453,8 +449,7 @@ async def test_settings_broadcast(
                 'simulation': {'fail cycle points': '1945, 1977, 1066'},
                 'execution retry delays': '3*PT2S'
             }])
-        schd.task_job_mgr.submit_nonlive_task_jobs(
-            schd.workflow, [itask], RunMode.SIMULATION)
+        schd.task_job_mgr.submit_nonlive_task_jobs([itask], RunMode.SIMULATION)
         assert itask.mode_settings.sim_task_fails is True
         assert itask.try_timers['execution-retry'].delays == [2.0, 2.0, 2.0]
         # n.b. rtconfig should remain unchanged, lest we cancel broadcasts:

--- a/tests/integration/run_modes/test_skip.py
+++ b/tests/integration/run_modes/test_skip.py
@@ -52,7 +52,6 @@ async def test_settings_override_from_broadcast(
         foo, = schd.pool.get_tasks()
 
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             schd.server.curve_auth,
             schd.server.client_pub_key_dir
@@ -216,7 +215,6 @@ async def test_prereqs_marked_satisfied_by_skip_mode(
     async with start(schd):
         foo = schd.pool.get_task(IntegerPoint(1), 'foo')
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             [foo],
             schd.server.curve_auth,
             schd.server.client_pub_key_dir,
@@ -241,7 +239,6 @@ async def test_outputs_can_be_changed(one_conf, flow, start, scheduler, validate
             ],
         )
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             None,
             None
@@ -252,7 +249,6 @@ async def test_outputs_can_be_changed(one_conf, flow, start, scheduler, validate
             ['1'], ['one'], [{'skip': {'outputs': 'succeeded'}}]
         )
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             None,
             None

--- a/tests/integration/test_job_runner_mgr.py
+++ b/tests/integration/test_job_runner_mgr.py
@@ -73,7 +73,6 @@ async def test_kill_error(one, start, test_dir, capsys, log_filter):
                 out=out,
                 err=err,
             ),
-            one.workflow,
             [itask],
         )
 

--- a/tests/integration/test_platforms.py
+++ b/tests/integration/test_platforms.py
@@ -23,7 +23,7 @@ async def test_prep_submit_task_tries_multiple_platforms(
     task platform setting matches a group, and that after all platforms
     have been tried that the hosts matching that platform group are
     cleared.
-    
+
     See https://github.com/cylc/cylc-flow/pull/6109
     """
     global_conf = '''
@@ -47,7 +47,7 @@ async def test_prep_submit_task_tries_multiple_platforms(
         itask.submit_num = 1
         # simulate failed attempts to contact the job hosts
         schd.task_job_mgr.bad_hosts = {'broken', 'broken2'}
-        res = schd.task_job_mgr._prep_submit_task_job(schd.workflow, itask)
+        res = schd.task_job_mgr._prep_submit_task_job(itask)
         assert res is False
         # ensure the bad hosts have been cleared
         assert not schd.task_job_mgr.bad_hosts

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -152,7 +152,6 @@ async def test__always_insert_task_job(
     schd.bad_hosts = {'no-such-host-1', 'no-such-host-2'}
     async with start(schd):
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             schd.server.curve_auth,
             schd.server.client_pub_key_dir,

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -84,10 +84,7 @@ async def test_run_job_cmd_no_hosts_error(
         schd.task_job_mgr.bad_hosts.add('no-host-platform')
 
         # polling the task should not result in an error...
-        schd.task_job_mgr.poll_task_jobs(
-            schd.workflow,
-            schd.pool.get_tasks()
-        )
+        schd.task_job_mgr.poll_task_jobs(schd.pool.get_tasks())
 
         # ...but the failure should be logged
         assert log_filter(
@@ -96,10 +93,7 @@ async def test_run_job_cmd_no_hosts_error(
         log.clear()
 
         # killing the task should not result in an error...
-        schd.task_job_mgr.kill_task_jobs(
-            schd.workflow,
-            schd.pool.get_tasks()
-        )
+        schd.task_job_mgr.kill_task_jobs(schd.pool.get_tasks())
 
         # ...but the failure should be logged
         assert log_filter(
@@ -119,7 +113,6 @@ async def test__run_job_cmd_logs_platform_lookup_fail(
         from types import SimpleNamespace
         schd.task_job_mgr._run_job_cmd(
             schd.task_job_mgr.JOBS_POLL,
-            'foo',
             [SimpleNamespace(platform={'name': 'culdee fell summit'})],
             None,
             None
@@ -163,14 +156,16 @@ async def test__prep_submit_task_job_impl_handles_execution_time_limit(
         # in the summary state.
         with suppress(FileExistsError):
             schd.task_job_mgr._prep_submit_task_job_impl(
-                schd.workflow, task_a, task_a.tdef.rtconfig)
+                task_a, task_a.tdef.rtconfig
+            )
         assert task_a.summary['execution_time_limit'] == 5.0
 
         # If we delete the etl it gets deleted in the summary:
         task_a.tdef.rtconfig['execution time limit'] = None
         with suppress(FileExistsError):
             schd.task_job_mgr._prep_submit_task_job_impl(
-                schd.workflow, task_a, task_a.tdef.rtconfig)
+                task_a, task_a.tdef.rtconfig
+            )
         assert not task_a.summary.get('execution_time_limit', '')
 
         # put everything back and test broadcast too.
@@ -181,8 +176,7 @@ async def test__prep_submit_task_job_impl_handles_execution_time_limit(
         with suppress(FileExistsError):
             # We run a higher level function here to ensure
             # that the broadcast is applied.
-            schd.task_job_mgr._prep_submit_task_job(
-                schd.workflow, task_a)
+            schd.task_job_mgr._prep_submit_task_job(task_a)
         assert not task_a.summary.get('execution_time_limit', '')
 
 
@@ -224,7 +218,6 @@ async def test_broadcast_platform_change(
 
         # Attempt job submission:
         schd.task_job_mgr.submit_task_jobs(
-            schd.workflow,
             schd.pool.get_tasks(),
             schd.server.curve_auth,
             schd.server.client_pub_key_dir)


### PR DESCRIPTION
Split off from https://github.com/cylc/cylc-flow/pull/6535

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are not needed
- [x] No changelog entry needed
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
