### PR TITLE
psutil: allow accessing psutil object methods

### DIFF
--- a/changes.d/6733.fix.md
+++ b/changes.d/6733.fix.md
@@ -1,0 +1,1 @@
+Fix an issue where the message "Cannot tell if the workflow is running" error could appear erroneously.

--- a/cylc/flow/scripts/psutil.py
+++ b/cylc/flow/scripts/psutil.py
@@ -53,7 +53,7 @@ def _call_psutil_interface(interface, *args):
         interface:
             The psutil method we want to call, e.g. "cpu_percent".
 
-            In the case of objects, this may include attribures, e.g.
+            In the case of objects, this may include attributes, e.g.
             "Process.cmdline".
         args:
             The arguments to provide to the psutil method.
@@ -74,7 +74,6 @@ def _call_psutil_interface(interface, *args):
             sys.exit(2)
 
         if is_first:
-            args = args
             is_first = False
         else:
             args = ()

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -411,7 +411,7 @@ def _is_process_running(
     from cylc.flow.terminal import parse_dirty_json
 
     # See if the process is still running or not.
-    metric = f'[["Process", {pid}]]'
+    metric = f'[["Process.cmdline", {pid}]]'
     if is_remote_host(host):
         cmd = ['psutil']
         cmd = construct_cylc_server_ssh_cmd(cmd, host)
@@ -459,7 +459,7 @@ def _is_process_running(
             f'\n{command}'
         )
 
-    return cli_format(process['cmdline']) == command
+    return cli_format(process) == command
 
 
 def detect_old_contact_file(

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -291,9 +291,7 @@ def test_is_process_running_dirty_output(monkeypatch, caplog):
     # respond with something Cylc should be able to make sense of
     stdout = dedent('''
         % simulated stdout pollution %
-        [{
-            "cmdline": ["expected", "command"]
-        }]
+        [["expected", "command"]]
     ''')
 
     caplog.set_level(logging.WARN, logger=CYLC_LOG)

--- a/tests/unit/test_psutil.py
+++ b/tests/unit/test_psutil.py
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import os
+
+from psutil import Process
 
 from cylc.flow.scripts.psutil import _psutil
 
@@ -38,3 +41,11 @@ def test_psutil_basic():
         assert key in mem
         # all of which should be integers
         assert isinstance(mem[key], int)
+
+
+def test_psutil_object():
+    """It should call object methods."""
+    # obtain the commandline for this test process
+    ret = _psutil(f'[["Process.cmdline", {os.getpid()}]]')
+
+    assert ret[0] == Process().cmdline()


### PR DESCRIPTION
We have recently seen a case where the `_is_process_running` check would timeout every time for a certain user.

Why only this one user is affected is something I do not understand, however, it's clear that the `cylc psutil` call made by this function is returning way too much data, we only need one field!

Reviewers, please ensure this change is back-compatible, note you can invoke the `cylc psutil` command like so:

```
# return the process listing for PID=1
$ cylc psutil <<< '[["Process", 1]]'
```

To active this logic in a functional test, try:

```
cylc vip --pause <x>
cylc vr --yes <x>
```

You might want to use this patch to confirm that the logic is being called and the cmdline is being returned as expected:

```diff
diff --git a/cylc/flow/workflow_files.py b/cylc/flow/workflow_files.py
index add79adbb..64e748e47 100644
--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -459,6 +459,7 @@ def _is_process_running(
             f'\n{command}'
         )
 
+    print('#', cli_format(process['cmdline']), command)
     return cli_format(process['cmdline']) == command
 
 
```

---

* The `_is_process_running` check was requesting the `psutil.Process` object via the `cylc psutil` command.
* It would appear that these objects can get large enough to fill up the buffer. This means that `subprocess.Process.communicate` or `.wait` will hang indefinitely unless something reads from stdout to clear out the buffers.
* This commit changes the `is_process_running` check to request only the one field it actually requires, `psutil.Process.cmdline` to reduce the data volume to a level where pipe polling is not required.

---

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.