### PR TITLE
tests: remove string templating in SQL statements

### DIFF
--- a/tests/integration/test_workflow_db_mgr.py
+++ b/tests/integration/test_workflow_db_mgr.py
@@ -71,11 +71,11 @@ def db_remove_column(schd: 'Scheduler', table: str, column: str) -> None:
             [fields[1] for fields in desc if fields[1] != column]
         )
         # Copy table data to a temporary table, and rename it back.
-        conn.execute(rf'CREATE TABLE "tmp"({c_names})')
+        conn.execute(rf"CREATE TABLE 'tmp'({c_names})")
         conn.execute(
-            rf'INSERT INTO "tmp"({c_names}) SELECT {c_names} FROM {table}')
-        conn.execute(rf'DROP TABLE "{table}"')
-        conn.execute(rf'ALTER TABLE "tmp" RENAME TO "{table}"')
+            rf"INSERT INTO 'tmp'({c_names}) SELECT {c_names} FROM {table}")
+        conn.execute(rf"DROP TABLE '{table}'")
+        conn.execute(rf"ALTER TABLE 'tmp' RENAME TO '{table}'")
         conn.commit()
 
 

--- a/tests/unit/test_rundb.py
+++ b/tests/unit/test_rundb.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
-import json
 from pathlib import Path
 import sqlite3
 from types import SimpleNamespace
@@ -224,9 +223,8 @@ def test_select_latest_flow_nums(
         )
         for (fnums, timestamp) in values:
             conn.execute(
-                "INSERT INTO task_states VALUES ("
-                f"{json.dumps(serialise_set(fnums))}, {json.dumps(timestamp)}"
-                ")"
+                'INSERT INTO task_states VALUES (?, ?)',
+                (serialise_set(fnums), timestamp)
             )
         conn.commit()
 

--- a/tests/unit/test_templatevars.py
+++ b/tests/unit/test_templatevars.py
@@ -118,21 +118,25 @@ def _setup_db(tmp_path_factory):
     db_path = logfolder / WorkflowFiles.LogDir.DB
     with CylcWorkflowDAO(db_path, create_tables=True) as dao:
         dao.connect().execute(
-            rf'''
+            r'''
                 INSERT INTO workflow_params
                 VALUES
-                    ("cylc_version", "{cylc_version}")
-            '''
+                    (?, ?)
+            ''',
+            ("cylc_version", cylc_version),
         )
-        dao.connect().execute(
+        dao.connect().executemany(
             r'''
                 INSERT INTO workflow_template_vars
                 VALUES
-                    ("FOO", "42"),
-                    ("BAR", "'hello world'"),
-                    ("BAZ", "'foo', 'bar', 48"),
-                    ("QUX", "['foo', 'bar', 21]")
-            '''
+                    (?, ?)
+            ''',
+            [
+                ("FOO", "42"),
+                ("BAR", "'hello world'"),
+                ("BAZ", "'foo', 'bar', 48"),
+                ("QUX", "['foo', 'bar', 21]"),
+            ],
         )
         dao.connect().commit()
     yield get_template_vars_from_db(tmp_path)


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/6630
* Didn't find any functional breakages with newer versions of sqlite3 (tested with 3.49.1).
* Fixed failing tests by moving away from templating variables into SQL statements.

Note: We can't presently test this compatibility in our CI setup as we are dependent on the GH "setup-python" action. We need to look at switching over to Mamba to provision Python at some point so we can test with bleeding edge Python / Conda stack.

No functional issues detected, so no need to push this into 8.4.x

There are functional issues in metomi-rose however :(

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.