### PR TITLE
Speedup.replace uniq with list of iter uniq

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -134,7 +134,7 @@ def workflow_ids_filter(workflow_tokens, items) -> bool:
                 or workflow_tokens['workflow_sel'] == item['workflow_sel']
             )
         )
-        for item in uniq(items)
+        for item in iter_uniq(items)
     )
 
 

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -59,11 +59,7 @@ def uniq(iterable):
         [1, 2, 3, 5, 8]
 
     """
-    ret = []
-    for item in iterable:
-        if item not in ret:
-            ret.append(item)
-    return ret
+    return list(iter_uniq(iterable))
 
 
 def iter_uniq(iterable):


### PR DESCRIPTION
```python
list(iter_uniq(iterable))
# Is an order of magnitude faster than
uniq(iterable)
```

In both Python 3.8 and 3.13.

Full experiment posted in notebook in [this comment](https://github.com/cylc/cylc-flow/pull/6574#discussion_r1990954884).

> [!NOTE]
> This will conflict with #6574  and will need to either be merged first or rebased.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] This is a change of method, not interface:
  - Existing tests cover change.
  - Changelog not req'd
  - Opened against master
  - Docs not req'd
