### PR TITLE
Poll comms: always process standard outputs on poll

### DIFF
--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -25,6 +25,11 @@ Please update this file as the interface changes.
 """
 
 from contextlib import suppress
+from dataclasses import (
+    dataclass,
+    field,
+    fields,
+)
 import json
 import os
 from pathlib import Path
@@ -35,9 +40,9 @@ import stat
 from subprocess import DEVNULL  # nosec
 import sys
 import traceback
+from typing import Literal
 
 from cylc.flow.cylc_subproc import procopen
-from cylc.flow.parsec.OrderedDict import OrderedDict
 from cylc.flow.task_job_logs import (
     JOB_LOG_ERR,
     JOB_LOG_JOB,
@@ -58,59 +63,45 @@ from cylc.flow.wallclock import get_current_time_string
 JOB_FILES_REMOVED_MESSAGE = 'ERR_JOB_FILES_REMOVED'
 
 
-class JobPollContext():
+@dataclass(slots=True)
+class JobPollContext:
     """Context object for a job poll."""
-    CONTEXT_ATTRIBUTES = (
-        'job_log_dir',  # cycle/task/submit_num
-        'job_runner_name',
-        'job_id',  # job id in job runner
-        'job_runner_exit_polled',  # 0 for false, 1 for true
-        'run_status',  # 0 for success, 1 for failure
-        'run_signal',  # signal received on run failure
-        'time_submit_exit',  # submit (exit) time
-        'time_run',  # run start time
-        'time_run_exit',  # run exit time
-        'job_runner_call_no_lines',  # line count in job runner call stdout
-    )
+    job_log_dir: str
+    job_runner_name: str | None = None
+    job_id: str | None = None
+    """Job ID in job runner."""
+    job_runner_exit_polled: Literal[0, 1, None] = None
+    """Has exited job runner? 0 for false, 1 for true."""
+    run_status: 'Literal[0, 1, None]' = None
+    """0 for success, 1 for failure."""
+    run_signal: str | None = None
+    """Signal received on run failure."""
+    time_submit_exit: str | None = None
+    """Time when the job runner finished submitting the job."""
+    time_run: str | None = None
+    """Time when the job started running."""
+    time_run_exit: str | None = None
+    """Time when the job finished running."""
 
-    __slots__ = CONTEXT_ATTRIBUTES + (
-        'pid',
-        'messages'
-    )
+    pid: str | None = field(default=None, init=False)
+    """Job process ID."""
+    messages: list[str] = field(default_factory=list, init=False)
+    """Messages sent by the job."""
 
-    def __init__(self, job_log_dir, **attrs):
-        self.job_log_dir = job_log_dir
-        self.job_runner_name: str | None = None
-        self.job_id = None
-        self.job_runner_exit_polled: int | None = None
-        self.pid = None
-        self.run_status: int | None = None
-        self.run_signal: str | None = None
-        self.time_submit_exit: str | None = None
-        self.time_run: str | None = None
-        self.time_run_exit: str | None = None
-        self.job_runner_call_no_lines = None
-        self.messages = []
-
-        if attrs:
-            for key, value in attrs.items():
-                if key not in self.CONTEXT_ATTRIBUTES:
-                    raise ValueError('Invalid kwarg "%s"' % key)
-                setattr(self, key, value)
-
-    def update(self, other):
+    def update(self, other: 'JobPollContext') -> None:
         """Update my data from given file context."""
         for i in self.__slots__:
             setattr(self, i, getattr(other, i))
 
-    def get_summary_str(self):
+    def get_summary_str(self) -> str:
         """Return the poll context as a summary string delimited by "|"."""
-        ret = OrderedDict()
-        for key in self.CONTEXT_ATTRIBUTES:
-            value = getattr(self, key)
-            if key == 'job_log_dir' or value is None:
-                continue
-            ret[key] = value
+        ret = {
+            field.name: value
+            for field in fields(self)
+            if field.init
+            and field.name != 'job_log_dir'
+            and (value := getattr(self, field.name)) is not None
+        }
         return '%s|%s' % (self.job_log_dir, json.dumps(ret))
 
 
@@ -238,7 +229,7 @@ class JobRunnerManager():
             job_log_root = os.path.expandvars(job_log_root)
         self.configure_workflow_run_dir(job_log_root.rsplit(os.sep, 2)[0])
 
-        ctx_list = []  # Contexts for all relevant jobs
+        ctx_list: list[JobPollContext] = []  # Contexts for all relevant jobs
         ctx_list_by_job_runner = {}  # {job_runner_name1: [ctx1, ...], ...}
 
         for job_log_dir in job_log_dirs:
@@ -258,8 +249,11 @@ class JobRunnerManager():
             # We can trust:
             # * Jobs previously polled to have exited the job runner.
             # * Jobs succeeded or failed with ERR/EXIT.
-            if (ctx.job_runner_exit_polled or ctx.run_status == 0 or
-                    ctx.run_signal in ["ERR", "EXIT"]):
+            if (
+                ctx.job_runner_exit_polled
+                or ctx.run_status == 0
+                or ctx.run_signal in {"ERR", "EXIT"}
+            ):
                 continue
 
             if ctx.job_runner_name not in ctx_list_by_job_runner:

--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -29,22 +29,30 @@ import json
 import os
 from pathlib import Path
 import shlex
-import stat
-import sys
-import traceback
 from shutil import rmtree
 from signal import SIGKILL
+import stat
 from subprocess import DEVNULL  # nosec
+import sys
+import traceback
 
-from cylc.flow.task_message import (
-    CYLC_JOB_PID, CYLC_JOB_INIT_TIME, CYLC_JOB_EXIT_TIME, CYLC_JOB_EXIT,
-    CYLC_MESSAGE)
 from cylc.flow.cylc_subproc import procopen
+from cylc.flow.parsec.OrderedDict import OrderedDict
 from cylc.flow.task_job_logs import (
-    JOB_LOG_ERR, JOB_LOG_JOB, JOB_LOG_OUT, JOB_LOG_STATUS)
+    JOB_LOG_ERR,
+    JOB_LOG_JOB,
+    JOB_LOG_OUT,
+    JOB_LOG_STATUS,
+)
+from cylc.flow.task_message import (
+    CYLC_JOB_EXIT,
+    CYLC_JOB_EXIT_TIME,
+    CYLC_JOB_INIT_TIME,
+    CYLC_JOB_PID,
+    CYLC_MESSAGE,
+)
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.wallclock import get_current_time_string
-from cylc.flow.parsec.OrderedDict import OrderedDict
 
 
 JOB_FILES_REMOVED_MESSAGE = 'ERR_JOB_FILES_REMOVED'
@@ -72,15 +80,15 @@ class JobPollContext():
 
     def __init__(self, job_log_dir, **attrs):
         self.job_log_dir = job_log_dir
-        self.job_runner_name = None
+        self.job_runner_name: str | None = None
         self.job_id = None
-        self.job_runner_exit_polled = None
+        self.job_runner_exit_polled: int | None = None
         self.pid = None
-        self.run_status = None
-        self.run_signal = None
-        self.time_submit_exit = None
-        self.time_run = None
-        self.time_run_exit = None
+        self.run_status: int | None = None
+        self.run_signal: str | None = None
+        self.time_submit_exit: str | None = None
+        self.time_run: str | None = None
+        self.time_run_exit: str | None = None
         self.job_runner_call_no_lines = None
         self.messages = []
 

--- a/cylc/flow/run_modes/simulation.py
+++ b/cylc/flow/run_modes/simulation.py
@@ -95,7 +95,9 @@ def submit_task_job(
         task_job_mgr.get_simulation_job_conf(itask)
     )
     for output in (TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED):
-        task_job_mgr.task_events_mgr.process_message(itask, INFO, output)
+        task_job_mgr.task_events_mgr.process_message(
+            itask, INFO, output, event_time=now[1]
+        )
     task_job_mgr.workflow_db_mgr.put_insert_task_jobs(
         itask, {
             'time_submit': now[1],

--- a/cylc/flow/run_modes/simulation.py
+++ b/cylc/flow/run_modes/simulation.py
@@ -39,14 +39,12 @@ from cylc.flow.exceptions import PointParsingError
 from cylc.flow.platforms import FORBIDDEN_WITH_PLATFORM
 from cylc.flow.run_modes import RunMode
 from cylc.flow.task_outputs import (
+    TASK_OUTPUT_FAILED,
     TASK_OUTPUT_STARTED,
     TASK_OUTPUT_SUBMITTED,
+    TASK_OUTPUT_SUCCEEDED,
 )
-from cylc.flow.task_state import (
-    TASK_STATUS_FAILED,
-    TASK_STATUS_RUNNING,
-    TASK_STATUS_SUCCEEDED,
-)
+from cylc.flow.task_state import TASK_STATUS_RUNNING
 from cylc.flow.util import serialise_set
 from cylc.flow.wallclock import get_unix_time_from_time_string
 
@@ -374,12 +372,12 @@ def sim_time_check(
             # simulate job outcome
             if itask.mode_settings.sim_task_fails:
                 task_events_manager.process_message(
-                    itask, 'CRITICAL', TASK_STATUS_FAILED,
+                    itask, 'CRITICAL', TASK_OUTPUT_FAILED,
                     flag=task_events_manager.FLAG_RECEIVED
                 )
             else:
                 task_events_manager.process_message(
-                    itask, 'DEBUG', TASK_STATUS_SUCCEEDED,
+                    itask, 'DEBUG', TASK_OUTPUT_SUCCEEDED,
                     flag=task_events_manager.FLAG_RECEIVED
                 )
 

--- a/cylc/flow/run_modes/skip.py
+++ b/cylc/flow/run_modes/skip.py
@@ -92,7 +92,9 @@ def submit_task_job(
         process_outputs(itask, rtconfig),
         key=itask.state.outputs.output_sort_key,
     ):
-        task_job_mgr.task_events_mgr.process_message(itask, INFO, output)
+        task_job_mgr.task_events_mgr.process_message(
+            itask, INFO, output, event_time=now[1]
+        )
 
     return True
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -138,6 +138,7 @@ from cylc.flow.run_modes.simulation import sim_time_check
 from cylc.flow.subprocpool import SubProcPool
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_job_mgr import TaskJobManager
+from cylc.flow.task_outputs import TASK_OUTPUT_FAILED
 from cylc.flow.task_pool import TaskPool
 from cylc.flow.task_remote_mgr import (
     REMOTE_FILE_INSTALL_255,
@@ -148,7 +149,6 @@ from cylc.flow.task_remote_mgr import (
     REMOTE_INIT_FAILED,
 )
 from cylc.flow.task_state import (
-    TASK_STATUS_FAILED,
     TASK_STATUS_PREPARING,
     TASK_STATUS_RUNNING,
     TASK_STATUS_SUBMITTED,
@@ -1081,7 +1081,7 @@ class Scheduler:
                 if jobless:
                     # Directly set failed in sim mode:
                     self.task_events_mgr.process_message(
-                        itask, 'CRITICAL', TASK_STATUS_FAILED,
+                        itask, 'CRITICAL', TASK_OUTPUT_FAILED,
                         flag=self.task_events_mgr.FLAG_RECEIVED
                     )
         if warn and unkillable:

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -455,30 +455,25 @@ class TaskEventsManager():
     * Set up task (submission) retries on job (submission) failures.
     * Generate and manage task event handlers.
     """
-    EVENT_FAILED = TASK_OUTPUT_FAILED
     EVENT_LATE = "late"
     EVENT_RETRY = "retry"
-    EVENT_STARTED = TASK_OUTPUT_STARTED
-    EVENT_SUBMITTED = TASK_OUTPUT_SUBMITTED
-    EVENT_EXPIRED = TASK_OUTPUT_EXPIRED
-    EVENT_SUBMIT_FAILED = "submission failed"
+    _EVENT_SUBMIT_FAILED = "submission failed"
     EVENT_SUBMIT_RETRY = "submission retry"
     EVENT_SUBMIT_TIMEOUT = "submission timeout"
     EVENT_EXEC_TIMEOUT = "execution timeout"
-    EVENT_SUCCEEDED = TASK_OUTPUT_SUCCEEDED
     NON_UNIQUE_EVENTS = ('warning', 'critical', 'custom')
     STD_EVENTS = [
-        EVENT_SUBMITTED,
+        TASK_OUTPUT_SUBMITTED,
         EVENT_SUBMIT_TIMEOUT,
         EVENT_SUBMIT_RETRY,
-        EVENT_SUBMIT_FAILED,
-        EVENT_STARTED,
+        _EVENT_SUBMIT_FAILED,
+        TASK_OUTPUT_STARTED,
         EVENT_EXEC_TIMEOUT,
         EVENT_RETRY,
-        EVENT_SUCCEEDED,
-        EVENT_FAILED,
+        TASK_OUTPUT_SUCCEEDED,
+        TASK_OUTPUT_FAILED,
         EVENT_LATE,
-        EVENT_EXPIRED,
+        TASK_OUTPUT_EXPIRED,
         *NON_UNIQUE_EVENTS,
     ]
 
@@ -488,16 +483,16 @@ class TaskEventsManager():
     HANDLER_JOB_LOGS_RETRIEVE = "job-logs-retrieve"
     FLAG_INTERNAL = "(internal)"
     FLAG_RECEIVED = "(received)"
-    FLAG_RECEIVED_IGNORED = "(received-ignored)"
+    _FLAG_RECEIVED_IGNORED = "(received-ignored)"
     FLAG_POLLED = "(polled)"
-    FLAG_POLLED_IGNORED = "(polled-ignored)"
+    _FLAG_POLLED_IGNORED = "(polled-ignored)"
     KEY_EXECUTE_TIME_LIMIT = 'execution_time_limit'
     JOB_SUBMIT_SUCCESS_FLAG = 0
     JOB_SUBMIT_FAIL_FLAG = 1
     JOB_LOGS_RETRIEVAL_EVENTS = {
-        EVENT_FAILED,
+        TASK_OUTPUT_FAILED,
         EVENT_RETRY,
-        EVENT_SUCCEEDED
+        TASK_OUTPUT_SUCCEEDED
     }
 
     workflow_cfg: Dict[str, Any]
@@ -735,9 +730,16 @@ class TaskEventsManager():
         # TODO: https://github.com/cylc/cylc-flow/issues/6857
         # LOG.debug(f'Message {flag} for {itask}: "{message}"')
 
-        # Log messages
         if event_time is None:
             event_time = get_current_time_string()
+
+        event = message
+        if message == TASK_OUTPUT_SUBMIT_FAILED:
+            # Previously we were using the event name as the message
+            event = self._EVENT_SUBMIT_FAILED
+        elif message == self._EVENT_SUBMIT_FAILED:
+            message = TASK_OUTPUT_SUBMIT_FAILED
+
         if submit_num is None:
             submit_num = itask.submit_num
         if isinstance(severity, int):
@@ -773,6 +775,9 @@ class TaskEventsManager():
 
         output_completed: bool | None = False
         if task_output not in {TASK_OUTPUT_SUBMIT_FAILED, TASK_OUTPUT_FAILED}:
+            # Do not complete (submit-)failed outputs as there might be
+            # retries. We check this in the respective _process_message_x
+            # helper functions and complete the outputs there if appropriate.
             output_completed = (
                 itask.state.outputs.set_message_complete(task_output, forced)
             )
@@ -790,7 +795,7 @@ class TaskEventsManager():
                 self.FLAG_INTERNAL, submit_num, forced
             )
 
-        if message == self.EVENT_STARTED:
+        if message == TASK_OUTPUT_STARTED:
             if flag == self.FLAG_RECEIVED and itask.state.is_gt(
                 TASK_STATUS_RUNNING
             ):
@@ -799,15 +804,15 @@ class TaskEventsManager():
             self._process_message_started(itask, event_time, forced)
             self.spawn_children(itask, TASK_OUTPUT_STARTED, forced)
 
-        elif message == self.EVENT_SUCCEEDED:
+        elif message == TASK_OUTPUT_SUCCEEDED:
             self._process_message_succeeded(itask, event_time, forced)
             self.spawn_children(itask, TASK_OUTPUT_SUCCEEDED, forced)
 
-        elif message == self.EVENT_EXPIRED:
+        elif message == TASK_OUTPUT_EXPIRED:
             self._process_message_expired(itask, forced)
             self.spawn_children(itask, TASK_OUTPUT_EXPIRED, forced)
 
-        elif task_output == self.EVENT_FAILED:
+        elif task_output == TASK_OUTPUT_FAILED:
             if flag == self.FLAG_RECEIVED and itask.state.is_gt(
                 TASK_STATUS_FAILED
             ):
@@ -833,7 +838,7 @@ class TaskEventsManager():
             ):
                 self.spawn_children(itask, TASK_OUTPUT_FAILED, forced)
 
-        elif message == self.EVENT_SUBMIT_FAILED:
+        elif message == TASK_OUTPUT_SUBMIT_FAILED:
             if flag == self.FLAG_RECEIVED and itask.state.is_gt(
                 TASK_STATUS_SUBMIT_FAILED
             ):
@@ -844,7 +849,7 @@ class TaskEventsManager():
             ):
                 self.spawn_children(itask, TASK_OUTPUT_SUBMIT_FAILED, forced)
 
-        elif message == self.EVENT_SUBMITTED:
+        elif message == TASK_OUTPUT_SUBMITTED:
             if flag == self.FLAG_RECEIVED and itask.state.is_gte(
                 TASK_STATUS_SUBMITTED
             ):
@@ -858,7 +863,7 @@ class TaskEventsManager():
 
         elif run_signal is not None and task_output == VACATION_MESSAGE_PREFIX:
             # Task job pre-empted into a vacation state
-            self._db_events_insert(itask, "vacated", message)
+            self._db_events_insert(itask, "vacated", event)
             itask.set_summary_time('started')  # unset
             if TimerFlags.SUBMISSION_RETRY in itask.try_timers:
                 itask.try_timers[TimerFlags.SUBMISSION_RETRY].num = 0
@@ -872,7 +877,7 @@ class TaskEventsManager():
             # this feature can only be used on the deprecated loadleveler
             # system, we should probably aim to remove support for job vacation
             # instead. Otherwise, we should have:
-            # self.setup_event_handlers(itask, 'vacated', message)
+            # self.setup_event_handlers(itask, 'vacated', event)
 
         elif output_completed:
             # Must be a message of a custom task output.
@@ -880,7 +885,7 @@ class TaskEventsManager():
             # Log completion of o      (not needed for standard outputs)
             trigger = itask.state.outputs.get_trigger(message)
             LOG.info(f"[{itask}] completed output {trigger}")
-            self.setup_event_handlers(itask, trigger, message)
+            self.setup_event_handlers(itask, trigger, event)
             self.spawn_children(itask, task_output, forced)
 
         else:
@@ -891,11 +896,11 @@ class TaskEventsManager():
             # No state change.
             LOG.debug(f"[{itask}] unhandled: {message}")
             self._db_events_insert(
-                itask, (f"message {lseverity}"), message)
+                itask, (f"message {lseverity}"), event)
 
         if lseverity in self.NON_UNIQUE_EVENTS:
             itask.non_unique_events.update({lseverity: 1})
-            self.setup_event_handlers(itask, lseverity, message)
+            self.setup_event_handlers(itask, lseverity, event)
 
         return False
 
@@ -926,7 +931,7 @@ class TaskEventsManager():
             # Ignore received messages from old jobs
             LOG.warning(
                 f"[{itask}] "
-                f"{self.FLAG_RECEIVED_IGNORED}{message}{timestamp} "
+                f"{self._FLAG_RECEIVED_IGNORED}{message}{timestamp} "
                 f"for job({submit_num:02d}) != job({itask.submit_num:02d})"
             )
             return False
@@ -962,26 +967,26 @@ class TaskEventsManager():
             if flag == self.FLAG_RECEIVED:
                 LOG.warning(
                     f"[{itask}] "
-                    f"{self.FLAG_RECEIVED_IGNORED}{message}{timestamp}"
+                    f"{self._FLAG_RECEIVED_IGNORED}{message}{timestamp}"
                 )
 
             else:
                 LOG.warning(
                     f"[{itask}] "
-                    f"{self.FLAG_POLLED_IGNORED}{message}{timestamp}"
+                    f"{self._FLAG_POLLED_IGNORED}{message}{timestamp}"
                 )
             return False
 
         severity_lvl: int = LOG_LEVELS.get(severity, INFO)
         # Don't log submit/failure messages here:
         if flag != self.FLAG_POLLED and message in {
-            self.EVENT_SUBMIT_FAILED, f'{FAIL_MESSAGE_PREFIX}/ERR'
+            TASK_OUTPUT_SUBMIT_FAILED, f'{FAIL_MESSAGE_PREFIX}/ERR'
         }:
             return True
         # Demote log level to DEBUG if this is a message that duplicates what
         # gets logged by itask state change anyway (and not manual poll)
         if severity_lvl > DEBUG and flag != self.FLAG_POLLED and message in {
-            self.EVENT_SUBMITTED, self.EVENT_STARTED, self.EVENT_SUCCEEDED,
+            TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_STARTED, TASK_OUTPUT_SUCCEEDED
         }:
             severity_lvl = DEBUG
         LOG.log(severity_lvl, f"[{itask}] {flag}{message}{timestamp}")
@@ -1408,7 +1413,7 @@ class TaskEventsManager():
         no_retries = False
         if not forced:
             self._process_job_failed(itask, event_time, run_signal)
-        LOG.error(f'[{itask}] {full_message or self.EVENT_FAILED}')
+        LOG.error(f'[{itask}] {full_message or TASK_OUTPUT_FAILED}')
         if (
             forced
             or TimerFlags.EXECUTION_RETRY not in itask.try_timers
@@ -1422,7 +1427,7 @@ class TaskEventsManager():
                     self.workflow_db_mgr.put_update_task_state(itask)
                 else:
                     self.setup_event_handlers(
-                        itask, self.EVENT_FAILED, message
+                        itask, TASK_OUTPUT_FAILED, message
                     )
                 itask.state.outputs.set_message_complete(TASK_OUTPUT_FAILED)
                 self.data_store_mgr.delta_task_output(
@@ -1467,7 +1472,8 @@ class TaskEventsManager():
             LOG.info(f"[{itask}] Vacated job restarted")
         if itask.state_reset(TASK_STATUS_RUNNING, forced=forced):
             self.setup_event_handlers(
-                itask, self.EVENT_STARTED, f'job {self.EVENT_STARTED}')
+                itask, TASK_OUTPUT_STARTED, f'job {TASK_OUTPUT_STARTED}'
+            )
             self.data_store_mgr.delta_task_state(itask)
         self._reset_job_timers(itask)
 
@@ -1490,7 +1496,7 @@ class TaskEventsManager():
         self.data_store_mgr.delta_task_state(itask)
         self.setup_event_handlers(
             itask,
-            self.EVENT_EXPIRED,
+            TASK_OUTPUT_EXPIRED,
             "Task expired: will not submit job."
         )
 
@@ -1511,7 +1517,8 @@ class TaskEventsManager():
             )
         if itask.state_reset(TASK_STATUS_SUCCEEDED, forced=forced):
             self.setup_event_handlers(
-                itask, self.EVENT_SUCCEEDED, f"job {self.EVENT_SUCCEEDED}")
+                itask, TASK_OUTPUT_SUCCEEDED, f"job {TASK_OUTPUT_SUCCEEDED}"
+            )
             self.data_store_mgr.delta_task_state(itask)
         self._reset_job_timers(itask)
 
@@ -1532,7 +1539,7 @@ class TaskEventsManager():
         Return True if no retries (hence go to the submit-failed state).
         """
         no_retries = False
-        LOG.error(f"[{itask}] {self.EVENT_SUBMIT_FAILED}")
+        LOG.error(f"[{itask}] {self._EVENT_SUBMIT_FAILED}")
         if (
             TimerFlags.SUBMISSION_RETRY not in itask.try_timers
             or itask.try_timers[TimerFlags.SUBMISSION_RETRY].next() is None
@@ -1546,8 +1553,8 @@ class TaskEventsManager():
                     self.workflow_db_mgr.put_update_task_state(itask)
                 else:
                     self.setup_event_handlers(
-                        itask, self.EVENT_SUBMIT_FAILED,
-                        f'job {self.EVENT_SUBMIT_FAILED}'
+                        itask, self._EVENT_SUBMIT_FAILED,
+                        f'job {self._EVENT_SUBMIT_FAILED}'
                     )
                 itask.state.outputs.set_message_complete(
                     TASK_OUTPUT_SUBMIT_FAILED
@@ -1561,7 +1568,7 @@ class TaskEventsManager():
             self._retry_task(itask, timer.timeout, submit_retry=True)
             delay_msg = f"retrying in {timer.delay_timeout_as_str()}"
             LOG.warning(f"[{itask}] {delay_msg}")
-            msg = f"job {self.EVENT_SUBMIT_FAILED}, {delay_msg}"
+            msg = f"job {self._EVENT_SUBMIT_FAILED}, {delay_msg}"
             self.setup_event_handlers(itask, self.EVENT_SUBMIT_RETRY, msg)
 
         self._process_job_submit_failed(itask, event_time)
@@ -1599,8 +1606,8 @@ class TaskEventsManager():
                 itask.state_reset(is_queued=False)
                 self.setup_event_handlers(
                     itask,
-                    self.EVENT_SUBMITTED,
-                    f'job {self.EVENT_SUBMITTED}',
+                    TASK_OUTPUT_SUBMITTED,
+                    f'job {TASK_OUTPUT_SUBMITTED}',
                 )
                 self.data_store_mgr.delta_task_state(itask)
             self._reset_job_timers(itask)

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -706,7 +706,7 @@ class TaskEventsManager():
             severity:
                 Message severity, should be a recognised logging level.
             message:
-                Message content.
+                Message content (usually a task output).
             event_time:
                 Event time stamp. Expect ISO8601 date time string.
                 If not specified, use current time.
@@ -804,7 +804,7 @@ class TaskEventsManager():
             self.spawn_children(itask, TASK_OUTPUT_SUCCEEDED, forced)
 
         elif message == self.EVENT_EXPIRED:
-            self._process_message_expired(itask, event_time, forced)
+            self._process_message_expired(itask, forced)
             self.spawn_children(itask, TASK_OUTPUT_EXPIRED, forced)
 
         elif task_output == self.EVENT_FAILED:
@@ -1483,7 +1483,7 @@ class TaskEventsManager():
             "time_run": event_time,
         })
 
-    def _process_message_expired(self, itask, event_time, forced):
+    def _process_message_expired(self, itask: 'TaskProxy', forced: bool):
         """Helper for process_message, handle task expiry."""
         if not itask.state_reset(TASK_STATUS_EXPIRED, forced=forced):
             return

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -102,6 +102,7 @@ from cylc.flow.task_message import FAIL_MESSAGE_PREFIX
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_FAILED,
     TASK_OUTPUT_STARTED,
+    TASK_OUTPUT_SUBMIT_FAILED,
     TASK_OUTPUT_SUBMITTED,
     TASK_OUTPUT_SUCCEEDED,
 )
@@ -144,7 +145,7 @@ def _submitted_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
 
 def _submit_failed_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
     return {
-        TaskEventsManager.EVENT_SUBMIT_FAILED: jp_ctx.time_submit_exit,
+        TASK_OUTPUT_SUBMIT_FAILED: jp_ctx.time_submit_exit,
     }
 
 
@@ -759,8 +760,8 @@ class TaskJobManager:
             itask.state.kill_failed = True
         elif itask.state(TASK_STATUS_SUBMITTED):
             self.task_events_mgr.process_message(
-                itask, CRITICAL, self.task_events_mgr.EVENT_SUBMIT_FAILED,
-                ctx.timestamp)
+                itask, CRITICAL, TASK_OUTPUT_SUBMIT_FAILED, ctx.timestamp
+            )
         elif itask.state(TASK_STATUS_RUNNING):
             self.task_events_mgr.process_message(
                 itask, CRITICAL, TASK_OUTPUT_FAILED)
@@ -1168,8 +1169,8 @@ class TaskJobManager:
                 itask, DEBUG, TASK_OUTPUT_SUBMITTED, ctx.timestamp)
         else:
             self.task_events_mgr.process_message(
-                itask, CRITICAL, self.task_events_mgr.EVENT_SUBMIT_FAILED,
-                ctx.timestamp)
+                itask, CRITICAL, TASK_OUTPUT_SUBMIT_FAILED, ctx.timestamp
+            )
 
     def _prep_submit_task_job(
         self,
@@ -1387,7 +1388,8 @@ class TaskJobManager:
             }
         )
         self.task_events_mgr.process_message(
-            itask, CRITICAL, self.task_events_mgr.EVENT_SUBMIT_FAILED)
+            itask, CRITICAL, TASK_OUTPUT_SUBMIT_FAILED
+        )
 
     def _prep_submit_task_job_impl(self, itask, rtconfig):
         """Helper for self._prep_submit_task_job."""

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -764,7 +764,8 @@ class TaskJobManager:
             )
         elif itask.state(TASK_STATUS_RUNNING):
             self.task_events_mgr.process_message(
-                itask, CRITICAL, TASK_OUTPUT_FAILED)
+                itask, CRITICAL, TASK_OUTPUT_FAILED, ctx.timestamp
+            )
         else:
             log_lvl = DEBUG
             log_msg = (

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -136,6 +136,39 @@ if TYPE_CHECKING:
     from cylc.flow.workflow_db_mgr import WorkflowDatabaseManager
 
 
+def _submitted_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
+    return {
+        TASK_STATUS_SUBMITTED: jp_ctx.time_submit_exit,
+    }
+
+
+def _submit_failed_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
+    return {
+        TaskEventsManager.EVENT_SUBMIT_FAILED: jp_ctx.time_submit_exit,
+    }
+
+
+def _started_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
+    return {
+        **_submitted_msgs(jp_ctx),
+        TASK_OUTPUT_STARTED: jp_ctx.time_run,
+    }
+
+
+def _succeeded_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
+    return {
+        **_started_msgs(jp_ctx),
+        TASK_OUTPUT_SUCCEEDED: jp_ctx.time_run_exit,
+    }
+
+
+def _failed_msgs(jp_ctx: 'JobPollContext') -> dict[str, str | None]:
+    return {
+        **_started_msgs(jp_ctx),
+        TASK_OUTPUT_FAILED: jp_ctx.time_run_exit,
+    }
+
+
 class TaskJobManager:
     """Manage task job submit, poll and kill.
 
@@ -850,58 +883,62 @@ class TaskJobManager:
                 ctx, self.workflow, itask.point, itask.tdef.name
             )
 
-        flag = self.task_events_mgr.FLAG_POLLED
-        # Only log at INFO level if manually polling
-        log_lvl = DEBUG if (
-            itask.platform.get('communication method') == 'poll'
-        ) else INFO
-
         if jp_ctx.run_signal == JOB_FILES_REMOVED_MESSAGE:
             LOG.error(
                 f"platform: {itask.platform['name']} - job log directory "
                 f"{itask.job_tokens.relative_id} no longer exists"
             )
 
-        if jp_ctx.run_status == 1 and jp_ctx.run_signal in ["ERR", "EXIT"]:
-            # Failed normally
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_OUTPUT_FAILED, jp_ctx.time_run_exit, flag)
-        elif jp_ctx.run_status == 1 and jp_ctx.job_runner_exit_polled == 1:
-            # Failed by a signal, and no longer in job runner
-            self.task_events_mgr.process_message(
-                itask, log_lvl, f"{FAIL_MESSAGE_PREFIX}/{jp_ctx.run_signal}",
-                jp_ctx.time_run_exit,
-                flag)
-        elif jp_ctx.run_status == 1:  # noqa: SIM114
-            # The job has terminated, but is still managed by job runner.
-            # Some job runners may restart a job in this state, so don't
-            # mark as failed yet.
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_OUTPUT_STARTED, jp_ctx.time_run, flag)
+        if jp_ctx.run_status == 1:
+            if jp_ctx.run_signal in {"ERR", "EXIT"}:
+                # Failed normally
+                messages = _failed_msgs(jp_ctx)
+            elif jp_ctx.job_runner_exit_polled == 1:
+                # Failed by a signal, and no longer in job runner
+                messages = {
+                    **_started_msgs(jp_ctx),
+                    f'{FAIL_MESSAGE_PREFIX}/{jp_ctx.run_signal}': (
+                        jp_ctx.time_run_exit
+                    ),
+                }
+            else:
+                # The job has terminated, but is still managed by job runner.
+                # Some job runners may restart a job in this state, so don't
+                # mark as failed yet.
+                messages = _started_msgs(jp_ctx)
         elif jp_ctx.run_status == 0:
             # The job succeeded
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_OUTPUT_SUCCEEDED, jp_ctx.time_run_exit,
-                flag)
+            messages = _succeeded_msgs(jp_ctx)
         elif jp_ctx.time_run and jp_ctx.job_runner_exit_polled == 1:
             # The job has terminated without executing the error trap
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_OUTPUT_FAILED, get_current_time_string(),
-                flag)
+            messages = {
+                **_failed_msgs(jp_ctx),
+                TASK_OUTPUT_FAILED: get_current_time_string(),
+            }
         elif jp_ctx.time_run:
             # The job has started, and is still managed by job runner
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_OUTPUT_STARTED, jp_ctx.time_run, flag)
+            messages = _started_msgs(jp_ctx)
         elif jp_ctx.job_runner_exit_polled == 1:
             # The job never ran, and no longer in job runner
-            self.task_events_mgr.process_message(
-                itask, log_lvl, self.task_events_mgr.EVENT_SUBMIT_FAILED,
-                jp_ctx.time_submit_exit, flag)
+            messages = _submit_failed_msgs(jp_ctx)
         else:
             # The job never ran, and is in job runner
-            self.task_events_mgr.process_message(
-                itask, log_lvl, TASK_STATUS_SUBMITTED, jp_ctx.time_submit_exit,
-                flag)
+            messages = _submitted_msgs(jp_ctx)
+
+        # Only log at INFO level if manually polling
+        log_lvl = DEBUG if (
+            itask.platform.get('communication method') == 'poll'
+        ) else INFO
+
+        for message, event_time in messages.items():
+            if event_time is not None:
+                self.task_events_mgr.process_message(
+                    itask,
+                    log_lvl,
+                    message,
+                    event_time,
+                    flag=self.task_events_mgr.FLAG_POLLED,
+                )
 
     def _poll_task_job_message_callback(self, itask, cmd_ctx, line):
         """Helper for _poll_task_jobs_callback, on message of one task job."""

--- a/cylc/flow/task_outputs.py
+++ b/cylc/flow/task_outputs.py
@@ -423,7 +423,7 @@ class TaskOutputs:
         # output was already completed
         return False
 
-    def is_message_complete(self, message: str) -> Optional[bool]:
+    def is_message_complete(self, message: str) -> bool | None:
         """Return True if this message is complete.
 
         Returns:
@@ -431,11 +431,9 @@ class TaskOutputs:
             * False if the message is not complete.
             * None if the message does not apply to these outputs.
         """
-        if message in self._completed:
-            return self._completed[message]
-        return None
+        return self._completed.get(message)
 
-    def get_completed_outputs(self) -> Dict[str, str]:
+    def get_completed_outputs(self) -> dict[str, str]:
         """Return a dict {trigger: message} of completed outputs.
 
         Replace message with "forced" if the output was forced.

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -491,7 +491,7 @@ class TaskProxy:
             and self.state.xtriggers_all_satisfied()
         )
 
-    def set_summary_time(self, event_key, time_str=None):
+    def set_summary_time(self, event_key: str, time_str: str | None = None):
         """Set an event time in self.summary
 
         Set values of both event_key + "_time" and event_key + "_time_string".
@@ -549,8 +549,13 @@ class TaskProxy:
         )
 
     def state_reset(
-        self, status=None, is_held=None, is_queued=None, is_runahead=None,
-        silent=False, forced=False
+        self,
+        status: str | None = None,
+        is_held: bool | None = None,
+        is_queued: bool | None = None,
+        is_runahead: bool | None = None,
+        silent: bool = False,
+        forced: bool = False,
     ) -> bool:
         """Set new state and log the change. Return whether it changed.
 

--- a/cylc/flow/wallclock.py
+++ b/cylc/flow/wallclock.py
@@ -93,8 +93,11 @@ def now(override_use_utc: bool | None = None) -> tuple[datetime, bool]:
         return datetime.now().astimezone(), True
 
 
-def get_current_time_string(display_sub_seconds=False, override_use_utc=None,
-                            use_basic_format=False):
+def get_current_time_string(
+    display_sub_seconds: bool = False,
+    override_use_utc: bool | None = None,
+    use_basic_format: bool = False,
+) -> str:
     """Return a string representing the current system time.
 
     Keyword arguments:

--- a/tests/functional/remote/10-poll-timings.t
+++ b/tests/functional/remote/10-poll-timings.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) Earth Sciences New Zealand & British Crown (Met Office)
+# & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that the task_jobs DB table timings are consistent with the job.status
+# file when comms method = poll.
+export REQUIRE_PLATFORM='loc:remote comms:poll'
+. "$(dirname "$0")/test_header"
+set_test_number 6
+
+create_test_global_config '' "
+[platforms]
+    [[$CYLC_TEST_PLATFORM]]
+        execution polling intervals = PT6S, PT1M
+        submission polling intervals = PT6S, PT1M
+        retrieve job logs = True
+"
+
+init_workflow "${TEST_NAME_BASE}" << __EOF__
+[scheduler]
+    [[events]]
+        workflow timeout = PT40S
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        platform = ${CYLC_TEST_PLATFORM}
+        script = sleep 2
+__EOF__
+
+run_ok "${TEST_NAME_BASE}-val" cylc validate "${WORKFLOW_NAME}"
+
+TEST_NAME="${TEST_NAME_BASE}-run"
+workflow_run_ok "$TEST_NAME" cylc play "${WORKFLOW_NAME}" --no-detach -vv
+
+# Should include both state changes from single poll
+log_scan "${TEST_NAME_BASE}-log" "${WORKFLOW_RUN_DIR}/log/scheduler/log" \
+    1 0 \
+    "(polled)started" \
+    "(polled)succeeded" \
+
+sqlite3 "${WORKFLOW_RUN_DIR}/.service/db" \
+    "SELECT time_submit_exit, time_run, time_run_exit FROM task_jobs;" \
+    > db.out
+
+JOB_STATUS_FILE="${WORKFLOW_RUN_DIR}/log/job/1/foo/01/job.status"
+exists_ok "$JOB_STATUS_FILE"
+# shellcheck disable=SC1090
+. "$JOB_STATUS_FILE"
+
+cmp_ok db.out <<< "${CYLC_JOB_RUNNER_SUBMIT_TIME}|${CYLC_JOB_INIT_TIME}|${CYLC_JOB_EXIT_TIME}"
+
+purge

--- a/tests/functional/restart/58-removed-task.t
+++ b/tests/functional/restart/58-removed-task.t
@@ -40,8 +40,8 @@ workflow_run_ok "${TEST_NAME}" cylc play --no-detach "${WORKFLOW_NAME}"
 TEST_NAME="${TEST_NAME_BASE}-restart"
 workflow_run_ok "${TEST_NAME}" cylc play --set="INCL_B_C=False" --no-detach "${WORKFLOW_NAME}"
 
-grep_workflow_log_ok "grep-3" "\[1/a/01:running\] (polled)started"
-grep_workflow_log_ok "grep-4" "\[1/b/01:failed\] (polled)failed"
+grep_workflow_log_ok "grep-3" "\[1/a/01.*\] (polled)started"
+grep_workflow_log_ok "grep-4" "\[1/b/01.*\] (polled)failed"
 
 # Failed (but not incomplete) task c should not have been polled.
 grep_fail "\[1/c/01:failed\] (polled)failed" "${WORKFLOW_RUN_DIR}/log/scheduler/log"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,10 +48,11 @@ from cylc.flow.scripts.show import (
     prereqs_and_outputs_query,
 )
 from cylc.flow.scripts.validate import ValidateOptions
-from cylc.flow.task_state import (
-    TASK_STATUS_SUBMITTED,
-    TASK_STATUS_SUCCEEDED,
+from cylc.flow.task_outputs import (
+    TASK_OUTPUT_SUBMITTED,
+    TASK_OUTPUT_SUCCEEDED,
 )
+from cylc.flow.task_state import TASK_STATUS_SUBMITTED
 from cylc.flow.util import serialise_set
 from cylc.flow.wallclock import get_current_time_string
 from cylc.flow.workflow_files import infer_latest_run_from_id
@@ -755,11 +756,11 @@ def capture_live_submissions(capcall, monkeypatch):
     def fake_submit(self, itasks, *_):
         self.submit_nonlive_task_jobs(itasks, RunMode.SIMULATION)
         for itask in itasks:
-            for status in (TASK_STATUS_SUBMITTED, TASK_STATUS_SUCCEEDED):
+            for output in (TASK_OUTPUT_SUBMITTED, TASK_OUTPUT_SUCCEEDED):
                 self.task_events_mgr.process_message(
                     itask,
                     'INFO',
-                    status,
+                    output,
                     '2000-01-01T00:00:00Z',
                     '(received)',
                 )

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -50,7 +50,6 @@ from cylc.flow.id import (
 )
 from cylc.flow.network.log_stream_handler import ProtobufStreamHandler
 from cylc.flow.scheduler import Scheduler
-from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_FAILED,
     TASK_OUTPUT_STARTED,
@@ -863,7 +862,7 @@ async def test_delta_task_outputs(one: 'Scheduler', start):
         # satisfy the submitted & started outputs
         # (note started implies submitted)
         one.task_events_mgr.process_message(
-            itask, 'INFO', TaskEventsManager.EVENT_STARTED
+            itask, 'INFO', TASK_OUTPUT_STARTED
         )
 
         # the delta should be populated with the newly satisfied outputs
@@ -883,7 +882,7 @@ async def test_delta_task_outputs(one: 'Scheduler', start):
 
         # satisfy the succeeded output
         one.task_events_mgr.process_message(
-            itask, 'INFO', TaskEventsManager.EVENT_SUCCEEDED
+            itask, 'INFO', TASK_OUTPUT_SUCCEEDED
         )
 
         # the delta should be populated with ALL satisfied outputs

--- a/tests/integration/test_optional_outputs.py
+++ b/tests/integration/test_optional_outputs.py
@@ -23,7 +23,6 @@ https://cylc.github.io/cylc-admin/proposal-optional-output-extension.html#propos
 """
 
 from itertools import combinations
-from typing import TYPE_CHECKING
 
 import logging
 import pytest
@@ -38,27 +37,23 @@ from cylc.flow.cycling.iso8601 import ISO8601Point
 from cylc.flow.exceptions import WorkflowConfigError
 from cylc.flow.id import TaskTokens, Tokens
 from cylc.flow.network.resolvers import TaskMsg
-from cylc.flow.task_events_mgr import (
-    TaskEventsManager,
-)
+from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_outputs import (
-    TASK_OUTPUTS,
     TASK_OUTPUT_EXPIRED,
     TASK_OUTPUT_FAILED,
     TASK_OUTPUT_FINISHED,
+    TASK_OUTPUT_SUBMIT_FAILED,
     TASK_OUTPUT_SUCCEEDED,
+    TASK_OUTPUTS,
     get_completion_expression,
 )
+from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import (
     TASK_STATUS_EXPIRED,
     TASK_STATUS_PREPARING,
     TASK_STATUS_RUNNING,
     TASK_STATUS_WAITING,
 )
-
-if TYPE_CHECKING:
-    from cylc.flow.task_proxy import TaskProxy
-    from cylc.flow.scheduler import Scheduler
 
 
 OPT_BOTH_ERR = "Output {} can't be both required and optional"
@@ -218,7 +213,7 @@ async def test_expire_orthogonality(flow, scheduler, start):
                 Tokens('//1/a/01'),
                 '2000-01-01T00:00:00+00',
                 'INFO',
-                TaskEventsManager.EVENT_SUBMIT_FAILED
+                TASK_OUTPUT_SUBMIT_FAILED,
             ),
         )
         schd.process_queued_task_messages()
@@ -232,7 +227,7 @@ async def test_expire_orthogonality(flow, scheduler, start):
                 Tokens('//1/a/01'),
                 '2000-01-01T00:00:00+00',
                 'INFO',
-                TaskEventsManager.EVENT_FAILED,
+                TASK_OUTPUT_FAILED,
             ),
         )
         schd.process_queued_task_messages()
@@ -246,7 +241,7 @@ async def test_expire_orthogonality(flow, scheduler, start):
                 Tokens('//1/a/01'),
                 '2000-01-01T00:00:00+00',
                 'INFO',
-                TaskEventsManager.EVENT_EXPIRED,
+                TASK_OUTPUT_EXPIRED,
             ),
         )
         schd.process_queued_task_messages()

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -37,12 +37,17 @@ from cylc.flow.task_events_mgr import (
     TaskJobLogsRetrieveContext,
 )
 from cylc.flow.task_job_logs import get_task_job_log
+from cylc.flow.task_outputs import (
+    TASK_OUTPUT_SUBMIT_FAILED,
+    TASK_OUTPUT_SUBMITTED,
+)
 from cylc.flow.task_state import (
     TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMIT_FAILED,
 )
 
 from .test_workflow_events import TEMPLATES
+
 
 # NOTE: we do not test custom event handlers here because these are tested
 # as a part of workflow validation (now also performed by cylc play)
@@ -218,12 +223,12 @@ async def test__submit_failed_job_id(flow, scheduler, start, db_select):
         itask.summary['submit_method_id'] = job_id
         schd.workflow_db_mgr.put_insert_task_jobs(itask, {})
         schd.task_events_mgr.process_message(
-            itask, 'INFO', schd.task_events_mgr.EVENT_SUBMITTED
+            itask, 'INFO', TASK_OUTPUT_SUBMITTED
         )
         assert await get_ds_job_id(schd) == job_id
 
         schd.task_events_mgr.process_message(
-            itask, 'CRITICAL', schd.task_events_mgr.EVENT_SUBMIT_FAILED
+            itask, 'CRITICAL', TASK_OUTPUT_SUBMIT_FAILED
         )
         assert itask.state(TASK_STATUS_SUBMIT_FAILED)
         assert await get_ds_job_id(schd) == job_id

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -243,6 +243,7 @@ async def test_poll_job_deleted_log_folder(
         'run_signal': JOB_FILES_REMOVED_MESSAGE,
         'run_status': 1,
         'job_runner_exit_polled': 1,
+        'time_run_exit': '2025-02-13T12:08:28Z',
     }
     schd: Scheduler = scheduler(flow(one_conf))
     async with start(schd):

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -44,7 +44,6 @@ from cylc.flow.exceptions import WorkflowConfigError
 from cylc.flow.flow_mgr import FLOW_NONE
 from cylc.flow.id import TaskTokens, Tokens
 from cylc.flow.run_modes import RunMode
-from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_FAILED,
     TASK_OUTPUT_SUCCEEDED,
@@ -1056,27 +1055,26 @@ async def test_detect_incomplete_tasks(
     incomplete_final_task_states = {
         # final task states that would leave a task with
         # completion=succeeded incomplete
-        TASK_STATUS_FAILED: TaskEventsManager.EVENT_FAILED,
-        TASK_STATUS_EXPIRED: TaskEventsManager.EVENT_EXPIRED,
-        TASK_STATUS_SUBMIT_FAILED: TaskEventsManager.EVENT_SUBMIT_FAILED
+        TASK_STATUS_FAILED,
+        TASK_STATUS_EXPIRED,
+        TASK_STATUS_SUBMIT_FAILED,
     }
     id_ = flow({
         'scheduling': {
             'graph': {
                 # a workflow with one task for each of the final task states
-                'R1': '\n'.join(incomplete_final_task_states.keys())
+                'R1': '\n'.join(incomplete_final_task_states)
             }
         }
     })
-    schd = scheduler(id_)
+    schd: Scheduler = scheduler(id_)
     async with start(schd, level=logging.DEBUG):
         itasks = schd.pool.get_tasks()
         for itask in itasks:
             itask.state_reset(is_queued=False)
             # spawn the output corresponding to the task
             schd.pool.task_events_mgr.process_message(
-                itask, 1,
-                incomplete_final_task_states[itask.tdef.name]
+                itask, 1, message=itask.tdef.name
             )
             # ensure that it is correctly identified as incomplete
             assert not itask.state.outputs.is_complete()

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1206,8 +1206,7 @@ async def test_set_failed_complete(
             contains=f'[{one}] removed from the n=0 window: completed')
 
         db_outputs = db_select(
-            schd, True, 'task_outputs', 'outputs',
-            **{'name': 'one'}
+            schd, True, 'task_outputs', 'outputs', name='one'
         )
         assert (
             sorted(loads((db_outputs[0])[0])) == [

--- a/tests/unit/test_task_outputs.py
+++ b/tests/unit/test_task_outputs.py
@@ -20,6 +20,7 @@ from typing import (
     Optional,
     Set,
 )
+from unittest.mock import Mock
 
 import pytest
 
@@ -415,3 +416,18 @@ def test_get_trigger_completion_variable_maps():
     t2c, c2t = get_trigger_completion_variable_maps(('a', 'b-b', 'c-c-c'))
     assert t2c == {'a': 'a', 'b-b': 'b_b', 'c-c-c': 'c_c_c'}
     assert c2t == {'a': 'a', 'b_b': 'b-b', 'c_c_c': 'c-c-c'}
+
+
+@pytest.mark.parametrize('message, complete, expected', [
+    ('succeeded', [], ['submitted', 'started']),  # order matters!
+    ('failed', [], ['submitted', 'started']),
+    ('started', [], ['submitted']),
+    ('foo', [], []),
+    ('succeeded', ['started'], ['submitted']),
+    ('succeeded', ['started', 'submitted'], []),
+    ('started', ['submitted'], []),
+])
+def test_get_incomplete_implied(message, complete, expected):
+    """It should return an ordered list of incomplete implied messages."""
+    mock_tout = Mock(is_message_complete=lambda x: x in complete)
+    assert TaskOutputs.get_incomplete_implied(mock_tout, message) == expected


### PR DESCRIPTION
In case a task went through >1 state change since the last poll, always process the all outputs gleaned from the job poll info.

However this means that repeated polls will repeat the same outputs, so this PR also needs a fix for:
 - https://github.com/cylc/cylc-flow/issues/5526

Also closes #6593

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
