### PR TITLE
remove obsolete config item

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1425,12 +1425,6 @@ with Conf('global.cylc', desc='''
 
                    {replaces}
             ''')
-            Conf('shell', VDR.V_STRING, '/bin/bash', desc='''
-
-                .. versionchanged:: 8.0.0
-
-                   Moved from ``suite.rc[runtime][<namespace>]job``.
-            ''')
             Conf('communication method',
                  VDR.V_STRING, 'zmq',
                  options=[meth.value for meth in CommsMeth], desc=f'''


### PR DESCRIPTION
* Config was removed in https://github.com/cylc/cylc-flow/pull/3093
* But was somehow reincarnated at a later date.
* It does nothing as [`bash` is hardcoded](https://github.com/cylc/cylc-flow/blob/30253e2847faf52b84a417dd2d9fa81c170c27c6/cylc/flow/job_file.py#L158).
* The Bash interpreter can still be configured by prepending it to `$PATH` in `.bashrc` / `.bash_profile`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.