### PR TITLE
trigger: support ^/$ syntax for referencing the initial/final cycle points

### DIFF
--- a/changes.d/6844.feat.md
+++ b/changes.d/6844.feat.md
@@ -1,0 +1,1 @@
+Cylc command including `cylc trigger` now supports the `^` and `$` syntax for referencing the initial and final cycle points respectively.

--- a/changes.d/6844.feat.md
+++ b/changes.d/6844.feat.md
@@ -1,1 +1,1 @@
-Cylc command including `cylc trigger` now supports the `^` and `$` syntax for referencing the initial and final cycle points respectively.
+Cylc commands including `cylc trigger` now support the `^` and `$` syntax for referencing the initial and final cycle points respectively.

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -21,6 +21,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Optional,
     TYPE_CHECKING,
     # Tuple,
     # Union,
@@ -78,6 +79,8 @@ if TYPE_CHECKING:
 def filter_ids(
     pool: 'Pool',
     ids: 'Iterable[str]',
+    icp: 'PointBase',
+    fcp: 'Optional[PointBase]',
     *,
     warn: 'bool' = True,
     out: 'IDTokens' = IDTokens.Task,
@@ -112,6 +115,7 @@ def filter_ids(
     _cycles: 'List[PointBase]' = []
     _tasks: 'List[TaskProxy]' = []
     _not_matched: 'List[str]' = []
+    _invalid: 'List[str]' = []
 
     # enable / disable pattern matching
     match: Callable[[Any, Any], bool]
@@ -138,7 +142,7 @@ def filter_ids(
         try:
             id_tokens_map[id_] = Tokens(id_, relative=True)
         except ValueError:
-            _not_matched.append(id_)
+            _invalid.append(id_)
             LOG.warning(f'Invalid ID: {id_}')
 
     for id_, tokens in id_tokens_map.items():
@@ -174,6 +178,19 @@ def filter_ids(
             task = tokens[IDTokens.Task.value]
             task_sel_raw = tokens.get(IDTokens.Task.value + '_sel')
             task_sel = task_sel_raw or '*'
+
+            # support ^/$ derefencing of the initial and final cycle points
+            if cycle == '^':
+                cycle = str(icp)
+            elif cycle == '$':
+                if not fcp:
+                    _invalid.append(id_)
+                    LOG.warning(
+                        'ID references final cycle point, but none is set:'
+                        f' {id_}'
+                    )
+                cycle = str(fcp)
+
             for icycle, itasks in pool.items():
                 if not point_match(icycle, cycle, pattern_match):
                     continue
@@ -208,7 +225,9 @@ def filter_ids(
             raise NotImplementedError
 
         if not (cycles or tasks):
-            _not_matched.append(id_)
+            _not_matched.append(
+                id_.replace('^', str(icp)).replace('$', str(fcp))
+            )
             if warn:
                 LOG.warning(f"No active tasks matching: {id_}")
         else:
@@ -227,7 +246,7 @@ def filter_ids(
             if icycle in pool:
                 _tasks.extend(pool[icycle].values())
         ret = _tasks
-    return ret, _not_matched
+    return ret, _not_matched, _invalid
 
 
 def point_match(

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2570,9 +2570,11 @@ class TaskPool:
             (matched, inactive_matched, unmatched)
 
         """
-        matched, unmatched = filter_ids(
+        matched, unmatched, invalid = filter_ids(
             self.active_tasks,
             ids,
+            self.config.initial_point,
+            self.config.final_point,
             warn=warn_no_active,
         )
         inactive_matched: 'Set[Tuple[TaskDef, PointBase]]' = set()
@@ -2581,7 +2583,7 @@ class TaskPool:
                 unmatched
             )
 
-        return matched, inactive_matched, unmatched
+        return matched, inactive_matched, unmatched + invalid
 
     def match_inactive_tasks(
         self,

--- a/tests/functional/cylc-trigger/00-compat/flow.cylc
+++ b/tests/functional/cylc-trigger/00-compat/flow.cylc
@@ -3,6 +3,6 @@
         R1 = foo => bar
 [runtime]
     [[foo]]
-        script = cylc trigger "${CYLC_WORKFLOW_ID}//1/bar"
+        script = cylc trigger "${CYLC_WORKFLOW_ID}//^/bar"
     [[bar]]
         script = true


### PR DESCRIPTION
* Closes #6537

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.