### PR TITLE
fix infinite submission retry bug

### DIFF
--- a/changes.d/6798.fix.md
+++ b/changes.d/6798.fix.md
@@ -1,0 +1,1 @@
+Prevent unintended submission reties that could result from platform connection issues in certain circumstances.

--- a/changes.d/6798.fix.md
+++ b/changes.d/6798.fix.md
@@ -1,1 +1,1 @@
-Prevent unintended submission reties that could result from platform connection issues in certain circumstances.
+Prevent unintended submission retries that could result from platform connection issues in certain circumstances.

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -340,10 +340,11 @@ class TaskJobManager:
             # Find the first platform where >1 host has not been tried and
             # found to be unreachable.
             # If there are no good hosts for a task then the task submit-fails.
+            out_of_hosts = False
             for itask in itasks:
                 # If there are any hosts left for this platform which we
                 # have not previously failed to contact with a 255 error.
-                if any(
+                if not out_of_hosts and any(
                     host not in self.task_remote_mgr.bad_hosts
                     for host in itask.platform['hosts']
                 ):


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/6797
* Fixes an issue where multiple tasks being submitted in the same batch could interact via the "bad hosts" set.
* This would result in one task entering an infinite submission retry loop despite this not having been configured.

I fear this one is going to be a right pain to test, or that the test will become a false negative check. The cause was simple variable scope error, so maybe not in need of a direct test?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.