### PR TITLE
cylc: fix blindspot and fill some CLI coverage holes

### DIFF
--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -19,7 +19,7 @@
 
 . "$(dirname "$0")/test_header"
 # Number of tests depends on the number of 'cylc' commands.
-set_test_number 28
+set_test_number 37
 
 # Top help
 run_ok "${TEST_NAME_BASE}-0" cylc
@@ -57,12 +57,27 @@ run_ok "${TEST_NAME_BASE}-validate-h" cylc validate -h
 run_ok "${TEST_NAME_BASE}-help-validate" cylc help validate
 run_ok "${TEST_NAME_BASE}-help-va" cylc help va
 for FILE in \
+    "${TEST_NAME_BASE}-validate--help.stdout" \
     "${TEST_NAME_BASE}-validate-h.stdout" \
     "${TEST_NAME_BASE}-help-validate.stdout" \
     "${TEST_NAME_BASE}-help-va.stdout"
 do
     cmp_ok "${FILE}" "${TEST_NAME_BASE}-validate--help.stdout"
 done
+
+# Alias help
+run_ok "${TEST_NAME_BASE}-broadcast-h" cylc broadcast -h
+run_ok "${TEST_NAME_BASE}-bcast-h" cylc bcast -h
+cmp_ok "${TEST_NAME_BASE}-broadcast-h.stdout" "${TEST_NAME_BASE}-bcast-h.stdout"
+
+# Dead end
+run_fail "${TEST_NAME_BASE}-broadcast-h" cylc check-software
+
+# Misc
+run_ok "${TEST_NAME_BASE}-help-id" cylc help id
+grep_ok 'Every Installed Cylc workflow has an ID' "${TEST_NAME_BASE}-help-id.stdout"
+run_ok "${TEST_NAME_BASE}-help-licence" cylc help licence
+grep_ok 'GNU GENERAL PUBLIC LICENSE' "${TEST_NAME_BASE}-help-licence.stdout"
 
 # Version
 run_ok "${TEST_NAME_BASE}-version" cylc version

--- a/tests/functional/cli/01-help.t
+++ b/tests/functional/cli/01-help.t
@@ -73,7 +73,7 @@ cmp_ok "${TEST_NAME_BASE}-broadcast-h.stdout" "${TEST_NAME_BASE}-bcast-h.stdout"
 # Dead end
 run_fail "${TEST_NAME_BASE}-broadcast-h" cylc check-software
 
-# Misc
+# Help with IDs and the Licence
 run_ok "${TEST_NAME_BASE}-help-id" cylc help id
 grep_ok 'Every Installed Cylc workflow has an ID' "${TEST_NAME_BASE}-help-id.stdout"
 run_ok "${TEST_NAME_BASE}-help-licence" cylc help licence

--- a/tests/unit/scripts/test_cylc.py
+++ b/tests/unit/scripts/test_cylc.py
@@ -25,8 +25,6 @@ import pytest
 
 from cylc.flow.scripts.cylc import iter_commands, pythonpath_manip
 
-from ..conftest import MonkeyMock
-
 
 @pytest.fixture
 def mock_entry_points(monkeypatch: pytest.MonkeyPatch):
@@ -93,7 +91,6 @@ def test_iter_commands_bad(mock_entry_points):
 
 def test_execute_cmd(
     mock_entry_points,
-    monkeymock: MonkeyMock,
     capsys: pytest.CaptureFixture,
 ):
     """It should fail with a warning for commands with missing dependencies."""
@@ -103,25 +100,18 @@ def test_execute_cmd(
 
     mock_entry_points(include_bad=True)
 
-    # capture sys.exit calls
-    capexit = monkeymock('cylc.flow.scripts.cylc.sys.exit')
-
     # the "good" entry point should exit 0 (exit with no args)
-    execute_cmd('good')
-    capexit.assert_called_once_with()
+    assert execute_cmd('good') == 0
     assert capsys.readouterr().err == ''
 
     # the "missing" entry point should exit 1 with a warning to stderr
-    capexit.reset_mock()
-    execute_cmd('missing')
-    capexit.assert_any_call(1)
+    assert execute_cmd('missing') == 1
     assert capsys.readouterr().err.strip() == (
         '"cylc missing" requires "foo"\n\nModuleNotFoundError: foo'
     )
 
     # the "bad" entry point should log an error
-    execute_cmd('bad')
-    capexit.assert_any_call(1)
+    assert execute_cmd('bad') == 1
 
     stderr = capsys.readouterr().err.strip()
     assert '"cylc bad" requires "d"' in stderr


### PR DESCRIPTION
Spotted some coverage holes in the CLI code when reviewing something else:

https://app.codecov.io/gh/cylc/cylc-flow/commit/6b6f0037e05aee5f001d9047683a341952374cf0/blob/cylc/flow/scripts/cylc.py?dropdown=coverage#L649

I think the `sys.exit` calls made within the `with pycoverage` block can prevent the capture of coverage.

This change moves the `sys.exit` outside of the block and adds a couple of missing tests.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.