### PR TITLE
Pre batch processing task state (Option 2)

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -114,6 +114,7 @@ from cylc.flow.task_state import (
     TASK_STATUS_RUNNING,
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_FAILED,
+    TASK_STATUS_UNKNOWN,
     TASK_STATUSES_ORDERED
 )
 from cylc.flow.task_state_prop import extract_group_state
@@ -1277,6 +1278,7 @@ class DataStoreMgr:
             id=tp_id,
             task=t_id,
             cycle_point=point_string,
+            state=TASK_STATUS_UNKNOWN,
             is_held=(
                 (name, point)
                 in self.schd.pool.tasks_to_hold

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -60,6 +60,8 @@ TASK_STATUS_RUNNING = "running"
 TASK_STATUS_SUCCEEDED = "succeeded"
 # Job execution failed:
 TASK_STATUS_FAILED = "failed"
+# Task status to be determined
+TASK_STATUS_UNKNOWN = "unknown"
 # Job execution failed, but will try again soon:
 
 TASK_STATUS_DESC = {
@@ -78,7 +80,9 @@ TASK_STATUS_DESC = {
     TASK_STATUS_FAILED:
         'Job has returned non-zero exit code.',
     TASK_STATUS_SUCCEEDED:
-        'Job has returned zero exit code.'
+        'Job has returned zero exit code.',
+    TASK_STATUS_UNKNOWN:
+        'Job status yet to be determined.'
 }
 
 # Task statuses ordered according to task runtime progression.
@@ -90,7 +94,8 @@ TASK_STATUSES_ORDERED = [
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_RUNNING,
     TASK_STATUS_FAILED,
-    TASK_STATUS_SUCCEEDED
+    TASK_STATUS_SUCCEEDED,
+    TASK_STATUS_UNKNOWN
 ]
 
 # Task statuses ordered according to display importance
@@ -103,6 +108,7 @@ TASK_STATUS_DISPLAY_ORDER = [
     TASK_STATUS_PREPARING,
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_WAITING,
+    TASK_STATUS_UNKNOWN
 ]
 
 TASK_STATUSES_ALL = set(TASK_STATUSES_ORDERED)

--- a/cylc/flow/task_state_prop.py
+++ b/cylc/flow/task_state_prop.py
@@ -23,7 +23,8 @@ from cylc.flow.task_state import (
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_RUNNING,
     TASK_STATUS_SUCCEEDED,
-    TASK_STATUS_FAILED
+    TASK_STATUS_FAILED,
+    TASK_STATUS_UNKNOWN,
 )
 
 
@@ -37,7 +38,8 @@ def extract_group_state(child_states, is_stopped=False):
         TASK_STATUS_SUBMITTED,
         TASK_STATUS_PREPARING,
         TASK_STATUS_WAITING,
-        TASK_STATUS_SUCCEEDED
+        TASK_STATUS_SUCCEEDED,
+        TASK_STATUS_UNKNOWN
     ]
     if is_stopped:
         ordered_states = [
@@ -48,7 +50,8 @@ def extract_group_state(child_states, is_stopped=False):
             TASK_STATUS_EXPIRED,
             TASK_STATUS_PREPARING,
             TASK_STATUS_SUCCEEDED,
-            TASK_STATUS_WAITING
+            TASK_STATUS_WAITING,
+            TASK_STATUS_UNKNOWN
         ]
     for state in ordered_states:
         if state in child_states:

--- a/cylc/flow/tui/__init__.py
+++ b/cylc/flow/tui/__init__.py
@@ -24,7 +24,8 @@ from cylc.flow.task_state import (
     TASK_STATUS_SUBMITTED,
     TASK_STATUS_RUNNING,
     TASK_STATUS_FAILED,
-    TASK_STATUS_SUCCEEDED
+    TASK_STATUS_SUCCEEDED,
+    TASK_STATUS_UNKNOWN
 )
 
 TUI = """
@@ -82,7 +83,8 @@ TASK_ICONS = {
     f'{TASK_STATUS_SUCCEEDED}': '\u25CF',
     f'{TASK_STATUS_EXPIRED}': '\u25CC',
     f'{TASK_STATUS_SUBMIT_FAILED}': '\u2298',
-    f'{TASK_STATUS_FAILED}': '\u2297'
+    f'{TASK_STATUS_FAILED}': '\u2297',
+    f'{TASK_STATUS_UNKNOWN}': '\u003f',
 }
 
 # unicode modifiers for special task states


### PR DESCRIPTION
closes #6567, closes #6860, closes #6861

**Note:** The following view, will almost never been seen (otherwise TUI would've be crashing all the time previously), and has been generated by commenting out this batch block:
<img width="782" height="439" alt="image" src="https://github.com/user-attachments/assets/ad6706f4-f5fe-4098-a990-5596702abaf9" />

With that said, momentarily the pre batch processed DB would show:
<img width="1525" height="655" alt="image" src="https://github.com/user-attachments/assets/9e0d5db3-007c-4c04-8a15-91c87fba7184" />

(The WUI should change the ICON to `(?)` or something appropriate)

description
```
    TASK_STATUS_UNKNOWN:
        'Job status yet to be determined.'
```


**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
