### PR TITLE
#6598 cat-log: new auto cat/tail mode

### DIFF
--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -158,6 +158,7 @@ MODES = {
     'd': 'print-dir',
     'c': 'cat',
     't': 'tail',
+    'a': 'auto',
 }
 
 
@@ -367,7 +368,7 @@ def get_task_job_attrs(workflow_id, point, task, submit_num):
     """Retrieve job info from the database.
 
     * live_job_id is the job ID if job is running, else None.
-    * submit_failed is True if the the submission failed.
+    * submit_failed is True if the submission failed.
 
     Returns:
         tuple - (platform, job_runner_name, live_job_id, submit_failed)
@@ -466,6 +467,10 @@ def _main(
         file_name: str = options.filename or 's'
         log_file_path: Path
 
+        # auto mode only applies to task logs. Default to cat mode.
+        if mode == 'auto':
+            mode = 'cat'
+
         if mode == 'list-dir':
             # list workflow logs
             print('\n'.join(sorted(
@@ -540,6 +545,10 @@ def _main(
                 # KeyError: Is already long form (standard log, or custom).
         platform_name, _, live_job_id, submit_failed = get_task_job_attrs(
             workflow_id, point, task, submit_num)
+        if mode == 'auto' and live_job_id is None:
+            mode = 'cat'
+        elif mode == 'auto' and live_job_id:
+            mode = 'tail'
         platform = get_platform(platform_name)
         batchview_cmd = None
         if live_job_id is not None:

--- a/tests/functional/cylc-cat-log/14-auto-mode.t
+++ b/tests/functional/cylc-cat-log/14-auto-mode.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc cat-log" using auto mode with a custom tail /command
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 4
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+create_test_global_config "" "
+[platforms]
+   [[localhost]]
+        tail command template = $PWD/bin/my-tailer.sh %(filename)s
+"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}"
+cylc workflow-state "${WORKFLOW_NAME}//1/foo:started" --interval=1
+sleep 3
+# Test that the custom tail command is used when the task is live
+TEST_NAME=${TEST_NAME_BASE}-cat-log
+cylc cat-log "${WORKFLOW_NAME}//1/foo" -f o -m a > "${TEST_NAME}.out"
+grep_ok "HELLO from foo 1" "${TEST_NAME}.out"
+#-------------------------------------------------------------------------------
+cylc stop --kill --max-polls=20 --interval=1 "${WORKFLOW_NAME}"
+#-------------------------------------------------------------------------------
+# Test that the custom tail command is not used when the task is not live
+# (i.e., auto mode should not use the custom tail command)
+cylc cat-log "${WORKFLOW_NAME}//1/foo" -f o -m a > "${TEST_NAME}.out"
+grep_fail "HELLO from foo 1" "${TEST_NAME}.out"
+purge

--- a/tests/functional/cylc-cat-log/14-auto-mode/bin/my-tailer.sh
+++ b/tests/functional/cylc-cat-log/14-auto-mode/bin/my-tailer.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Modify 'tail' output to prove that cylc used the custom tailer.
+# Exit immediately, for the test (i.e. don't 'tail -F')
+FILE="$1"
+tail -n +1 "${FILE}" | awk '{print "HELLO", $0; fflush() }'

--- a/tests/functional/cylc-cat-log/14-auto-mode/flow.cylc
+++ b/tests/functional/cylc-cat-log/14-auto-mode/flow.cylc
@@ -1,0 +1,15 @@
+[scheduler]
+   [[events]]
+       abort on stall timeout = True
+       stall timeout = PT2M
+[scheduling]
+    [[graph]]
+        R1 = foo
+[runtime]
+    [[foo]]
+        script = """
+            for I in $(seq 1 100); do
+                echo "from $CYLC_TASK_NAME $I"
+                sleep 1
+            done
+        """


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

This PR addresses issue #6598.
This adds a new 'auto' mode to the cylc cat-log command. When asking for job logs (Not workflow logs), the logic will determine if the workflow is live, tail will be used otherwise cat will be used.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
