### PR TITLE
Reimpliment suicide trigger as expire trigger

### DIFF
--- a/changes.d/6835.feat.md
+++ b/changes.d/6835.feat.md
@@ -1,0 +1,3 @@
+Reformulate suicide triggers to expire tasks.
+Fixes a rare bug that could allow tasks to run after suicide triggering.
+The "expired" output is now completed on suicide triggered tasks.

--- a/changes.d/6835.feat.md
+++ b/changes.d/6835.feat.md
@@ -1,3 +1,4 @@
-Reformulate suicide triggers to expire tasks.
-Fixes a rare bug that could allow tasks to run after suicide triggering.
-The "expired" output is now completed on suicide triggered tasks.
+Reformulate suicide triggers to expire tasks. The task's "expired" output will
+now be completed by the trigger, and will automatically be marked optional,
+but custom completion conditions must be adapted accordingly.
+This also fixes a rare bug that could allow tasks to run after suicide triggering.

--- a/changes.d/6835.feat.md
+++ b/changes.d/6835.feat.md
@@ -1,4 +1,5 @@
-Reformulate suicide triggers to expire tasks. The task's "expired" output will
-now be completed by the trigger, and will automatically be marked optional,
-but custom completion conditions must be adapted accordingly.
-This also fixes a rare bug that could allow tasks to run after suicide triggering.
+A new experimental feature that can be switched on in workflow config:
+Suicide triggers expire tasks rather than just remove them. This fixes
+a bug that could allow tasks to run after suicide triggering. The
+"expired" output will automatically be marked as optional for the
+task, but custom completion conditions must be adapted accordingly.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -435,7 +435,7 @@ with Conf(
                 This reimplements "suicide triggers" as "expire triggers".
 
                 * When the condition is met, the task will generate the
-                  ``expired`` output rather than just being removed from the pool.
+                  ``expired`` output rather than just being removed.
                 * The triggered task's
                   `flow.cylc[runtime][<namespace>]completion condition`
                   will be automatically modified so that expiry completes the

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -435,7 +435,7 @@ with Conf(
                 This reimplements "suicide triggers" as "expire triggers".
 
                 * When the condition is met, the task will generate the
-                  ``expired`` output rather than being removed from the pool.
+                  ``expired`` output rather than just being removed from the pool.
                 * The triggered task's
                   `flow.cylc[runtime][<namespace>]completion condition`
                   will be automatically modified so that expiry completes the

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -416,6 +416,40 @@ with Conf(
                The default time zone is now ``Z`` instead of the local time of
                the first workflow start.
         ''')
+        with Conf('experimental', desc='''
+            Activate experimental features.
+
+            These are preview features which will become the default in future
+            releases.
+
+            .. versionadded:: 8.6.0
+        '''):
+            Conf('all', VDR.V_BOOLEAN, False, desc='''
+                Activate all experimental features.
+
+                Encouraged for canary testing.
+
+                .. versionadded:: 8.6.0
+            ''')
+            Conf('expire triggers', VDR.V_BOOLEAN, False, desc='''
+                This reimplements "suicide triggers" as "expire triggers".
+
+                * When the condition is met, the task will generate the
+                  ``expired`` output rather than being removed from the pool.
+                * The triggered task's
+                  `flow.cylc[runtime][<namespace>]completion condition`
+                  will be automatically modified so that expiry completes the
+                  task's outputs.
+                * This should be functionally equivalent to "suicide triggers"
+                  in that the triggered task will not run.
+                * However, the triggered task will now be left in the
+                  ``expired`` state making it clearer in the GUI/logs that
+                  the task has been triggered in this way.
+                * It is possible to trigger other tasks off of this ``expired``
+                  output for more advanced failure recovery.
+
+                .. versionadded:: 8.6.0
+            ''')
 
         with Conf(   # noqa: SIM117 (keep same format)
             'main loop',

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -436,10 +436,10 @@ with Conf(
 
                 * When the condition is met, the task will generate the
                   ``expired`` output rather than just being removed.
-                * The triggered task's
-                  `flow.cylc[runtime][<namespace>]completion condition`
-                  will be automatically modified so that expiry completes the
-                  task's outputs.
+                * The ``expired`` output will be marked as :term:`optional`
+                  for the triggered task, but a custom
+                  `flow.cylc[runtime][<namespace>]completion condition
+                  will need to be modified accordingly.
                 * This should be functionally equivalent to "suicide triggers"
                   in that the triggered task will not run.
                 * However, the triggered task will now be left in the

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -462,7 +462,7 @@ class WorkflowConfig:
         self.mem_log("config.py: after get(sparse=False)")
 
         # These 2 must be called before call to init_cyclers(self.cfg):
-        self.set_exerimental_features()
+        self.set_experimental_features()
         self.process_utc_mode()
         self.process_cycle_point_tz()
 
@@ -616,7 +616,7 @@ class WorkflowConfig:
 
         skip_mode_validate(self.taskdefs)
 
-    def set_exerimental_features(self):
+    def set_experimental_features(self):
         all_ = self.cfg['scheduler']['experimental']['all']
         self.experimental = SimpleNamespace(**{
             key.replace(' ', '_'): value or all_

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -1072,8 +1072,13 @@ class WorkflowConfig:
         for name, taskdef in self.taskdefs.items():
             expr = taskdef.rtconfig['completion']
             if expr:
+                any_suicide = any(
+                    dep.suicide
+                    for d in taskdef.dependencies.values()
+                    for dep in d
+                )
                 # check the user-defined expression
-                self._check_completion_expression(name, expr)
+                self._check_completion_expression(name, expr, any_suicide)
             else:
                 # derive a completion expression for this taskdef
                 expr = get_completion_expression(taskdef)
@@ -1096,7 +1101,9 @@ class WorkflowConfig:
             # on after the TaskDef has been created
             taskdef.rtconfig['completion'] = expr
 
-    def _check_completion_expression(self, task_name: str, expr: str) -> None:
+    def _check_completion_expression(
+        self, task_name: str, expr: str, any_suicide: bool
+    ) -> None:
         """Checks a user-defined completion expression.
 
         Args:
@@ -1104,6 +1111,8 @@ class WorkflowConfig:
                 The name of the task we are checking.
             expr:
                 The completion expression as defined in the config.
+            any_suicide:
+                Does this task have any suicide triggers
 
         """
         # check completion expressions are not being used in compat mode
@@ -1252,12 +1261,21 @@ class WorkflowConfig:
                 and expr_opt is None
                 and compvar in {'submit_failed', 'expired'}
             ):
-                raise WorkflowConfigError(
+                msg = (
                     f'{task_name}:{trigger} is permitted in the graph'
-                    ' but is not referenced in the completion'
-                    ' expression (so is not permitted by it).'
-                    f'\nTry: completion = "{expr} or {compvar}"'
+                    ' but is not referenced in the completion.'
                 )
+                if (
+                    any_suicide
+                    and trigger == "expired"
+                    and self.experimental.expire_triggers
+                ):
+                    msg += (
+                        "\nThis may be due to use of an expire "
+                        "(formerly suicide) trigger."
+                    )
+                msg += f'\nTry: completion = "{expr} or {compvar}"'
+                raise WorkflowConfigError(msg)
 
             if (
                 graph_opt is False

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -744,6 +744,10 @@ class GraphParser:
         self.original.setdefault(name, {})
         self.original[name][expr] = orig_expr
 
+        if suicide:
+            # Make expiry optional for suicide triggered tasks.
+            self._set_output_opt(name, TASK_OUTPUT_EXPIRED, True, False, False)
+
     def _set_output_opt(
         self,
         name: str,

--- a/cylc/flow/graph_parser.py
+++ b/cylc/flow/graph_parser.py
@@ -19,11 +19,11 @@ import re
 import contextlib
 
 from typing import (
-    Set,
     Dict,
     List,
-    Tuple,
     Optional,
+    Set,
+    Tuple,
     Union
 )
 
@@ -264,7 +264,8 @@ class GraphParser:
         family_map: Optional[Dict[str, List[str]]] = None,
         parameters: Optional[Dict] = None,
         task_output_opt:
-            Optional[Dict[Tuple[str, str], Tuple[bool, bool, bool]]] = None
+            Optional[Dict[Tuple[str, str], Tuple[bool, bool, bool]]] = None,
+        expire_triggers: bool = False,
     ) -> None:
         """Initialize the graph string parser.
 
@@ -283,6 +284,7 @@ class GraphParser:
         self.triggers: Dict = {}
         self.original: Dict = {}
         self.workflow_state_polling_tasks: Dict = {}
+        self.expire_triggers = expire_triggers
 
         # Record task outputs as optional or required:
         #   {(name, output): (is_optional, is_member)}
@@ -744,7 +746,7 @@ class GraphParser:
         self.original.setdefault(name, {})
         self.original[name][expr] = orig_expr
 
-        if suicide:
+        if suicide and self.expire_triggers:
             # Make expiry optional for suicide triggered tasks.
             self._set_output_opt(name, TASK_OUTPUT_EXPIRED, True, False, False)
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1827,7 +1827,7 @@ class TaskPool:
                 # revive as incomplete.
                 msg = "incomplete"
 
-            if LOG.level == logging.DEBUG:
+            if LOG.level <= logging.DEBUG:
                 # avoid unnecessary compute when we are not in debug mode
                 id_ = itask.tokens.duplicate(
                     task_sel=prev_status

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1827,7 +1827,7 @@ class TaskPool:
                 # revive as incomplete.
                 msg = "incomplete"
 
-            if cylc.flow.flags.verbosity >= 1:
+            if LOG.level == logging.DEBUG:
                 # avoid unnecessary compute when we are not in debug mode
                 id_ = itask.tokens.duplicate(
                     task_sel=prev_status

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1539,7 +1539,9 @@ class TaskPool:
                         suicide.append(t)
 
         for c_task in suicide:
-            self.remove(c_task, self.__class__.SUICIDE_MSG)
+            self.task_queue_mgr.remove_task(c_task)
+            self.task_events_mgr.process_message(
+                c_task, logging.WARNING, TASK_OUTPUT_EXPIRED)
 
         if suicide:
             # Update DB now in case of very quick respawn attempt.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1539,9 +1539,13 @@ class TaskPool:
                         suicide.append(t)
 
         for c_task in suicide:
-            self.task_queue_mgr.remove_task(c_task)
-            self.task_events_mgr.process_message(
-                c_task, logging.WARNING, TASK_OUTPUT_EXPIRED)
+            if self.config.experimental.expire_triggers:
+                self.task_queue_mgr.remove_task(c_task)
+                self.task_events_mgr.process_message(
+                    c_task, logging.WARNING, TASK_OUTPUT_EXPIRED
+                )
+            else:
+                self.remove(c_task, self.__class__.SUICIDE_MSG)
 
         if suicide:
             # Update DB now in case of very quick respawn attempt.

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2045,11 +2045,9 @@ async def test_remove_by_suicide(
         assert schd.pool.get_task_ids() == {"1/a", "1/b"}
         a = schd.pool.get_task(IntegerPoint("1"), "a")
 
-        # mark 1/a as failed and ensure 1/b is removed by suicide trigger
+        # mark 1/a as failed and ensure 1/b expires
         schd.pool.spawn_on_output(a, TASK_OUTPUT_FAILED)
-        assert log_filter(
-            regex="1/b.*removed from the n=0 window: suicide trigger"
-        )
+        assert log_filter(regex="1/b.*=> expired")
         assert schd.pool.get_task_ids() == {"1/a"}
 
         # ensure that we are able to bring 1/b back by triggering it


### PR DESCRIPTION
Close #6813

This simplifies the system a bit by unifying suicide triggers with task expiry.

Also fixes a long-standing bug: tasks removed by suicide triggers can respawn by other dependencies.

Rationale explained at https://github.com/cylc/cylc-flow/issues/6813#issuecomment-3021516979. Summary:

> On master, suicide triggers just delete tasks from the active pool (n=0)
> - (the bug is: no record of the removal, so suicided tasks can respawn by other dependencies)
> 
> On this branch, suicide triggers just expire tasks
> - expired tasks leave the active pool immediately (which is exactly what suicide is supposed to do)
>   but they're recorded as expired, which stops them respawning
> - every existing suicide test passes as-is
> 
> **The only functional change is**: if a suicide-triggered task also has an :expired trigger, that will now run on suicide - that is (a) very niche; and (b) actually sensible


<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc issue](https://github.com/cylc/cylc-doc/issues/841) 
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
