### PR TITLE
(no) Pre batch processing task state (Option 3)

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1143,6 +1143,9 @@ class DataStoreMgr:
                 self.prune_trigger_nodes[active_id])
             del self.prune_trigger_nodes[active_id]
 
+        # load database history for flagged nodes
+        self.apply_task_proxy_db_history()
+
     def generate_edge(
         self,
         parent_tokens: Tokens,
@@ -1284,8 +1287,6 @@ class DataStoreMgr:
             depth=task_def.depth,
             graph_depth=n_depth,
             name=name,
-            # Set default before history DB batch application
-            flow_nums=serialise_set(set()),
         )
         self.all_n_window_nodes.add(tp_id)
         self.n_window_depths.setdefault(n_depth, set()).add(tp_id)
@@ -1776,9 +1777,6 @@ class DataStoreMgr:
             self.n_edge_distance = self.next_n_edge_distance
             self.window_resize_rewalk()
             self.next_n_edge_distance = None
-
-        # load database history for flagged nodes
-        self.apply_task_proxy_db_history()
 
         self.updates_pending_follow_on = False
         self.prune_data_store()


### PR DESCRIPTION
closes #6567 

Tasks batched (for DB read) during a graph walk, and processed at the end of that walk.

Window resizes typically include many walks (for each active task), so the DB will have that many calls.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
