### PR TITLE
Wrapper script: fix `PATH` override preventing selection of Cylc version in GUI under Cylc Hub

### DIFF
--- a/changes.d/6616.fix.md
+++ b/changes.d/6616.fix.md
@@ -1,0 +1,1 @@
+Fixed wrapper script `PATH` override preventing selection of Cylc version in the GUI when running Cylc Hub.

--- a/cylc/flow/etc/cylc
+++ b/cylc/flow/etc/cylc
@@ -174,7 +174,7 @@ fi
 
 # Set PATH when running cylc hub so that configurable-http-proxy can find node
 if [[ ${0##*/} == "cylc" && ${1:-} == "hub" ]]; then
-    PATH=${CYLC_HOME}/bin:${PATH}
+    PATH=${PATH}:${CYLC_HOME}/bin
 fi
 
 # Run the executable from the selected installation.


### PR DESCRIPTION
Closes #5847

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests N/A
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
