### PR TITLE
schema: remove list default value

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -833,7 +833,6 @@ class Workflow(ObjectType):
             messages. It is down to the client to store / preserve previous
             records.
         '''),
-        default_value=[],
     )
 
 


### PR DESCRIPTION
Should fix an integration failure reported in https://github.com/cylc/cylc-uiserver/pull/672#issuecomment-2988076657

* This worked under graphene v2 but not v3 for reasons unknown.
* However, the default appears to be unnecessary which makes sense since it's `List(LogRecords)` not `List(NonNull(LogRecords))`.

Reviewer(s), please test the end-to-end functionality of [this feature](https://github.com/cylc/cylc-ui/pull/2169) on the graphene v3 branches before approving.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.