### PR TITLE
runahead: handle no sequences within start-stop cycle interval

### DIFF
--- a/changes.d/6638.fix.md
+++ b/changes.d/6638.fix.md
@@ -1,0 +1,1 @@
+Fixed possible crash when restarting a workflow after changing the graph.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -408,8 +408,11 @@ class TaskPool:
             self._prev_runahead_base_point = base_point
 
         if count_cycles:
-            # (len(list) may be less than ilimit due to sequence end)
-            limit_point = sorted(sequence_points)[:ilimit + 1][-1]
+            if not sequence_points:
+                limit_point = base_point
+            else:
+                # (len(list) may be less than ilimit due to sequence end)
+                limit_point = sorted(sequence_points)[:ilimit + 1][-1]
         else:
             limit_point = max(sequence_points)
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1800,6 +1800,35 @@ async def test_compute_runahead_with_no_tasks(flow, scheduler, run):
         assert schd.pool.get_tasks() == []
 
 
+async def test_compute_runahead_with_no_sequences(flow, scheduler, start, run, complete):
+    """It should handle no sequences within the start-stop cycle range.
+
+    See https://github.com/cylc/cylc-flow/issues/6154
+    """
+    cfg = {
+        'scheduling': {
+            'cycling mode': 'integer',
+            'initial cycle point': '1',
+            'graph': {
+               'P1': 'foo[-P1] => foo'
+            }
+        }
+    }
+    id_ = flow(cfg)
+    schd = scheduler(id_, paused_start=False)
+    async with run(schd):
+        await complete(schd, '2/foo')
+
+    cfg['scheduling']['graph']['R1'] = cfg['scheduling']['graph']['P1']
+    cfg['scheduling']['graph'].pop('P1')
+    flow(cfg, workflow_id=id_)
+
+    schd = scheduler(id_, paused_start=False)
+    async with start(schd):
+        schd.pool.compute_runahead()
+        assert schd.pool.runahead_limit_point == IntegerPoint('3')
+
+
 @pytest.mark.parametrize('rhlimit', ['P2D', 'P2'])
 @pytest.mark.parametrize('compat_mode', ['compat-mode', 'normal-mode'])
 async def test_runahead_future_trigger(


### PR DESCRIPTION
* Closes #6154
* Fix a traceback which can occur in some niche circumstances where there are no sequences left within the `start cycle point` -> `stop cycle point` window after a restart.
* This can happen as the result of a graph change.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.