### PR TITLE
Run hosts random-selection bug

### DIFF
--- a/changes.d/6745.fix.md
+++ b/changes.d/6745.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug affecting `cylc play` with run hosts specified in the global config, but no ranking expression specified.

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -397,30 +397,34 @@ class PlatformLookupError(CylcConfigError):
 
 
 class HostSelectException(CylcError):
-    """No hosts could be selected from the provided configuration."""
+    """No hosts could be selected from the provided configuration.
 
-    def __init__(self, data: Dict[str, dict]):
+    Args:
+        data: Mapping of hostnames to error info.
+        ranking: The ranking expression used to select the host.
+    """
+
+    def __init__(self, data: Dict[str, dict], ranking: Optional[str] = None):
         self.data = data
+        self.ranking = ranking
 
     def __str__(self) -> str:
         ret = 'Could not select host from:'
         for host, data in sorted(self.data.items()):
-            if host != 'ranking':
-                ret += f'\n    {host}:'
-                for key, value in data.items():
-                    ret += f'\n        {key}: {value}'
+            ret += f'\n    {host}:'
+            for key, value in data.items():
+                ret += f'\n        {key}: {value}'
         hint = self.get_hint()
         if hint:
             ret += f'\n\n{hint}'
         return ret
 
-    def get_hint(self):
+    def get_hint(self) -> Optional[str]:
         """Return a hint to explain this error for certain cases."""
         if all(
             # all procs came back with special SSH error code 255
             datum.get('returncode') == 255
-            for key, datum in self.data.items()
-            if key != 'ranking'
+            for datum in self.data.values()
         ):
             # likely SSH issues
             return (
@@ -431,18 +435,17 @@ class HostSelectException(CylcError):
 
         if (
             # a ranking expression was used
-            self.data.get('ranking')
+            self.ranking
             # and all procs came back with special 'cylc psutil' error code 2
             # (which is used for errors relating to the extraction of metrics)
             and all(
                 datum.get('returncode') == 2
-                for key, datum in self.data.items()
-                if key != 'ranking'
+                for datum in self.data.values()
             )
         ):
             # likely an issue with the ranking expression
             lines = wrap(
-                self.data.get("ranking"),
+                self.ranking,
                 initial_indent='    ',
                 subsequent_indent='    ',
             )

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -260,8 +260,10 @@ def select_host(
         # no metrics or ranking required, pick host at random
         random.shuffle(hosts)
         for host in hosts:
-            # check host is contactable
-            if _get_metrics([host], [], data):
+            if (not is_remote_host(host)) or (
+                # check host is contactable
+                _get_metrics([host], [], data)
+            ):
                 return hostname_map[host], host
         raise HostSelectException(data)
 

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -206,8 +206,11 @@ class HostUtil:
 
         """
         if name not in self._remote_hosts:
-            if not name or name.startswith("localhost"):
-                # e.g. localhost4.localdomain4
+            if (
+                not name
+                or name.startswith("localhost")  # e.g. localhost4.localdomain4
+                or name == self.get_host()
+            ):
                 self._remote_hosts[name] = False
             else:
                 try:

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -50,7 +50,12 @@ import pwd
 import socket
 import sys
 from time import time
-from typing import List, Optional, Tuple
+from typing import (
+    List,
+    Optional,
+    Tuple,
+    cast,
+)
 
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 
@@ -141,11 +146,14 @@ class HostUtil:
         return self._host_exs[target]
 
     @staticmethod
-    def _get_identification_cfg(key):
+    def _get_identification_cfg(key) -> str:
         """Return the [workflow host self-identification]key global conf."""
-        return glbl_cfg().get(['scheduler', 'host self-identification', key])
+        return cast(
+            'str',  # Possible keys: method, target, host are all strings
+            glbl_cfg().get(['scheduler', 'host self-identification', key])
+        )
 
-    def get_host(self):
+    def get_host(self) -> str:
         """Return the preferred identifier for the workflow (or current) host.
 
         As specified by the "[scheduler][host self-identification]" settings in

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -28,7 +28,6 @@ from queue import (
 )
 from shlex import quote
 import signal
-from socket import gaierror
 from subprocess import (
     DEVNULL,
     PIPE,
@@ -1706,7 +1705,7 @@ class Scheduler:
             proc = None
             try:
                 new_host = select_workflow_host(cached=False)[0]
-            except (gaierror, HostSelectException) as exc:
+            except HostSelectException as exc:
                 error = str(exc)
             else:
                 LOG.info(f'Attempting to restart on "{new_host}"')

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from itertools import zip_longest
 from pathlib import Path
 from shlex import quote
+from socket import gaierror
 import sys
 from typing import TYPE_CHECKING, Tuple
 
@@ -608,7 +609,11 @@ def _distribute(
 
     """
     # Check whether a run host is explicitly specified, else select one.
-    host = options.host or select_workflow_host()[0]
+    try:
+        host = options.host or select_workflow_host()[0]
+    except gaierror as exc:
+        LOG.error(f"Host selection failed: {exc}")
+        sys.exit(1)
     if is_remote_host(host):
         # Protect command args from second shell interpretation
         cmd = list(map(quote, sys.argv[1:]))

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -641,8 +641,9 @@ def _distribute(
         # Re-invoke the command
         # NOTE: has the potential to raise NoHostsError, however, this will
         # most likely have been raised during host-selection
-        cylc_server_cmd(cmd, host=host)
-        sys.exit(0)
+        sys.exit(
+            cylc_server_cmd(cmd, host=host)
+        )
 
 
 async def _setup(scheduler: Scheduler) -> None:

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -22,7 +22,6 @@ from functools import lru_cache
 from itertools import zip_longest
 from pathlib import Path
 from shlex import quote
-from socket import gaierror
 import sys
 from typing import TYPE_CHECKING, Tuple
 
@@ -609,11 +608,7 @@ def _distribute(
 
     """
     # Check whether a run host is explicitly specified, else select one.
-    try:
-        host = options.host or select_workflow_host()[0]
-    except gaierror as exc:
-        LOG.error(f"Host selection failed: {exc}")
-        sys.exit(1)
+    host = options.host or select_workflow_host()[0]
     if is_remote_host(host):
         # Protect command args from second shell interpretation
         cmd = list(map(quote, sys.argv[1:]))

--- a/tests/flakyfunctional/restart/39-auto-restart-no-suitable-host.t
+++ b/tests/flakyfunctional/restart/39-auto-restart-no-suitable-host.t
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
-set_test_number 5
+set_test_number 3
 
 BASE_GLOBAL_CONFIG="
 [scheduler]
@@ -64,10 +64,8 @@ ${BASE_GLOBAL_CONFIG}
 FILE=$(cylc cat-log "${WORKFLOW_NAME}" -m p |xargs readlink -f)
 log_scan "${TEST_NAME_BASE}-no-auto-restart" "${FILE}" 20 1 \
     'The Cylc workflow host will soon become un-available' \
-    'Workflow cannot automatically restart because:' \
-    'No alternative host to restart workflow on.' \
-    'Workflow cannot automatically restart because:' \
-    'No alternative host to restart workflow on.'
+    'Workflow cannot automatically restart: No alternative host' \
+    'Workflow cannot automatically restart: No alternative host' \
 
 cylc stop --kill --max-polls=10 --interval=2 "${WORKFLOW_NAME}"
 purge

--- a/tests/functional/cylc-play/11-remote-reinvoke-uncontactable.t
+++ b/tests/functional/cylc-play/11-remote-reinvoke-uncontactable.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test that remote reinvocation exits non-zero if the remote host is
+# uncontactable.
+# https://github.com/cylc/cylc-flow/pull/6745
+# Ideally we would test with multiple hosts in [scheduler][run hosts]available
+# to ensure each is tried, but that is not feasible.
+
+export REQUIRE_PLATFORM='loc:remote fs:shared'
+# (We need a valid remote host; the platform itself is not used)
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+# create an SSH config that will fail to connect to a valid host
+mock_ssh_config_file="/var/tmp/cylc-test-ssh-config"
+cat > "${mock_ssh_config_file}" << __EOF__
+Host ${CYLC_TEST_HOST}*
+    User BorkedMushroom25
+__EOF__
+
+create_test_global_config "" "
+[scheduler]
+    [[run hosts]]
+        available = ${CYLC_TEST_HOST}
+        ranking =
+[platforms]
+    [[localhost]]
+        ssh command = ssh -oBatchMode=yes -oStrictHostKeyChecking=no -F ${mock_ssh_config_file}
+"
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduler]
+    allow implicit tasks = True
+[scheduling]
+    [[graph]]
+        R1 = a
+__FLOW_CONFIG__
+
+TEST_NAME="${TEST_NAME_BASE}-run"
+workflow_run_fail "$TEST_NAME" \
+    cylc play "${WORKFLOW_NAME}" --no-detach --mode=simulation
+
+grep_ok "Cylc could not establish SSH connection to the run hosts" \
+    "${TEST_NAME}.stderr"

--- a/tests/unit/main_loop/test_auto_restart.py
+++ b/tests/unit/main_loop/test_auto_restart.py
@@ -64,7 +64,9 @@ def test_can_auto_restart_fail(monkeypatch, caplog):
         assert 'No alternative host to restart workflow on' in msg
 
 
-def test_can_auto_restart_fail_horribly(monkeypatch, caplog):
+def test_can_auto_restart_fail_horribly(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
     """Test can_auto_restart for really unsuccessful host selection."""
     def select_workflow_host(**_):
         raise Exception('Unexpected error in host selection')
@@ -72,11 +74,10 @@ def test_can_auto_restart_fail_horribly(monkeypatch, caplog):
         'cylc.flow.main_loop.auto_restart.select_workflow_host',
         select_workflow_host
     )
-    with caplog.at_level(level=logging.DEBUG, logger=CYLC_LOG):
+    with caplog.at_level(level=logging.ERROR, logger=CYLC_LOG):
         assert not _can_auto_restart()
-        [(_, level, msg)] = caplog.record_tuples
-        assert level == logging.CRITICAL
-        assert 'Error in host selection' in msg
+        assert 'Error in host selection' in caplog.text
+        assert "Traceback (most recent call last):" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -39,15 +39,14 @@ def test_host_select_exception():
 
     """
     # it should format the selection results nicely
-    assert str(HostSelectException({
-        'ranking': 'virtual_memory().available > 1',
-        'host-1': {
-            'returncode': 1
+    exc = HostSelectException(
+        {
+            'host-1': {'returncode': 1},
+            'host-2': {'returncode': 1},
         },
-        'host-2': {
-            'returncode': 1
-        },
-    })) == dedent('''
+        ranking='virtual_memory().available > 1',
+    )
+    assert str(exc) == dedent('''
         Could not select host from:
             host-1:
                 returncode: 1
@@ -68,13 +67,12 @@ def test_host_select_exception():
     ]
 )
 def test_host_select_exception_returncodes(ret_code, expect):
-    assert expect in (
-        str(HostSelectException({
-            'ranking': 'virtual_memory().available > 1',
-            'host-1': {
-                'returncode': ret_code
+    assert expect in str(
+        HostSelectException(
+            {
+                'host-1': {'returncode': ret_code},
+                'host-2': {'returncode': ret_code},
             },
-            'host-2': {
-                'returncode': ret_code
-            },
-        })))
+            ranking='virtual_memory().available > 1',
+        )
+    )

--- a/tests/unit/test_host_select.py
+++ b/tests/unit/test_host_select.py
@@ -21,6 +21,7 @@ NOTE: these are functional tests, for unit tests see the docstrings in
 
 """
 import logging
+from secrets import token_hex
 import socket
 
 import pytest
@@ -75,9 +76,18 @@ def test_filter():
         select_host(
             [localhost],
             blacklist=[localhost],
-            blacklist_name='Localhost not allowed'
+            blacklist_name=message
         )
     assert message in str(excinfo.value)
+
+
+def test_filter_invalid_blacklist(log_filter):
+    """Test that invalid blacklist doesn't bring down the program."""
+    result = select_host(
+        [localhost], blacklist=[f'non_exist_{token_hex(4)}']
+    )
+    assert result[0] == localhost
+    assert log_filter(logging.WARNING, "Could not resolve blacklisted host")
 
 
 def test_rankings():

--- a/tests/unit/test_host_select.py
+++ b/tests/unit/test_host_select.py
@@ -211,7 +211,8 @@ def test_get_metrics_no_hosts_error(caplog):
     If a host is not contactable then it should be shipped.
     """
     caplog.set_level(logging.WARN, CYLC_LOG)
-    host_stats, data = _get_metrics(['not-a-host'], None)
+    data = {}
+    host_stats = _get_metrics(['not-a-host'], None, data)
     # a warning should be logged
     assert len(caplog.records) == 1
     # no data for the host should be returned

--- a/tests/unit/test_host_select_remote.py
+++ b/tests/unit/test_host_select_remote.py
@@ -113,10 +113,7 @@ def test_remote_exclude(monkeypatch):
     than one host is provided to choose from."""
     def mocked_get_metrics(hosts, metrics, _=None):
         # pretend that ssh to remote_platform failed
-        return (
-            {f'{local_host_fqdn}': {('cpu_count',): 123}},
-            {}
-        )
+        return {f'{local_host_fqdn}': {('cpu_count',): 123}}
     monkeypatch.setattr(
         'cylc.flow.host_select._get_metrics',
         mocked_get_metrics

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -277,6 +277,7 @@ def test_distribute_colour(
     _is_terminal = monkeymock('cylc.flow.scheduler_cli.is_terminal')
     _is_terminal.return_value = is_terminal
     _cylc_server_cmd = monkeymock('cylc.flow.scheduler_cli.cylc_server_cmd')
+    _cylc_server_cmd.return_value = 0
     opts = RunOptions(host='myhost', color=cli_colour)
     with pytest.raises(SystemExit) as excinfo:
         _distribute('foo', 'foo/run1', opts)
@@ -294,6 +295,7 @@ def test_distribute_upgrade(
         'sys.argv', ['cylc', 'play', 'foo']  # no upgrade option here
     )
     _cylc_server_cmd = monkeymock('cylc.flow.scheduler_cli.cylc_server_cmd')
+    _cylc_server_cmd.return_value = 0
     opts = RunOptions(
         host='myhost',
         upgrade=True,  # added by interactive upgrade

--- a/tests/unit/test_scheduler_cli.py
+++ b/tests/unit/test_scheduler_cli.py
@@ -20,7 +20,7 @@ import sqlite3
 
 import pytest
 
-from cylc.flow.exceptions import ServiceFileError
+from cylc.flow.exceptions import HostSelectException, ServiceFileError
 from cylc.flow.scheduler_cli import (
     RunOptions,
     _distribute,
@@ -323,8 +323,5 @@ def test_distribute_invalid_host(
                     available = non_exist_{token_hex(4)}
         '''
     )
-    with pytest.raises(SystemExit) as excinfo:
+    with pytest.raises(HostSelectException):
         _distribute('foo', 'foo/run1', RunOptions())
-    assert excinfo.value.code != 0
-    assert len(caplog.records) == 1
-    assert caplog.records[0].message.startswith("Host selection failed: ")


### PR DESCRIPTION
This fixes a bug where remote reinvocation would exit 0 even if it failed when `[scheduler][run hosts]ranking` is empty (which means random host selection).
- Now it exits non-zero if it failed.
- It also keeps trying hosts if any are uncontactable, until it either finds one that is contactable or exhausts all listed run hosts. (Contact-ability is checked by an empty `cylc psutil <<< '[]'` call on the host)
- Also fixes traceback if an invalid run host is specified in the global config

#### Steps to reproduce

```cylc
# global.cylc
[scheduler]
    [[run hosts]]
        available = somehost1, somehost2, somehost3
        ranking =  # (empty!)
```
```ini
# ~/.ssh/config
Host somehost*
  User borked
```
```console
$ cylc play AnyWorkflow

 ▪ ■  Cylc Workflow Engine 8.4.2
 ██   Copyright (C) 2008-2025 NIWA
▝▘    & British Crown (Met Office) & Contributors

borked@somehost3: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
$ echo $?
0
```

#### After fix

```console
$ cylc play AnyWorkflow

 ▪ ■  Cylc Workflow Engine 8.4.3.dev
 ██   Copyright (C) 2008-2025 NIWA
▝▘    & British Crown (Met Office) & Contributors

WARNING - Could not contact somehost2.example.com:
    borked@somehost2.example.com: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
WARNING - Could not contact somehost1.example.com:
    borked@somehost1.example.com: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
WARNING - Could not contact somehost3.example.com:
    borked@somehost3.example.com: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).
HostSelectException: Could not select host from:
    somehost1.example.com
        returncode: 255
    somehost2.example.com
        returncode: 255
    somehost3.example.com
        returncode: 255

Cylc could not establish SSH connection to the run hosts.
Ensure you can SSH to these hosts without having to answer any prompts.
$ echo $?
1
```

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
