### PR TITLE
GH Actions: Drop Ubuntu 20.04

### DIFF
--- a/.github/workflows/test_manylinux.yml
+++ b/.github/workflows/test_manylinux.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         manylinux: ['1']
-        os: ['ubuntu-20.04']  # run on the oldest linux we have access to
+        os: ['ubuntu-22.04']  # run on the oldest linux we have access to
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
Ubuntu 20.04 going away by 1 April. Brownouts starting in March. https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes or docs or tests etc
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
