### PR TITLE
work around NFS caching issues

### DIFF
--- a/changes.d/6506.fix.md
+++ b/changes.d/6506.fix.md
@@ -1,0 +1,1 @@
+Work around NFS caching behaviour which could cause workflows to appear to be stopped when they are running in some situations where NFS filesystems are used.

--- a/changes.d/6506.fix.md
+++ b/changes.d/6506.fix.md
@@ -1,1 +1,1 @@
-Work around NFS caching behaviour which could cause workflows to appear to be stopped when they are running in some situations where NFS filesystems are used.
+Work around caching behaviour observed on NFS filesystems which could cause workflows to appear to be stopped or even to not exist, when they are running.

--- a/cylc/flow/network/scan.py
+++ b/cylc/flow/network/scan.py
@@ -316,10 +316,21 @@ async def is_active(flow, is_active):
             False to filter for stopped and unregistered flows.
 
     """
-    contact = flow['path'] / SERVICE / CONTACT
-    _is_active = contact.exists()
+    service = flow['path'] / SERVICE
+    # NOTE: We must list the service directory contents rather than checking
+    # for the existence of the contact file directly, because listing the
+    # directory forces NFS filesystems to recompute their local cache.
+    # See https://github.com/cylc/cylc-flow/issues/6506
+    try:
+        contents = await scandir(service)
+    except FileNotFoundError:
+        _is_active = False
+    else:
+        _is_active = any(
+            path.name == WorkflowFiles.Service.CONTACT for path in contents
+        )
     if _is_active:
-        flow['contact'] = contact
+        flow['contact'] = service / CONTACT
     return _is_active == is_active
 
 

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -25,7 +25,7 @@ See also:
 from contextlib import suppress
 from enum import Enum
 import errno
-from queue import deque
+from collections import deque
 import os
 from pathlib import Path
 import re

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -25,6 +25,7 @@ See also:
 from contextlib import suppress
 from enum import Enum
 import errno
+from queue import deque
 import os
 from pathlib import Path
 import re
@@ -640,7 +641,7 @@ def refresh_nfs_cache(path: Path):
     """
     cylc_run_dir = get_cylc_run_dir()
     for subdir in reversed(path.relative_to(cylc_run_dir).parents):
-        list((cylc_run_dir / subdir).iterdir())
+        deque((cylc_run_dir / subdir).iterdir(), maxlen=0)
 
 
 def load_contact_file(id_: str, run_dir=None) -> Dict[str, str]:


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/6506 (hopefully!)

NFS filesystems have a caching mechanism that can take a while to clear. This may cause workflows to appear stopped on the CLI, in the Tui & GUI when they are in fact running.

Refresh NFS cache before:

* Scanning workflows:
  * Fixes: Delay between startup and workflows appearing in `cylc scan`, `cylc tui` and `cylc gui` (on other servers).
  * Cost: We've traded a file access for a directory listing (`.service` dir only contains a few files, no biggie).
* Loading the contact file:
  * Fixes: Delay between workflow startup and the CLI being able to operate on the workflow on other servers (the second three cases in the test script).
  * Cost: An additional file access (always) and additional directory listings (only when needed).
* Inferring the latest run:
  * Fixes: Workflow not visible on one server after being installed on another (the last three cases in the test script).
  * Cost: An additional file access (always) and additional directory listings (only when needed).

> Note these cashes are specific to the server, so you may get different results running Cylc commands on different servers.

<details>
<summary>To test, try running this script. It should say "no fix needed" for all cases.</summary>

```bash
#!/bin/bash -l

set -u

WORKFLOW="$1"
SERVER="$2"
RUN_ROOT="$HOME/cylc-run/$WORKFLOW"

reset () {
  cylc stop "*" >/dev/null
  rm -r "$HOME/cylc-run/$WORKFLOW" 2>/dev/null
  rm -r "$DATADIR/cylc-run/$WORKFLOW" 2>/dev/null
  rm -r "$SCRATCH/cylc-run/$WORKFLOW" 2>/dev/null
}

test_startup () {
  local run="$1"

  if cylc ping "$WORKFLOW/$run" >/dev/null 2>/dev/null; then
    echo "  no fix needed"
    return
  fi

  local directory
  for directory in "$HOME/cylc-run" "$HOME/cylc-run/$WORKFLOW" "$HOME/cylc-run/$WORKFLOW/$run"; do
    ls "$directory" >/dev/null
    if cylc ping "$WORKFLOW/$run" >/dev/null 2>/dev/null; then
      echo "  ls $directory needed"
      return
    fi
  done
}


run () {
  echo -e "\n$@"
  "$@" --pause "$WORKFLOW" >/dev/null 2>/dev/null
}

reset

run cylc vip --host=localhost
test_startup run1
reset

run cylc vip --host=localhost --run-name=foo
test_startup foo
reset

run cylc vip --host=localhost --no-run-name
test_startup ""
reset

run cylc vip --host="$SERVER"
test_startup runN
reset

run cylc vip --host="$SERVER" --run-name=foo
test_startup foo
reset

run cylc vip --host="$SERVER" --no-run-name
test_startup ""
reset

run ssh "$SERVER" CYLC_ENV_NAME="$CYLC_ENV_NAME" cylc vip --host=localhost
test_startup runN
reset

run ssh "$SERVER" CYLC_ENV_NAME="$CYLC_ENV_NAME" cylc vip --host=localhost --run-name=foo
test_startup foo
reset

run ssh "$SERVER" CYLC_ENV_NAME="$CYLC_ENV_NAME" cylc vip --host=localhost --no-run-name
test_startup ""
reset

```

</details>

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.