### PR TITLE
Fix data store job accumulation bug

### DIFF
--- a/changes.d/6656.fix.md
+++ b/changes.d/6656.fix.md
@@ -1,0 +1,1 @@
+Fix bug where old cycle points could accumulate in the UI.

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1734,7 +1734,7 @@ class DataStoreMgr:
             self.update_workflow()
 
             # Don't process updated deltas of pruned nodes
-            self.prune_pruned_updated_nodes()
+            self.dedupe_pruned_updated_task_proxies()
 
             # Gather deltas
             self.batch_deltas()
@@ -1958,8 +1958,8 @@ class DataStoreMgr:
         if fp_id in parent_ids:
             parent_ids.remove(fp_id)
 
-    def prune_pruned_updated_nodes(self):
-        """Remove updated nodes that will also be pruned this batch.
+    def dedupe_pruned_updated_task_proxies(self):
+        """Remove updated task proxies that will also be pruned in this batch.
 
         This will avoid processing and sending deltas that will immediately
         be pruned. Kept separate from other pruning to allow for update
@@ -1969,19 +1969,19 @@ class DataStoreMgr:
         tp_data = self.data[self.workflow_id][TASK_PROXIES]
         tp_added = self.added[TASK_PROXIES]
         tp_updated = self.updated[TASK_PROXIES]
-        j_updated = self.updated[JOBS]
         for tp_id in self.pruned_task_proxies:
             if tp_id in tp_updated:
                 if tp_id in tp_data:
-                    node = tp_data[tp_id]
+                    node: PbTaskProxy = tp_data[tp_id]
                 elif tp_id in tp_added:
                     node = tp_added[tp_id]
                 else:
                     continue
-                update_node = tp_updated.pop(tp_id)
-                for j_id in list(node.jobs) + list(update_node.jobs):
-                    if j_id in j_updated:
-                        del j_updated[j_id]
+                update_node: PbTaskProxy = tp_updated.pop(tp_id)
+                # Remove this task's added/updated jobs in this batch too:
+                for j_id in set(node.jobs).union(update_node.jobs):
+                    for record in (self.added, self.updated):
+                        record[JOBS].pop(j_id, None)
                 self.n_window_edges.difference_update(update_node.edges)
                 self.deltas[EDGES].pruned.extend(update_node.edges)
         self.pruned_task_proxies.clear()

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -514,12 +514,14 @@ async def test_remove_added_jobs_of_pruned_task(one: Scheduler, start):
     """When a task is pruned, any of its jobs added in the same batch
     must be removed from the batch.
 
-    See https://github.com/cylc/cylc-ui/issues/1999#issuecomment-2701024180
+    See https://github.com/cylc/cylc-flow/pull/6656
     """
     async with start(one):
         itask = one.pool.get_tasks()[0]
         itask.state_reset(TASK_STATUS_PREPARING)
         one.task_events_mgr.process_message(itask, INFO, TASK_OUTPUT_SUCCEEDED)
+        assert not one.data_store_mgr.data[one.id][JOBS]
         assert len(one.data_store_mgr.added[JOBS]) == 1
         one.data_store_mgr.update_data_structure()
         assert not one.data_store_mgr.data[one.id][JOBS]
+        assert not one.data_store_mgr.added[JOBS]

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -14,11 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Iterable, List, TYPE_CHECKING, cast
+from logging import INFO
+from typing import (
+    Iterable,
+    List,
+    cast,
+)
 
 import pytest
 
-from cylc.flow.data_messages_pb2 import PbPrerequisite, PbTaskProxy
+from cylc.flow.data_messages_pb2 import (
+    PbPrerequisite,
+    PbTaskProxy,
+)
 from cylc.flow.data_store_mgr import (
     EDGES,
     FAMILY_PROXIES,
@@ -31,20 +39,17 @@ from cylc.flow.id import Tokens
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
-    TASK_OUTPUT_SUBMITTED,
     TASK_OUTPUT_STARTED,
+    TASK_OUTPUT_SUBMITTED,
     TASK_OUTPUT_SUCCEEDED,
 )
 from cylc.flow.task_state import (
     TASK_STATUS_FAILED,
+    TASK_STATUS_PREPARING,
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_WAITING,
 )
 from cylc.flow.wallclock import get_current_time_string
-
-
-if TYPE_CHECKING:
-    from cylc.flow.scheduler import Scheduler
 
 
 # NOTE: Some of these tests mutate the data store, so running them in
@@ -503,3 +508,18 @@ async def test_delta_task_outputs(one: 'Scheduler', start):
             TASK_OUTPUT_SUCCEEDED,
         }
         assert get_delta_outputs() is None
+
+
+async def test_remove_added_jobs_of_pruned_task(one: Scheduler, start):
+    """When a task is pruned, any of its jobs added in the same batch
+    must be removed from the batch.
+
+    See https://github.com/cylc/cylc-ui/issues/1999#issuecomment-2701024180
+    """
+    async with start(one):
+        itask = one.pool.get_tasks()[0]
+        itask.state_reset(TASK_STATUS_PREPARING)
+        one.task_events_mgr.process_message(itask, INFO, TASK_OUTPUT_SUCCEEDED)
+        assert len(one.data_store_mgr.added[JOBS]) == 1
+        one.data_store_mgr.update_data_structure()
+        assert not one.data_store_mgr.data[one.id][JOBS]


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-ui/issues/1999

https://github.com/cylc/cylc-ui/issues/1999#issuecomment-2701024180

> #### Steps to reproduce:
> 
> ```cylc
> [scheduler]
>     allow implicit tasks = True
> [scheduling]
>     cycling mode = integer
>     [[graph]]
>         P1 = foo[-P1] => foo => bar
> [runtime]
>     [[root]]
>         [[[simulation]]]
>             default run length = PT0S
> ```
> 
> 1. Start the workflow in simulation mode
> 2. Wait until several cycles have run, then stop the workflow
> 3. Navigate away and then back to the workflow
> 
> ![Image](https://github.com/user-attachments/assets/2000f58f-42a9-4147-ab34-2696ac355a82)
> 
> This is caused by an **accumulation of jobs** for the task `bar`:
> 
> ![Image](https://github.com/user-attachments/assets/15533380-00ac-44fd-813f-48d6b3017def)
> 
> Running jobs not becoming succeeded and being pruned?
> 
> <details><summary>Full delta copied from Network panel</summary>
> <p>
> 
> ```json
> {
>   "data": {
>     "deltas": {
>       "added": {
>         "workflow": {
>           "id": "~ronnie.dutta/empty-cycles",
>           "status": "stopped",
>           "statusMsg": "stopped",
>           "nEdgeDistance": 1,
>           "reloaded": true,
>           "__typename": "Workflow"
>         },
>         "familyProxies": [
>           {
>             "__typename": "FamilyProxy",
>             "id": "~ronnie.dutta/empty-cycles//20/root",
>             "state": "waiting",
>             "ancestors": [],
>             "childTasks": [
>               {
>                 "id": "~ronnie.dutta/empty-cycles//20/foo",
>                 "__typename": "TaskProxy"
>               },
>               {
>                 "id": "~ronnie.dutta/empty-cycles//20/bar",
>                 "__typename": "TaskProxy"
>               }
>             ]
>           },
>           {
>             "__typename": "FamilyProxy",
>             "id": "~ronnie.dutta/empty-cycles//21/root",
>             "state": "waiting",
>             "ancestors": [],
>             "childTasks": [
>               {
>                 "id": "~ronnie.dutta/empty-cycles//21/foo",
>                 "__typename": "TaskProxy"
>               },
>               {
>                 "id": "~ronnie.dutta/empty-cycles//21/bar",
>                 "__typename": "TaskProxy"
>               }
>             ]
>           },
>           {
>             "__typename": "FamilyProxy",
>             "id": "~ronnie.dutta/empty-cycles//22/root",
>             "state": "waiting",
>             "ancestors": [],
>             "childTasks": [
>               {
>                 "id": "~ronnie.dutta/empty-cycles//22/foo",
>                 "__typename": "TaskProxy"
>               }
>             ]
>           }
>         ],
>         "taskProxies": [
>           {
>             "id": "~ronnie.dutta/empty-cycles//20/foo",
>             "state": "succeeded",
>             "isHeld": false,
>             "isQueued": false,
>             "isRunahead": false,
>             "task": {
>               "meanElapsedTime": 0,
>               "__typename": "Task"
>             },
>             "firstParent": {
>               "id": "~ronnie.dutta/empty-cycles//20/root",
>               "__typename": "FamilyProxy"
>             },
>             "flowNums": "[1]",
>             "__typename": "TaskProxy"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//20/bar",
>             "state": "waiting",
>             "isHeld": false,
>             "isQueued": true,
>             "isRunahead": false,
>             "task": {
>               "meanElapsedTime": 0,
>               "__typename": "Task"
>             },
>             "firstParent": {
>               "id": "~ronnie.dutta/empty-cycles//20/root",
>               "__typename": "FamilyProxy"
>             },
>             "flowNums": "[1]",
>             "__typename": "TaskProxy"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//21/foo",
>             "state": "waiting",
>             "isHeld": false,
>             "isQueued": true,
>             "isRunahead": false,
>             "task": {
>               "meanElapsedTime": 0,
>               "__typename": "Task"
>             },
>             "firstParent": {
>               "id": "~ronnie.dutta/empty-cycles//21/root",
>               "__typename": "FamilyProxy"
>             },
>             "flowNums": "[1]",
>             "__typename": "TaskProxy"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//21/bar",
>             "state": "waiting",
>             "isHeld": false,
>             "isQueued": false,
>             "isRunahead": false,
>             "task": {
>               "meanElapsedTime": 0,
>               "__typename": "Task"
>             },
>             "firstParent": {
>               "id": "~ronnie.dutta/empty-cycles//21/root",
>               "__typename": "FamilyProxy"
>             },
>             "flowNums": "[1]",
>             "__typename": "TaskProxy"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//22/foo",
>             "state": "waiting",
>             "isHeld": false,
>             "isQueued": false,
>             "isRunahead": false,
>             "task": {
>               "meanElapsedTime": 0,
>               "__typename": "Task"
>             },
>             "firstParent": {
>               "id": "~ronnie.dutta/empty-cycles//22/root",
>               "__typename": "FamilyProxy"
>             },
>             "flowNums": "[1]",
>             "__typename": "TaskProxy"
>           }
>         ],
>         "jobs": [
>           {
>             "id": "~ronnie.dutta/empty-cycles//1/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//2/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//3/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//4/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//5/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//6/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//7/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//8/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//9/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//10/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//11/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//12/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//13/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//14/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//15/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//16/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//17/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//18/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//20/foo/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "2025-03-05T14:15:14Z",
>             "submittedTime": "2025-03-05T14:15:14Z",
>             "finishedTime": "2025-03-05T14:15:14Z",
>             "state": "succeeded",
>             "submitNum": 1,
>             "messages": [
>               "succeeded"
>             ],
>             "taskProxy": {
>               "outputs": [
>                 {
>                   "label": "submitted",
>                   "message": "submitted",
>                   "__typename": "Output"
>                 },
>                 {
>                   "label": "started",
>                   "message": "started",
>                   "__typename": "Output"
>                 },
>                 {
>                   "label": "succeeded",
>                   "message": "succeeded",
>                   "__typename": "Output"
>                 }
>               ],
>               "__typename": "TaskProxy"
>             },
>             "__typename": "Job"
>           },
>           {
>             "id": "~ronnie.dutta/empty-cycles//19/bar/01",
>             "jobRunnerName": "",
>             "jobId": "",
>             "platform": "simulation",
>             "startedTime": "",
>             "submittedTime": "",
>             "finishedTime": "",
>             "state": "running",
>             "submitNum": 1,
>             "messages": [],
>             "__typename": "Job"
>           }
>         ],
>         "__typename": "Added"
>       },
>       "updated": {
>         "__typename": "Updated"
>       },
>       "pruned": {
>         "familyProxies": [],
>         "taskProxies": [],
>         "jobs": [],
>         "__typename": "Pruned"
>       },
>       "id": "~ronnie.dutta/empty-cycles",
>       "__typename": "Deltas"
>     }
>   }
> }
> ```
> 
> </p>
> </details> 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
