### PR TITLE
pbs: update connection failed error message

### DIFF
--- a/changes.d/6586.fix.md
+++ b/changes.d/6586.fix.md
@@ -1,0 +1,2 @@
+Update PBS job runner to reflect error message change. This change
+continues to support older PBS versions.

--- a/cylc/flow/job_runner_handlers/pbs.py
+++ b/cylc/flow/job_runner_handlers/pbs.py
@@ -81,7 +81,7 @@ class PBSHandler:
     # N.B. The "qstat JOB_ID" command returns 1 if JOB_ID is no longer in the
     # system, so there is no need to filter its output.
     POLL_CMD = "qstat"
-    POLL_CANT_CONNECT_ERR = "Connection refused"
+    POLL_CANT_CONNECT_ERR = "cannot connect to server"
     REC_ID_FROM_SUBMIT_OUT = re.compile(r"^\s*(?P<id>\d+)", re.M)
     SUBMIT_CMD_TMPL = "qsub '%(job)s'"
     TIME_LIMIT_DIRECTIVE = "-l walltime"


### PR DESCRIPTION
Closes #6531 

* Addresses #6531 on the 8.4.x branch.
* Cylc 8 port of 7b6d8cb6f7d1cd0598740ad35d64de14b3232a7b
* Update the PBS job runner to reflect a change in error message.
* The new pattern will also match the old format.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.