### PR TITLE
tui: increase comms timeout

### DIFF
--- a/cylc/flow/scripts/tui.py
+++ b/cylc/flow/scripts/tui.py
@@ -66,12 +66,12 @@ def get_option_parser() -> COP:
         metavar='SEC',
         help=(
             "Set a timeout for network connections"
-            " to the running workflow. The default is 3 seconds."
+            " to the running workflow. The default is 5 seconds."
             " For task messaging connections see"
             " site/user config file documentation."
         ),
         action='store',
-        default=3,
+        default=5,
         dest='comms_timeout',
         type=int,
     )


### PR DESCRIPTION
* Some people have encountered timeouts.
* Because Tui uses a global update, the app updates at the rate of the slowest workflow it is connected to.
* So it is advantageous to set a lower timeout to keep the app responsive.
* However, multi-workflow monitoring is less common and it is unhelpful not to be able to view the workflow at all.
* Increasing the timeout from 3 to 5 seconds as a compromise.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.