### PR TITLE
Add SQLite detailed error codes to error messages

### DIFF
--- a/changes.d/6730.feat.md
+++ b/changes.d/6730.feat.md
@@ -1,0 +1,1 @@
+Add SQLite detailed error codes to error logs

--- a/tests/unit/test_rundb.py
+++ b/tests/unit/test_rundb.py
@@ -25,6 +25,7 @@ from typing import (
 )
 import unittest
 from unittest import mock
+import sys
 
 import pytest
 
@@ -132,6 +133,13 @@ def test_operational_error(tmp_path, caplog):
     assert 'DELETE FROM task_jobs' in message
     assert 'INSERT OR REPLACE INTO task_jobs' in message
     assert 'UPDATE task_jobs' in message
+    assert 'The error was: no such table: task_jobs' in message
+    if sys.version_info.major == 3 and sys.version_info.minor >= 11:
+        assert 'SQLite error code: 1' in message
+        assert 'SQLite error name: SQLITE_ERROR' in message
+    else:
+        assert 'SQLite error code: Not available' in message
+        assert 'SQLite error name: Not available' in message
 
 
 def test_table_creation(tmp_path: Path):


### PR DESCRIPTION
For python >= 3.11, we can access [detailed error codes](https://sqlite.org/rescode.html), making debugging SQLite errors easier.

This change checks for the existence of the attributes so it's compatible with earlier versions of python.


**Check List**

- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [X] Does not contain off-topic changes (use other PRs for other changes).
- [X] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [X] Tests are included (or explain why tests are not needed).
  - Just changing print statements
- [X] Changelog entry included if this is a change that can affect users
- [X] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
  - N/A
- [X] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
  - Feature

Fixes #6730 