### PR TITLE
task pool: demote "already finished" log message

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1764,17 +1764,22 @@ class TaskPool:
 
         if prev_status in TASK_STATUSES_FINAL:
             # Task finished previously.
-            msg = f"[{point}/{name}:{prev_status}] already finished"
             if itask.is_complete():
-                msg += " and completed"
+                msg = "and completed"
                 itask.transient = True
             else:
                 # revive as incomplete.
-                msg += " incomplete"
+                msg = "incomplete"
 
-            LOG.info(
-                f"{msg} {repr_flow_nums(flow_nums, full=True)})"
-            )
+            if cylc.flow.flags.verbosity >= 1:
+                # avoid unnecessary compute when we are not in debug mode
+                id_ = itask.tokens.duplicate(
+                    task_sel=prev_status
+                ).relative_id_with_selectors
+                LOG.debug(
+                    f"[{id_}] already finished {msg}"
+                    f" {repr_flow_nums(flow_nums, full=True)})"
+                )
             if prev_flow_wait:
                 self._spawn_after_flow_wait(itask)
 


### PR DESCRIPTION
~Remove~ Demote an unnecessary log message:
* This message tells us that the task's outcome was loaded from the DB rather than from memory.
* This information isn't pertinent information for the user.
* This message duplicates information that is already in the log.
* This message gets duplicated once for each trigger, potentially resulting in a very large number of messages.

Accept or close.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.