### PR TITLE
actions: update build action to support python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Inspect
         run: |
           unzip -l dist/*.whl | tee files
-          grep 'cylc_flow.*.dist-info/COPYING' files
+          grep -E 'cylc_flow.*.dist-info/.*COPYING' files
           grep 'cylc/flow/py.typed' files
           grep 'cylc/flow/etc' files
           grep 'cylc/flow/etc/cylc-completion.bash' files


### PR DESCRIPTION
* The COPYING file appears to have moved from `dist-info/COPYING` into `dist-info/licenses/COPYING`.
