### PR TITLE
restart timeout: fire event for stop after cycle point scenarios

### DIFF
--- a/changes.d/6903.fix.md
+++ b/changes.d/6903.fix.md
@@ -1,0 +1,1 @@
+Workflows that have hit the `stop after cycle point` will no longer shut down immediately when restart according to the `restart timeout` configuration.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -370,13 +370,39 @@ EVENTS_SETTINGS: Dict[str, Union[str, Dict[str, Any]]] = {  # workflow events
     ''',
     'restart timeout': '''
         How long to wait for intervention on restarting a completed workflow.
-        The timer stops if any task is triggered.
+
+        When a workflow reaches the end of the :term:`graph`, it will
+        :term:`shut down <shutdown>` automatically. We call such workflows
+        :ref:`completed <workflow completion>` as there are no more tasks for
+        Cylc to run.
+
+        Completed workflows can be caused by:
+
+        * Cylc reaching the end of the :term:`graph`.
+        * The workflow reaching the
+          :cylc:conf:`flow.cylc[scheduling]final cycle point`.
+        * The workflow reaching the
+          :cylc:conf:`flow.cylc[scheduling]stop after cycle point`.
+        * Tasks being manually removed :ref:`interventions.remove_tasks`.
+
+        When you restart a completed workflow, it will detect that there are no
+        more tasks to run, and shut itself down again. The ``restart timeout``
+        delays this shutdown for a configured period allowing you to trigger
+        more task(s) to run.
 
         .. seealso::
 
-           :ref:`user_guide.scheduler.workflow_events`
+           * :ref:`user_guide.scheduler.workflow_events`
+           * :ref:`workflow completion`
+           * :ref:`examples.extending-workflow`
 
         .. versionadded:: 8.2.0
+
+        .. versionchanged:: 8.5.2
+
+           The ``restart timeout`` is now also activated for workflows that
+           have hit the
+           :cylc:conf:`flow.cylc[scheduling]stop after cycle point`.
 
     '''
 }

--- a/tests/functional/restart/08-stop-after-cycle-point/flow.cylc
+++ b/tests/functional/restart/08-stop-after-cycle-point/flow.cylc
@@ -10,6 +10,9 @@ description = """
 [scheduler]
     UTC mode = True
     cycle point format = %Y
+    [[events]]
+        # prevent workflow hanging if restarted with nothing more to do
+        restart timeout = PT0S
 
 [scheduling]
     runahead limit = P0


### PR DESCRIPTION
* If a workflow hits the `final cycle point` and is restarted, it is considered complete.
* If a `restart timeout` is configured, the scheduler will stay up for a configured period.
* However, if a workflow hits the `stop after after cycle point` and is restarted, the `restart timeout` event is not yielded and the scheduler will instantly shut down again.

This has been reported as a problem for people following this design pattern: https://cylc.github.io/cylc-doc/stable/html/user-guide/examples/extending-workflow/index.html

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.