### PR TITLE
reinstall: log reinstallation in the reinstall log

### DIFF
--- a/changes.d/6710.fix.md
+++ b/changes.d/6710.fix.md
@@ -1,0 +1,1 @@
+Restore `rsync` output into the workflow reinstallation log.

--- a/cylc/flow/install.py
+++ b/cylc/flow/install.py
@@ -224,6 +224,10 @@ def reinstall_workflow(
     # * command is constructed via internal interface
     stdout, stderr = (i.strip() for i in proc.communicate())
 
+    reinstall_log.info(
+        f"Copying files from {source} to {rundir}"
+        f"\n{stdout}"
+    )
     if proc.returncode != 0:
         raise WorkflowFilesError(
             f'An error occurred reinstalling from {source} to {rundir}'


### PR DESCRIPTION
Follow on from https://github.com/cylc/cylc-flow/pull/6658#discussion_r2031123602, we've got a reinstall log file, but it's missing the one thing we actually want from it!

* Accidental omission, the reinstall log was missing, well, the log of what got reinstalled :(
* This commit includes it in the same format seen in the install log.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.