### PR TITLE
fix typo in stop.py - options.max_poll -> options.max_polls

### DIFF
--- a/changes.d/6645.fix.md
+++ b/changes.d/6645.fix.md
@@ -1,0 +1,1 @@
+Fixed a typo in stop.py which caused a different exception to be raised than was desired

--- a/cylc/flow/scripts/stop.py
+++ b/cylc/flow/scripts/stop.py
@@ -268,7 +268,7 @@ async def _run(
     if int(options.max_polls) > 0 and not await spoller.poll():
         # (test to avoid the "nothing to do" warning for # --max-polls=0)
         raise CylcError(
-            f'Workflow did not shut down after {options.max_poll} polls'
+            f'Workflow did not shut down after {options.max_polls} polls'
         )
     return ret
 


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.


I did not update any tests. The pathway leads to failure no matter what, this just fixes the exception type and message. No documentation updates are required.