### PR TITLE
broadcast: report invalid settings

### DIFF
--- a/changes.d/6574.fix.md
+++ b/changes.d/6574.fix.md
@@ -1,0 +1,1 @@
+Broadcast: Report any settings that are not compatible with the scheduler Cylc version.

--- a/cylc/flow/broadcast_mgr.py
+++ b/cylc/flow/broadcast_mgr.py
@@ -37,7 +37,7 @@ from cylc.flow.platforms import (
     fail_if_platform_and_host_conflict,
     PlatformLookupError,
 )
-
+from cylc.flow.util import uniq
 
 if TYPE_CHECKING:
     from cylc.flow.id import Tokens
@@ -151,7 +151,7 @@ class BroadcastMgr:
             LOG.error(get_broadcast_bad_options_report(bad_options))
         if modified_settings:
             self.data_store_mgr.delta_broadcast()
-        return modified_settings, bad_options
+        return uniq(modified_settings), bad_options
 
     def expire_broadcast(self, cutoff=None, **kwargs):
         """Clear all broadcasts targeting cycle points earlier than cutoff."""
@@ -284,18 +284,24 @@ class BroadcastMgr:
           bad_options is as described in the docstring for self.clear().
         """
         modified_settings = []
-        bad_point_strings = []
-        bad_namespaces = []
+        bad_settings = []
+        bad_point_strings = set()
+        bad_namespaces = set()
 
         with self.lock:
             for setting in settings or []:
                 # Coerce setting to cylc runtime object,
                 # i.e. str to  DurationFloat.
                 coerced_setting = deepcopy(setting)
-                BroadcastConfigValidator().validate(
-                    coerced_setting,
-                    SPEC['runtime']['__MANY__'],
-                )
+                try:
+                    BroadcastConfigValidator().validate(
+                        coerced_setting,
+                        SPEC['runtime']['__MANY__'],
+                    )
+                except Exception as exc:
+                    LOG.error(exc)
+                    bad_settings.append(setting)
+                    continue
 
                 # Skip and warn if a run mode is broadcast to a workflow
                 # running in simulation or dummy mode.
@@ -308,6 +314,7 @@ class BroadcastMgr:
                         f' running in {self.workflow_run_mode.value} mode'
                         ' will have no effect, and will not be actioned.'
                     )
+                    bad_settings.append(setting)
                     continue
 
                 for point_string in point_strings or []:
@@ -315,15 +322,16 @@ class BroadcastMgr:
                     bad_point = False
                     try:
                         point_string = standardise_point_string(point_string)
+
                     except PointParsingError:
                         if point_string != '*':
-                            bad_point_strings.append(point_string)
+                            bad_point_strings.add(point_string)
                             bad_point = True
                     if not bad_point and point_string not in self.broadcasts:
                         self.broadcasts[point_string] = {}
                     for namespace in namespaces or []:
                         if namespace not in self.linearized_ancestors:
-                            bad_namespaces.append(namespace)
+                            bad_namespaces.add(namespace)
                         elif not bad_point:
                             # Check broadcast against config and against
                             # existing broadcasts:
@@ -340,6 +348,7 @@ class BroadcastMgr:
                                 namespace,
                                 coerced_setting,
                             ):
+                                bad_settings.append(setting)
                                 continue
 
                             if namespace not in self.broadcasts[point_string]:
@@ -362,13 +371,15 @@ class BroadcastMgr:
         LOG.info(get_broadcast_change_report(modified_settings))
 
         bad_options = {}
+        if bad_settings:
+            bad_options["settings"] = uniq(bad_settings)
         if bad_point_strings:
-            bad_options["point_strings"] = bad_point_strings
+            bad_options["point_strings"] = sorted(bad_point_strings)
         if bad_namespaces:
-            bad_options["namespaces"] = bad_namespaces
+            bad_options["namespaces"] = sorted(bad_namespaces)
         if modified_settings:
             self.data_store_mgr.delta_broadcast()
-        return modified_settings, bad_options
+        return uniq(modified_settings), bad_options
 
     @staticmethod
     def bc_mixes_old_and_new_platform_settings(

--- a/cylc/flow/broadcast_report.py
+++ b/cylc/flow/broadcast_report.py
@@ -26,6 +26,13 @@ CHANGE_PREFIX_SET = "+"
 CHANGE_TITLE_CANCEL = "Broadcast cancelled:"
 CHANGE_TITLE_SET = "Broadcast set:"
 
+CLI_OPT_MAP = {
+    # broadcast field: cli option
+    'point_strings': 'point',
+    'namespaces': 'namespace',
+    'settings': 'set',
+}
+
 
 def get_broadcast_bad_options_report(bad_options, is_set=False):
     """Return a string to report bad options for broadcast cancel/clear."""
@@ -48,7 +55,11 @@ def get_broadcast_bad_options_report(bad_options, is_set=False):
                         value_str += val
             else:
                 value_str = value
-            msg += BAD_OPTIONS_FMT % (key, value_str)
+            if isinstance(value, dict):
+                value_str = ', '.join(
+                    f'{key}={val}' for key, val in value.items()
+                )
+            msg += BAD_OPTIONS_FMT % (CLI_OPT_MAP.get(key, key), value_str)
     return msg
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1795,17 +1795,6 @@ class Broadcast(Mutation):
             )
         )
 
-        # TODO: work out how to implement this feature, it needs to be
-        #       handled client-side which makes it slightly awkward in
-        #       api-on-the-fly land
-
-        # files = graphene.List(
-        #    String,
-        #    description=sstrip('''
-        #        File with config to broadcast. Can be used multiple times
-        #    ''')
-        # )
-
     result = GenericScalar()
 
 

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -45,6 +45,45 @@ BOOL_SYMBOLS: Dict[bool, str] = {
 _NAT_SORT_SPLIT = re.compile(r'([\d\.]+)')
 
 
+def uniq(iterable):
+    """Return a unique collection of the provided items preserving item order.
+
+    Useful for unhashable things like dicts, relies on __eq__ for testing
+    equality.
+
+    Examples:
+        >>> uniq([1, 1, 2, 3, 5, 8, 1])
+        [1, 2, 3, 5, 8]
+
+    """
+    ret = []
+    for item in iterable:
+        if item not in ret:
+            ret.append(item)
+    return ret
+
+
+def iter_uniq(iterable):
+    """Iterate over an iterable omitting any duplicate entries.
+
+    Useful for unhashable things like dicts, relies on __eq__ for testing
+    equality.
+
+    Note:
+        More efficient than "uniq" for iteration use cases.
+
+    Examples:
+        >>> list(iter_uniq([1, 1, 2, 3, 5, 8, 1]))
+        [1, 2, 3, 5, 8]
+
+    """
+    cache = set()
+    for item in iterable:
+        if item not in cache:
+            cache.add(item)
+            yield item
+
+
 def sstrip(text):
     """Simple function to dedent and strip text.
 

--- a/tests/functional/broadcast/00-simple/expected-prep.err
+++ b/tests/functional/broadcast/00-simple/expected-prep.err
@@ -1,14 +1,14 @@
 ERROR: No broadcast to cancel/clear for these options:
   --cancel=[environment]BCAST
-  --namespaces=m4
-  --point_strings=20100809T00
+  --namespace=m4
+  --point=20100809T00
 ERROR: No broadcast to cancel/clear for these options:
   --cancel=[environment]BCAST
-  --namespaces=m5
-  --point_strings=*
+  --namespace=m5
+  --point=*
 ERROR: No broadcast to cancel/clear for these options:
-  --namespaces=m6
+  --namespace=m6
 ERROR: No broadcast to cancel/clear for these options:
-  --namespaces=m7
+  --namespace=m7
 ERROR: No broadcast to cancel/clear for these options:
-  --namespaces=ENS3
+  --namespace=ENS3

--- a/tests/integration/run_modes/test_simulation.py
+++ b/tests/integration/run_modes/test_simulation.py
@@ -424,10 +424,12 @@ async def test_settings_broadcast(
 
         # Assert that setting run mode on a simulation mode task fails with
         # warning:
-        schd.broadcast_mgr.put_broadcast(
+        good, bad = schd.broadcast_mgr.put_broadcast(
             ['1066'], ['one'], [{
                 'run mode': 'live',
             }])
+        assert good == []
+        assert bad == {'settings': [{'run mode': 'live'}]}
         record = log_filter(contains='will not be actioned')[0]
         assert record[0] == logging.WARNING
         assert 'run mode' not in schd.broadcast_mgr.broadcasts


### PR DESCRIPTION
broadcast: report invalid settings
    
* We already report invalid cycle points and namespaces.
* However, we have been relying on client-side validation for settings  (which doesn't apply to the GraphQL mutation).
* This also raises the potential for inter-version compatibility issues going unreported.
* This commit explicitly handles invalid settings in the same way as invalid cycle points and namespaces so that they are reported back to the user.
* Closes the issue part of #6429.
* Additionally:
  * This change also strips duplicate entries from broadcast reports.
  * And fixes the CLI options in broadcast report to match `cylc broadcast`.



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.