### PR TITLE
Validation of order of initial/start/stop/final cycle points

### DIFF
--- a/changes.d/6874.fix.md
+++ b/changes.d/6874.fix.md
@@ -1,0 +1,1 @@
+Improved warnings for suspect start and stop cycle points.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -491,6 +491,10 @@ class WorkflowConfig:
         self.process_start_cycle_point()
         self.process_final_cycle_point()
         self.process_stop_cycle_point()
+        if self.start_point:
+            self.cycle_point_warning('start', 'before', 'initial')
+            self.cycle_point_warning('start', 'after', 'final')
+            self.cycle_point_warning('stop', 'before', 'start')
 
         # Parse special task cycle point offsets, and replace family names.
         LOG.debug("Parsing [special tasks]")
@@ -813,6 +817,7 @@ class WorkflowConfig:
             if self.cycling_type == ISO8601_CYCLING_TYPE:
                 self.options.startcp = _parse_iso_cycle_point(startcp)
             self.start_point = get_point(self.options.startcp).standardise()
+
         elif starttask:
             # Start from designated task(s).
             # Select the earliest start point for use in pre-initial ignore.
@@ -830,6 +835,24 @@ class WorkflowConfig:
         else:
             # Start from the initial point.
             self.start_point = self.initial_point
+
+    def cycle_point_warning(self, label1, order, label2):
+        """Centralized logic for warning that start, stop, initial and
+        final cycle points are not sensibly ordered.
+        """
+        point1 = getattr(self, label1 + '_point')
+        point2 = getattr(self, label2 + '_point')
+        if (
+            order == 'before' and point1 < point2
+            or order == 'after' and point1 > point2
+        ):
+            msg = (
+                f"{label1} cycle point '{point1}' will have no effect as"
+                f" it is {order} the {label2} cycle point '{point2}'."
+            )
+            LOG.warning(msg)
+            return True
+        return False
 
     def process_final_cycle_point(self) -> None:
         """Validate and set the final cycle point from flow.cylc or options.
@@ -911,15 +934,15 @@ class WorkflowConfig:
                 self.initial_point,
             ).standardise()
             if (
-                self.final_point is not None
-                and self.stop_point is not None
-                and self.stop_point > self.final_point
-            ):
-                LOG.warning(
-                    f"Stop cycle point '{self.stop_point}' will have no "
-                    "effect as it is after the final cycle "
-                    f"point '{self.final_point}'."
+                self.stop_point is not None
+                and (
+                    (
+                        self.final_point is not None
+                        and self.cycle_point_warning('stop', 'after', 'final')
+                    )
+                    or self.cycle_point_warning('stop', 'before', 'initial')
                 )
+            ):
                 self.stop_point = None
             stopcp_str = str(self.stop_point) if self.stop_point else None
             self.cfg['scheduling']['stop after cycle point'] = stopcp_str

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -850,8 +850,7 @@ class WorkflowConfig:
                 f"{label1} cycle point '{point1}' will have no effect as"
                 f" it is {order} the {label2} cycle point '{point2}'."
             )
-            LOG.warning(msg)
-            return True
+            raise WorkflowConfigError(msg)
         return False
 
     def process_final_cycle_point(self) -> None:

--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -46,10 +46,10 @@ for SCP in 1 2 3; do
         --no-detach --stopcp="${SCP}"
 
     if [[ "${SCP}" -lt 3 ]]; then
-        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
+        grep_ok "stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/scheduler/log" "-v"
     else
-        grep_ok "Stop cycle point '.*'.*after.*final cycle point '.*'" \
+        grep_ok "stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/scheduler/log"
     fi
 done

--- a/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
+++ b/tests/functional/cylc-play/06-warnif-scp-after-fcp.t
@@ -42,13 +42,14 @@ run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
 
 for SCP in 1 2 3; do
     TEST_NAME="${TEST_NAME_BASE}-play-integer-scp=${SCP}"
-        workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
-        --no-detach --stopcp="${SCP}"
-
     if [[ "${SCP}" -lt 3 ]]; then
+        workflow_run_ok "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
+            --no-detach --stopcp="${SCP}"
         grep_ok "stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/scheduler/log" "-v"
     else
+        workflow_run_fail "${TEST_NAME}" cylc play "${WORKFLOW_NAME}" \
+            --no-detach --stopcp="${SCP}"
         grep_ok "stop cycle point '.*'.*after.*final cycle point '.*'" \
             "${RUN_DIR}/${WORKFLOW_NAME}/log/scheduler/log"
     fi

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -843,64 +843,20 @@ async def test_icp_now_reload(
     'a, b, c, d, validation_fail, err',
     (
         ('initial', 'start', 'stop', 'final', True, False),
-        (
-            'initial', 'start', 'final', 'stop', True,
-            "stop cycle point '20030101T0000Z' will have no effect as it"
-            " is after the final cycle point '20020101T0000Z'."
-        ),
-        (
-            'initial', 'stop', 'start', 'final', False,
-            "stop cycle point '20010101T0000Z' will have no effect as it"
-            " is before the start cycle point '20020101T0000Z'."
-        ),
-        (
-            'initial', 'stop', 'final', 'start', False,
-            "start cycle point '20030101T0000Z' will have no effect as it"
-            " is after the final cycle point '20020101T0000Z'."
-        ),
-        (
-            'initial', 'final', 'start', 'stop', True,
-            "stop cycle point '20030101T0000Z' will have no effect as it"
-            " is after the final cycle point '20010101T0000Z'."
-        ),
-        (
-            'initial', 'final', 'stop', 'start', True,
-            "stop cycle point '20020101T0000Z' will have no effect as it"
-            " is after the final cycle point '20010101T0000Z'."
-        ),
-        (
-            'start', 'initial', 'stop', 'final', False,
-            "start cycle point '20000101T0000Z' will have no effect as it"
-            " is before the initial cycle point '20010101T0000Z'."
-        ),
-        (
-            'start', 'initial', 'final', 'stop', True,
-            "stop cycle point '20030101T0000Z' will have no effect as it"
-            " is after the final cycle point '20020101T0000Z'."
-        ),
-        (
-            'start', 'stop', 'initial', 'final', True,
-            "stop cycle point '20010101T0000Z' will have no effect as it"
-            " is before the initial cycle point '20020101T0000Z'."
-        ),
+        ('initial', 'start', 'final', 'stop', True, WorkflowConfigError),
+        ('initial', 'stop', 'start', 'final', False, WorkflowConfigError),
+        ('initial', 'stop', 'final', 'start', False, WorkflowConfigError),
+        ('initial', 'final', 'start', 'stop', True, WorkflowConfigError),
+        ('initial', 'final', 'stop', 'start', True, WorkflowConfigError),
+        ('start', 'initial', 'stop', 'final', False, WorkflowConfigError),
+        ('start', 'initial', 'final', 'stop', True, WorkflowConfigError),
+        ('start', 'stop', 'initial', 'final', True, WorkflowConfigError),
         ('start', 'stop', 'final', 'initial', True, WorkflowConfigError),
         ('start', 'final', 'initial', 'stop', True, WorkflowConfigError),
         ('start', 'final', 'stop', 'initial', True, WorkflowConfigError),
-        (
-            'stop', 'initial', 'start', 'final', True,
-            "stop cycle point '20000101T0000Z' will have no effect as it"
-            " is before the initial cycle point '20010101T0000Z'."
-        ),
-        (
-            'stop', 'initial', 'final', 'start', True,
-            "stop cycle point '20000101T0000Z' will have no effect as it"
-            " is before the initial cycle point '20010101T0000Z'."
-        ),
-        (
-            'stop', 'start', 'initial', 'final', True,
-            "stop cycle point '20000101T0000Z' will have no effect as it"
-            " is before the initial cycle point '20020101T0000Z'."
-        ),
+        ('stop', 'initial', 'start', 'final', True, WorkflowConfigError),
+        ('stop', 'initial', 'final', 'start', True, WorkflowConfigError),
+        ('stop', 'start', 'initial', 'final', True, WorkflowConfigError),
         ('stop', 'start', 'final', 'initial', True, WorkflowConfigError),
         ('stop', 'final', 'initial', 'start', True, WorkflowConfigError),
         ('stop', 'final', 'start', 'initial', True, WorkflowConfigError),
@@ -951,5 +907,6 @@ async def test_milestone_cycle_points(
 
     else:
         schd = scheduler(wid, startcp=str(order['start']))
-        async with start(schd):
-            assert err in caplog.messages
+        with pytest.raises(err):
+            async with start(schd):
+                pass

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,10 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import partial
+import os
+from optparse import Values
+import pytest
 from contextlib import suppress
 import logging
-from optparse import Values
-import os
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace
@@ -31,8 +33,6 @@ from typing import (
     Type,
 )
 from unittest.mock import Mock
-
-import pytest
 
 from cylc.flow import (
     CYLC_LOG,
@@ -719,7 +719,7 @@ def test_process_fcp(
             id="stopcp-beyond-fcp"
         ),
         pytest.param(
-            '+P12Y -P2Y', None, '2000', None, None,
+            '+P12Y -P2Y', None, '1010', None, None,
             id="stopcp-relative-to-icp"
         ),
     ]
@@ -751,11 +751,13 @@ def test_process_stop_cycle_point(
                 'stop after cycle point': cfg_stopcp
             }
         },
-        initial_point=ISO8601Point('1990'),
+        initial_point=ISO8601Point('1000'),
         final_point=fcp,
         stop_point=None,
         options=RunOptions(stopcp=options_stopcp),
     )
+    mock_config.cycle_point_warning = partial(
+        WorkflowConfig.cycle_point_warning, mock_config)
 
     WorkflowConfig.process_stop_cycle_point(mock_config)
     assert str(mock_config.stop_point) == str(expected_value)


### PR DESCRIPTION
Closes #6866 

Follow-up to #4302

Apparently there was no systematic validation of whether users were supplying sensible values for these, except in a small number of cases.

In this PR, I write a thorough set of cases and ensure that they all pass.

Currently this targets 8.4.x, but I understand that given the refactoring it might be sensible enough to target 8.6.0.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
