### PR TITLE
config: turn invalid workflow event errors into warnings

### DIFF
--- a/changes.d/6902.feat.md
+++ b/changes.d/6902.feat.md
@@ -1,0 +1,1 @@
+Invalid workflow events in the `mail events` or `handler events` configurations will result in warnings rather than errors.

--- a/cylc/flow/parsec/config.py
+++ b/cylc/flow/parsec/config.py
@@ -249,6 +249,10 @@ class ConfigNode(ContextNode):
         depr_options:
             List of deprecated options. These are not displayed in the docs
             but are used for backwards compatibility.
+        warn_options:
+            If True, parsec will warn if invalid options are present rather
+            than raising an exception. Any invalid options will be stripped
+            from the config.
         default:
             The default value.
         desc:
@@ -279,6 +283,7 @@ class ConfigNode(ContextNode):
         'vdr',
         'options',
         'depr_options',
+        'warn_options',
         'default',
         'desc',
         'display_name',
@@ -294,6 +299,7 @@ class ConfigNode(ContextNode):
         desc: Optional[str] = None,
         meta: Optional['ConfigNode'] = None,
         depr_options: Optional[list] = None,
+        warn_options: bool = False,
     ):
         display_name = name
         if name.startswith('<'):
@@ -318,6 +324,7 @@ class ConfigNode(ContextNode):
         self.default = default
         self.options = options or []
         self.depr_options = depr_options or []
+        self.warn_options = warn_options
         self.desc = dedent(desc).strip() if desc else None
         self.meta = meta
 

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -33,6 +33,7 @@ from metomi.isodatetime.dumpers import TimePointDumper
 from metomi.isodatetime.parsers import TimePointParser, DurationParser
 from metomi.isodatetime.exceptions import IsodatetimeError, ISO8601SyntaxError
 
+from cylc.flow import LOG
 from cylc.flow.parsec.exceptions import (
     ListValueError, IllegalValueError, IllegalItemError)
 from cylc.flow.subprocctx import SubFuncContext
@@ -236,9 +237,19 @@ class ParsecValidator:
                                 str(i) for i in cfg[key] if i not in voptions
                             ]
                             if bad:
-                                raise IllegalValueError(
+                                exc = IllegalValueError(
                                     'option', [*keys, key], ', '.join(bad)
                                 )
+                                if specval.warn_options:
+                                    LOG.warning(
+                                        f'{exc}'
+                                        '\nInvalid items have been removed'
+                                    )
+                                    cfg[key] = [
+                                        x for x in cfg[key] if x not in bad
+                                    ]
+                                else:
+                                    raise exc
                         elif cfg[key] not in voptions:
                             raise IllegalValueError(
                                 'option', [*keys, key], cfg[key]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -52,7 +52,6 @@ from cylc.flow.exceptions import (
     XtriggerConfigError,
 )
 from cylc.flow.parsec.exceptions import (
-    IllegalValueError,
     Jinja2Error,
 )
 from cylc.flow.scheduler_cli import RunOptions
@@ -1776,8 +1775,8 @@ def test_upg_wflow_event_names(back_compat, tmp_flow_config, log_filter):
 
 
 @pytest.mark.parametrize('item', ['handler events', 'mail events'])
-def test_val_wflow_event_names(item, tmp_flow_config):
-    """Any invalid workflow handler/mail events raise an error."""
+def test_val_wflow_event_names(item, tmp_flow_config, log_filter):
+    """Any invalid workflow handler/mail events raise a warning."""
     flow_file = tmp_flow_config('foo', f"""
         [scheduler]
             allow implicit tasks = true
@@ -1787,9 +1786,8 @@ def test_val_wflow_event_names(item, tmp_flow_config):
             [[graph]]
                 R1 = foo
     """)
-    with pytest.raises(IllegalValueError) as ex_info:
-        WorkflowConfig('foo', str(flow_file), ValidateOptions())
-    assert f"{item} = badger, alpaca" in str(ex_info.value)
+    WorkflowConfig('foo', str(flow_file), ValidateOptions())
+    assert log_filter(contains=f"{item} = badger, alpaca")
 
 
 @pytest.mark.parametrize('item', ['handler events', 'mail events'])


### PR DESCRIPTION
* Turns out a lot of workflows have invalid mail/handler events.
* Turn this hard error into a soft warning to make migration easier.
* Also include the list of valid task events in the config docs. Closes https://github.com/cylc/cylc-flow/issues/6870

Docs build:

<img width="628" height="374" alt="Screenshot from 2025-08-06 16-31-53" src="https://github.com/user-attachments/assets/e2e088c6-f85a-45b7-8778-06d5a90f3bdf" />


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.