### PR TITLE
Group trigger: re-use already-completed outputs of active group start tasks.

### DIFF
--- a/changes.d/6910.fix.md
+++ b/changes.d/6910.fix.md
@@ -1,2 +1,1 @@
-Trigger command: automatically satisfy in-group dependence on any
-already-completed outputs of triggered group-start tasks.
+Trigger command: automatically handle already-completed outputs of triggered tasks.

--- a/changes.d/6910.fix.md
+++ b/changes.d/6910.fix.md
@@ -1,0 +1,2 @@
+Trigger command: automatically satisfy in-group dependence on any
+already-completed outputs of triggered group-start tasks.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -835,7 +835,7 @@ def _force_trigger_tasks(
                 set_all=True  # prerequisites
             )
         else:
-            # Off-flow prereqs to set:
+            # Off-flow prereqs to satisfy, for the triggered flow:
             prereqs_to_set = {
                 PrereqTuple(str(key.point), str(key.task), key.output)
                 for pre in tdef.get_prereqs(point)
@@ -848,8 +848,8 @@ def _force_trigger_tasks(
                 for key in pre.keys()
                 if (key.task, str(key.point)) in group_ids
             )
-            # Prereqs to set for the triggered flow, from already-completed
-            # outputs of active group start tasks.
+            # Prereqs to satisfy, from already-completed outputs of active
+            # group start tasks, for the triggered flow.
             prereqs_to_set.update({
                 PrereqTuple(str(key.point), str(key.task), key.output)
                 for pre in tdef.get_prereqs(point)

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,39 +17,23 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-For tasks to trigger, while respecting dependencies among them.
+Trigger a group of one or more tasks, respecting dependencies among them.
 
-Triggered tasks can run even if the workflow is paused.
+Prerequisites on tasks outside of the group will be satisfied automatically.
 
-Live tasks (preparing, submitted, running) can't be triggered until finished.
+Tasks will be removed if necessary to allow re-run without intervention, so
+triggered tasks that are preparing, submitted, or running may be killed.
 
-Triggering an unqueued task queues it, and triggering a queued task runs it
-regardless of the queue limit; so it may take two triggers to run a task now.
+Tasks that lead into a group will run immediately even if the workflow is
+paused; activity will flow on from them once the workflow is resumed.
 
-Triggering a group of tasks: prerequisites on tasks outside of the group will
-be satisfied automatically; tasks in the group that already ran will be removed
-to allow re-run without intervention, and live tasks will be removed if
-necessary to allow the group to re-run in order.
+Triggering an unqueued task queues it; triggering a queued task runs it.
 
-If the workflow is paused, group start tasks will trigger immediately and the
-flow will continue downstream of them once the workflow is resumed.
-
-  Cylc will automatically:
-  * Erase the run history of members, so they can re-run in the same flow.
-  * Identify group start tasks, and trigger them to start the flow.
-  * Identify off-group dependencies, and satisfy them to avoid a stall.
-  * Leave in-group dependencies to be satisfied by the triggered flow.
-
-  How live (preparing, submitted, or running) tasks are handled:
-  * Live in-group tasks are killed and removed, to rerun in the triggered flow.
-  * Live group-start tasks are left alone; they don't need to be retriggered.
-
-Flow number assignment in triggered tasks:
-  Active tasks (n=0) already have flows assigned; inactive tasks (n>0) do not.
+How flow numbers are assigned to triggered tasks:
+  Active tasks (n=0) already have assigned flows; inactive tasks (n>0) do not.
   * If an interdependent group of triggered tasks includes active tasks, the
     flow will be assigned the existing flow numbers of those active tasks.
   * Otherwise the flow will be assigned all current active flow numbers.
-
 
 Examples:
   # trigger task foo in cycle 1, in workflow "test"
@@ -64,16 +48,6 @@ Examples:
 
   # rerun sub-graph "a => b & c" in the same flow, ignoring "off => b"
   $ cylc trigger test //1/a //1/b //1/c
-
- Flow numbers of triggered tasks are determined as follows:
-  Active tasks (n=0) already have existing flow numbers.
-   * default: merge active and existing flow numbers
-   * --flow=INT or "new": merge given and existing flow numbers
-   * --flow="none": ERROR (not valid for already-active tasks)
-  Inactive tasks (n>0) do not have flow numbers assigned:
-   * default: run with all active flow numbers
-   * --flow=INT or "new": run with the given flow numbers
-   * --flow="none": run as no-flow (activity will not flow on downstream)
 
 """
 

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -35,13 +35,9 @@ Triggering a group of tasks at once (e.g. members of a sub-graph):
   If the workflow is paused, group start tasks will trigger immediately; the
   flow will continue downstream of them when you resume the workflow.
 
-  Beware of triggering live (preparing, submitted, or running) tasks:
-  * Live in-group tasks will be killed and their run history erased, to allow
-    them to re-run in the triggered flow.
-  * Live group-start tasks are left to run; they don't need to be retriggered.
-    WARNING: if they already completed outputs that other group members depend
-    on, you must manually satisfy those prerequisites again for the triggered
-    flow (run history erasure wipes out the original satisfied prerequisites).
+  How live (preparing, submitted, or running) tasks are handled:
+  * Live in-group tasks are killed and removed, to rerun in the triggered flow.
+  * Live group-start tasks are left alone; they don't need to be retriggered.
 
 Flow number assignment in triggered tasks:
   Active tasks (n=0) already have flows assigned; inactive tasks (n>0) do not.

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -17,28 +17,28 @@
 
 """cylc trigger [OPTIONS] ARGS
 
-Manually trigger tasks, respecting dependencies among them.
+For tasks to trigger, while respecting dependencies among them.
 
-Triggering individual tasks:
-  * Triggering an unqueued task queues it, triggering a queued task runs it.
-    So you many need to trigger an unqueued task twice to run it immediately.
-  * Live tasks (preparing, submitted, or running) can't be triggered.
-  * Triggered tasks can run even if the workflow is paused.
+Triggered tasks can run even if the workflow is paused.
 
-Triggering a group of tasks at once (e.g. members of a sub-graph):
-        Prerequisites on any tasks that are outside of the group of tasks being triggered are automatically satisfied.
-        Any tasks which have already run within the group will be automatically removed (i.e. cylc remove) to allow them to be re-run without intervention.
-        Any preparing, submitted or running tasks within the group will also be removed if necessary to allow the tasks to re-run in order.
+Live tasks (preparing, submitted, running) can't be triggered until finished.
 
+Triggering an unqueued task queues it, and triggering a queued task runs it
+regardless of the queue limit; so it may take two triggers to run a task now.
+
+Triggering a group of tasks: prerequisites on tasks outside of the group will
+be satisfied automatically; tasks in the group that already ran will be removed
+to allow re-run without intervention, and live tasks will be removed if
+necessary to allow the group to re-run in order.
+
+If the workflow is paused, group start tasks will trigger immediately and the
+flow will continue downstream of them once the workflow is resumed.
 
   Cylc will automatically:
   * Erase the run history of members, so they can re-run in the same flow.
   * Identify group start tasks, and trigger them to start the flow.
   * Identify off-group dependencies, and satisfy them to avoid a stall.
   * Leave in-group dependencies to be satisfied by the triggered flow.
-
-  If the workflow is paused, group start tasks will trigger immediately; the
-  flow will continue downstream of them when you resume the workflow.
 
   How live (preparing, submitted, or running) tasks are handled:
   * Live in-group tasks are killed and removed, to rerun in the triggered flow.

--- a/cylc/flow/scripts/trigger.py
+++ b/cylc/flow/scripts/trigger.py
@@ -26,6 +26,11 @@ Triggering individual tasks:
   * Triggered tasks can run even if the workflow is paused.
 
 Triggering a group of tasks at once (e.g. members of a sub-graph):
+        Prerequisites on any tasks that are outside of the group of tasks being triggered are automatically satisfied.
+        Any tasks which have already run within the group will be automatically removed (i.e. cylc remove) to allow them to be re-run without intervention.
+        Any preparing, submitted or running tasks within the group will also be removed if necessary to allow the tasks to re-run in order.
+
+
   Cylc will automatically:
   * Erase the run history of members, so they can re-run in the same flow.
   * Identify group start tasks, and trigger them to start the flow.
@@ -44,6 +49,7 @@ Flow number assignment in triggered tasks:
   * If an interdependent group of triggered tasks includes active tasks, the
     flow will be assigned the existing flow numbers of those active tasks.
   * Otherwise the flow will be assigned all current active flow numbers.
+
 
 Examples:
   # trigger task foo in cycle 1, in workflow "test"

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -31,7 +31,10 @@ from cylc.flow.commands import (
     set_prereqs_and_outputs,
 )
 from cylc.flow.cycling.integer import IntegerPoint
-from cylc.flow.task_state import TASK_STATUS_WAITING
+from cylc.flow.task_state import (
+    TASK_STATUS_WAITING,
+    TASK_STATUS_RUNNING
+)
 
 
 async def test_trigger_workflow_paused(
@@ -619,47 +622,76 @@ async def test_trigger_n0_tasks(
         }
 
 
-async def test_replay_outputs(flow, scheduler, run, complete, log_filter):
-    """Triggered tasks re-emit earlier outputs.
+async def test_replay_outputs(flow, scheduler, start, complete, log_filter):
+    """Triggered group start tasks re-emit (kind of) earlier outputs.
 
     https://github.com/cylc/cylc-flow/issues/6858
 
-    in these examples a graph:
+    Example graph:
         a:started => b => end
         k:kustom => l => end
+        k:kustom => offg
 
-    would lead to a user running:
+    If I trigger a, b, k, l AFTER a:started and k:kustom have completed:
         cylc trigger workflow //1/a //1/b //1/k //1/l
 
-    To expect outputs `k:kustom` and `a:started` to be re-emitted
-    allowing b and l to start.
+    Then I should expect outputs `k:kustom` and `a:started` to be re-used
+    to satify b and l in the triggered flow, but NOT off-group task offg.
     """
-    msg = '[1/{}:waiting(runahead)] prerequisite force-satisfied: 1/{}'
-    msg2 = '[1/{}/02:running] => succeeded'
+    msg_prereq = '[1/{}:waiting(runahead)] prerequisite force-satisfied: 1/{}'
+    msg_spawned = "[1/{}:waiting(runahead)] => waiting"
+    msg_removed = "Removed tasks: 1/{}"
+
     wid = flow({
         'scheduling': {
-            'graph': {'R1': 'a:started => b => end\nk:kustom => l => end'}
+            'graph': {
+                'R1': """
+                    a:started => b => end
+                    k:kustom => l => end
+                    k:kustom => offg
+                """
+            }
         },
         'runtime': {
-            'a': {'script': 'sleep 10'},
+            'a': {},
             'k': {
-                'script': 'cylc message -- "custom message"; sleep 10',
                 'outputs': {'kustom': 'custom message'}
             }
         }
     })
-    schd = scheduler(wid, paused_start=False, run_mode='live')
-    async with run(schd):
-        await complete(schd, '1/b', '1/l')
+    schd = scheduler(wid, paused_start=True)
+    async with start(schd):
+        # Set initial tasks a and k to "running" so they are recognized as
+        # live during the forthcoming trigger operation.
+
+        # Complete the a:started and k:kustom outputs.
+        schd.pool.set_prereqs_and_outputs(
+            ['1/a'], ['started'], [], []
+        )
+        schd.pool.set_prereqs_and_outputs(
+            ['1/k'], ['kustom'], [], []
+        )
+        # It should spawn b, l, and offg.
+        for task in ['b', 'l', 'offg']:
+            assert log_filter(contains=msg_spawned.format(task))
+
+        # Set a and k as running so they're recognized as live start tasks
+        # by the trigger operation.
+        for itask in schd.pool.get_tasks():
+            itask.state_reset(TASK_STATUS_RUNNING)
+
+        # Now trigger the group.
         await run_cmd(
             force_trigger_tasks(schd, ['1/a', '1/b', '1/k', '1/l'], [])
         )
-        await complete(schd, '1/b', '1/l')
+        # It should remove b and l (in-group tasks)
+        for task in ['b', 'l']:
+            assert log_filter(contains=msg_removed.format(task))
 
-        # Trigger force has re-satisfied outputs:
-        assert log_filter(contains=msg.format('b', 'a:started'))
-        assert log_filter(contains=msg.format('l', 'k:custom message'))
-
-        # Second copies of tasks triggered by outputs _have_ been run:
-        assert log_filter(contains=msg2.format('b'))
-        assert log_filter(contains=msg2.format('l'))
+        # But they will be respawned immediately by re-satisfying dependence
+        # on the earlier outputs of a and k for in-group tasks:
+        assert log_filter(contains=msg_prereq.format('b', 'a:started'))
+        assert log_filter(contains=msg_prereq.format('l', 'k:custom message'))
+        # But not for the off-group task offg:
+        assert not log_filter(
+            contains=msg_prereq.format('offg', 'k:custom message'))


### PR DESCRIPTION
Close #6858 

Re-spawn **in-group** children of already-completed group start task outputs - because triggering is event-driven and group trigger removes in-group tasks and their already-completed prerequisites.

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
