### PR TITLE
demote warnings

### DIFF
--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -419,7 +419,7 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
         # logged by the TaskPool.
         add = set(schd.config.get_task_name_list()) - old_tasks
         for task in add:
-            LOG.warning(f"Added task: '{task}'")
+            LOG.info(f"Added task: '{task}'")
         schd.workflow_db_mgr.put_workflow_template_vars(schd.template_vars)
         schd.workflow_db_mgr.put_runtime_inheritance(schd.config)
         schd.workflow_db_mgr.put_workflow_params(schd)

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2351,7 +2351,7 @@ class WorkflowConfig:
                     suicides += 1
 
         if suicides and not cylc.flow.flags.cylc7_back_compat:
-            LOG.warning(
+            LOG.info(
                 f"{suicides} suicide trigger(s) detected. These are rarely "
                 "needed in Cylc 8 - see https://cylc.github.io/cylc-doc/"
                 "stable/html/7-to-8/major-changes/suicide-triggers.html"

--- a/cylc/flow/run_modes/skip.py
+++ b/cylc/flow/run_modes/skip.py
@@ -188,4 +188,4 @@ def skip_mode_validate(taskdefs: 'Dict[str, TaskDef]') -> None:
         message = 'The following tasks are set to run in skip mode:'
         for taskname in skip_mode_tasks:
             message += f'\n    * {taskname}'
-        LOG.warning(message)
+        LOG.info(message)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -2179,7 +2179,7 @@ class Scheduler:
             return
         if not self.is_paused:
             if not quiet:
-                LOG.warning("No need to resume - workflow is not paused")
+                LOG.info("No need to resume - workflow is not paused")
             return
         if not quiet:
             LOG.info("RESUMING the workflow now")

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -597,6 +597,7 @@ async def test_glbl_cfg(monkeypatch, tmp_path, caplog):
 def test_nonlive_mode_validation(flow, validate, caplog, log_filter):
     """Nonlive tasks return a warning at validation.
     """
+    caplog.set_level(logging.INFO)
     msg1 = dedent(
         'The following tasks are set to run in skip mode:\n    * skip'
     )

--- a/tests/unit/run_modes/test_skip_units.py
+++ b/tests/unit/run_modes/test_skip_units.py
@@ -110,7 +110,7 @@ def test_process_outputs(outputs, required, expect):
 
 
 def test_skip_mode_validate(caplog, log_filter):
-    """It warns us if we've set a task config to nonlive mode.
+    """It logs a message if we've set a task config to nonlive mode.
 
     (And not otherwise)
 
@@ -120,7 +120,13 @@ def test_skip_mode_validate(caplog, log_filter):
     | If the run mode is set to simulation or skip in the workflow
     | configuration, then cylc validate and cylc lint should produce
     | warning (similar to development features in other languages / systems).
+
+    Edit:
+        Warning demoted to info to prevent the orange warning triangles
+        popping up in the GUI every time a workflow with configured skip tasks
+        is started. See: https://github.com/cylc/cylc-flow/pull/6854
     """
+    caplog.set_level(logging.INFO)
     taskdefs = {
         f'{run_mode}_task': SimpleNamespace(
             rtconfig={'run mode': run_mode},
@@ -134,7 +140,7 @@ def test_skip_mode_validate(caplog, log_filter):
 
     assert len(caplog.records) == 1
     assert log_filter(
-        level=logging.WARNING,
+        level=logging.INFO,
         exact_match=(
             "The following tasks are set to run in skip mode:\n"
             "    * skip_task"


### PR DESCRIPTION
Some more warnings that I think are likely to frustrate users.

I don't think these should be controversial.

**Please bump to 8.6.0 rather than delay 8.5.0 if it comes to it.**

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.