### PR TITLE
GH Actions: use explicit `bash` shell & other defaults

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -11,6 +11,19 @@ on:
         required: false
         default: 'master'
 
+concurrency:
+  # Only let this run 1 at a time
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
+
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/2_auto_publish_release.yml
+++ b/.github/workflows/2_auto_publish_release.yml
@@ -7,7 +7,18 @@ on:
     # NOTE: While this is too generic, we use the `if` condition of the job to narrow it down
     # NOTE: Don't use `branches` as we might create release on any branch
 
+concurrency:
+  # Only let this run 1 at a time
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
 env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
   # Best not to include the GH token here, only do it for the steps that need it
   MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
   CHANGELOG_FILE: CHANGES.md

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -31,6 +31,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
+
 jobs:
   bash-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,20 @@ on:
       - 'MANIFEST.in'     # check packaging
       - 'pyproject.toml'  # check build config
       - 'setup.cfg'       # check deps and project config
+      - '.gitignore'
+      - '.github/workflows/build.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
 
 jobs:
   test:
@@ -18,21 +32,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        python: ['3.8', '3.9', '3.10', '3.11']
-        include:
-          - os: 'ubuntu-22.04'
-            python: '3.7'
+        os: ['ubuntu-latest', 'macos-latest']
+        python: ['3.7', '3.8', '3.9', '3.10', '3']
+        exclude:
           - os: 'macos-latest'
-            python: '3.8'
+            python: '3.7'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ matrix.python }}
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: cylc-build
+          create-args: >-
+            python=${{ matrix.python }}
 
       - name: Build
         uses: cylc/release-actions/build-python-package@v1

--- a/.github/workflows/test_conda-build.yml
+++ b/.github/workflows/test_conda-build.yml
@@ -13,6 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: 2
+
 jobs:
   test_conda_install:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -16,6 +16,9 @@ defaults:
   run:
     shell: bash -c "exec $CONDA_PREFIX/bin/bash -elo pipefail {0}"
 
+env:
+  PIP_PROGRESS_BAR: off
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -32,11 +35,9 @@ jobs:
           - os: 'ubuntu-latest'
             python-version: '3.9'  # not the oldest, not the most recent version
             time-zone: 'XXX-09:35'
-
     env:
       TZ: ${{ matrix.time-zone }}
       PYTEST_ADDOPTS: --cov --cov-append -n 5 --color=yes
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,6 +107,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3']
+    env:
+      FORCE_COLOR: 2
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -36,6 +36,10 @@ defaults:
   run:
     shell: bash -c "exec $CONDA_PREFIX/bin/bash -elo pipefail {0}"
 
+env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -17,6 +17,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
+env:
+  FORCE_COLOR: 2
+  PIP_PROGRESS_BAR: off
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

>| Supported platform | `shell` parameter | Description | Command run internally |
>| --- | --- | --- | --- |
>| Linux / macOS | unspecified | The default shell on non-Windows platforms. **Note that this runs a different command to when `bash` is specified explicitly.** If `bash` is not found in the path, this is treated as `sh`. | **`bash -e {0}`** |
>| All | `bash` | The default shell on non-Windows platforms with a fallback to `sh`. When specifying a bash shell on Windows, the bash shell included with Git for Windows is used.| **`bash --noprofile --norc -eo pipefail {0}`** |

This was added to the docs in https://github.com/actions/runner/issues/1955; I was unaware that there was a difference between not specifying the default and specifying `bash`.

We seem to be missing `-o pipefail` by default. (This change will also introduce `--norc`, `--noprofile`; not sure why these are included 🤷)

> [!TIP]
> If/when we change to using setup-micromamba/miniconda, we will need to provide the full set of options we want, which will have to include `-l`. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] tests, docs, etc not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
