### PR TITLE
host-select: fix compatibility with force-condemned hosts

### DIFF
--- a/changes.d/6623.fix.md
+++ b/changes.d/6623.fix.md
@@ -1,0 +1,3 @@
+Auto restart: The option to condemn a host in "force" mode (that tells
+workflows running on a server to shutdown as opposed to migrate) hasn't worked
+with the host-selection mechanism since Cylc 8.0.0. This has now been fixed.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -833,7 +833,7 @@ with Conf('global.cylc', desc='''
                 preventing new workflows from starting on the "condemned" host.
 
                 Any workflows running on these hosts will either migrate
-                to another host, or shutdown according to
+                to another host, or shut down according to
                 :py:mod:`the configuration <cylc.flow.main_loop.auto_restart>`.
 
                 This feature requires ``auto restart`` to be listed

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -826,15 +826,51 @@ with Conf('global.cylc', desc='''
                    range.
             ''')
             Conf('condemned', VDR.V_ABSOLUTE_HOST_LIST, desc=f'''
-                These hosts will not be used to run jobs.
+                List run hosts that workflows should *not* run on.
 
-                If workflows are already running on
-                condemned hosts, Cylc will shut them down and
-                restart them on different hosts.
+                These hosts will be subtracted from the
+                `available <global.cylc[scheduler][run hosts]>` hosts
+                preventing new workflows from starting on the "condemned" host.
+
+                Any workflows running on these hosts will either migrate
+                to another host, or shutdown according to
+                :py:mod:`the configuration <cylc.flow.main_loop.auto_restart>`.
+
+                This feature requires ``auto restart`` to be listed
+                in `global.cylc[scheduler][main loop]plugins`.
+
+                For more information, see the
+                :py:mod:`auto restart <cylc.flow.main_loop.auto_restart>`
+                plugin.
+
+                .. rubric:: Example:
+
+                .. code-block:: cylc
+
+                   [scheduler]
+                       [[main loop]]
+                           # activate the "auto restart" plugin
+                           plugins = auto restart
+                       [[run hosts]]
+                           # there are three hosts in the "pool"
+                           available = host1, host2, host3
+
+                           # however two have been taken out:
+                           # * workflows running on "host1" will attempt to
+                           #   restart on "host3"
+                           # * workflows running on "host2" will shutdown
+                           condemned = host1, host2!
 
                 .. seealso::
 
+                   :py:mod:`cylc.flow.main_loop.auto_restart`
                    :ref:`auto-stop-restart`
+
+                .. versionchanged:: 8.4.2
+
+                   The "force mode" (activated by a "!" suffix) caused issues
+                   at workflow startup for Cylc versions between 8.0.0 and
+                   8.4.1 inclusive.
 
                 .. versionchanged:: 8.0.0
 
@@ -1336,7 +1372,7 @@ with Conf('global.cylc', desc='''
                 The means by which task progress messages are reported back to
                 the running workflow.
 
-                ..rubric:: Options:
+                .. rubric:: Options:
 
                 zmq
                    Direct client-server TCP communication via network ports

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -128,6 +128,13 @@ def select_workflow_host(cached=True):
     # be returned with the up-to-date configuration.
     global_config = glbl_cfg(cached=cached)
 
+    # condemned hosts may be suffixed with an "!" to activate "force mode"
+    blacklist = []
+    for host in global_config.get(['scheduler', 'run hosts', 'condemned'], []):
+        if host.endswith('!'):
+            host = host[:-1]
+        blacklist.append(host)
+
     return select_host(
         # list of workflow hosts
         global_config.get([
@@ -138,9 +145,7 @@ def select_workflow_host(cached=True):
             'scheduler', 'run hosts', 'ranking'
         ]),
         # list of condemned hosts
-        blacklist=global_config.get(
-            ['scheduler', 'run hosts', 'condemned']
-        ),
+        blacklist=blacklist,
         blacklist_name='condemned host'
     )
 

--- a/tests/functional/restart/43-auto-restart-force-override-normal.t
+++ b/tests/functional/restart/43-auto-restart-force-override-normal.t
@@ -50,7 +50,10 @@ create_test_global_config '' "
 ${BASE_GLOBAL_CONFIG}
 [scheduler]
     [[run hosts]]
-        available = ${CYLC_TEST_HOST_1}
+        available = ${CYLC_TEST_HOST_1}, ${CYLC_TEST_HOST_2}
+        # ensure the workflow can start if a host is condemned
+        # in force mode see #6623
+        condemned = ${CYLC_TEST_HOST_2}!
 "
 
 set_test_number 8


### PR DESCRIPTION
Supersedes https://github.com/cylc/cylc-flow/pull/6623

Fix an issue with host-select which prevented us from condemning hosts in "force mode".

Also, better link into the "auto restart" docs which can be found here: https://cylc.github.io/cylc-doc/stable/html/plugins/main-loop/built-in/cylc.flow.main_loop.auto_restart.html#module-cylc.flow.main_loop.auto_restart

I am **not** going to go applying terminology changes to this long-standing feature as part of this bugfix (out of scope).

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.