### PR TITLE
add missing proto def fields of PR6671

### DIFF
--- a/cylc/flow/data_messages.proto
+++ b/cylc/flow/data_messages.proto
@@ -231,6 +231,9 @@ message PbTaskProxy {
     optional bool flow_wait = 27;
     optional PbRuntime runtime = 28;
     optional int32 graph_depth = 29;
+    optional bool is_retry = 30;
+    optional bool is_wallclock = 31;
+    optional bool is_xtriggered = 32;
 }
 
 message PbFamily {
@@ -270,6 +273,9 @@ message PbFamilyProxy {
     optional int32 is_runahead_total = 20;
     optional PbRuntime runtime = 21;
     optional int32 graph_depth = 22;
+    optional bool is_retry = 23;
+    optional bool is_wallclock = 24;
+    optional bool is_xtriggered = 25;
 }
 
 message PbEdge {


### PR DESCRIPTION
Add missing new proto fields generated in #6671 

Using the same version `4.25.3` generates no differences

The code was generated with 4.25.3, although I think the difference isn't breaking between 4.24.4 and this:
![image](https://github.com/user-attachments/assets/6de8d23f-9e06-43d2-9e1a-14b95f3ee1c5)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
