### PR TITLE
demote unnecessary warnings

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -914,10 +914,10 @@ class WorkflowConfig:
         """Check for circular dependence in graph."""
         if (len(self.taskdefs) > self.CHECK_CIRCULAR_LIMIT and
                 not getattr(self.options, 'check_circular', False)):
-            LOG.warning(
+            LOG.info(
                 f"Number of tasks is > {self.CHECK_CIRCULAR_LIMIT}; will not "
-                "check graph for circular dependencies. To enforce this "
-                "check, use the option --check-circular.")
+                "check graph for circular dependencies. To run this check"
+                " anyway use the option --check-circular.")
             return
         start_point_str = self.cfg['scheduling']['initial cycle point']
         raw_graph = self.get_graph_raw(start_point_str,

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -535,7 +535,7 @@ class CylcWorkflowDAO:
                 )
                 raise
             self.n_tries += 1
-            LOG.warning(
+            LOG.info(
                 "%(file)s: write attempt (%(attempt)d)"
                 " did not complete: %(error)s\n"
                 " SQLite error code: %(error_code)s\n"
@@ -560,7 +560,7 @@ class CylcWorkflowDAO:
                 table.update_queues.clear()
             # Report public database retry recovery if necessary
             if self.n_tries:
-                LOG.warning(
+                LOG.info(
                     "%(file)s: recovered after (%(attempt)d) attempt(s)\n" % {
                         "file": self.db_file_name, "attempt": self.n_tries})
             self.n_tries = 0
@@ -601,7 +601,10 @@ class CylcWorkflowDAO:
             for i, stmt_args in enumerate(stmt_args_list):
                 err_log += ("\nstmt_args[%(i)d]=%(stmt_args)s" % {
                     "i": i, "stmt_args": stmt_args})
-            LOG.warning(err_log)
+            if self.is_public:
+                LOG.info(err_log)
+            else:
+                LOG.warning(err_log)
             raise
 
     def pre_select_broadcast_states(self, order=None):

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1375,7 +1375,7 @@ class TaskEventsManager():
         """Helper for process_message, handle a started message."""
         if itask.job_vacated:
             itask.job_vacated = False
-            LOG.warning(f"[{itask}] Vacated job restarted")
+            LOG.info(f"[{itask}] Vacated job restarted")
         job_tokens = itask.tokens.duplicate(job=str(itask.submit_num))
         self.data_store_mgr.delta_job_time(job_tokens, 'started', event_time)
         self.data_store_mgr.delta_job_state(job_tokens, TASK_STATUS_RUNNING)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1169,7 +1169,9 @@ class TaskPool:
                     # Job file might have been written at this point?
                     _warn_tasks.append(str(itask))
 
-        for may, tasks in (('', warn_tasks), ('may be', warn_tasks)):
+        for may, tasks in [('', n) for n in warn_tasks] + [
+            ('may be', n) for n in _warn_tasks
+        ]:
             if tasks:
                 _tasks = "\n * ".join(tasks)
                 LOG.info(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1169,9 +1169,7 @@ class TaskPool:
                     # Job file might have been written at this point?
                     _warn_tasks.append(str(itask))
 
-        for may, tasks in [('', n) for n in warn_tasks] + [
-            ('may be', n) for n in _warn_tasks
-        ]:
+        for may, tasks in (('', warn_tasks), ('may be', _warn_tasks)):
             if tasks:
                 _tasks = "\n * ".join(tasks)
                 LOG.info(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1123,7 +1123,11 @@ class TaskPool:
         # Log tasks orphaned by a reload but not currently in the task pool.
         for name in orphans:
             if name not in (itask.tdef.name for itask in tasks):
-                LOG.warning("Removed task: '%s'", name)
+                LOG.info("Removed task: '%s'", name)
+        # Store lists of tasks which were active before reload.
+        warn_tasks: List[str] = []
+        _warn_tasks: List[str] = []
+
         for itask in tasks:
             if itask.tdef.name in orphans:
                 if (
@@ -1136,7 +1140,7 @@ class TaskPool:
                 else:
                     # Keep active orphaned task, but stop it from spawning.
                     itask.graph_children = {}
-                    LOG.warning(
+                    LOG.info(
                         f"[{itask}] will not spawn children "
                         "- task definition removed"
                     )
@@ -1158,15 +1162,18 @@ class TaskPool:
                 self._swap_out(new_task)
                 self.data_store_mgr.delta_task_prerequisite(new_task)
                 LOG.info(f"[{itask}] reloaded task definition")
+
                 if itask.state(*TASK_STATUSES_ACTIVE):
-                    LOG.warning(
-                        f"[{itask}] active with pre-reload settings"
-                    )
+                    warn_tasks.append(str(itask))
                 elif itask.state(TASK_STATUS_PREPARING):
                     # Job file might have been written at this point?
-                    LOG.warning(
-                        f"[{itask}] may be active with pre-reload settings"
-                    )
+                    _warn_tasks.append(str(itask))
+
+        for may, tasks in (('', warn_tasks), ('may be', warn_tasks)):
+            if tasks:
+                _tasks = "\n * ".join(tasks)
+                LOG.info(
+                    f"Tasks {may} active with pre-reload settings:\n{_tasks}")
 
         # Reassign live tasks to the internal queue
         del self.task_queue_mgr
@@ -1250,22 +1257,18 @@ class TaskPool:
                     orphans_kill_failed.append(itask)
                 else:
                     orphans.append(itask)
-        if orphans_kill_failed:
-            LOG.warning(
-                "Orphaned tasks (kill failed):\n"
-                + "\n".join(
-                    f"* {itask.identity} ({itask.state.status})"
-                    for itask in orphans_kill_failed
+
+        for orphanlist, extra_text in (
+            (orphans_kill_failed, ' (kill failed)'),
+            (orphans, '')
+        ):
+            if orphanlist:
+                LOG.warning(
+                    f"Orphaned tasks{extra_text}:\n"
+                    + "\n".join(
+                        f"* {itask.identity} ({itask.state.status})"
+                        for itask in orphanlist)
                 )
-            )
-        if orphans:
-            LOG.warning(
-                "Orphaned tasks:\n"
-                + "\n".join(
-                    f"* {itask.identity} ({itask.state.status})"
-                    for itask in orphans
-                )
-            )
 
         for id_key in self.task_events_mgr._event_timers:
             LOG.warning(

--- a/tests/functional/database/04-lock-recover.t
+++ b/tests/functional/database/04-lock-recover.t
@@ -25,12 +25,12 @@ workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach --reference-test "${WORKFLOW_NAME}"
 
 # Ensure that DB statement and its args are printed to STDERR
-grep -A 3 -F 'WARNING - cannot execute database statement:' \
+grep -A 3 -F 'INFO - cannot execute database statement:' \
     "${TEST_NAME_BASE}-run.stderr" > "${TEST_NAME_BASE}-run.stderr.grep"
 # The following "sed" turns the value for "time_submit_exit" to "?"
 sed -i "s/, '[^T']*T[^Z']*Z',/, '?',/" "${TEST_NAME_BASE}-run.stderr.grep"
 # Cannot use cmp_ok as the error message is prefixed by a timestamp.
-grep_ok "WARNING - cannot execute database statement:" \
+grep_ok "INFO - cannot execute database statement:" \
     "${TEST_NAME_BASE}-run.stderr.grep"
 
 DB_FILE="$RUN_DIR/${WORKFLOW_NAME}/log/db"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1116,7 +1116,7 @@ def test_process_runahead_limit(
 def test_check_circular(opt, monkeypatch, caplog, tmp_flow_config):
     """Test WorkflowConfig._check_circular()."""
     # ----- Setup -----
-    caplog.set_level(logging.WARNING, CYLC_LOG)
+    caplog.set_level(logging.INFO, CYLC_LOG)
 
     options = SimpleNamespace(is_validate=True)
     if opt:

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -207,7 +207,7 @@ def test_infer_latest_run_warns_for_runN(
     monkeypatch.setattr('cylc.flow.LOG.level', logging.INFO)
     infer_latest_run(runN_path, warn_runN=warn_arg)
     filtered_log = log_filter(
-        logging.INFO, contains="You need only include"
+        logging.WARNING, contains="You do not need to include"
     )
     assert filtered_log if warn_arg else not filtered_log
 

--- a/tests/unit/test_workflow_files.py
+++ b/tests/unit/test_workflow_files.py
@@ -198,14 +198,16 @@ def test_infer_latest_run_warns_for_runN(
     warn_arg: bool,
     log_filter: Callable,
     tmp_run_dir: Callable,
+    monkeypatch: pytest.MonkeyPatch
 ):
     """Tests warning is produced to discourage use of /runN in workflow_id"""
     (tmp_run_dir() / 'run1').mkdir()
     runN_path = tmp_run_dir() / 'runN'
     runN_path.symlink_to('run1')
+    monkeypatch.setattr('cylc.flow.LOG.level', logging.INFO)
     infer_latest_run(runN_path, warn_runN=warn_arg)
     filtered_log = log_filter(
-        logging.WARNING, "You do not need to include runN in the workflow ID"
+        logging.INFO, contains="You need only include"
     )
     assert filtered_log if warn_arg else not filtered_log
 


### PR DESCRIPTION
Closes #6760 

https://github.com/cylc/cylc-ui/pull/2169 adds streaming warnings to the UI, but this highlights some warnings which may be either very large, or of no interest to the user.

I am aware that this change may engender controversy - feel free to persuade me that my choices are wrong.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Refactor and log level change - should be covered by existing tests, and indeed a number broke.
- [x] ~Changelog entry included if this is a change that can affect users~ No: These changes are being made because these warning should NOT affect users.
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc)~ N/A
- [x] Not a bug fix => master
