### PR TITLE
cat-log: reduce process poll frequency

### DIFF
--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -84,7 +84,7 @@ def watch_and_kill(proc):
     """Kill proc if my PPID (etc.) changed - e.g. ssh connection dropped."""
     gpa = get_proc_ancestors()
     while True:
-        sleep(0.5)
+        sleep(60)
         if proc.poll() is not None:
             break
         if get_proc_ancestors() != gpa:


### PR DESCRIPTION
Process polling was added in 5d9e469d98.

I believe the intention was to detect remote processes which had become orphaned as the result of a collapsed SSH connection. The PID of these processes changes when this happens.

See `def elucidate` in `bin/cylc-cat-log`, elucidate!

The code polls the process twice every second which is pretty extreme. With Cylc Hub these processes are concentrated onto one machine, we're seeing a lot of these polling processes.

I think it should be reasonable to turn down the frequency.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.