### PR TITLE
Update datastore xtriggers on restart.

### DIFF
--- a/changes.d/6721.fix.md
+++ b/changes.d/6721.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug that could mark satisfied xtriggers as unsatisfied after a restart, in task queries.

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -574,6 +574,8 @@ class XtriggerManager:
             LOG.info("LOADING satisfied xtriggers")
         sig, results = row
         self.sat_xtrig[sig] = json.loads(results)
+        # Tell the datastore this xtrigger is satisfied.
+        self.data_store_mgr.delta_task_xtrigger(sig, True)
 
     def _get_xtrigs(self, itask: 'TaskProxy', unsat_only: bool = False,
                     sigs_only: bool = False):


### PR DESCRIPTION
Close #6720 

Just needed one call to the datastore after loading xtriggers for restart.

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.
-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
