### PR TITLE
Deprecate async-timeout dependency

### DIFF
--- a/conda-environment.yml
+++ b/conda-environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - ansimarkup >=1.0.0
-  - async-timeout>=3.0.0
+  - async-timeout>=3.0.0 # [py<3.11]
   - colorama >=0.4,<1.0
   - graphene >=2.1,<3
   - graphviz  # for static graphing

--- a/cylc/flow/network/ssh_client.py
+++ b/cylc/flow/network/ssh_client.py
@@ -14,17 +14,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from async_timeout import timeout as asyncto
 import asyncio
 import json
 import os
-from typing import Any, List, Optional, Tuple, Union, Dict
+import sys
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
-from cylc.flow.exceptions import ClientError, ClientTimeout
+from cylc.flow.exceptions import (
+    ClientError,
+    ClientTimeout,
+)
 from cylc.flow.network.client import WorkflowRuntimeClientBase
 from cylc.flow.network.client_factory import CommsMeth
 from cylc.flow.remote import remote_cylc_cmd
-from cylc.flow.workflow_files import load_contact_file, ContactFileFields
+from cylc.flow.workflow_files import (
+    ContactFileFields,
+    load_contact_file,
+)
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout as asyncto
+else:
+    from async_timeout import timeout as asyncto
 
 
 class WorkflowRuntimeClient(WorkflowRuntimeClientBase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
     ansimarkup>=1.0.0
-    async-timeout>=3.0.0
+    async-timeout>=3.0.0; python_version < "3.11"
     colorama>=0.4,<1
     graphene>=2.1,<3
     # Note: can't pin jinja2 any higher than this until we give up on Cylc 7 back-compat

--- a/tests/integration/test_publisher.py
+++ b/tests/integration/test_publisher.py
@@ -13,13 +13,18 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from async_timeout import timeout
-import pytest
+import sys
 
 from cylc.flow.network.subscriber import (
     WorkflowSubscriber,
-    process_delta_msg
+    process_delta_msg,
 )
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 
 async def test_publisher(flow, scheduler, run, one_conf, port_range):

--- a/tests/integration/test_replier.py
+++ b/tests/integration/test_replier.py
@@ -14,12 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from async_timeout import timeout
+import sys
 from cylc.flow.network import decode_
 from cylc.flow.network.client import WorkflowRuntimeClient
 import asyncio
 
 import pytest
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 
 async def test_listener(one, start, ):

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -14,14 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
-from async_timeout import timeout
 from getpass import getuser
+import sys
+from typing import Callable
 
 import pytest
 
 from cylc.flow.network.server import PB_METHOD_MAP
 from cylc.flow.scheduler import Scheduler
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/test_workflow_events.py
+++ b/tests/integration/test_workflow_events.py
@@ -15,11 +15,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import sys
 
-from async_timeout import timeout as async_timeout
 import pytest
 
 from cylc.flow.scheduler import SchedulerError
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 
 
 EVENTS = (

--- a/tests/integration/tui/test_updater.py
+++ b/tests/integration/tui/test_updater.py
@@ -19,9 +19,9 @@ from copy import deepcopy
 from pathlib import Path
 from queue import Queue
 import re
+import sys
 from time import time
 
-from async_timeout import timeout
 import pytest
 
 from cylc.flow.cycling.integer import IntegerPoint
@@ -31,6 +31,12 @@ from cylc.flow.tui.updater import (
     get_default_filters,
 )
 from cylc.flow.workflow_status import WorkflowStatus
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 
 @pytest.fixture

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -22,21 +22,38 @@ Use the fixtures provided in the conftest instead.
 """
 
 import asyncio
-from pathlib import Path
-from async_timeout import timeout
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import (
+    asynccontextmanager,
+    contextmanager,
+)
 import logging
-import pytest
-from typing import Any, Optional, Union
+from pathlib import Path
 from secrets import token_hex
+import sys
+from typing import (
+    Any,
+    Optional,
+    Union,
+)
+
+import pytest
 
 from cylc.flow import CYLC_LOG
-from cylc.flow.workflow_files import WorkflowFiles
-from cylc.flow.scheduler import Scheduler, SchedulerStop
+from cylc.flow.scheduler import (
+    Scheduler,
+    SchedulerStop,
+)
 from cylc.flow.scheduler_cli import RunOptions
+from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.workflow_status import StopMode
 
 from .flow_writer import flow_config_str
+
+
+if sys.version_info[:2] >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 
 def _make_src_flow(src_path, conf, filename=WorkflowFiles.FLOW_FILE):


### PR DESCRIPTION
https://pypi.org/project/async-timeout/

>### DEPRECATED
>
>This library has effectively been upstreamed into Python 3.11+.
>
>Therefore this library is considered deprecated and no longer actively supported.
>
>Version 5.0+ provides dual-mode when executed on Python 3.11+: `asyncio_timeout.Timeout` is fully compatible with `asyncio.Timeout` and old versions of the library.
>
>Anyway, using upstream is highly recommended. `asyncio_timeout` exists only for the sake of backward compatibility, easy supporting both old and new Python by the same code, and easy misgration.
>
>If rescheduling API is not important and only `async with timeout(...): ...` functionality is required, a user could apply conditional import

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests, docs, changelog not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
