### PR TITLE
Cylc Review: support alternate home dirs.

### DIFF
--- a/bin/cylc-review
+++ b/bin/cylc-review
@@ -23,8 +23,15 @@ logs via an HTTP interface.
 
 With no arguments, the status of the ad-hoc web service server is printed.
 
-For 'cylc review start', if 'PORT' is not specified, port 8080 is used."""
+For 'cylc review start', if 'PORT' is not specified, port 8080 is used.
 
+If $CYLC_REVIEW_HOME is defined, look there for run directories instead of
+in user home directories. This can be used to view symlinked run directories
+directly when home directories are private. For example with symlinking as:
+  /home/USER/cylc-run/WORKFLOW -> /project/PROJECT/USER/cylc-run/WORKFLOW
+set the environment variable as:
+  CYLC_REVIEW_HOME=/project/PROJECT
+"""
 
 import sys
 

--- a/lib/cylc/review.py
+++ b/lib/cylc/review.py
@@ -23,7 +23,15 @@ logs via an HTTP interface.
 
 With no arguments, the status of the ad-hoc web service server is printed.
 
-For 'cylc review start', if 'PORT' is not specified, port 8080 is used."""
+For 'cylc review start', if 'PORT' is not specified, port 8080 is used.
+
+If $CYLC_REVIEW_HOME is defined, look there for run directories instead of
+in user home directories. This can be used to view symlinked run directories
+directly when home directories are private. For example with symlinking as:
+  /home/USER/cylc-run/WORKFLOW -> /project/PROJECT/USER/cylc-run/WORKFLOW
+set the environment variable as:
+  CYLC_REVIEW_HOME=/project/PROJECT
+"""
 
 import cherrypy
 from fnmatch import fnmatch
@@ -883,7 +891,9 @@ class CylcReviewService(object):
 
     @staticmethod
     def _get_user_home(user):
-        """Return, e.g. ~/cylc-run/ for a cylc suite.
+        """Return user home dir.
+
+        If $CYLC_REVIEW_HOME is defined, use that; else normal home dir.
 
         N.B. os.path.expanduser does not fail if ~user is invalid.
 
@@ -891,6 +901,11 @@ class CylcReviewService(object):
             cherrypy.HTTPError(404)
 
         """
+        if os.environ.get('CYLC_REVIEW_HOME', False):
+            return os.path.join(
+                os.environ['CYLC_REVIEW_HOME'],
+                str(user)
+            )
         try:
             return pwd.getpwnam(user).pw_dir
         except KeyError:

--- a/lib/cylc/review_dao.py
+++ b/lib/cylc/review_dao.py
@@ -29,6 +29,20 @@ from cylc.task_state import TASK_STATUS_GROUPS
 """Provide data access object to the suite runtime database for Cylc Review."""
 
 
+def get_prefix(user_name):
+    """Return user "home" dir under $CYLC_REVIEW_HOME, or else ~user_name."""
+    if os.environ.get('CYLC_REVIEW_HOME', False) and user_name:
+        prefix = os.path.join(
+            os.environ['CYLC_REVIEW_HOME'],
+            str(user_name)
+        )
+    else:
+        prefix = "~"
+        if user_name:
+            prefix += user_name
+    return prefix
+
+
 class CylcReviewDAO(object):
     """Cylc Review data access object to the suite runtime database."""
 
@@ -108,12 +122,11 @@ class CylcReviewDAO(object):
         """Initialise a named CylcSuiteDAO database connection."""
         key = (user_name, suite_name)
         if key not in self.daos:
-            prefix = "~"
-            if user_name:
-                prefix += user_name
             for name in [os.path.join("log", "db"), "cylc-suite.db"]:
                 db_f_name = os.path.expanduser(os.path.join(
-                    prefix, os.path.join("cylc-run", suite_name, name)))
+                    get_prefix(user_name),
+                    os.path.join("cylc-run",
+                    suite_name, name)))
                 self.daos[key] = CylcSuiteDAO(db_f_name, is_public=True)
                 if os.path.exists(db_f_name):
                     break
@@ -382,11 +395,8 @@ class CylcReviewDAO(object):
         relevant entries of that cycle.
         Modify each entry in entries.
         """
-        prefix = "~"
-        if user_name:
-            prefix += user_name
         user_suite_dir = os.path.expanduser(os.path.join(
-            prefix, os.path.join("cylc-run", suite_name)))
+            get_prefix(user_name), os.path.join("cylc-run", suite_name)))
         try:
             fs_log_cycles = os.listdir(
                 os.path.join(user_suite_dir, "log", "job"))
@@ -519,11 +529,8 @@ class CylcReviewDAO(object):
             integer_mode = row[0].isdigit()
             break
 
-        prefix = "~"
-        if user_name:
-            prefix += user_name
         user_suite_dir = os.path.expanduser(os.path.join(
-            prefix, os.path.join("cylc-run", suite_name)))
+            get_prefix(user_name), os.path.join("cylc-run", suite_name)))
         targzip_log_cycles = []
         try:
             for item in os.listdir(os.path.join(user_suite_dir, "log")):


### PR DESCRIPTION
This is a minimal change to support viewing symlinked run dirs directly instead of via $HOME.

At ESNZ our HPC home directories now have to be private, but we have shared project dirs at the end of our `cylc install` symlinks. This change allows a Cylc Review service running as a project member to see the run dirs of all project members, via the symlinked dirs instead of `$HOME`.

From `cylc review --help` on this branch:

```
If $CYLC_REVIEW_HOME is defined, look there for run directories instead of
of user home directories. This can be used to view symlinked run directories
directly when home directories are private. For example with symlinking as:
    /home/USER/cylc-run/WORKFLOW -> /project/PROJECT/USER/cylc-run/WORKFLOW
set the environment variable as:
    CYLC_REVIEW_HOME=/project/PROJECT
```

There were several places in the code where home dirs were assumed. To avoid any chance of breaking existing use cases, I just banged handling of `$CYLC_REVIEW_HOME` in first, in those locations: if the variable exists, do it the new way; else do it the old way.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
