### PR TITLE
flake8++

### DIFF
--- a/cylc/flow/async_util.py
+++ b/cylc/flow/async_util.py
@@ -393,7 +393,6 @@ def pipe(func=None, preproc=None):
     if preproc and not func:
         # @pipe(preproc=x)
         def _pipe(func):
-            nonlocal preproc
             return _PipeFunction(func, preproc)
         return _pipe
     elif func:
@@ -433,7 +432,6 @@ def wrap_exception(coroutine):
 
     """
     async def _inner(*args, **kwargs):
-        nonlocal coroutine
         try:
             return await coroutine(*args, **kwargs)
         except Exception as exc:
@@ -503,7 +501,6 @@ def make_async(fcn):
     """
     @wraps(fcn)
     async def _fcn(*args, executor=None, **kwargs):
-        nonlocal fcn
         return await asyncio.get_event_loop().run_in_executor(
             executor,
             partial(fcn, *args, **kwargs),

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -103,7 +103,6 @@ COMMANDS: 'Dict[str, Command]' = {}
 def _command(name: str):
     """Decorator to register a command."""
     def _command(fcn: '_TCommand') -> '_TCommand':
-        nonlocal name
         COMMANDS[name] = fcn
         fcn.command_name = name  # type: ignore[attr-defined]
         return fcn

--- a/cylc/flow/main_loop/log_db.py
+++ b/cylc/flow/main_loop/log_db.py
@@ -63,7 +63,6 @@ def _patch_db_connect(db_connect_method):
     are also patched.
     """
     def _inner(*args, **kwargs):
-        nonlocal db_connect_method
         conn = db_connect_method(*args, **kwargs)
         conn.set_trace_callback(_log)
         return conn

--- a/cylc/flow/parsec/include.py
+++ b/cylc/flow/parsec/include.py
@@ -16,24 +16,23 @@
 
 import os
 import re
+from typing import List
 
 from cylc.flow.parsec.exceptions import (
     FileParseError, IncludeFileNotFoundError)
 
 
-done = []
-flist = []
+done: List[str] = []
+flist: List[str] = []
 
 include_re = re.compile(r'\s*%include\s+([\'"]?)(.*?)([\'"]?)\s*$')
 
 
 def inline(lines, dir_, filename, for_grep=False, viewcfg=None, level=None):
     """Recursive inlining of parsec include-files"""
-
-    global flist
     if level is None:
         # avoid being affected by multiple *different* calls to this function
-        flist = [filename]
+        flist[:] = [filename]
     else:
         flist.append(filename)
     single = False
@@ -45,8 +44,6 @@ def inline(lines, dir_, filename, for_grep=False, viewcfg=None, level=None):
         label = viewcfg['label']
     else:
         viewcfg = {}
-
-    global done
 
     outf = []
     initial_line_index = 0

--- a/cylc/flow/pipe_poller.py
+++ b/cylc/flow/pipe_poller.py
@@ -58,7 +58,6 @@ def pipe_poller(proc, *files, chunk_size=4096):
 
     def _read(timeout=1.0):
         # read any data from files
-        nonlocal chunk_size, files
         for file in select(list(files), [], [], timeout)[0]:
             buffer = file.read(chunk_size)
             if len(buffer) > 0:

--- a/cylc/flow/task_outputs.py
+++ b/cylc/flow/task_outputs.py
@@ -548,7 +548,6 @@ class TaskOutputs:
         _gutter: str = ' ' * gutter
 
         def color_wrap(string, is_complete):
-            nonlocal ansimarkup
             if ansimarkup == 0:
                 return string
             if is_complete:

--- a/cylc/flow/tui/overlay.py
+++ b/cylc/flow/tui/overlay.py
@@ -107,7 +107,6 @@ def filter_workflow_state(app):
     workflow_id_prompt = 'id (regex)'
 
     def update_id_filter(widget, value):
-        nonlocal app
         try:
             # ensure the filter is value before updating the filter
             re.compile(value)
@@ -301,8 +300,6 @@ def context(app):
         is_running = False
 
     def _mutate(mutation, _):
-        nonlocal app, selection
-
         app.open_overlay(partial(progress, text='Running Command'))
         overlay_fcn = None
         try:
@@ -381,12 +378,10 @@ def log(app, id_=None, list_files=None, get_log=None):
 
     def open_menu(*_args, **_kwargs):
         """Open an overlay for selecting a log file."""
-        nonlocal app, id_
         app.open_overlay(select_log)
 
     def select_log(*_args, **_kwargs):
         """Create an overlay for selecting a log file."""
-        nonlocal list_files, id_
         try:
             files = list_files()
         except Exception as exc:
@@ -424,8 +419,6 @@ def log(app, id_=None, list_files=None, get_log=None):
                 selected. Use this to close the "select_log" overlay.
 
         """
-
-        nonlocal host_widget, file_widget, text_widget
         try:
             host, path, text = get_log(filename)
         except Exception as exc:

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -288,8 +288,6 @@ def restricted_evaluator(
     visitor = RestrictedNodeVisitor(whitelist)
 
     def _eval(expr, **variables):
-        nonlocal visitor
-
         # parse the expression
         try:
             expr_node = ast.parse(expr.strip(), mode='eval')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,14 +82,12 @@ def mock_glbl_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """
     # TODO: modify Parsec so we can use StringIO rather than a temp file.
     def _mock_glbl_cfg(pypath: str, global_config: str) -> None:
-        nonlocal tmp_path, monkeypatch
         global_config_path = tmp_path / 'global.cylc'
         global_config_path.write_text(global_config)
         glbl_cfg = ParsecConfig(SPEC, validator=cylc_config_validate)
         glbl_cfg.loadcfg(global_config_path)
 
         def _inner(cached=False):
-            nonlocal glbl_cfg
             return glbl_cfg
 
         monkeypatch.setattr(pypath, _inner)
@@ -196,8 +194,6 @@ def capcall(monkeypatch):
         calls = []
 
         def _call(*args, **kwargs):
-            nonlocal calls
-            nonlocal substitute_function
             calls.append((args, kwargs))
             if substitute_function:
                 return substitute_function(*args, **kwargs)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -424,7 +424,6 @@ def capture_submission():
         submitted_tasks: 'Set[TaskProxy]' = set()
 
         def _submit_task_jobs(itasks):
-            nonlocal submitted_tasks
             for itask in itasks:
                 itask.state_reset(TASK_STATUS_SUBMITTED)
             submitted_tasks.update(itasks)
@@ -457,7 +456,6 @@ def capture_polling():
         def run_job_cmd(
             _1, _2, itasks, _3, _4=None
         ):
-            nonlocal polled_tasks
             polled_tasks.update(itasks)
             return itasks
 
@@ -567,7 +565,6 @@ def reflog():
         triggers = set()
 
         def _submit_task_jobs(*args, **kwargs):
-            nonlocal submit_task_jobs, triggers, flow_nums
             itasks = submit_task_jobs(*args, **kwargs)
             for itask in itasks:
                 deps = tuple(sorted(itask.state.get_resolved_dependencies()))
@@ -631,7 +628,6 @@ async def _complete(
     remove_if_complete = schd.pool.remove_if_complete
 
     def _remove_if_complete(itask, output=None):
-        nonlocal tokens_list
         ret = remove_if_complete(itask)
         if ret and itask.tokens.task in tokens_list:
             tokens_list.remove(itask.tokens.task)
@@ -642,7 +638,7 @@ async def _complete(
     stop_requested = False
 
     def _set_stop(mode=None):
-        nonlocal stop_requested, stop_mode
+        nonlocal stop_requested
         if mode == stop_mode:
             stop_requested = True
             return set_stop(mode)
@@ -760,7 +756,6 @@ def capture_live_submissions(capcall, monkeypatch):
 
 
     def get_submissions():
-        nonlocal submit_live_calls
         return {
             itask.identity
             for ((_self, _workflow, itasks, *_), _kwargs) in submit_live_calls

--- a/tests/integration/network/test_resolvers.py
+++ b/tests/integration/network/test_resolvers.py
@@ -269,7 +269,6 @@ async def test_command_validation_failure(
 
     # submit a command with invalid arguments:
     async def submit_invalid_command(verbosity=0):
-        nonlocal caplog, mock_flow, flow_args
         monkeypatch.setattr('cylc.flow.flags.verbosity', verbosity)
         caplog.clear()
         return await mock_flow.resolvers.mutator(

--- a/tests/integration/scripts/test_completion_server.py
+++ b/tests/integration/scripts/test_completion_server.py
@@ -28,7 +28,6 @@ def setify(coro):
     Convenience function to use when you want to test output not order.
     """
     async def _coro(*args, **kwargs):
-        nonlocal coro
         ret = await coro(*args, **kwargs)
         if isinstance(ret, list):
             return set(ret)

--- a/tests/integration/scripts/test_list.py
+++ b/tests/integration/scripts/test_list.py
@@ -57,7 +57,6 @@ async def cylc_list(mod_flow, mod_scheduler, mod_start):
     schd = mod_scheduler(id_)
 
     async def _list(capsys, **kwargs):
-        nonlocal schd
         capsys.readouterr()
         await _main(ListOptions(**kwargs), schd.workflow)
         out, err = capsys.readouterr()

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -420,7 +420,6 @@ async def test_delta_task_outputs(one: 'Scheduler', start):
 
     def get_data_outputs():
         """Return satisfied outputs from the *data* store."""
-        nonlocal one, itask
         return {
             output.label
             for output in one.data_store_mgr.data[one.id][TASK_PROXIES][
@@ -434,7 +433,6 @@ async def test_delta_task_outputs(one: 'Scheduler', start):
 
         Or return None if there's nothing there.
         """
-        nonlocal one, itask
         try:
             return {
                 output.label

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -169,7 +169,6 @@ async def test_install_gets_back_compat_mode_for_plugins(
     @EntryPointWrapper
     def failIfDeprecated(*args, **kwargs):
         """A fake Cylc Plugin entry point"""
-        nonlocal check_deprecation_calls
         # print the number of times the check_deprecation method has been
         # called
         print(f'CALLS={len(check_deprecation_calls)}')

--- a/tests/integration/test_reinstall.py
+++ b/tests/integration/test_reinstall.py
@@ -313,11 +313,8 @@ def my_install_plugin(monkeypatch):
     @EntryPointWrapper
     def post_install_basic(*_, **__):
         """Simple plugin that returns one env var and one template var."""
-        nonlocal progress
-
         async def my_async():
             # the async task
-            nonlocal progress
             await asyncio.sleep(2)
             progress.append('end')
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2117,7 +2117,6 @@ async def test_reload_xtriggers(flow, scheduler, start):
 
     def list_xtrig_mgr():
         """List xtrigs from the xtrigger_mgr."""
-        nonlocal schd
         return {
             key: repr(value)
             for key, value in schd.xtrigger_mgr.xtriggers.functx_map.items()
@@ -2125,7 +2124,6 @@ async def test_reload_xtriggers(flow, scheduler, start):
 
     async def list_data_store():
         """List xtrigs from the data_store_mgr."""
-        nonlocal schd
         await schd.update_data_structure()
         return {
             value.label: key

--- a/tests/integration/test_workflow_events.py
+++ b/tests/integration/test_workflow_events.py
@@ -41,7 +41,6 @@ async def test_scheduler(flow, scheduler, capcall):
     )
 
     def get_events():
-        nonlocal events
         return {e[0][1] for e in events}
 
     def _schd(config=None, **opts):

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -81,7 +81,6 @@ async def workflow(flow, scheduler, one_conf, run_dir):
     )
 
     def dump_contact(**kwargs):
-        nonlocal contact_data, id_
         dump_contact_file(
             id_,
             {
@@ -208,8 +207,6 @@ def test_detect_old_contact_file_removal_errors(
     """
     # patch the is_process_running method
     def mocked_is_process_running(*args):
-        nonlocal workflow
-        nonlocal process_running
         if not contact_present_after:
             # remove the contact file midway through detect_old_contact_file
             unlink(workflow.contact_file)
@@ -284,7 +281,6 @@ def test_is_process_running_dirty_output(monkeypatch, caplog):
             self.returncode = 0
 
         def communicate(self, *args, **kwargs):
-            nonlocal stdout
             return (stdout, '')
 
     monkeypatch.setattr(

--- a/tests/integration/tui/test_logs.py
+++ b/tests/integration/tui/test_logs.py
@@ -101,7 +101,7 @@ def wait_log_loaded(monkeypatch):
             delay: The delay between retries.
 
         """
-        nonlocal before, count
+        nonlocal before
         for _try in range(tries):
             if count > before:
                 await asyncio.sleep(0)

--- a/tests/integration/tui/test_mutations.py
+++ b/tests/integration/tui/test_mutations.py
@@ -150,7 +150,6 @@ def capture_commands(monkeypatch):
 
     class _Popen:
         def __init__(self, *args, **kwargs):
-            nonlocal ret
             ret.append(args)
 
         def communicate(self):
@@ -158,7 +157,6 @@ def capture_commands(monkeypatch):
 
         @property
         def returncode(self):
-            nonlocal returncode
             return returncode[0]
 
     monkeypatch.setattr(

--- a/tests/integration/validate/test_jinja2.py
+++ b/tests/integration/validate/test_jinja2.py
@@ -27,7 +27,6 @@ import pytest
 def flow_cylc(tmp_path):
     """Write a flow.cylc file containing the provided text."""
     def _inner(text):
-        nonlocal tmp_path
         (tmp_path / 'flow.cylc').write_text(dedent(text).strip())
         return tmp_path
 

--- a/tests/unit/main_loop/test_auto_restart.py
+++ b/tests/unit/main_loop/test_auto_restart.py
@@ -296,7 +296,6 @@ async def test_log_config_error(caplog, log_filter, monkeypatch, exc_class):
     """
     # make the global config raise an error
     def global_config_load_error(*args, **kwargs):
-        nonlocal exc_class
         raise exc_class('something even more bizarrely inexplicable')
 
     monkeypatch.setattr(

--- a/tests/unit/main_loop/test_main_loop.py
+++ b/tests/unit/main_loop/test_main_loop.py
@@ -72,9 +72,9 @@ def test_wrapper_calls_function():
     flag = False
 
     async def test_coro(arg1, arg2):
+        nonlocal flag
         assert arg1 == 'arg1'
         assert arg2 == 'arg2'
-        nonlocal flag
         flag = True
 
     coro = _wrapper(
@@ -152,7 +152,6 @@ def basic_plugins():
     calls = []
 
     def capture(*args):
-        nonlocal calls
         calls.append(args)
 
     plugins = {

--- a/tests/unit/parsec/test_upgrade.py
+++ b/tests/unit/parsec/test_upgrade.py
@@ -96,7 +96,6 @@ def test_conflicting_items():
     }
 
     def get_upgrader():
-        nonlocal cfg
         upg = upgrader(cfg, 'test file')
         upg.deprecate('1.3', ['item one'], ['item two'])
         return upg

--- a/tests/unit/scripts/test_clean.py
+++ b/tests/unit/scripts/test_clean.py
@@ -52,7 +52,6 @@ def mute(monkeypatch: pytest.MonkeyPatch) -> List[str]:
     items = []
 
     def _clean(id_, *_):
-        nonlocal items
         items.append(id_)
 
     monkeypatch.setattr('cylc.flow.scripts.clean.init_clean', _clean)

--- a/tests/unit/scripts/test_completion_server.py
+++ b/tests/unit/scripts/test_completion_server.py
@@ -54,7 +54,6 @@ def setify(coro):
     Convenience function to use when you want to test output not order.
     """
     async def _coro(*args, **kwargs):
-        nonlocal coro
         ret = await coro(*args, **kwargs)
         if isinstance(ret, list):
             return set(ret)
@@ -86,7 +85,6 @@ def dummy_workflow(tmp_path, monkeypatch, mock_glbl_cfg):
     # patch scan for list_workflows
     @pipe
     async def _scan(*args, **kwargs):
-        nonlocal tmp_path
         kwargs['run_dir'] = tmp_path
         async for flow in scan(*args, **kwargs):
             yield flow
@@ -319,7 +317,6 @@ async def test_complete_argument(monkeypatch):
     # register two fake commands with their own special completions
     def _complete_arg(x):
         async def __complete_arg(*args):
-            nonlocal x
             return x
         return __complete_arg
 

--- a/tests/unit/scripts/test_config.py
+++ b/tests/unit/scripts/test_config.py
@@ -81,7 +81,6 @@ def capload(monkeypatch):
     files = []
 
     def _capload(glblcfg, fname, _):
-        nonlocal files
         if 'invalid' not in fname:
             # if the file is called invalid skip it
             # this is to replicate the behaviour of skipping files that

--- a/tests/unit/test_id_cli.py
+++ b/tests/unit/test_id_cli.py
@@ -284,7 +284,6 @@ def patch_expand_workflow_tokens(monkeypatch):
     def _patch_expand_workflow_tokens(_ids):
 
         async def _expand_workflow_tokens_impl(tokens, match_active=True):
-            nonlocal _ids
             for id_ in _ids:
                 yield tokens.duplicate(workflow=id_)
 

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -35,7 +35,6 @@ def stopped_workflow_db(tmp_path):
 
     """
     def _stopped_workflow_db(version):
-        nonlocal tmp_path
         db_file = tmp_path / 'db'
         conn = sqlite3.connect(db_file)
         conn.execute('''
@@ -66,7 +65,6 @@ def set_cylc_version(monkeypatch):
 
     """
     def _set_cylc_version(version):
-        nonlocal monkeypatch
         monkeypatch.setattr(
             'cylc.flow.scheduler_cli.__version__',
             version,
@@ -87,11 +85,10 @@ def answer(monkeypatch):
     """
     @contextmanager
     def _answer(response):
-        nonlocal monkeypatch
         calls = 0
 
         def prompt(*args, **kwargs):
-            nonlocal response, calls
+            nonlocal calls
             calls += 1
             return response
 

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -164,7 +164,6 @@ def stdinput(monkeypatch):
         lines = list(lines)
 
         def __input(_message):
-            nonlocal lines
             try:
                 return lines.pop(0)
             except IndexError:


### PR DESCRIPTION
Fix violations of recently added F824.

The `global` and `nonlocal` statements allow variables to be rebound from within a nested scope (more info: [1](https://stackoverflow.com/a/1261961), [2](https://docs.python.org/3/reference/simple_stmts.html#the-nonlocal-statement)).

The overwhelming majority of these statements were added by myself. It's a once bitten, always cautious thing:

```python
x = 0
y = []

def foo():
   x = 1  # this rebinds x (so does nothing without `global` / `nonlocal`)

def bar():
   y.append(1)  # this adds to x (but does not rebind it)

>>> foo()
>>> x
0   # <= with `global` / `nonlocal`, this would be 1

>>> bar()
y
[1]
```

Because these two examples behave differently, I always used `nonlocal` to prevent the potential for confusion. I also thought that it was good to always indicate where a variable is being "borrowed" from a nonlocal scope due to the implications of this (be careful with this variable, it is shared with other scopes).

However, I'm happy to be overruled on it. If `flake8` has swung this way (don't use `nonlocal` / `global` unless you are actually rebinding the variable(s)), I'm happy to follow.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.