### PR TITLE
host-select: fix compatibility with force-condemned hosts

### DIFF
--- a/changes.d/6623.fix.md
+++ b/changes.d/6623.fix.md
@@ -1,4 +1,4 @@
-auto restart: The "force condemn" option (that tells workflows running on a
+Auto restart: The "force condemn" option (that tells workflows running on a
 server to shutdown as opposed to migrate) hasn't worked with the host-selection
 mechanism since Cylc 8.0.0. This has now been fixed and the "force condemn"
 option has been restored in the documentation.

--- a/changes.d/6623.fix.md
+++ b/changes.d/6623.fix.md
@@ -1,0 +1,4 @@
+auto restart: The "force condemn" option (that tells workflows running on a
+server to shutdown as opposed to migrate) hasn't worked with the host-selection
+mechanism since Cylc 8.0.0. This has now been fixed and the "force condemn"
+option has been restored in the documentation.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -828,23 +828,22 @@ with Conf('global.cylc', desc='''
             Conf('condemned', VDR.V_ABSOLUTE_HOST_LIST, desc=f'''
                 List run hosts that workflows should *not* run on.
 
-                Any hosts listed here will be subtracted from the
-                `available <global.cylc[scheduler][run hosts]>`
-                hosts:
+                These will be subtracted from the
+                `available <global.cylc[scheduler][run hosts]>`:
 
                 * Workflows will not start on condemned hosts.
                 * Workflows that are running on condemned hosts will attempt
-                  to migrate to an uncondemned host (providing the
+                  to migrate to an available host (providing the
                   `auto restart
                   <global.cylc[scheduler][main loop][auto restart]>`
                   plugin is enabled).
 
                 This feature can be used to drain a host for patching, or
-                remove a host that is surplus to requirement.
+                remove a host that is surplus to requirements.
 
-                Hostnames listed here may be followed by a ``!`` character.
-                This activates "force mode", workflows running on a
-                force-condenmed host will shutdown rather than attempting to
+                If a hostname listed here is followed by a ``!`` character
+                ("force mode"), workflows running on it
+                will shutdown rather than attempting to
                 migrate (providing the
                 `auto restart
                 <global.cylc[scheduler][main loop][auto restart]>` plugin
@@ -871,7 +870,7 @@ with Conf('global.cylc', desc='''
 
                 .. versionchanged:: 8.4.2
 
-                   The "force-condemn" option caused issues at workflow
+                   The force-condemn ("!") option caused issues at workflow
                    startup for Cylc versions between 8.0.0 and 8.4.1
                    inclusive.
 

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -826,15 +826,54 @@ with Conf('global.cylc', desc='''
                    range.
             ''')
             Conf('condemned', VDR.V_ABSOLUTE_HOST_LIST, desc=f'''
-                These hosts will not be used to run jobs.
+                List run hosts that workflows should *not* run on.
 
-                If workflows are already running on
-                condemned hosts, Cylc will shut them down and
-                restart them on different hosts.
+                Any hosts listed here will be subtracted from the
+                `available <global.cylc[scheduler][run hosts]>`
+                hosts:
+
+                * Workflows will not start on condemned hosts.
+                * Workflows that are running on condemned hosts will attempt
+                  to migrate to an uncondemned host (providing the
+                  `auto restart
+                  <global.cylc[scheduler][main loop][auto restart]>`
+                  plugin is enabled).
+
+                This feature can be used to drain a host for patching, or
+                remove a host that is surplus to requirement.
+
+                Hostnames listed here may be followed by a ``!`` character.
+                This activates "force mode", workflows running on a
+                force-condenmed host will shutdown rather than attempting to
+                migrate (providing the
+                `auto restart
+                <global.cylc[scheduler][main loop][auto restart]>` plugin
+                is enabled).
+
+                .. rubric:: Example:
+
+                .. code-block:: cylc
+
+                   [scheduler]
+                       [[run hosts]]
+                           # there are three hosts in the "pool"
+                           available = host1, host2, host3
+
+                           # however two have been taken out:
+                           # * workflows running on "host1" will attempt to
+                           #   restart on "host3"
+                           # * workflows running on "host2" will shutdown
+                           condemned = host1, host2!
 
                 .. seealso::
 
                    :ref:`auto-stop-restart`
+
+                .. versionchanged:: 8.4.2
+
+                   The "force-condemn" option caused issues at workflow
+                   startup for Cylc versions between 8.0.0 and 8.4.1
+                   inclusive.
 
                 .. versionchanged:: 8.0.0
 
@@ -1336,7 +1375,7 @@ with Conf('global.cylc', desc='''
                 The means by which task progress messages are reported back to
                 the running workflow.
 
-                ..rubric:: Options:
+                .. rubric:: Options:
 
                 zmq
                    Direct client-server TCP communication via network ports

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -128,6 +128,13 @@ def select_workflow_host(cached=True):
     # be returned with the up-to-date configuration.
     global_config = glbl_cfg(cached=cached)
 
+    # condemned hosts may be suffixed with an "!" to activate "force mode"
+    blacklist = []
+    for host in global_config.get(['scheduler', 'run hosts', 'condemned'], []):
+        if host.endswith('!'):
+            host = host[:-1]
+        blacklist.append(host)
+
     return select_host(
         # list of workflow hosts
         global_config.get([
@@ -138,9 +145,7 @@ def select_workflow_host(cached=True):
             'scheduler', 'run hosts', 'ranking'
         ]),
         # list of condemned hosts
-        blacklist=global_config.get(
-            ['scheduler', 'run hosts', 'condemned']
-        ),
+        blacklist=blacklist,
         blacklist_name='condemned host'
     )
 

--- a/tests/functional/restart/43-auto-restart-force-override-normal.t
+++ b/tests/functional/restart/43-auto-restart-force-override-normal.t
@@ -50,7 +50,10 @@ create_test_global_config '' "
 ${BASE_GLOBAL_CONFIG}
 [scheduler]
     [[run hosts]]
-        available = ${CYLC_TEST_HOST_1}
+        available = ${CYLC_TEST_HOST_1}, ${CYLC_TEST_HOST_2}
+        # ensure the workflow can start if a host is force-condemned
+        # see #6623
+        condemned = ${CYLC_TEST_HOST_2}!
 "
 
 set_test_number 8


### PR DESCRIPTION
The "force mode" option in the auto-restart feature hasn't been used for a while.

It still works at Cylc 8, but force-condemning a host causes workflow startup to fail.

This PR:
* Fixes the issue with host-select.
* Adds a note about the "force-condemn" mode in the cfgspec docs.
* A cylc-doc PR will follow in due course. ... Issue https://github.com/cylc/cylc-doc/issues/809

For info on the "force mode", see the Cylc 7 docs: https://cylc.github.io/cylc-doc/7.9.3/html/running-suites.html#auto-stop-restart

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened - soon, soon ...
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.