### PR TITLE
Fix evaluation of conditional expressions at negative cycle points

### DIFF
--- a/changes.d/6590.fix.md
+++ b/changes.d/6590.fix.md
@@ -1,0 +1,1 @@
+Fix validation of conditional expressions with negative integer offsets larger than `-P1`.

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -198,16 +198,15 @@ class Prerequisite:
 
         Examples:
             # GH #3644 construct conditional expression when one task name
-            # is a substring of another: foo | xfoo => bar.
-            # Add 'foo' to the 'satisfied' dict before 'xfoo'.
+            # is a substring of another: 11/foo | 1/foo => bar.
             >>> preq = Prerequisite(1)
             >>> preq[(1, 'foo', 'succeeded')] = False
-            >>> preq[(1, 'xfoo', 'succeeded')] = False
-            >>> preq.set_conditional_expr("1/foo succeeded|1/xfoo succeeded")
+            >>> preq[(11, 'foo', 'succeeded')] = False
+            >>> preq.set_conditional_expr("11/foo succeeded|1/foo succeeded")
             >>> expr = preq.conditional_expression
             >>> expr.split('|')  # doctest: +NORMALIZE_WHITESPACE
-            ['bool(self._satisfied[("1", "foo", "succeeded")])',
-            'bool(self._satisfied[("1", "xfoo", "succeeded")])']
+            ['bool(self._satisfied[("11", "foo", "succeeded")])',
+            'bool(self._satisfied[("1", "foo", "succeeded")])']
 
             # GH #6588 integer offset "x[-P2] | a" gives a negative cycle point
             # during validation, for evaluation at the initial cycle point 1.

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -225,8 +225,14 @@ class Prerequisite:
             for t_output in self._satisfied:
                 # Use '\b' in case one task name is a substring of another
                 # and escape special chars ('.', timezone '+') in task IDs.
+                msg = self.MESSAGE_TEMPLATE % t_output
+                if msg[0] == '-':
+                    # -ve cycles: \b needs to be to the right of the `-` char.
+                    pattern = fr"-\b{re.escape(msg[1:])}\b"
+                else:
+                    pattern = fr"\b{re.escape(msg)}\b"
                 expr = re.sub(
-                    fr"{re.escape(self.MESSAGE_TEMPLATE % t_output)}\b",
+                    pattern,
                     self.SATISFIED_TEMPLATE % t_output,
                     expr
                 )

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -209,6 +209,16 @@ class Prerequisite:
             ['bool(self._satisfied[("1", "foo", "succeeded")])',
             'bool(self._satisfied[("1", "xfoo", "succeeded")])']
 
+            # GH #6588 integer offset "x[-P2] | a" gives a negative cycle point
+            # during validation, for evaluation at the initial cycle point 1.
+            >>> preq = Prerequisite(1)
+            >>> preq[(-1, 'x', 'succeeded')] = False
+            >>> preq[(1, 'a', 'succeeded')] = False
+            >>> preq.set_conditional_expr("-1/x succeeded|1/a succeeded")
+            >>> expr = preq.conditional_expression
+            >>> expr.split('|')  # doctest: +NORMALIZE_WHITESPACE
+            ['bool(self._satisfied[("-1", "x", "succeeded")])',
+            'bool(self._satisfied[("1", "a", "succeeded")])']
         """
         self._cached_satisfied = None
         if '|' in expr:

--- a/cylc/flow/prerequisite.py
+++ b/cylc/flow/prerequisite.py
@@ -217,7 +217,7 @@ class Prerequisite:
                 # Use '\b' in case one task name is a substring of another
                 # and escape special chars ('.', timezone '+') in task IDs.
                 expr = re.sub(
-                    fr"\b{re.escape(self.MESSAGE_TEMPLATE % t_output)}\b",
+                    fr"{re.escape(self.MESSAGE_TEMPLATE % t_output)}\b",
                     self.SATISFIED_TEMPLATE % t_output,
                     expr
                 )


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.
-->

Integer offsets `[-P2]` or bigger aren't getting replaced with Python code in prerequisite conditional expressions because they generate negative cycle points when evaluated at initial cycle point 1. (There's no problem with `[-P1]` - that generates a cycle point of 0).

Close #6588 


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
