### PR TITLE
Allow platform setting to have prefix/suffix around subshell

### DIFF
--- a/changes.d/6848.fix.md
+++ b/changes.d/6848.fix.md
@@ -1,0 +1,1 @@
+Allow `flow.cylc[runtime][<task>]platform` setting to have a prefix/suffix around a subshell expression.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1211,6 +1211,7 @@ with Conf(
 
                    # run a command to select the platform (or platform group):
                    platform = $(select-platform)
+                   platform = prefix-$(select-platform)-suffix
 
                 .. versionadded:: 8.0.0
             ''')

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -57,7 +57,7 @@ SINGLE_HOST_JOB_RUNNERS = ['background', 'at']
 
 # Regex to check whether a string is a command
 HOST_REC_COMMAND = re.compile(r'(`|\$\()\s*(.*)\s*([`)])$')
-PLATFORM_REC_COMMAND = re.compile(r'(\$\()\s*(.*)\s*([)])$')
+PLATFORM_REC_COMMAND = re.compile(r'(\$\()\s*(.*)\s*(\))')
 
 HOST_SELECTION_METHODS = {
     'definition order': lambda goodhosts: goodhosts[0],

--- a/cylc/flow/task_remote_mgr.py
+++ b/cylc/flow/task_remote_mgr.py
@@ -143,9 +143,9 @@ class TaskRemoteMgr:
             return 'localhost'
 
         # Host selection command: $(command) or `command`
-        match = command_pattern.match(eval_str)
+        match = command_pattern.search(eval_str)
         if match:
-            cmd_str = match.groups()[1]
+            cmd_str = match.group(2)
             if cmd_str in self.remote_command_map:
                 # Command recently launched
                 value = self.remote_command_map[cmd_str]
@@ -153,7 +153,8 @@ class TaskRemoteMgr:
                     raise value  # command failed
                 if value is None:
                     return None  # command not yet ready
-                eval_str = value  # command succeeded
+                # command succeeded
+                eval_str = eval_str.replace(match.group(0), value)
             else:
                 # Command not launched (or already reset)
                 self.proc_pool.put_command(

--- a/tests/functional/job-submission/19-platform_select.t
+++ b/tests/functional/job-submission/19-platform_select.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # Test recovery of a failed host select command for a group of tasks.
 . "$(dirname "$0")/test_header"
-set_test_number 6
+set_test_number 7
 
 install_workflow "${TEST_NAME_BASE}"
 
@@ -29,20 +29,24 @@ logfile="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 # Check that host = $(cmd) is correctly evaluated
 grep_ok \
-    "1/host_subshell.* evaluated as improbable host name$" \
+    "1/host_subshell/01:.* evaluated as improbable host name$" \
     "${logfile}"
 grep_ok \
-    "1/localhost_subshell.* evaluated as localhost$" \
+    "1/localhost_subshell/01:.* evaluated as localhost$" \
     "${logfile}"
 
 # Check that host = `cmd` is correctly evaluated
 grep_ok \
-    "1/host_subshell_backticks.* evaluated as improbable host name$" \
+    "1/host_subshell_backticks/01:.* evaluated as improbable host name$" \
     "${logfile}"
 
 # Check that platform = $(cmd) correctly evaluated
 grep_ok \
-    "1/platform_subshell.* evaluated as improbable platform name$" \
+    "1/platform_subshell:.* evaluated as improbable platform name$" \
+    "${logfile}"
+
+grep_ok \
+    "1/platform_subshell_suffix:.* evaluated as prefix-middle-suffix$" \
     "${logfile}"
 
 purge

--- a/tests/functional/job-submission/19-platform_select/flow.cylc
+++ b/tests/functional/job-submission/19-platform_select/flow.cylc
@@ -15,10 +15,11 @@ purpose = """
         R1 = """
             host_no_subshell
             localhost_subshell
-            platform_subshell:submit-fail? => fin_platform
-            platform_no_subshell:submit-fail? => fin_platform
-            host_subshell:submit-fail? => fin_host
-            host_subshell_backticks:submit-fail? => fin_host
+            platform_subshell:submit-fail?
+            platform_no_subshell:submit-fail?
+            platform_subshell_suffix:submit-fail?
+            host_subshell:submit-fail?
+            host_subshell_backticks:submit-fail?
         """
 
 [runtime]
@@ -35,6 +36,9 @@ purpose = """
     [[platform_subshell]]
         platform = $(echo "improbable platform name")
 
+    [[platform_subshell_suffix]]
+        platform = prefix-$( echo middle )-suffix
+
     [[host_subshell]]
         [[[remote]]]
             host = $(echo "improbable host name")
@@ -46,9 +50,3 @@ purpose = """
     [[localhost_subshell]]
         [[[remote]]]
             host = $(echo "localhost4.localdomain4")
-
-    [[fin_platform]]
-        script = cylc remove "${CYLC_WORKFLOW_ID}//1/platform_*"
-
-    [[fin_host]]
-        script = cylc remove "${CYLC_WORKFLOW_ID}//1/host_subshell*"

--- a/tests/functional/job-submission/19-platform_select/reference.log
+++ b/tests/functional/job-submission/19-platform_select/reference.log
@@ -4,5 +4,4 @@
 1/host_subshell -triggered off [] in flow 1
 1/host_subshell_backticks -triggered off [] in flow 1
 1/localhost_subshell -triggered off [] in flow 1
-1/fin_platform -triggered off ['1/platform_no_subshell', '1/platform_subshell'] in flow 1
-1/fin_host -triggered off ['1/host_subshell', '1/host_subshell_backticks'] in flow 1
+1/platform_subshell_suffix -triggered off [] in flow 1

--- a/tests/unit/test_platforms_get_platform.py
+++ b/tests/unit/test_platforms_get_platform.py
@@ -272,6 +272,7 @@ def test_get_platform_groups_basic(mock_glbl_cfg):
     'task_conf, expected_err_msg',
     [
         ({'platform': '$(host)'}, None),
+        ({'platform': '$(host)-suffix'}, None),
         ({'platform': '`echo ${chamber}`'}, "backticks are not supported")
     ]
 )


### PR DESCRIPTION
This so that we can do e.g.
```cylc
platform = $(rose config platform hpc_live)-bg
```
Currently we have to resort to
```cylc
platform = $(echo "$(rose config platform hpc_live)-bg")
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs PR applicable
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
