### PR TITLE
Address play and vr timeouts: ping first

### DIFF
--- a/changes.d/6909.fix.md
+++ b/changes.d/6909.fix.md
@@ -1,0 +1,3 @@
+Fix potential timeout of the play and vr commands for workflows with contact
+files, due to an unnecessary remote process check - now only done if the
+workflow fails to respond on the network.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1044,7 +1044,23 @@ with Conf('global.cylc', desc='''
 
                    {REPLACES}``[suite servers][run host select]rank``.
             ''')
+            Conf('process check timeout', VDR.V_INTERVAL, DurationFloat(10),
+                 desc='''
+                Maximum time for the `cylc play` and `cylc vr` commands to wait
+                for a remote process that checks if an unresponsive scheduler
+                is still alive (for workflows with existing contact files).
 
+                .. note::
+
+                   This check involves running ``cylc psutil`` on the run host.
+                   You may need to increase the timeout if shared filesystem
+                   latency (for example) results in slow Python script startup.
+                   Increasing the timeout unnecessarily, however, will just
+                   cause these commands to hang for an unnecessarily long time
+                   in this circumstance.
+
+                .. versionadded:: 8.5.2
+            ''')
         with Conf('host self-identification', desc=f'''
             How Cylc determines and shares the identity of the workflow host.
 

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -48,7 +48,7 @@ from typing import (
 from cylc.flow import LOG
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import (
-    ContactFileExists,
+    SchedulerAlive,
     CylcError,
     InputError,
     PlatformError,
@@ -123,7 +123,7 @@ def _clean_check(opts: 'Values', id_: str, run_dir: Path) -> None:
         return
     try:
         detect_old_contact_file(id_)
-    except ContactFileExists as exc:
+    except SchedulerAlive as exc:
         raise ServiceFileError(
             f"Cannot clean running workflow {id_}.\n\n{exc}"
         ) from None

--- a/cylc/flow/exceptions.py
+++ b/cylc/flow/exceptions.py
@@ -136,8 +136,8 @@ class WorkflowFilesError(CylcError):
     bullet = "\n    -"
 
 
-class ContactFileExists(CylcError):
-    """Workflow contact file exists."""
+class SchedulerAlive(CylcError):
+    """Workflow contact file exists and scheduler is alive."""
 
 
 class FileRemovalError(CylcError):

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -41,7 +41,7 @@ from cylc.flow import (
 )
 from cylc.flow.exceptions import (
     ClientTimeout,
-    ContactFileExists,
+    SchedulerAlive,
     CylcError,
     RequestError,
     WorkflowStopped,
@@ -181,7 +181,7 @@ class WorkflowRuntimeClientBase(metaclass=ABCMeta):
         # behind a contact file?
         try:
             detect_old_contact_file(self.workflow)
-        except ContactFileExists:
+        except SchedulerAlive:
             # old contact file exists and the workflow process still alive
             return
         else:

--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -158,6 +158,10 @@ class WorkflowRuntimeClientBase(metaclass=ABCMeta):
             WorkflowStopped: if the workflow has already stopped.
             CyclError: if the workflow has moved to different host/port.
         """
+        LOG.warning(
+            f"{self.workflow} {self.host}:{self.port}:"
+            f" Connection timed out ({self.timeout} ms)"
+        )
         contact_host, contact_port, *_ = get_location(self.workflow)
         if (
             contact_host != get_fqdn_by_host(self._orig_host)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1144,7 +1144,7 @@ class Scheduler:
         """Create contact file."""
         # Make sure another workflow of the same name hasn't started while this
         # one is starting
-        # NOTE: raises ContactFileExists if workflow is running
+        # NOTE: raises SchedulerAlive if workflow is running
         workflow_files.detect_old_contact_file(self.workflow)
 
         # Extract contact data.

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -486,7 +486,8 @@ async def _resume(workflow_id, options):
     try:
         await cylc_ping(options, workflow_id, pclient)
     except WorkflowStopped:
-        # Not running (orphaned contact file).
+        # Not running, restart instead of resume.
+        # (Orphaned contact file will be removed by cylc_ping client logic).
         return
     except CylcError as exc:
         # PID check failed - abort.

--- a/cylc/flow/scheduler_cli.py
+++ b/cylc/flow/scheduler_cli.py
@@ -34,9 +34,7 @@ from cylc.flow.exceptions import (
     ServiceFileError,
     WorkflowStopped,
 )
-from cylc.flow.scripts.ping import (
-    run as cylc_ping,
-)
+from cylc.flow.scripts.ping import run as cylc_ping
 import cylc.flow.flags
 from cylc.flow.id import upgrade_legacy_ids
 from cylc.flow.host_select import select_workflow_host

--- a/cylc/flow/scripts/clean.py
+++ b/cylc/flow/scripts/clean.py
@@ -220,7 +220,7 @@ async def run(*ids: str, opts: 'Values') -> None:
         workflows, multi_mode = await scan(workflows, multi_mode)
 
         if not workflows:
-            LOG.warning(f"No workflows matching {', '.join(ids)}")
+            LOG.warning(f"No stopped workflows matching {', '.join(ids)}")
             return
 
         workflows.sort()

--- a/cylc/flow/scripts/reinstall.py
+++ b/cylc/flow/scripts/reinstall.py
@@ -217,7 +217,8 @@ async def reinstall_cli(
                 # no rsync output == no changes => exit
                 print(cparse(
                     '<magenta>'
-                    f'{workflow_id} up to date with {source}'
+                    'No changes made:'
+                    f' {workflow_id} is up to date with {source}'
                     '</magenta>'
                 ))
                 return False
@@ -249,7 +250,7 @@ async def reinstall_cli(
     else:
         # no reinstall
         print(
-            cparse('<magenta>Reinstall canceled, no changes made.</magenta>')
+            cparse('<magenta>No changes made: reinstall cancelled.</magenta>')
         )
         return False
 

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -24,8 +24,8 @@ If the source has changed and you respond Yes to the reinstall prompt:
 * reinstall and reload the workflow, if it is running
 * or reinstall and restart the workflow, if it is not running
 
-If the source has not changed or you respond No to the reinstall prompt, the
-workflow will not be reloaded or restarted.
+If the source has not changed or you respond No to the reinstall prompt
+the workflow will not be reinstalled, reloaded, or restarted.
 
 This command is equivalent to:
   $ cylc validate myworkflow --against-source

--- a/cylc/flow/scripts/validate_reinstall.py
+++ b/cylc/flow/scripts/validate_reinstall.py
@@ -18,14 +18,12 @@
 
 """cylc validate-reinstall [OPTIONS] ARGS
 
-Validate, reinstall, and reload or restart a workflow.
+Validate, reinstall and apply changes to a workflow.
 
-If the source has changed and you respond Yes to the reinstall prompt:
-* reinstall and reload the workflow, if it is running
-* or reinstall and restart the workflow, if it is not running
+Validate and reinstall a workflow then either:
 
-If the source has not changed or you respond No to the reinstall prompt
-the workflow will not be reinstalled, reloaded, or restarted.
+* "Reload" the workflow (if it is running),
+* or "play" it (if it is stopped).
 
 This command is equivalent to:
   $ cylc validate myworkflow --against-source

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -48,6 +48,7 @@ from typing import (
 import cylc.flow.flags
 from cylc.flow import LOG
 from cylc.flow.async_util import make_async
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import (
     ContactFileExists,
     CylcError,
@@ -372,6 +373,7 @@ def _is_process_running(
 ) -> bool:
     """Check if a workflow process is still running.
 
+    Runs `cylc psutil` on the scheduler run host.
     * Returns True if the process is still running.
     * Returns False if it is not.
     * Raises CylcError if we cannot tell (e.g. due to network issues).
@@ -428,8 +430,13 @@ def _is_process_running(
         text=True
     )  # * hardcoded command
     try:
-        # Terminate command after 10 seconds to prevent hanging, etc.
-        out, err = proc.communicate(timeout=10, input=metric)
+        out, err = proc.communicate(
+            timeout=(
+                glbl_cfg().get(
+                    ['scheduler', 'run hosts', 'process check timeout'])
+            ),
+            input=metric
+        )
     except TimeoutExpired:
         raise CylcError(
             f'Attempt to determine whether workflow is running on {host}'

--- a/cylc/flow/workflow_files.py
+++ b/cylc/flow/workflow_files.py
@@ -50,7 +50,7 @@ from cylc.flow import LOG
 from cylc.flow.async_util import make_async
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.exceptions import (
-    ContactFileExists,
+    SchedulerAlive,
     CylcError,
     InputError,
     ServiceFileError,
@@ -486,7 +486,7 @@ def detect_old_contact_file(
     * If one does exist but the workflow process is definitely not alive,
       remove it.
     * If one exists and the workflow process is still alive, raise
-      ContactFileExists.
+      SchedulerAlive.
 
     Args:
         id_: workflow ID
@@ -496,7 +496,7 @@ def detect_old_contact_file(
         CylcError:
             If it is not possible to tell for sure if the workflow is running
             or not.
-        ContactFileExists:
+        SchedulerAlive:
             If old contact file exists and the workflow process still alive.
         ServiceFileError:
             For corrupt / incompatible contact files.
@@ -529,7 +529,7 @@ def detect_old_contact_file(
     fname = get_contact_file_path(id_)
     if process_is_running:
         # ... the process is running, raise an exception
-        raise ContactFileExists(
+        raise SchedulerAlive(
             CONTACT_FILE_EXISTS_MSG % {
                 "host": old_host,
                 "port": old_port,

--- a/tests/functional/cylc-clean/00-basic.t
+++ b/tests/functional/cylc-clean/00-basic.t
@@ -21,7 +21,7 @@
 if ! command -v 'tree' >'/dev/null'; then
     skip_all '"tree" command not available'
 fi
-set_test_number 10
+set_test_number 12
 
 # Generate random name for symlink dirs to avoid any clashes with other tests
 SYM_NAME="$(mktemp -u)"
@@ -122,6 +122,13 @@ run_ok "$TEST_NAME" cylc clean "$WORKFLOW_NAME"
 dump_std "$TEST_NAME"
 cmp_ok "${TEST_NAME}.stdout" << __EOF__
 INFO - No directory to clean at ${WORKFLOW_RUN_DIR}
+__EOF__
+# -----------------------------------------------------------------------------
+TEST_NAME="clean-non-exist-pattern"
+run_ok "$TEST_NAME" cylc clean "nope*"
+dump_std "$TEST_NAME"
+cmp_ok "${TEST_NAME}.stderr" << __EOF__
+WARNING - No stopped workflows matching nope*
 __EOF__
 # -----------------------------------------------------------------------------
 purge

--- a/tests/functional/cylc-combination-scripts/05-vr-fail-is-running.t
+++ b/tests/functional/cylc-combination-scripts/05-vr-fail-is-running.t
@@ -52,7 +52,7 @@ sed -i 's@CYLC_WORKFLOW_HOST=.*@CYLC_WORKFLOW_HOST=elephantshrew@' "${CONTACTFIL
 # Change source workflow and run vr:
 run_fail "${TEST_NAME_BASE}-runs" cylc vr "${WORKFLOW_NAME}"
 
-grep_ok "on elephantshrew." "${TEST_NAME_BASE}-runs.stderr"
+grep_ok "elephantshrew." "${TEST_NAME_BASE}-runs.stderr"
 
 # Clean Up:
 mv "${CONTACTFILE}.old" "$CONTACTFILE"

--- a/tests/functional/cylc-play/00-contact.t
+++ b/tests/functional/cylc-play/00-contact.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test `cylc play` start up or resume under various contact scenarios:
+#  - running, normally
+#  - stopped, normally
+#  - stopped, but orphaned contact file
+#  - running, but can't be contacted
+
+. "$(dirname "$0")/test_header"
+
+set_test_number 10
+
+init_workflow "${TEST_NAME_BASE}" <<'__FLOW_CONFIG__'
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = false
+__FLOW_CONFIG__
+
+run_ok "${TEST_NAME_BASE}-validate" \
+    cylc validate "${WORKFLOW_NAME}"
+
+# Not running: play should start it up.
+# (run like this "(cmd &) >/dev/null" to discard the process killed message) 
+(cylc play --pause --no-detach "${WORKFLOW_NAME}" \
+    1>"${TEST_NAME_BASE}.out" 2>&1 &) 2>/dev/null
+poll_workflow_running
+poll_grep_workflow_log "Pausing the workflow: Paused on start up"
+
+# Already running: play should resume.
+TEST_NAME="${TEST_NAME_BASE}-resume"
+run_ok "${TEST_NAME}" \
+    cylc play "${WORKFLOW_NAME}"
+
+grep_ok "Resuming already-running workflow" "${TEST_NAME}.stdout"
+poll_grep_workflow_log "RESUMING the workflow now"
+
+# Orphan the contact file
+# Play should timeout, remove the contact file, and start up.
+TEST_NAME="${TEST_NAME_BASE}-orphan"
+
+eval "$(cylc get-workflow-contact "${WORKFLOW_NAME}" | grep CYLC_WORKFLOW_PID)"
+kill -9 "${CYLC_WORKFLOW_PID}" > /dev/null 2>&1
+
+run_ok "${TEST_NAME}" \
+    cylc play "${WORKFLOW_NAME}" --comms-timeout=1 --pause
+grep_ok "Connection timed out (1000.0 ms)" "${TEST_NAME}.stderr"
+grep_ok "Removed contact file" "${TEST_NAME}.stderr"
+poll_grep_workflow_log "Pausing the workflow: Paused on start up"
+
+# Mess with the port: play aborts as can't tell if workflow is running or not.
+# (The ping times out, then `cylc psutil` can't find the workflow).
+eval "$(cylc get-workflow-contact "${WORKFLOW_NAME}" | grep CYLC_WORKFLOW_PORT)"
+sed -i 's/CYLC_WORKFLOW_PORT=.*/CYLC_WORKFLOW_PORT=490001/' \
+    "$WORKFLOW_RUN_DIR/.service/contact"
+run_fail "${TEST_NAME}" \
+    cylc play "${WORKFLOW_NAME}" --comms-timeout=1
+grep_ok "Connection timed out (1000.0 ms)" "${TEST_NAME}.stderr"
+grep_ok "Cannot tell if the workflow is running" "${TEST_NAME}.stderr"
+
+# Restore contact file and shut down.
+sed -i "s/CYLC_WORKFLOW_PORT=.*/CYLC_WORKFLOW_PORT=${CYLC_WORKFLOW_PORT}/" \
+    "$WORKFLOW_RUN_DIR/.service/contact"
+run_ok "${TEST_NAME}" \
+    cylc stop --now "${WORKFLOW_NAME}"
+
+purge

--- a/tests/integration/test_reinstall.py
+++ b/tests/integration/test_reinstall.py
@@ -178,7 +178,7 @@ async def test_interactive(
 
     # only one rsync call should have been made (i.e. the --dry-run)
     assert [call[1].get('dry_run') for call in reinstall_calls] == [True]
-    assert 'Reinstall canceled, no changes made.' in capsys.readouterr().out
+    assert 'reinstall cancelled' in capsys.readouterr().out
     reinstall_calls.clear()
 
     answer_prompt('y')
@@ -287,7 +287,7 @@ async def test_keyboard_interrupt(
     )
 
     await reinstall_cli(opts=ReInstallOptions(), workflow_id=one_run.id)
-    assert 'Reinstall canceled, no changes made' in capsys.readouterr().out
+    assert 'reinstall cancelled' in capsys.readouterr().out
 
 
 async def test_rsync_fail(one_src, one_run, mock_glbl_cfg, non_interactive):

--- a/tests/integration/test_workflow_files.py
+++ b/tests/integration/test_workflow_files.py
@@ -25,7 +25,7 @@ import pytest
 
 from cylc.flow import CYLC_LOG
 from cylc.flow.exceptions import (
-    ContactFileExists,
+    SchedulerAlive,
     CylcError,
 )
 from cylc.flow.workflow_files import (
@@ -107,7 +107,7 @@ async def workflow(flow, scheduler, one_conf, run_dir):
 def test_detect_old_contact_file_running(workflow):
     """It should raise an error if the workflow is running."""
     # the workflow is running so we should get a ServiceFileError
-    with pytest.raises(ContactFileExists):
+    with pytest.raises(SchedulerAlive):
         detect_old_contact_file(workflow.id_)
     # the contact file is valid so should be left alone
     assert workflow.contact_file.exists()
@@ -234,7 +234,7 @@ def test_detect_old_contact_file_removal_errors(
     # try to remove the contact file
     if process_running:
         # this should error if the process is running
-        with pytest.raises(ContactFileExists):
+        with pytest.raises(SchedulerAlive):
             detect_old_contact_file(workflow.id_)
     else:
         detect_old_contact_file(workflow.id_)

--- a/tests/unit/test_clean.py
+++ b/tests/unit/test_clean.py
@@ -44,7 +44,7 @@ from cylc.flow.clean import (
     init_clean,
 )
 from cylc.flow.exceptions import (
-    ContactFileExists,
+    SchedulerAlive,
     CylcError,
     InputError,
     PlatformError,
@@ -119,7 +119,7 @@ def test_clean_check__fail(
     """
     def mocked_detect_old_contact_file(*a, **k):
         if not stopped:
-            raise ContactFileExists('Mocked error')
+            raise SchedulerAlive('Mocked error')
 
     monkeypatch.setattr(
         'cylc.flow.clean.detect_old_contact_file',
@@ -236,7 +236,7 @@ def test_init_clean__running_workflow(
 ) -> None:
     """Test init_clean() fails when workflow is still running"""
     def mock_err(*args, **kwargs):
-        raise ContactFileExists("Mocked error")
+        raise SchedulerAlive("Mocked error")
     monkeypatch.setattr('cylc.flow.clean.detect_old_contact_file',
                         mock_err)
     tmp_run_dir('yavin')


### PR DESCRIPTION
Close #6846 
~~Partially address #6261 (by documenting exactly what `cylc vr` does now, rather than changing its behaviour)~~ [off-topic, punted to #6354]

> We currently perform the `detect_old_contact_file` check before we resume a workflow (i.e. `cylc play`) and additionally for`cylc vr`.
> With all other commands, we only perform this check if a network timeout has occurred. But in these situations we just do it anyway.
> I don't think there is any good reason to perform these checks, we should be able to replace it with a simple cylc ping type check 

The `detect_old_contact_file` check runs `cylc psutil` over ssh on a hard-wired 10 second timeout. With NFS latency issues on HPC, that may not be nearly long enough.

This change:
- do a (typically much faster) ping type check first, and only resort to `detect_old_contact_file` if that times out (#6846)
- make the timeout configurable - it's still needed for orphaned contact files, and 10 sec ain't enough
- fix badly named exception `ContactFileExists` -> `SchedulerAlive`
  - (it is not raised if the contact file exists but the scheduler is not alive)
- (somewhat relatedly) remove the ability of `cylc ping` to detect running tasks (as opposed to running workflows)
  - this very old feature was untested and broken, so I can conclude no one was using it

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
