### PR TITLE
increase restart timeout to PT5M

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1043,7 +1043,7 @@ with Conf('global.cylc', desc='''
                     if item == "stall timeout":
                         default = DurationFloat(3600)
                     elif item == "restart timeout":
-                        default = DurationFloat(120)
+                        default = DurationFloat(300)
                     else:
                         default = None
                 Conf(item, vdr_type, default, desc=desc)


### PR DESCRIPTION
If you restart a completed workflow, you currently get PT2M to trigger tasks to allow the workflow to continue.

From recent experience, this is a bit short for users to load the GUI, locate the workflow, figure out what tasks they want to trigger and fire off the mutation.

5 mins seems more reasonable.

I can't see this as being contentious, one review should do.