### PR TITLE
tests/f: fix tests which hang on restart timeout

### DIFF
--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -25,6 +25,10 @@ set_test_number 7
 init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
 [scheduler]
     allow implicit tasks = True
+    [[events]]
+      # The third subtest will restart with an empty task pool.
+      # This ensures the workflow shuts down prompty.
+      restart timeout = PT0S
 [scheduling]
     initial cycle point = 1
     final cycle point = 2

--- a/tests/functional/restart/20-event-retry/bin/my-handler
+++ b/tests/functional/restart/20-event-retry/bin/my-handler
@@ -4,6 +4,8 @@ WORKFLOW="$1"
 OUT_FILE="$CYLC_WORKFLOW_RUN_DIR/file"
 if grep -q -F '1' "${OUT_FILE}" 2>'/dev/null'; then
     echo '2' >>"${OUT_FILE}"
+    cylc shutdown "${WORKFLOW}"
+    exit 0
 else
     echo '1' >"${OUT_FILE}"
     cylc shutdown --now --now "${WORKFLOW}"

--- a/tests/functional/startup/01-log-flow-config.t
+++ b/tests/functional/startup/01-log-flow-config.t
@@ -28,6 +28,7 @@ init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
     [[events]]
         abort on stall timeout = True
         stall timeout = PT0S
+        restart timeout = PT0S  # shut down when restarted with empty pool
 [scheduling]
     [[graph]]
         R1 = reloader => whatever


### PR DESCRIPTION
* These tests restart workflows with empty task pools.
* In early Cylc 8, the workflow would have just shut down (empty pool).
* In later Cylc 8, a restart timeout was introduced.
* These tests subsequently hung on the restart timeout and failed (due to hitting the inactivity timeout) when the restart timeout was extended in #6787.
