### PR TITLE
Tui memory leak

### DIFF
--- a/changes.d/6722.fix.md
+++ b/changes.d/6722.fix.md
@@ -1,0 +1,1 @@
+Fix a slow memory leak in Tui.

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -22,13 +22,8 @@ from multiprocessing import Process
 import re
 
 import urwid
-try:
-    from urwid.widget import SelectableIcon
-except ImportError:
-    # BACK COMPAT: urwid.wimp
-    # From: urwid 2.0
-    # To: urwid 2.2
-    from urwid.wimp import SelectableIcon
+from urwid.canvas import CanvasCache
+from urwid.widget import SelectableIcon
 
 from cylc.flow.id import Tokens
 from cylc.flow.task_state import (
@@ -540,6 +535,11 @@ class TuiApp:
         # schedule the next run of this update method
         if self.loop:
             self.loop.set_alarm_in(self.UPDATE_INTERVAL, self.update)
+
+        # NOTE: prevent a memory leak by clearing out any caches that urwid
+        # may have accumulated for the previous TuiNode instance
+        # (and its child widgets)
+        CanvasCache.clear()
 
         return True
 

--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -515,8 +515,11 @@ class TuiApp:
         _, old_node = self.listbox.body.get_focus()
 
         # nuke the tree
-        self.tree_walker = urwid.TreeWalker(topnode)
-        self.listbox.body = self.tree_walker
+        if not (self.tree_walker):
+            self.tree_walker = urwid.TreeWalker(topnode)
+            self.listbox.body = self.tree_walker
+        else:
+            self.tree_walker.set_focus(topnode)
 
         # get the new focus
         _, new_node = self.listbox.body.get_focus()

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ install_requires =
     pyzmq>=22
     importlib_metadata>=5.0; python_version < "3.12"
     # NOTE: exclude two urwid versions that were not compatible with Tui
-    urwid==2.*,!=2.6.2,!=2.6.3
+    urwid>=2.2,!=2.6.2,!=2.6.3,<3
     # unpinned transient dependencies used for type checking
     rx
     promise


### PR DESCRIPTION
Fix a slow memory leak in Tui:
* Urwid has a cache (CanvasCache) that caches the render of each widget to speed up future render cycles.
* Tui is a dynamic tool, it creates a new TuiNode for each update.
* The old TuiNode and its child nodes were not being cleared out of the urwid cache preventing Python's garbage clearance from doing its job.
* This change explicitly clears the urwid cache for each Tui update.
* Preserving the cache post-update isn't really a performance boost for Tui as pretty much every node on the screen has changed anyway (besides the application header and footer). So this is likely of little consequence performance wise. The cache is still active between updates so things like expand/collapse operations will still benefit.
* There is an open issue in urwid for a similar issue with the cache so we may be able to drop this workaround one day.

How to test:

* The `memray` profiler didn't seem to pick up on this issue (I guess caches are unlikely to be noticed by an internal sampling profiler).
* I found easier to spot using an external profiler tool like the Python `memory_profiler`, but you can also spot it by counting objects using `pympler.muppy`.
* Start a workflow in paused mode.
* Launch Tui and open it on the given workflow.
* Find the lead process ID and attach your profiler tool (note the subprocess will have the PPID of the lead process), e.g. `mprof attach PID`.
* Leave it for ~60 seconds and stop your profiler, e.g. quit Tui and run `mprof graph $PWD/<data-file>`.
* It should reveal a steady ratcheting of memory before this change and a flat line after (nothing is changing in the workflow, so the line should be quite flat).

Example output from memory_profiler before:

![before](https://github.com/user-attachments/assets/a3b4f863-abf0-47ff-9364-7b41bc1bb54c)

And after:

![after](https://github.com/user-attachments/assets/1cefdd1a-b2fb-4ade-8bc5-579e2fae8b6d)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included - hard to test for memory leaks.
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
