### PR TITLE
Clarify task ID glob help

### DIFF
--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -242,19 +242,20 @@ class CylcOptionParser(OptionParser):
 
     MULTITASK_USAGE = dedent('''
         This command can operate on multiple tasks. Globs and selectors may
-        be used to match active tasks:
+        be used to match tasks in the n=0 active window (except in the
+        `cylc show` command, where globs match in the wider n-window):
             Multiple Tasks:
                 # Operate on two tasks
                 workflow //cycle-1/task-1 //cycle-2/task-2
 
-            Globs (note: globs should be quoted and only match active tasks):
-                # Match any active task "foo" in all cycles
+            Globs (note: quote globs; they only match in the active-window):
+                # Match any active-window task "foo" in all cycles
                 '//*/foo'
 
                 # Match the tasks "foo-1" and "foo-2"
                 '//*/foo-[12]'
 
-            Selectors (note: selectors only match active tasks):
+            Selectors (note: selectors only match in the active window too):
                 # match all failed tasks in cycle "1"
                 //1:failed
 

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -146,8 +146,7 @@ Workflow IDs:
       $ cylc pause foo/run1
       $ cylc stop foo/run1
 
-    In the case of numbered runs (e.g. "run1", "run2", ...) you can omit
-    the run number, Cylc will infer latest run.
+    If you omit run number ("run1", "run2", ...) Cylc will infer latest run.
       $ cylc play foo
       $ cylc pause foo
       $ cylc stop foo
@@ -164,8 +163,7 @@ Workflow IDs:
     You can omit the user name when working on your own workflows.
 
 Cycle / Family / Task / Job IDs:
-    Just as workflows have IDs, the things within workflows have IDs too.
-    These IDs take the format:
+    Just as workflows have IDs, so do objects within workflows:
       cycle/task_or_family/job
 
     Examples:
@@ -174,8 +172,7 @@ Cycle / Family / Task / Job IDs:
       1/a/1  # The first job of the task "a" in the cycle point "1".
 
 Full ID
-    We join the workflow and cycle/task/job IDs together using //:
-      workflow//cycle/task/job
+    Join workflow and cycle/task/job IDs with //: workflow//cycle/task/job
 
     Examples:
       w//         # The workflow "w"
@@ -201,8 +198,9 @@ Patterns
       workflow//cycle/task/* # All jobs in workflow//cycle/job
 
     Warning:
-      Remember to write IDs inside single quotes when using them on the
-      command line otherwise your shell may expand them.
+      Quote IDs on the command line to protect them from shell expansion.
+      Patterns only match tasks in the n=0 active window (except for the
+      `cylc show` command where they match in the wider n-window).
 
 Filters
     Filters allow you to filter for specific states.


### PR DESCRIPTION
To avoid any ambiguity, change globs match *"active tasks" to "tasks in the n=0 active window"*.

And mention `cylc show` as an exception - globs match in the n-window there.
(This is easier than separately providing different glob help for `cylc show` and for the rest; good enough for now as this will change again in the near-ish future).

https://cylc.discourse.group/t/cylc-trigger-isnt-triggering-anything/1117/4

(I also made several lines in the ID help more concise - it's good to incrementally improve existing docs when we get a chance. If you can say it just as clearly in fewer words, that's a good thing, but it's damn near impossible to get optimal clarity+conciseness first try)

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
