### PR TITLE
simulation: complete custom outputs before final outputs

### DIFF
--- a/changes.d/6828.fix.md
+++ b/changes.d/6828.fix.md
@@ -1,0 +1,1 @@
+Simulation mode will no longer erroneously complain about unsatisfied custom outputs.

--- a/cylc/flow/run_modes/simulation.py
+++ b/cylc/flow/run_modes/simulation.py
@@ -366,6 +366,14 @@ def sim_time_check(
             )
 
         if now > itask.mode_settings.timeout:
+            # simulate custom outputs
+            for msg in itask.tdef.rtconfig['outputs'].values():
+                task_events_manager.process_message(
+                    itask, 'DEBUG', msg,
+                    flag=task_events_manager.FLAG_RECEIVED
+                )
+
+            # simulate job outcome
             if itask.mode_settings.sim_task_fails:
                 task_events_manager.process_message(
                     itask, 'CRITICAL', TASK_STATUS_FAILED,
@@ -374,12 +382,6 @@ def sim_time_check(
             else:
                 task_events_manager.process_message(
                     itask, 'DEBUG', TASK_STATUS_SUCCEEDED,
-                    flag=task_events_manager.FLAG_RECEIVED
-                )
-            # Simulate message outputs.
-            for msg in itask.tdef.rtconfig['outputs'].values():
-                task_events_manager.process_message(
-                    itask, 'DEBUG', msg,
                     flag=task_events_manager.FLAG_RECEIVED
                 )
 


### PR DESCRIPTION
Reverse sync (aka cherry-pick) of https://github.com/cylc/cylc-flow/pull/6828