### PR TITLE
Don't add new db flow rows if prior history exists.

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1754,6 +1754,9 @@ class TaskPool:
         if itask is None:
             return None
 
+        if prev_status is None:
+            self.db_add_new_flow_rows(itask)
+
         if (
             prev_status is not None
             and not itask.state.outputs.get_completed_outputs()
@@ -1820,7 +1823,6 @@ class TaskPool:
                     for cycle, task, output in self.abs_outputs_done
                 ])
 
-        self.db_add_new_flow_rows(itask)
         return itask
 
     def _spawn_after_flow_wait(self, itask: TaskProxy) -> None:


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

Bug found while investigating #6813 

Newly spawned tasks add new rows to the DB, which wipes out prior outputs (e.g. via use of `cylc set`).

This is not as bad as it seems because newly spawned tasks load prior outputs before the new rows are added, so the original outputs get restored to the DB quickly at the next outputs table update.

However, it is still a bug, and there is at least one niche situation that exposes it: if a suicide-triggered task has prior completed outputs (e.g. via `cylc set`):

```cylc
[scheduling]
    [[graph]]
        R1 = """
            setter
            slow:fail? => foo
            slow? => !foo
            foo:x => x
        """
[runtime]
    [[setter]]
        script = "cylc set -o x ${CYLC_WORKFLOW_ID}//1/foo"
    [[slow]]
        script = "sleep 5"
    [[foo]]
        [[[outputs]]]
            x = x
    [[x]]
```
Example: 
- `setter` sets future output `foo:x`, which spawns task `x`
- a little later, `slow` succeeds and suicides `foo` (so `foo` never runs)

In Cylc 8 `foo => ! bar` is usually unnecessary, because `bar` does not get pre-spawned and so does not actually need to be removed. But to continue supporting suicide triggers in Cylc 8 we made it work like this: the suicide trigger spawns `bar` then immediately removes it. This quick spawn-and-remove exposes the bug as described above.

On 8.4.x and master, the workflow runs and leaves this in the DB:
```console
$ sqlite3 -header ~/cylc-run/bug/runN/.service/db 'select * from task_outputs;'
cycle|name|flow_nums|outputs
1|setter|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
1|slow|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
1|x|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
1|foo|[1]|{}  # <------  output x missing
```

On this branch, the manually completed output correctly remains in the DB:
```console
$ sqlite3 -header ~/cylc-run/bug/runN/.service/db 'select * from task_outputs;'
cycle|name|flow_nums|outputs
1|setter|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
1|slow|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
1|foo|[1]|{"x": "(manually completed)"}
1|x|[1]|{"submitted": "submitted", "started": "started", "succeeded": "succeeded"}
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
