### PR TITLE
Ensure `cylc message` exceptions are printed to stderr

### DIFF
--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -102,7 +102,9 @@ def write_messages(workflow, job_id, messages, event_time):
     _append_job_status_file(workflow, job_id, event_time, messages)
 
 
-def send_messages(workflow, job_id, messages, event_time):
+def send_messages(
+    workflow: str, job_id: str, messages: List[list], event_time: str
+) -> None:
     workflow = os.path.normpath(workflow)
     try:
         pclient = get_client(workflow)

--- a/cylc/flow/task_message.py
+++ b/cylc/flow/task_message.py
@@ -111,23 +111,24 @@ def send_messages(workflow, job_id, messages, event_time):
         # either the workflow is stopped or the contact file is not present
         # on the job host (i.e. comms method is polling)
         # eitherway don't try messaging
-        pass
-    except Exception:
-        # Backward communication not possible
+        return
+    except Exception as exc:
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
         if cylc.flow.flags.verbosity > 1:
             import traceback
             traceback.print_exc()
-    else:
-        mutation_kwargs = {
-            'request_string': MUTATION,
-            'variables': {
-                'wFlows': [workflow],
-                'taskJob': job_id,
-                'eventTime': event_time,
-                'messages': messages,
-            }
+        # cylc message shouldn't fail if the client can't initialize.
+        return
+    mutation_kwargs = {
+        'request_string': MUTATION,
+        'variables': {
+            'wFlows': [workflow],
+            'taskJob': job_id,
+            'eventTime': event_time,
+            'messages': messages,
         }
-        pclient('graphql', mutation_kwargs)
+    }
+    pclient('graphql', mutation_kwargs)
 
 
 def _append_job_status_file(workflow, job_id, event_time, messages):
@@ -138,7 +139,8 @@ def _append_job_status_file(workflow, job_id, event_time, messages):
     try:
         job_status_file = open(job_log_name + '.status', 'a')  # noqa: SIM115
         # TODO: niceify read/write/appending messages to this file
-    except IOError:
+    except IOError as exc:
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
         if cylc.flow.flags.verbosity > 1:
             import traceback
             traceback.print_exc()

--- a/tests/functional/cylc-message/00-ssh/flow.cylc
+++ b/tests/functional/cylc-message/00-ssh/flow.cylc
@@ -9,7 +9,7 @@
 [runtime]
     [[t0]]
         script = """
-            cylc broadcast "${CYLC_WORKFLOW_ID}" '--name=t1' '--set=script="true"'
+            cylc broadcast "${CYLC_WORKFLOW_ID}" --name=t1 --set=script="true"
         """
         platform = {{ environ['CYLC_TEST_PLATFORM'] }}
     [[t1]]

--- a/tests/unit/test_task_message.py
+++ b/tests/unit/test_task_message.py
@@ -1,0 +1,38 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from socket import gaierror
+
+import pytest
+
+from cylc.flow.task_message import send_messages
+
+
+def test_send_messages_err(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    """If an error occurs while initializing the client, it should be printed.
+    """
+    exc_msg = 'Relic malfunction detected'
+
+    def mock_get_client(*a, **k):
+        raise gaierror(-2, exc_msg)
+
+    monkeypatch.setattr('cylc.flow.task_message.get_client', mock_get_client)
+    send_messages(
+        'arasaka', '1/v/01', [['INFO', 'silverhand']], '2077-01-01T00:00:00Z'
+    )
+    assert f"gaierror: [Errno -2] {exc_msg}" in capsys.readouterr().err


### PR DESCRIPTION
Fixes problem reported internally.

> I had a problem... where task messaging wasn't working but there was no error reported by `cylc message`.

It was only printing errors in debug mode.

This change ensures it prints errors if they occur. But `cylc message` should not fail even if the workflow runtime client fails to initialize.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [ ] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
