### PR TITLE
pyproject: add ruff isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,9 @@ force_grid_wrap = 2
 lines_after_imports = 2
 combine_as_imports = true
 force_sort_within_sections = true
+
+[tool.ruff.lint.isort]
+# force-grid-wrap = 2  # astral-sh/ruff#2601
+lines-after-imports = 2
+combine-as-imports = true
+force-sort-within-sections = true


### PR DESCRIPTION
Add configuration for the ruff isort plugin.

```console
$ ruff check --select I --fix
```

This is a copy of the plain isort config with one option commented out because it hasn't been implemented, yet.