### PR TITLE
Fix workflow trigger commands broken in functional tests

### DIFF
--- a/tests/functional/cylc-cat-log/04-local-tail.t
+++ b/tests/functional/cylc-cat-log/04-local-tail.t
@@ -18,7 +18,7 @@
 # Test "cylc cat-log" with a custom tail /command
 . "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-set_test_number 3
+set_test_number 4
 install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
 create_test_global_config "" "
 [platforms]
@@ -29,8 +29,8 @@ create_test_global_config "" "
 TEST_NAME="${TEST_NAME_BASE}-validate"
 run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" cylc play "${WORKFLOW_NAME}"
-cylc workflow-state "${WORKFLOW_NAME}//1/foo:started" --interval=1
-sleep 1
+run_ok "wait-for-task-foo-start" \
+    cylc workflow-state "${WORKFLOW_NAME}//1/foo:started" --interval=1 --triggers
 TEST_NAME=${TEST_NAME_BASE}-cat-log
 cylc cat-log "${WORKFLOW_NAME}//1/foo" -f o -m t > "${TEST_NAME}.out"
 grep_ok "HELLO from foo 1" "${TEST_NAME}.out"

--- a/tests/functional/restart/38-auto-restart-stopping.t
+++ b/tests/functional/restart/38-auto-restart-stopping.t
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 export REQUIRE_PLATFORM='loc:remote fs:shared runner:background'
 . "$(dirname "$0")/test_header"
-set_test_number 2
+set_test_number 3
 if ${CYLC_TEST_DEBUG:-false}; then ERR=2; else ERR=1; fi
 #-------------------------------------------------------------------------------
 # ensure that workflows don't get auto stop-restarted if they are already stopping
@@ -52,7 +52,8 @@ ${BASE_GLOBAL_CONFIG}
 "
 
 run_ok "${TEST_NAME}-workflow-start" cylc play "${WORKFLOW_NAME}" --host=localhost
-cylc workflow-state "${WORKFLOW_NAME}//1/foo:running" --interval=1 --max-polls=20 >& $ERR
+run_ok "wait-for-task-foo-to-start" \
+    cylc workflow-state "${WORKFLOW_NAME}//1/foo:started" --triggers --interval=1 --max-polls=20 >& $ERR
 
 # condemn localhost
 create_test_global_config '' "


### PR DESCRIPTION
Tests relying on :started and :stopping needed --messages adding to make them work.
Tests relying on :running triggers will not have been working as workflow-trigger will return an error in this case.
Don't swallow errors!

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
