### PR TITLE
id_match: extend task matching to inactive tasks for globs and families

### DIFF
--- a/changes.d/6920.feat.md
+++ b/changes.d/6920.feat.md
@@ -1,0 +1,4 @@
+Cylc commands (e.g. `cylc trigger` and `cylc hold`) can now operate on tasks
+which are not "active" using globs and family IDs. E.g,
+`cylc trigger workflow//cycle/family` will now trigger all tasks in the family,
+not just the ones that are presently active.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -67,7 +67,6 @@ from typing import (
     List,
     Optional,
     Set,
-    Tuple,
     TypeVar,
 )
 
@@ -84,7 +83,7 @@ from cylc.flow.exceptions import (
 )
 import cylc.flow.flags
 from cylc.flow.flow_mgr import FLOW_NONE, repr_flow_nums
-from cylc.flow.id import Tokens
+from cylc.flow.id import TaskTokens
 from cylc.flow.log_level import log_level_to_verbosity
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.prerequisite import PrereqTuple
@@ -102,11 +101,9 @@ from cylc.flow.workflow_status import StopMode
 if TYPE_CHECKING:
     from enum import Enum
 
-    from cylc.flow.cycling import PointBase
     from cylc.flow.flow_mgr import FlowNums
     from cylc.flow.scheduler import Scheduler
     from cylc.flow.task_proxy import TaskProxy
-    from cylc.flow.taskdef import TaskDef
 
     # define a type for command implementations
     Command = Callable[..., AsyncGenerator]
@@ -144,45 +141,61 @@ def _command(name: str):
     return _command
 
 
+def _report_unmatched(unmatched: Set[TaskTokens]):
+    """Log unmatched IDs."""
+    if len(unmatched) == 1:
+        LOG.warning(
+            'No tasks match'
+            f' "{next(iter(unmatched)).relative_id_with_selectors}"'
+        )
+    elif len(unmatched) > 1:
+        LOG.warning(
+            'No tasks match the IDs:\n* '
+            + '\n* '.join(
+                sorted([id_.relative_id_with_selectors for id_ in unmatched])
+            )
+        )
+
+
 def _remove_matched_tasks(
     schd: 'Scheduler',
-    active: 'List[TaskProxy]',
-    inactive: 'Set[Tuple[TaskDef, PointBase]]',
-    flow_nums: 'FlowNums'
+    ids: Set[TaskTokens],
+    flow_nums: 'FlowNums',
 ):
     """Remove matched tasks."""
-
     # Mapping of *relative* task IDs to removed flow numbers:
-    removed: Dict[Tokens, FlowNums] = {}
-    not_removed: Set[Tokens] = set()
-    # All the matched tasks (will add applicable active tasks below):
-    matched_tasks = inactive.copy()
+    removed: Dict[TaskTokens, FlowNums] = {}
+    not_removed: Set[TaskTokens] = set()
     to_kill: List[TaskProxy] = []
 
-    for itask in active:
-        fnums_to_remove = itask.match_flows(flow_nums)
-        if not fnums_to_remove:
-            not_removed.add(itask.tokens.task)
-            continue
-        removed[itask.tokens.task] = fnums_to_remove
-        matched_tasks.add((itask.tdef, itask.point))
-        if fnums_to_remove == itask.flow_nums:
-            # Need to remove the task from the pool.
-            # Spawn next occurrence of xtrigger sequential task (otherwise
-            # this would not happen after removing this occurrence):
-            schd.pool.check_spawn_psx_task(itask)
-            schd.pool.remove(itask, 'request')
-            to_kill.append(itask)
-            itask.removed = True
-        itask.flow_nums.difference_update(fnums_to_remove)
+    for id_ in ids:
+        itask = schd.pool._get_task_by_id(id_.relative_id)
 
-    for tdef, point in matched_tasks:
-        tokens = Tokens(cycle=str(point), task=tdef.name)
+        if itask:
+            # remove active task from the pool
+            fnums_to_remove = itask.match_flows(flow_nums)
+            if not fnums_to_remove:
+                not_removed.add(itask.tokens.task)
+                continue
+            removed[itask.tokens.task] = fnums_to_remove
+            if fnums_to_remove == itask.flow_nums:
+                # Need to remove the task from the pool.
+                # Spawn next occurrence of xtrigger sequential task (otherwise
+                # this would not happen after removing this occurrence):
+                schd.pool.check_spawn_psx_task(itask)
+                schd.pool.remove(itask, 'request')
+                to_kill.append(itask)
+                itask.removed = True
+            itask.flow_nums.difference_update(fnums_to_remove)
+
+        # remove task from the DB
+        tdef = schd.config.taskdefs[id_['task']]
+        icycle = get_point(id_['cycle'])
 
         # Go through any tasks downstream of this matched task to see if
         # any need to stand down as a result of this task being removed:
         for child in set(itertools.chain.from_iterable(
-            generate_graph_children(tdef, point).values()
+            generate_graph_children(tdef, icycle).values()
         )):
             child_itask = schd.pool.get_task(child.point, child.name)
             if not child_itask:
@@ -197,9 +210,9 @@ def _remove_matched_tasks(
             ):
                 # Unset any prereqs naturally satisfied by these tasks
                 # (do not unset those satisfied by `cylc set --pre`):
-                if prereq.unset_naturally_satisfied(tokens.relative_id):
+                if prereq.unset_naturally_satisfied(id_.relative_id):
                     prereqs_changed = True
-                    removed.setdefault(tokens, set()).update(
+                    removed.setdefault(id_, set()).update(
                         fnums_to_remove
                     )
             if not prereqs_changed:
@@ -218,7 +231,7 @@ def _remove_matched_tasks(
             # Check if downstream task should remain spawned:
             if (
                 # Ignoring tasks we are already dealing with:
-                (child_itask.tdef, child_itask.point) in matched_tasks
+                child_itask.tokens.task in ids
                 or child_itask.state.any_satisfied_prerequisite_outputs()
             ):
                 continue
@@ -232,13 +245,13 @@ def _remove_matched_tasks(
 
         # Remove the matched tasks from the flows in the DB tables:
         db_removed_fnums = schd.workflow_db_mgr.remove_task_from_flows(
-            str(point), tdef.name, flow_nums,
+            id_['cycle'], id_['task'], flow_nums,
         )
         if db_removed_fnums:
-            removed.setdefault(tokens, set()).update(db_removed_fnums)
+            removed.setdefault(id_, set()).update(db_removed_fnums)
 
-        if tokens not in removed:
-            not_removed.add(tokens)
+        if id_ not in removed:
+            not_removed.add(id_)
 
     if to_kill:
         schd.kill_tasks(to_kill, warn=False)
@@ -308,7 +321,7 @@ async def set_prereqs_and_outputs(
     outputs = validate.outputs(outputs)
     prerequisites = validate.prereqs(prerequisites)
     validate.flow_opts(flow, flow_wait)
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
 
     yield
 
@@ -317,7 +330,7 @@ async def set_prereqs_and_outputs(
     if prerequisites is None:
         prerequisites = []
     yield schd.pool.set_prereqs_and_outputs(
-        tasks,
+        ids,
         outputs,
         prerequisites,
         flow,
@@ -385,9 +398,9 @@ async def stop(
 @_command('release')
 async def release(schd: 'Scheduler', tasks: Iterable[str]):
     """Release held tasks."""
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     yield
-    yield schd.pool.release_held_tasks(tasks)
+    yield schd.pool.release_held_tasks(ids)
 
 
 @_command('release_hold_point')
@@ -410,13 +423,15 @@ async def resume(schd: 'Scheduler'):
 @_command('poll_tasks')
 async def poll_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     """Poll pollable tasks or a task or family if options are provided."""
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     yield
     if schd.get_run_mode() == RunMode.SIMULATION:
         yield 0
-    itasks, _, bad_items = schd.pool.filter_task_proxies(tasks)
+    matched, unmatched = schd.pool.id_match(ids, only_match_pool=True)
+    _report_unmatched(unmatched)
+    itasks = schd.pool.get_itasks(matched)
     schd.task_job_mgr.poll_task_jobs(itasks)
-    yield len(bad_items)
+    yield len(unmatched)
 
 
 @_command('kill_tasks')
@@ -426,19 +441,21 @@ async def kill_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     Args:
         tasks: Tasks/families/globs to kill.
     """
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     yield
-    active, _, unmatched = schd.pool.filter_task_proxies(tasks)
-    num_unkillable = schd.kill_tasks(active)
+    matched, unmatched = schd.pool.id_match(ids, only_match_pool=True)
+    _report_unmatched(unmatched)
+    itasks = schd.pool.get_itasks(matched)
+    num_unkillable = schd.kill_tasks(itasks)
     yield len(unmatched) + num_unkillable
 
 
 @_command('hold')
 async def hold(schd: 'Scheduler', tasks: Iterable[str]):
     """Hold specified tasks."""
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     yield
-    yield schd.pool.hold_tasks(tasks)
+    yield schd.pool.hold_tasks(ids)
 
 
 @_command('set_hold_point')
@@ -485,18 +502,16 @@ async def remove_tasks(
         flow: flows to remove the tasks from.
     """
     flow = back_compat_flow_all(flow)  # BACK COMPAT (see func def)
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     validate.flow_opts(flow, flow_wait=False, allow_new_or_none=False)
     yield
 
-    active, inactive, _ = schd.pool.filter_task_proxies(
-        tasks, warn_no_active=False, inactive=True
-    )
-    if active or inactive:
+    matched, unmatched = schd.pool.id_match(ids)
+    _report_unmatched(unmatched)
+    if matched:
         _remove_matched_tasks(
             schd,
-            active,
-            inactive,
+            matched,
             schd.pool.flow_mgr.cli_to_flow_nums(flow)
         )
 
@@ -649,7 +664,7 @@ async def force_trigger_tasks(
 
     """
     flow = back_compat_flow_all(flow)  # BACK COMPAT (see func def)
-    validate.is_tasks(tasks)
+    ids = validate.is_tasks(tasks)
     validate.flow_opts(flow, flow_wait)
     if on_resume:
         LOG.warning(
@@ -657,50 +672,34 @@ async def force_trigger_tasks(
             "at Cylc 8.6."
         )
 
-    active, inactive, _ = schd.pool.filter_task_proxies(
-        tasks, inactive=True, warn_no_active=False,
-    )
-    tokens_list: List[Tokens] = [
-        *(itask.tokens for itask in active),
-        *(
-            Tokens(cycle=str(cycle), task=tdef.name)
-            for tdef, cycle in inactive
-        ),
-    ]
-
     yield
 
-    task_ids: Set[Tuple[str, str]] = {
-        (tokens['task'], tokens['cycle']) for tokens in tokens_list
-    }
+    matched, unmatched = schd.pool.id_match(ids)
+    _report_unmatched(unmatched)
 
-    adjacency: Dict[Tuple[str, str], Set[Tuple[str, str]]] = {}
-    for task, cycle in task_ids:
-        icycle = get_point(cycle)
-
+    # split IDs into connected groups of tasks
+    adjacency: Dict[TaskTokens, Set[TaskTokens]] = {}
+    for id_ in matched:
+        id_ = id_.duplicate(task_sel=None)  # strip the task selector
+        icycle = get_point(id_['cycle'])
         prereqs = {
-            (trg.task_name, str(trg.get_point(icycle)))
-            for trg in schd.config.taskdefs[task].get_triggers(icycle)
-            if (trg.task_name, str(trg.get_point(icycle))) in task_ids
+            prereq_id
+            for prereq_id in (
+                TaskTokens(str(trg.get_point(icycle)), trg.task_name)
+                for trg in schd.config.taskdefs[id_['task']].get_triggers(
+                    icycle
+                )
+            )
+            if prereq_id in matched
         }
-        adjacency.setdefault((task, cycle), set()).update(prereqs)
+        adjacency.setdefault((id_), set()).update(prereqs)
         for prereq in prereqs:
-            adjacency.setdefault(prereq, set()).add((task, cycle))
+            adjacency.setdefault(prereq, set()).add(id_)
 
+    # trigger each group of tasks individually
     for group in get_connected_groups(adjacency):
-        # trigger each group of tasks
         _force_trigger_tasks(
             schd,
-            {  # active tasks
-                itask
-                for itask in active
-                if (itask.tokens['task'], itask.tokens['cycle']) in group
-            },
-            {  # inactive tasks
-                (taskdef, icycle)
-                for taskdef, icycle in inactive
-                if (taskdef.name, str(icycle)) in group
-            },
             group,
             flow,
             flow_wait,
@@ -711,14 +710,13 @@ async def force_trigger_tasks(
 
 def _force_trigger_tasks(
     schd: 'Scheduler',
-    active: 'Set[TaskProxy]',
-    inactive: 'Set[Tuple[TaskDef, PointBase]]',
-    group_ids: Set[Tuple[str, str]],
+    group_ids: Set[TaskTokens],
     flow: List[str],
     flow_wait: bool = False,
     flow_descr: Optional[str] = None,
     on_resume: bool = False
 ):
+    active = schd.pool.get_itasks(group_ids)
     if flow or not active:
         flow_nums = schd.pool.flow_mgr.cli_to_flow_nums(flow, flow_descr)
         if flow != [FLOW_NONE] and not flow_nums:
@@ -731,12 +729,12 @@ def _force_trigger_tasks(
             flow_nums.update(itask.flow_nums)
 
     # Record off-group prerequisites, and active tasks to be removed.
-    active_to_remove = []
+    active_to_remove: List[TaskTokens] = []
 
     warnings_flow_none = []
     warnings_has_job = []
     active_completed_outputs = {}
-
+    inactive: Set[TaskTokens] = set(group_ids)
     for itask in active:
         # Find active group start tasks (parentless, or with only off-group
         # prerequisites) and set all prerequisites (to trigger them now).
@@ -752,9 +750,11 @@ def _force_trigger_tasks(
 
         # Group start tasks are not removed, but a reload would
         # replace them, so using the TaskDef is fine.
+        inactive.remove(itask.tokens.task)
 
         if not any(
-            (trg.task_name, str(trg.get_point(itask.point))) in group_ids
+            TaskTokens(str(trg.get_point(itask.point)), trg.task_name)
+            in group_ids
             for trg in itask.tdef.get_triggers(itask.point)
         ):
             # This is a group start task (it has no in-group prerequisites).
@@ -793,7 +793,7 @@ def _force_trigger_tasks(
                 schd.pool.queue_or_trigger(itask, on_resume)
 
         else:
-            active_to_remove.append(itask)
+            active_to_remove.append(itask.tokens.task)
 
     if warnings_flow_none:
         msg = '\n  * '.join(warnings_flow_none)
@@ -806,27 +806,25 @@ def _force_trigger_tasks(
     # Remove all inactive and selected active group members.
     if flow != [FLOW_NONE]:
         # (No need to remove tasks if triggering with no-flow).
-        _remove_matched_tasks(schd, active_to_remove, inactive, flow_nums)
+        _remove_matched_tasks(schd, {*active_to_remove, *inactive}, flow_nums)
         # Store removal results before moving on.
         schd.workflow_db_mgr.process_queued_ops()
 
     # Satisfy any off-group prerequisites in removed tasks.
     tasks_removed = inactive
     if active_to_remove:
-        tasks_removed.update(
-            {
-                (itask.tdef, itask.point)
-                for itask in active_to_remove
-            }
-        )
+        tasks_removed.update(active_to_remove)
 
-    for tdef, point in tasks_removed:
+    # for tdef, point in tasks_removed:
+    for id_ in tasks_removed:
+        tdef = schd.config.taskdefs[id_['task']]
+        icycle = get_point(id_['cycle'])
         in_flow_prereqs = False
         jtask: Optional[TaskProxy] = None
-        if tdef.is_parentless(point):
+        if tdef.is_parentless(icycle):
             # Parentless: set all prereqs to spawn the task.
             jtask = schd.pool._set_prereqs_tdef(
-                point, tdef,
+                icycle, tdef,
                 [],  # prerequisites
                 {"all": True},  # xtriggers
                 flow_nums,
@@ -834,36 +832,37 @@ def _force_trigger_tasks(
                 set_all=True  # prerequisites
             )
         else:
+            _prereqs = tdef.get_prereqs(icycle)
             # Off-flow prereqs to satisfy, for the triggered flow:
             prereqs_to_set = {
                 PrereqTuple(str(key.point), str(key.task), key.output)
-                for pre in tdef.get_prereqs(point)
+                for pre in _prereqs
                 for key in pre.keys()
-                if (key.task, str(key.point)) not in group_ids
+                if TaskTokens(cycle=key.point, task=key.task) not in group_ids
             }
             in_flow_prereqs = any(
                 key
-                for pre in tdef.get_prereqs(point)
+                for pre in _prereqs
                 for key in pre.keys()
-                if (key.task, str(key.point)) in group_ids
+                if TaskTokens(cycle=key.point, task=key.task) in group_ids
             )
             # Prereqs to satisfy, from already-completed outputs of active
             # group start tasks, for the triggered flow.
             prereqs_to_set.update({
                 PrereqTuple(str(key.point), str(key.task), key.output)
-                for pre in tdef.get_prereqs(point)
+                for pre in _prereqs
                 for key in pre.keys()
                 if (str(key.point), key.task) in active_completed_outputs
             })
 
             if (
                 prereqs_to_set
-                or tdef.get_xtrigs(point)
+                or tdef.get_xtrigs(icycle)
                 or tdef.external_triggers
             ):
                 # Satisfy any off-group prereqs or ext/xtriggers to spawn task.
                 jtask = schd.pool._set_prereqs_tdef(
-                    point, tdef,
+                    icycle, tdef,
                     prereqs_to_set,
                     {"all": True},  # xtriggers
                     flow_nums,

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -14,250 +14,238 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Utilities for matching IDs which may reference families or include globs."""
+
+from copy import deepcopy
 from fnmatch import fnmatchcase
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
     Iterable,
-    List,
-    Optional,
-    TYPE_CHECKING,
+    Set,
+    Tuple,
 )
 
-from metomi.isodatetime.exceptions import ISO8601SyntaxError
-
 from cylc.flow import LOG
-from cylc.flow.id import IDTokens, Tokens
-from cylc.flow.id_cli import contains_fnmatch
 from cylc.flow.cycling.loader import get_point
+from cylc.flow.id import TaskTokens
+from cylc.flow.id_cli import contains_fnmatch
+
 
 if TYPE_CHECKING:
-    from cylc.flow.task_pool import Pool
-    from cylc.flow.task_proxy import TaskProxy
-    from cylc.flow.cycling import PointBase
+    from cylc.flow.config import WorkflowConfig
 
 
-# @overload
-# def filter_ids(
-#     pool: 'Pool',
-#     ids: 'Iterable[str]',
-#     *,
-#     warn: 'bool' = True,
-#     out: 'Literal[IDTokens.Task]' = IDTokens.Task,
-#     pattern_match: 'bool' = True,
-# ) -> 'Tuple[List[TaskProxy], List[str]]':
-#     ...
-#
-#
-# @overload
-# def filter_ids(
-#     pool: 'Pool',
-#     ids: 'Iterable[str]',
-#     *,
-#     warn: 'bool' = True,
-#     out: 'Literal[IDTokens.Cycle]' = IDTokens.Cycle,
-#     pattern_match: 'bool' = True,
-# ) -> 'Tuple[List[PointBase], List[str]]':
-#     ...
-
-
-# _RET = (
-#     'Union['
-#     'Tuple[List[TaskProxy], List[str]]'
-#     ', '
-#     'Tuple[List[PointBase], List[str]]'
-#     ']'
-# )
-
-
-def filter_ids(
-    pool: 'Pool',
-    ids: 'Iterable[str]',
-    icp: 'PointBase',
-    fcp: 'Optional[PointBase]',
-    *,
-    warn: 'bool' = True,
-    out: 'IDTokens' = IDTokens.Task,
-    pattern_match: 'bool' = True,
-    # ) -> _RET:
-):
-    """Filter IDs against a pool of tasks.
+def id_match(
+    config: 'WorkflowConfig',
+    pool: Set[TaskTokens],
+    ids: Set[TaskTokens],
+    only_match_pool: bool = False,
+) -> Tuple[Set[TaskTokens], Set[TaskTokens]]:
+    """New Cylc 8.6.0 task matching interface.
 
     Args:
+        config:
+            The workflow config.
         pool:
-            The pool to match against.
+            The IDs in the pool of active tasks to match as a set of tokens.
+            The Tokens should include the task state using `task_sel` to
+            support task state matching.
         ids:
-            List of IDs to match against the pool.
-        out:
-            The type of object to match:
+            The provided IDs to match.
+        only_match_pool:
+            If True, tasks outside of the provided pool will not be matched.
 
-            * If IDTokens.Task all matching TaskProxies will be returned.
-            * If IDTokens.Cycle all CyclePoints with any matching tasks will
-              be returned.
-        warn:
-            Whether to log a warning if no matching tasks are found in the
-            pool.
-
-    TODO:
-        Consider using wcmatch which would add support for
-        extglobs, namely brace syntax e.g. {foo,bar}.
+    Returns:
+        (matched, unmatched)
 
     """
-    if out not in {IDTokens.Cycle, IDTokens.Task}:
-        raise ValueError(f'Invalid output format: {out}')
+    unmatched: Set[TaskTokens] = set()
 
-    _cycles: 'List[PointBase]' = []
-    _tasks: 'List[TaskProxy]' = []
-    _not_matched: 'List[str]' = []
-    _invalid: 'List[str]' = []
+    # mapping of family name to all contained tasks
+    family_lookup: Dict[str, Set[str]] = _get_family_lookup(config)
 
-    # enable / disable pattern matching
-    match: Callable[[Any, Any], bool]
-    if pattern_match:
-        match = fnmatchcase
-    else:
-        match = str.__eq__
-        pattern_ids = [
-            id_
-            for id_ in ids
-            if contains_fnmatch(id_)
-        ]
-        if pattern_ids:
-            LOG.warning(f'IDs cannot contain globs: {", ".join(pattern_ids)}')
-            ids = [
-                id_
-                for id_ in ids
-                if id_ not in pattern_ids
-            ]
-            _not_matched.extend(pattern_ids)
+    # set of all active cycles
+    all_cycles: Set[str] = {tokens['cycle'] for tokens in pool}
 
-    id_tokens_map: Dict[str, Tokens] = {}
+    # set of all possible namespaces (tasks + families)
+    all_namespaces: Dict[str, Any] = config.get_namespace_list(
+        'all namespaces'
+    )
+
+    # separate IDs targeting active tasks ONLY from the remainder
+    active_only_ids = {
+        id_
+        for id_ in ids
+        if id_.get('task_sel') or id_.get('cycle_sel')
+    }
+    plain_ids = ids - active_only_ids
+
+    # match active-only IDs
+    active_only_ids, _unmatched = _match(
+        config,
+        pool,
+        active_only_ids,
+        family_lookup,
+        all_cycles,
+        all_namespaces,
+        only_match_pool=True,
+        match_selectors=True,
+    )
+    unmatched.update(_unmatched)
+
+    # match IDs
+    plain_ids, _unmatched = _match(
+        config,
+        pool,
+        plain_ids,
+        family_lookup,
+        all_cycles,
+        all_namespaces,
+        only_match_pool=only_match_pool,
+    )
+    unmatched.update(_unmatched)
+
+    return {*active_only_ids, *plain_ids}, unmatched
+
+
+def _match(
+    config: 'WorkflowConfig',
+    pool: Set[TaskTokens],
+    ids: Set[TaskTokens],
+    family_lookup: Dict[str, Set[str]],
+    all_cycles: Set[str],
+    all_namespaces: Dict[str, Any],
+    only_match_pool: bool = False,
+    match_selectors: bool = False,
+) -> Tuple[Set[TaskTokens], Set[TaskTokens]]:
+    # results
+    unmatched: Set[TaskTokens] = set()
+    matched: Set[TaskTokens] = set()
+
     for id_ in ids:
-        try:
-            id_tokens_map[id_] = Tokens(id_, relative=True)
-        except ValueError:
-            _invalid.append(id_)
-            LOG.warning(f'Invalid ID: {id_}')
+        # replace the "^" token with the initial cycle point
+        if id_['cycle'] == '^':
+            id_ = id_.duplicate(cycle=str(config.initial_point))
 
-    for id_, tokens in id_tokens_map.items():
-        for lowest_token in reversed(IDTokens):
-            if tokens.get(lowest_token.value):
-                break
+        # replace the "$" token with the final cycle point
+        elif id_['cycle'] == '$':
+            if config.final_point:
+                id_ = id_.duplicate(cycle=str(config.final_point))
+            else:
+                LOG.warning(
+                    'ID references final cycle point, but none is set:'
+                    f' {id_.relative_id}'
+                )
+                unmatched.add(id_)
+                continue
 
-        cycles = set()
-        tasks = []
-
-        # filter by cycle
-        if lowest_token == IDTokens.Cycle:
-            cycle = tokens[IDTokens.Cycle.value]
-            cycle_sel = tokens.get(IDTokens.Cycle.value + '_sel') or '*'
-            for icycle, itasks in pool.items():
-                if not itasks:
-                    continue
-                if not point_match(icycle, cycle, pattern_match):
-                    continue
-                if cycle_sel == '*':
-                    cycles.add(icycle)
-                    continue
-                for itask in itasks.values():
-                    if match(itask.state.status, cycle_sel):
-                        cycles.add(icycle)
-                        break
-
-        # filter by task
-        elif lowest_token == IDTokens.Task:   # noqa SIM106
-            cycle = tokens[IDTokens.Cycle.value]
-            cycle_sel_raw = tokens.get(IDTokens.Cycle.value + '_sel')
-            cycle_sel = cycle_sel_raw or '*'
-            task = tokens[IDTokens.Task.value]
-            task_sel_raw = tokens.get(IDTokens.Task.value + '_sel')
-            task_sel = task_sel_raw or '*'
-
-            # support ^/$ derefencing of the initial and final cycle points
-            if cycle == '^':
-                cycle = str(icp)
-            elif cycle == '$':
-                if not fcp:
-                    _invalid.append(id_)
-                    LOG.warning(
-                        'ID references final cycle point, but none is set:'
-                        f' {id_}'
-                    )
-                cycle = str(fcp)
-
-            for icycle, itasks in pool.items():
-                if not point_match(icycle, cycle, pattern_match):
-                    continue
-                for itask in itasks.values():
-                    if (
-                        # check cycle selector
-                        (
-                            (
-                                # disable cycle_sel if not defined if
-                                # pattern matching is turned off
-                                pattern_match is False
-                                and cycle_sel_raw is None
-                            )
-                            or match(itask.state.status, cycle_sel)
-                        )
-                        # check namespace name
-                        and itask.name_match(task, match_func=match)
-                        # check task selector
-                        and (
-                            (
-                                # disable task_sel if not defined if
-                                # pattern matching is turned off
-                                pattern_match is False
-                                and task_sel_raw is None
-                            )
-                            or match(itask.state.status, task_sel)
-                        )
-                    ):
-                        tasks.append(itask)
-
+        # match cycles
+        if contains_fnmatch(id_['cycle']):
+            _cycles = _fnmatchcase_glob(id_['cycle'], all_cycles)
         else:
-            raise NotImplementedError
+            _cycles = {id_['cycle']}
 
-        if not (cycles or tasks):
-            _not_matched.append(
-                id_.replace('^', str(icp)).replace('$', str(fcp))
+        # match tasks
+        _namespace = id_.get('task', '*') or 'root'
+        _tasks = {
+            task
+            for namespace in _fnmatchcase_glob(_namespace, all_namespaces)
+            for task in family_lookup.get(namespace, {namespace})
+        }
+
+        # expand matched IDs
+        _matched = {
+            TaskTokens(
+                cycle=_cycle,
+                task=_task,
+                task_sel=id_.get('task_sel') or id_.get('cycle_sel'),
             )
-            if warn:
-                LOG.warning(f"No active tasks matching: {id_}")
+            for _cycle in _cycles
+            for _task in _tasks
+        }
+
+        if only_match_pool and match_selectors:
+            # filter against active tasks
+            _matched = _matched.intersection(pool)
+        elif only_match_pool:
+            _matched = _matched.intersection({
+                pool_task_id.duplicate(task_sel=None)
+                for pool_task_id in pool
+            })
         else:
-            _cycles.extend(list(cycles))
-            _tasks.extend(tasks)
+            # filter for on-sequence task instances
+            for id__ in list(_matched):
+                try:
+                    taskdef = config.taskdefs[id__['task']]
+                    if not taskdef.is_valid_point(get_point(id__['cycle'])):
+                        _matched.remove(id__)
+                        if (
+                            # was the specified ID a pattern?
+                            not contains_fnmatch(id_['task'])
+                            and not contains_fnmatch(id_['cycle'])
+                        ):
+                            # the cycle point is not valid for this task
+                            # NOTE: only log this if the user asked for a
+                            # specific cycle/task
+                            LOG.warning(
+                                'Invalid cycle point for task:'
+                                f' {id__["task"]}, {id__["cycle"]}'
+                            )
+                except (ValueError, KeyError):
+                    _matched.remove(id__)
 
-    ret: List[Any] = []
-    if out == IDTokens.Cycle:
-        _cycles.extend({
-            itask.point
-            for itask in _tasks
-        })
-        ret = _cycles
-    elif out == IDTokens.Task:
-        for icycle in _cycles:
-            if icycle in pool:
-                _tasks.extend(pool[icycle].values())
-        ret = _tasks
-    return ret, _not_matched, _invalid
+        if _matched:
+            matched = matched.union(_matched)
+        else:
+            unmatched.add(id_)
+
+    return matched, unmatched
 
 
-def point_match(
-    point: 'PointBase', value: str, pattern_match: bool = True
-) -> bool:
-    """Return whether a cycle point matches a string/pattern.
+def _fnmatchcase_glob(pattern: str, values: Iterable[str]) -> Set[str]:
+    """Convenience function for globbing over a list of values.
+
+    This uses the "fnmatchcase" function which is shell glob like.
 
     Args:
-        point: Cycle point to compare against.
-        value: String/pattern to test.
-        pattern_match: Whether to allow glob patterns in the value.
+        Pattern: The glob.
+        Values: The things to evaluate the glob over.
+
+    Examples:
+        >>> sorted(_fnmatchcase_glob('*', {'a', 'b', 'c'}))
+        ['a', 'b', 'c']
+
+        >>> sorted(_fnmatchcase_glob('a*', {'a1', 'a2', 'b1'}))
+        ['a1', 'a2']
+
     """
-    try:
-        return point == get_point(value)
-    except (ValueError, ISO8601SyntaxError):
-        # Could be glob pattern
-        if pattern_match:
-            return fnmatchcase(str(point), value)
-        return False
+    return {
+        value
+        for value in values
+        if fnmatchcase(value, pattern)
+    }
+
+
+def _get_family_lookup(config: 'WorkflowConfig') -> Dict[str, Set[str]]:
+    """Return a dict mapping families to all contained tasks.
+
+    This recursively expands families avoiding the need to do so later.
+    """
+    lookup = deepcopy(config.runtime['descendants'])
+
+    def _iter():
+        ret = False
+        for namespaces in lookup.values():
+            for namespace in list(namespaces):
+                if namespace in config.runtime['descendants']:
+                    ret = True
+                    namespaces.remove(namespace)
+                    namespaces.update(config.runtime['descendants'][namespace])
+        return ret
+
+    while _iter():
+        pass
+
+    return lookup

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1654,9 +1654,11 @@ class NamespaceName(String):
 class NamespaceIDGlob(String):
     """A task or family ID e.g. `2000/foo`.
 
-    Globs can be used to match active tasks or families.
+    Globs can be used to match tasks or families, e.g, `2*/foo*` might match
+    `2000/foot`. Cycle point globs will only match active cycles.
 
-    E.g `2*/foo*` might match `2000/foot`.
+    Selectors can be used to match active tasks by state, e.g, `*:failed` will
+    match all failed tasks.
     """
 
 

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -241,21 +241,28 @@ class CylcOptionParser(OptionParser):
     """Common options for all cylc CLI commands."""
 
     MULTITASK_USAGE = dedent('''
-        This command can operate on multiple tasks. Globs and selectors may
-        be used to match tasks in the n=0 active window (except in the
-        `cylc show` command, where globs match in the wider n-window):
+        This command can operate on multiple tasks:
             Multiple Tasks:
                 # Operate on two tasks
-                workflow //cycle-1/task-1 //cycle-2/task-2
+                //cycle-1/task-1 //cycle-2/task-2
 
-            Globs (note: quote globs; they only match in the active-window):
-                # Match any active-window task "foo" in all cycles
+                # Operate on all members of a family
+                //cycle-1/FAMILY-NAME
+
+                # Operate on all tasks in a cycle
+                //cycle  # shorthand for '//cycle/root'
+
+            Globs (note: quote globs or they might expand in your shell):
+                # Match all tasks in cycle "1" with names beginning with "foo"
+                ''//1/foo*'
+
+                # Match the task "foo" in all active (i.e. n=0) cycles
                 '//*/foo'
 
-                # Match the tasks "foo-1" and "foo-2"
+                # Match the tasks "foo-1" and "foo-2" in all active cycles.
                 '//*/foo-[12]'
 
-            Selectors (note: selectors only match in the active window too):
+            Selectors (note: selectors only match active tasks):
                 # match all failed tasks in cycle "1"
                 //1:failed
 

--- a/cylc/flow/run_modes/simulation.py
+++ b/cylc/flow/run_modes/simulation.py
@@ -158,7 +158,7 @@ class ModeSettings:
             db_info = db_mgr.pri_dao.select_task_job(
                 itask.tokens['cycle'],
                 itask.tokens['task'],
-                itask.tokens['job'],
+                itask.submit_num,
             )
 
             if db_info['time_submit']:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -63,6 +63,7 @@ import psutil
 from cylc.flow import (
     LOG,
     __version__ as CYLC_VERSION,
+    command_validation,
     commands,
     main_loop,
     workflow_files,
@@ -841,9 +842,10 @@ class Scheduler:
     def _load_pool_from_tasks(self):
         """Load task pool with specified tasks, for a new run."""
         LOG.info(f"Start task: {self.options.starttask}")
+        start_tasks = command_validation.is_tasks(self.options.starttask)
         # flow number set in this call:
         self.pool.set_prereqs_and_outputs(
-            self.options.starttask,
+            start_tasks,
             outputs=[],
             prereqs=["all"],
             flow=[FLOW_NEW],
@@ -1075,8 +1077,7 @@ class Scheduler:
             if not itask.state(TASK_STATUS_PREPARING, *TASK_STATUSES_ACTIVE):
                 unkillable.append(itask)
                 continue
-            if itask.state_reset(is_held=True):
-                self.data_store_mgr.delta_task_state(itask)
+            self.pool.hold_active_task(itask)
             if itask.state(TASK_STATUS_PREPARING):
                 self.task_job_mgr.kill_prep_task(itask)
             else:

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -187,26 +187,28 @@ Patterns
       *                      # All workflows
       test*                  # All workflows starting "test".
       test/*                 # All workflows starting "test/".
-      workflow//*            # All cycles in workflow
+      workflow//*            # All active cycles in workflow
       workflow//cycle/*      # All tasks in workflow//cycle
       workflow//cycle/task/* # All jobs in workflow//cycle/job
 
     Warning:
       Quote IDs on the command line to protect them from shell expansion.
-      Patterns only match tasks in the n=0 active window (except for the
-      `cylc show` command where they match in the wider n-window).
 
-Filters
-    Filters allow you to filter for specific states.
+Selectors
+    Selectors allow you to filter for specific states.
 
-    Filters are prefixed by a colon (:).
+    Selectors are prefixed by a colon (:).
 
     Examples:
       *:running                       # All running workflows
-      workflow//*:running             # All running cycles in workflow
+      workflow//*:running             # All running tasks in workflow
       workflow//cycle/*:running       # All running tasks in workflow//cycle
       workflow//cycle/task/*:running  # All running jobs in
                                       # workflow//cycle/task
+
+    When selectors are applied to tasks, they will only match active tasks.
+    I.e, "workflow//*:failed" will only select active failed tasks, not all
+    historical failed tasks going back to the start of the workflow.
 '''
 
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -32,7 +32,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 from cylc.flow import LOG
@@ -51,12 +50,11 @@ from cylc.flow.flow_mgr import (
     repr_flow_nums,
 )
 from cylc.flow.id import (
+    TaskTokens,
     Tokens,
-    detokenise,
     quick_relative_id,
 )
-from cylc.flow.id_cli import contains_fnmatch
-from cylc.flow.id_match import filter_ids
+from cylc.flow.id_match import id_match
 from cylc.flow.platforms import get_platform
 from cylc.flow.prerequisite import PrereqTuple
 from cylc.flow.run_modes import RunMode
@@ -984,6 +982,22 @@ class TaskPool:
                 return itask_ids[id_]
         return None
 
+    def get_itasks(self, ids: 'Iterable[Tokens]') -> List[TaskProxy]:
+        """Return a list of itasks matching the IDs provided.
+
+        Args:
+            ids: The exact IDs to match (no globs, families, etc supported).
+
+        Returns:
+            A list of an active tasks matching these IDs.
+
+        """
+        return [
+            itasks[id_]
+            for itasks in self.active_tasks.values()
+            for id_ in itasks.keys() & {id_.relative_id for id_ in ids}
+        ]
+
     def queue_task(self, itask: TaskProxy) -> None:
         """Queue a task that is ready to run.
 
@@ -1387,40 +1401,50 @@ class TaskPool:
                 self.hold_active_task(itask)
         self.workflow_db_mgr.put_workflow_hold_cycle_point(point)
 
-    def hold_tasks(self, items: Iterable[str]) -> int:
+    def hold_tasks(self, items: Set[TaskTokens]) -> int:
         """Hold tasks with IDs matching the specified items."""
-        # Hold active tasks:
-        itasks, inactive_tasks, unmatched = self.filter_task_proxies(
-            items,
-            warn_no_active=False,
-            inactive=True,
-        )
-        for itask in itasks:
-            self.hold_active_task(itask)
-
-        # Set inactive tasks to be held:
-        for tdef, cycle in inactive_tasks:
-            self.data_store_mgr.delta_task_held(tdef.name, cycle, True)
-            self.tasks_to_hold.add((tdef.name, cycle))
+        matched, unmatched = self.id_match(items)
+        for id_ in matched:
+            itask = self._get_task_by_id(id_.relative_id)
+            if itask:
+                # hold active task
+                self.hold_active_task(itask)
+            else:
+                # hold inactive task
+                icycle = get_point(id_['cycle'])
+                self.data_store_mgr.delta_task_held(id_['task'], icycle, True)
+                self.tasks_to_hold.add((id_['task'], icycle))
 
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
         LOG.debug(f"Tasks to hold: {self.tasks_to_hold}")
         return len(unmatched)
 
-    def release_held_tasks(self, items: Iterable[str]) -> int:
+    def release_held_tasks(self, items: Set[TaskTokens]) -> int:
         """Release held tasks with IDs matching any specified items."""
-        # Release active tasks:
-        itasks, inactive_tasks, unmatched = self.filter_task_proxies(
+        matched, unmatched = id_match(
+            self.config,
+            {
+                # only match held tasks
+                TaskTokens(cycle=str(cycle), task=task)
+                for task, cycle in self.tasks_to_hold
+            },
             items,
-            warn_no_active=False,
-            inactive=True,
+            # only match tasks within the held task list
+            only_match_pool=True,
         )
-        for itask in itasks:
-            self.release_held_active_task(itask)
-        # Unhold inactive tasks:
-        for tdef, cycle in inactive_tasks:
-            self.data_store_mgr.delta_task_held(tdef.name, cycle, False)
-            self.tasks_to_hold.discard((tdef.name, cycle))
+        for id_ in matched:
+            itask = self._get_task_by_id(id_.relative_id)
+            if itask:
+                # release active task
+                self.release_held_active_task(itask)
+            else:
+                # release inactive task
+                self.data_store_mgr.delta_task_held(
+                    id_['task'], get_point(id_['cycle']), False
+                )
+                self.tasks_to_hold.discard(
+                    (id_['task'], get_point(id_['cycle']))
+                )
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
         LOG.debug(f"Tasks to hold: {self.tasks_to_hold}")
         return len(unmatched)
@@ -1504,13 +1528,14 @@ class TaskPool:
                 # for an upcoming flow merge before spawning ... then spawn it.
                 c_task = self.spawn_task(c_name, c_point, itask.flow_nums)
 
+            tasks: List[TaskProxy]
             if c_task is not None:
                 # Have child task, update its prerequisites.
                 if is_abs:
-                    tasks, *_ = self.filter_task_proxies(
-                        [f'*/{c_name}'],
-                        warn_no_active=False,
+                    matched, _unmatched = self.id_match(
+                        {TaskTokens(cycle='*', task=c_name)}
                     )
+                    tasks = self.get_itasks(matched)
                     if c_task not in tasks:
                         tasks.append(c_task)
                 else:
@@ -1990,7 +2015,7 @@ class TaskPool:
 
     def set_prereqs_and_outputs(
         self,
-        items: Iterable[str],
+        items: 'Set[TaskTokens]',
         outputs: List[str],
         prereqs: List[str],
         flow: List[str],
@@ -2020,20 +2045,15 @@ class TaskPool:
         but it can complete a task so that it doesn't need to run.
 
         Args:
-            items: task ID match patterns
-            prereqs: prerequisites to satisfy
-            outputs: outputs to complete
-            flow: flow numbers for spawned or merged tasks
-            flow_wait: wait for flows to catch up before continuing
-            flow_descr: description of new flow
+            items: Parsed task ID patterns.
+            prereqs: Prerequisites to satisfy.
+            outputs: Outputs to complete.
+            flow: Flow numbers for spawned or merged tasks.
+            flow_wait: Wait for flows to catch up before continuing.
+            flow_descr: Description of new flow.
 
         """
-        # Get matching pool tasks and inactive task definitions.
-        itasks, inactive_tasks, _ = self.filter_task_proxies(
-            items,
-            inactive=True,
-            warn_no_active=False,
-        )
+        matched, _unmatched = self.id_match(set(items))
 
         no_op = True
 
@@ -2060,8 +2080,10 @@ class TaskPool:
 
         # Set active tasks.
         warnings_flow_none = []
-        if itasks:
-            for itask in itasks:
+        for id_ in matched:
+            itask = self._get_task_by_id(id_.relative_id)
+            if itask:
+                # set active task
                 if flow == [FLOW_NONE] and itask.flow_nums:
                     # Exclude --flow=none for active tasks.
                     warnings_flow_none.append(
@@ -2091,34 +2113,35 @@ class TaskPool:
                     self._set_outputs_itask(itask, outputs)
                     no_op = False
 
-        if warnings_flow_none:
-            msg = '\n  * '.join(warnings_flow_none)
-            LOG.warning(f"Already active - ignoring no-flow set: \n  * {msg}")
-
-        # Set inactive tasks.
-        if inactive_tasks:
-            for tdef, point in inactive_tasks:
+            else:
+                # set inactive task
+                tdef = self.config.taskdefs[id_['task']]
+                icycle = get_point(id_['cycle'])
                 if prereqs:
                     valid_prereqs = self._get_valid_prereqs(
-                        clean_pre, tdef, point)
+                        clean_pre, tdef, icycle)
                     valid_xtrigs = self._get_valid_xtrigs(
-                        clean_xtr, tdef, point)
+                        clean_xtr, tdef, icycle)
                     if not (set_all or valid_prereqs or valid_xtrigs):
                         continue
 
                     self._set_prereqs_tdef(
-                        point, tdef, valid_prereqs, valid_xtrigs, flow_nums,
+                        icycle, tdef, valid_prereqs, valid_xtrigs, flow_nums,
                         flow_wait, set_all)
                     no_op = False
                 else:
                     # Outputs (may be empty list)
                     trans = self._get_task_proxy_db_outputs(
-                        point, tdef, flow_nums,
+                        icycle, tdef, flow_nums,
                         flow_wait=flow_wait, transient=True
                     )
                     if trans is not None:
                         self._set_outputs_itask(trans, outputs)
                         no_op = False
+
+        if warnings_flow_none:
+            msg = '\n  * '.join(warnings_flow_none)
+            LOG.warning(f"Already active - ignoring no-flow set: \n  * {msg}")
 
         if not no_op:
             # for "cylc play --start-tasks" compute runahead after spawning
@@ -2460,129 +2483,28 @@ class TaskPool:
             )
         )
 
-    def filter_task_proxies(
+    def id_match(
         self,
-        ids: Iterable[str],
-        warn_no_active: bool = True,
-        inactive: bool = False,
-    ) -> 'Tuple[List[TaskProxy], Set[Tuple[TaskDef, PointBase]], List[str]]':
-        """Return task proxies and inactive tasks that match ids.
-
-        (TODO: method should be renamed to "filter_tasks").
-
-        Restrictions (for now):
-        - globs (cycle and name) only match in the pool
-        - inactive tasks must be specified individually
-        - family names are not expanded to members
-
-        Args:
-            ids:
-                ID strings.
-            warn_no_active:
-                Whether to log a warning if no matching tasks are found in the
-                pool.
-            inactive:
-                If True, unmatched IDs will be checked against taskdefs
-                and cycle, and any matches will be returned in the second
-                return value, provided that the ID:
-
-                * Specifies a cycle point.
-                * Is not a pattern. (e.g. `*/foo`).
-                * Does not contain a state selector (e.g. `:failed`).
-
-        Returns:
-            (matched, inactive_matched, unmatched)
-
-        """
-        matched, unmatched, invalid = filter_ids(
-            self.active_tasks,
-            ids,
-            self.config.initial_point,
-            self.config.final_point,
-            warn=warn_no_active,
-        )
-        inactive_matched: 'Set[Tuple[TaskDef, PointBase]]' = set()
-        if inactive and unmatched:
-            inactive_matched, unmatched = self.match_inactive_tasks(
-                unmatched
+        ids: Set[TaskTokens],
+        only_match_pool: bool = False,
+    ) -> Tuple[Set[TaskTokens], Set[TaskTokens]]:
+        """Match IDs against active tasks in the pool."""
+        active_task_ids: Set[TaskTokens] = {
+            TaskTokens(
+                cycle=itask.tokens['cycle'],
+                task=itask.tokens['task'],
+                task_sel=itask.state.status,
             )
+            for itasks in self.active_tasks.values()
+            for itask in itasks.values()
+        }
 
-        return matched, inactive_matched, unmatched + invalid
-
-    def match_inactive_tasks(
-        self,
-        ids: Iterable[str],
-    ) -> 'Tuple[Set[Tuple[TaskDef, PointBase]], List[str]]':
-        """Match task IDs against task definitions (rather than the task pool).
-
-        IDs will be matched providing the ID:
-
-        * Specifies a cycle point.
-        * Is not a pattern. (e.g. `*/foo`).
-        * Does not contain a state selector (e.g. `:failed`).
-
-        Returns:
-            (matched_tasks, unmatched_tasks)
-
-        """
-        matched_tasks: 'Set[Tuple[TaskDef, PointBase]]' = set()
-        unmatched_tasks: 'List[str]' = []
-        for id_ in ids:
-            try:
-                tokens = Tokens(id_, relative=True)
-            except ValueError:
-                LOG.warning(f'Invalid task ID: {id_}')
-                continue
-            if (
-                not tokens['cycle']
-                or not tokens['task']
-                or tokens['cycle_sel']
-                or tokens['task_sel']
-                or contains_fnmatch(id_)
-            ):
-                # Glob or task state was not matched by active tasks
-                if not tokens['task']:
-                    # make task globs explicit to make warnings clearer
-                    tokens = tokens.duplicate(task='*')
-                LOG.warning(
-                    'No active tasks matching:'
-                    # preserve :selectors when logging the id
-                    f' {detokenise(tokens, selectors=True, relative=True)}'
-                )
-                unmatched_tasks.append(id_)
-                continue
-
-            point_str = cast('str', tokens['cycle'])
-            try:
-                point_str = standardise_point_string(point_str)
-            except PointParsingError as exc:
-                LOG.warning(
-                    f"{id_} - invalid cycle point: {point_str} ({exc})")
-                unmatched_tasks.append(id_)
-                continue
-
-            name_str = cast('str', tokens['task'])
-
-            members = self.config.find_taskdefs(name_str)
-            if not members:
-                LOG.warning(self.ERR_TMPL_NO_TASKID_MATCH.format(name_str))
-                unmatched_tasks.append(id_)
-                continue
-
-            point = get_point(point_str)
-            for name in [m.name for m in members]:
-                taskdef = self.config.taskdefs[name]
-                if taskdef.is_valid_point(point):
-                    matched_tasks.add((taskdef, point))
-                else:
-                    LOG.warning(
-                        self.ERR_PREFIX_TASK_NOT_ON_SEQUENCE.format(
-                            taskdef.name, point
-                        )
-                    )
-                    unmatched_tasks.append(id_)
-                    continue
-        return matched_tasks, unmatched_tasks
+        return id_match(
+            self.config,
+            active_task_ids,
+            ids,
+            only_match_pool=only_match_pool,
+        )
 
     def merge_flows(self, itask: TaskProxy, flow_nums: 'FlowNums') -> None:
         """Merge flow_nums into itask.flow_nums, for existing itask.

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -54,7 +54,7 @@ from cylc.flow.wallclock import get_unix_time_from_time_string as str2time
 if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.flow_mgr import FlowNums
-    from cylc.flow.id import Tokens
+    from cylc.flow.id import Tokens, TaskTokens
     from cylc.flow.prerequisite import (
         PrereqTuple,
         SatisfiedState,
@@ -243,7 +243,7 @@ class TaskProxy:
             self.flow_nums = flow_nums.copy()
         self.flow_wait = flow_wait
         self.point = start_point
-        self.tokens = scheduler_tokens.duplicate(
+        self.tokens: TaskTokens = scheduler_tokens.duplicate(
             cycle=str(self.point),
             task=self.tdef.name,
         )

--- a/tests/integration/network/test_graphql.py
+++ b/tests/integration/network/test_graphql.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from graphql import parse, MiddlewareManager
 
 from cylc.flow.data_store_mgr import create_delta_store
-from cylc.flow.id import Tokens
+from cylc.flow.id import TaskTokens, Tokens
 from cylc.flow.network.client import WorkflowRuntimeClient
 from cylc.flow.network.schema import schema, SUB_RESOLVER_MAPPING
 from cylc.flow.network.graphql import (
@@ -129,7 +129,7 @@ async def harness(mod_flow, mod_scheduler, mod_run):
     schd: 'Scheduler' = mod_scheduler(id_)
     async with mod_run(schd):
         client = WorkflowRuntimeClient(id_)
-        schd.pool.hold_tasks(['*'])
+        schd.pool.hold_tasks({TaskTokens('*', 'root')})
         schd.resume_workflow()
         # Think this is needed to save the data state at first start (?)
         # Fails without it.. and a test needs to overwrite schd data with this.

--- a/tests/integration/network/test_resolvers.py
+++ b/tests/integration/network/test_resolvers.py
@@ -280,7 +280,7 @@ async def test_command_validation_failure(
         )
 
     # submitting the invalid command should result in this error
-    msg = 'This command does not take job ids:\n * cycle/task/job'
+    msg = 'This command does not take job IDs: cycle/task/job'
 
     # test submitting the command at *default* verbosity
     response = await submit_invalid_command()

--- a/tests/integration/run_modes/test_mode_overrides.py
+++ b/tests/integration/run_modes/test_mode_overrides.py
@@ -31,6 +31,7 @@ integration test framework.
 import pytest
 
 from cylc.flow.cycling.iso8601 import ISO8601Point
+from cylc.flow.id import TaskTokens
 from cylc.flow.run_modes import WORKFLOW_RUN_MODES, RunMode
 from cylc.flow.scheduler import Scheduler, SchedulerStop
 from cylc.flow.task_state import TASK_STATUS_WAITING
@@ -96,7 +97,7 @@ async def test_force_trigger_does_not_override_run_mode(
         foo = schd.pool.get_tasks()[0]
 
         # Force trigger task:
-        run_cmd(force_trigger_tasks(schd, '1/foo', [1]))
+        await run_cmd(force_trigger_tasks(schd, ['1/foo'], ['1']))
 
         # ... but job submission will always change this to the correct mode:
         schd.submit_task_jobs([foo])
@@ -121,12 +122,12 @@ async def test_run_mode_skip_abides_by_held(flow, scheduler, run):
         assert not foo.state.is_held
 
         # Hold task, check that it's held:
-        schd.pool.hold_tasks(['1/foo'])
+        schd.pool.hold_tasks({TaskTokens('1', 'foo')})
         assert foo.state.is_held
         await schd._main_loop()
         assert foo.state(TASK_STATUS_WAITING)
 
-        schd.pool.release_held_tasks(['1/foo'])
+        schd.pool.release_held_tasks({TaskTokens('1', 'foo')})
         assert not foo.state.is_held
         with pytest.raises(SchedulerStop):
             # Will shut down as foo has run

--- a/tests/integration/run_modes/test_nonlive.py
+++ b/tests/integration/run_modes/test_nonlive.py
@@ -19,6 +19,7 @@ from typing import Any, Dict
 
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
+from cylc.flow.id import TaskTokens
 from cylc.flow.scheduler import Scheduler
 
 
@@ -111,7 +112,9 @@ async def test_db_task_jobs(
         submit_and_check_db(schd)
 
         # Set outputs to failed:
-        schd.pool.set_prereqs_and_outputs('*', ['failed'], [], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('*', 'root')}, ['failed'], [], []
+        )
 
         submit_and_check_db(schd)
 

--- a/tests/integration/scripts/test_set.py
+++ b/tests/integration/scripts/test_set.py
@@ -31,6 +31,7 @@ from cylc.flow.commands import (
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.data_messages_pb2 import PbTaskProxy
 from cylc.flow.data_store_mgr import TASK_PROXIES
+from cylc.flow.id import TaskTokens
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_STARTED,
@@ -78,7 +79,10 @@ async def test_set_parentless_spawning(
     async with run(schd):
         # mark cycle 1 as succeeded
         schd.pool.set_prereqs_and_outputs(
-            ['1/a', '1/z'], ['succeeded'], [], ['1']
+            {TaskTokens('1', 'a'), TaskTokens('1', 'z')},
+            ['succeeded'],
+            [],
+            ['1'],
         )
 
         # the parentless task "a" should be spawned out to the runahead limit
@@ -108,7 +112,9 @@ async def test_rerun_incomplete(
     schd = scheduler(id_, paused_start=False)
     async with run(schd):
         # generate 1/a:x but do not complete 1/a
-        schd.pool.set_prereqs_and_outputs(['1/a'], ['x'], [], ['1'])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'a')}, ['x'], [], ['1']
+        )
         triggers = reflog(schd)
         await complete(schd)
 
@@ -145,7 +151,7 @@ async def test_data_store(
 
         # set the 1/a:succeeded prereq of 1/z
         schd.pool.set_prereqs_and_outputs(
-            ['1/z'], [], ['1/a:succeeded'], ['1'])
+            {TaskTokens('1', 'z')}, [], ['1/a:succeeded'], ['1'])
         task_z = data[TASK_PROXIES][
             schd.pool.get_task(IntegerPoint('1'), 'z').tokens.id
         ]
@@ -153,14 +159,18 @@ async def test_data_store(
         assert task_z.prerequisites[0].satisfied is True
 
         # set 1/a:x the task should be waiting with output x satisfied
-        schd.pool.set_prereqs_and_outputs(['1/a'], ['x'], [], ['1'])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'a')}, ['x'], [], ['1']
+        )
         await schd.update_data_structure()
         assert task_a.state == TASK_STATUS_WAITING
         assert task_a.outputs['x'].satisfied is True
         assert task_a.outputs['succeeded'].satisfied is False
 
         # set 1/a:succeeded the task should be succeeded with output x sat
-        schd.pool.set_prereqs_and_outputs(['1/a'], ['succeeded'], [], ['1'])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'a')}, ['succeeded'], [], ['1']
+        )
         await schd.update_data_structure()
         assert task_a.state == TASK_STATUS_SUCCEEDED
         assert task_a.outputs['x'].satisfied is True
@@ -177,7 +187,9 @@ async def test_incomplete_detection(
     """It should detect and log finished tasks left with incomplete outputs."""
     schd = scheduler(flow(one_conf))
     async with start(schd):
-        schd.pool.set_prereqs_and_outputs(['1/one'], ['failed'], [], ['1'])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'one')}, ['failed'], [], ['1']
+        )
     assert log_filter(contains='1/one did not complete')
 
 
@@ -188,7 +200,9 @@ async def test_pre_all(flow, scheduler, run):
     id_ = flow({'scheduling': {'graph': {'R1': 'a => z'}}})
     schd = scheduler(id_, paused_start=False)
     async with run(schd) as log:
-        schd.pool.set_prereqs_and_outputs(['1/z'], [], ['all'], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'z')}, [], ['all'], []
+        )
         warn_or_higher = [i for i in log.records if i.levelno > 30]
         assert warn_or_higher == []
 
@@ -210,14 +224,18 @@ async def test_bad_prereq(
     })
     schd = scheduler(id_, paused_start=False)
     async with run(schd):
-        schd.pool.set_prereqs_and_outputs(['1/c'], [], ['1/a'], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'c')}, [], ['1/a'], []
+        )
         assert schd.pool.get_task_ids() == {'1/a'}
         assert '1/c does not depend on "1/a:succeeded"' in caplog.text
 
         schd.workflow_db_mgr.process_queued_ops()
 
         # This will fail if the previous set left 1/c in the DB:
-        schd.pool.set_prereqs_and_outputs(['1/c'], [], ['1/b'], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'c')}, [], ['1/b'], []
+        )
         assert schd.pool.get_task_ids() == {'1/a', '1/c'}
         await complete(schd, '1/c', timeout=5)
 
@@ -251,7 +269,7 @@ async def test_no_outputs_given(flow, scheduler, start):
     async with start(schd):
         foo = schd.pool.get_tasks()[0]
         await run_cmd(
-            set_prereqs_and_outputs(schd, [foo.identity], [])
+            set_prereqs_and_outputs(schd, {foo.tokens}, [])
         )
         assert set(foo.state.outputs.get_completed_outputs()) == {
             TASK_OUTPUT_SUBMITTED,
@@ -287,7 +305,7 @@ async def test_completion_expr(flow, scheduler, start):
     async with start(schd):
         foo = schd.pool.get_tasks()[0]
         await run_cmd(
-            set_prereqs_and_outputs(schd, [foo.identity], [])
+            set_prereqs_and_outputs(schd, {foo.tokens}, [])
         )
         assert set(foo.state.outputs.get_completed_outputs()) == {
             TASK_OUTPUT_SUBMITTED,

--- a/tests/integration/test_data_store_mgr.py
+++ b/tests/integration/test_data_store_mgr.py
@@ -42,7 +42,7 @@ from cylc.flow.data_store_mgr import (
     TASKS,
     WORKFLOW,
 )
-from cylc.flow.id import Tokens
+from cylc.flow.id import TaskTokens, Tokens
 from cylc.flow.network.log_stream_handler import ProtobufStreamHandler
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_events_mgr import TaskEventsManager
@@ -296,7 +296,7 @@ async def test_delta_task_held(mod_harness):
     apply adeltas/updates given."""
     schd: Scheduler
     schd, data = mod_harness
-    schd.pool.hold_tasks(['*'])
+    schd.pool.hold_tasks({TaskTokens('*', 'root')})
     await schd.update_data_structure()
     assert True in {t.is_held for t in data[TASK_PROXIES].values()}
     for itask in schd.pool.get_tasks():
@@ -310,7 +310,7 @@ async def test_delta_task_held(mod_harness):
     }
 
     # put things back the way we found them
-    schd.pool.release_held_tasks('*')
+    schd.pool.release_held_tasks({TaskTokens('*', 'root')})
     await schd.update_data_structure()
 
 
@@ -381,12 +381,12 @@ async def test_update_data_structure(mod_harness):
     schd, data = mod_harness
     w_id = schd.data_store_mgr.workflow_id
     schd.data_store_mgr.data[w_id] = data
-    schd.pool.hold_tasks(['*'])
+    schd.pool.hold_tasks({TaskTokens('*', 'root')})
     await schd.update_data_structure()
     assert TASK_STATUS_FAILED not in set(collect_states(data, TASK_PROXIES))
     assert TASK_STATUS_FAILED not in set(collect_states(data, FAMILY_PROXIES))
     assert TASK_STATUS_FAILED not in data[WORKFLOW].state_totals
-    assert len({t.is_held for t in data[TASK_PROXIES].values()}) == 2
+    assert len({t.id for t in data[TASK_PROXIES].values() if t.is_held}) == 2
     for itask in schd.pool.get_tasks():
         itask.state.reset(TASK_STATUS_FAILED)
         schd.data_store_mgr.delta_task_state(itask)
@@ -436,14 +436,18 @@ async def test_prune_data_store(flow, scheduler, start):
         await schd.update_data_structure()
         w_id = schd.data_store_mgr.workflow_id
         data = schd.data_store_mgr.data[w_id]
-        schd.pool.hold_tasks(['*'])
+        schd.pool.hold_tasks({TaskTokens('*', 'root')})
         await schd.update_data_structure()
-        assert len({t.is_held for t in data[TASK_PROXIES].values()}) == 2
+        assert (
+            len({t.id for t in data[TASK_PROXIES].values() if t.is_held}) == 2
+        )
 
         # Window size reduction to invoke pruning
         schd.data_store_mgr.set_graph_window_extent(0)
         schd.data_store_mgr.update_data_structure()
-        assert len({t.is_held for t in data[TASK_PROXIES].values()}) == 1
+        assert (
+            len({t.id for t in data[TASK_PROXIES].values() if t.is_held}) == 1
+        )
 
         # Test rapid addition and removal
         # bar/BAR task/family proxies not in .added
@@ -521,8 +525,8 @@ def test_delta_task_prerequisite(mod_harness):
     schd: Scheduler
     schd, data = mod_harness
     schd.pool.set_prereqs_and_outputs(
-        schd.pool.get_task_ids(),
-        [(TASK_STATUS_SUCCEEDED,)],
+        {itask.tokens for itask in schd.pool.get_tasks()},
+        [TASK_STATUS_SUCCEEDED],
         [],
         flow=[]
     )
@@ -550,7 +554,7 @@ def test_delta_task_xtrigger(xharness):
 
     # satisfy foo's dependence on x
     schd.pool.set_prereqs_and_outputs(
-        ['1/foo'],
+        {TaskTokens('1', 'foo')},
         [],
         ['xtrigger/x:succeeded'],
         flow=[]
@@ -570,7 +574,7 @@ def test_delta_task_xtrigger(xharness):
 
     # unsatisfy it again
     schd.pool.set_prereqs_and_outputs(
-        ['1/foo'],
+        {TaskTokens('1', 'foo')},
         [],
         ['xtrigger/x:unsatisfied'],
         flow=[]
@@ -588,7 +592,7 @@ def test_delta_task_xtrigger(xharness):
 
     # satisfy both of foo's xtriggers at once
     schd.pool.set_prereqs_and_outputs(
-        ['1/foo'],
+        {TaskTokens('1', 'foo')},
         [],
         ['xtrigger/all:succeeded'],
         flow=[]

--- a/tests/integration/test_flow_assignment.py
+++ b/tests/integration/test_flow_assignment.py
@@ -30,7 +30,8 @@ from cylc.flow.flow_mgr import (
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.commands import (
     run_cmd,
-    force_trigger_tasks
+    force_trigger_tasks,
+    set_prereqs_and_outputs,
 )
 
 
@@ -113,12 +114,16 @@ async def test_flow_assignment(
     schd: Scheduler = scheduler(id_, run_mode='simulation', paused_start=True)
     async with start(schd):
         if command == 'set':
-            do_command: Callable = functools.partial(
-                schd.pool.set_prereqs_and_outputs, outputs=['x'], prereqs=[]
+            do_command = functools.partial(
+                set_prereqs_and_outputs,
+                schd,
+                outputs=['x'],
+                prerequisites=[],
             )
         else:
             do_command = functools.partial(
-                force_trigger_tasks, schd
+                force_trigger_tasks,
+                schd,
             )
 
         active_1, active_2 = schd.pool.get_tasks()  # foo, bar in any order
@@ -129,77 +134,52 @@ async def test_flow_assignment(
 
         # -----(1. Test active tasks)-----
 
+        await run_cmd(do_command([active_1.identity], flow=[]))
         if command == "set":
             # By default active tasks merge existing and active flows.
-            do_command([active_1.identity], flow=[])
             assert active_1.flow_nums == {1, 2}
         else:
             # By default active tasks keep existing flows.
-            await run_cmd(do_command([active_1.identity], flow=[]))
             assert active_1.flow_nums == {1}
 
         # Else merge existing and requested flows.
-        if command == "set":
-            do_command([active_1.identity], flow=['2'])
-        else:
-            await run_cmd(do_command([active_1.identity], flow=['2']))
+        await run_cmd(do_command([active_1.identity], flow=['2']))
         assert active_1.flow_nums == {1, 2}
 
         # (no-flow is ignored for active tasks)
-        if command == "set":
-            do_command([active_1.identity], flow=[FLOW_NONE])
-        else:
-            await run_cmd(do_command([active_1.identity], flow=[FLOW_NONE]))
+        await run_cmd(do_command([active_1.identity], flow=[FLOW_NONE]))
         assert active_1.flow_nums == {1, 2}
         assert log_filter(
             contains=("Already active - ignoring"),
             level=logging.WARNING
         )
 
-        if command == "set":
-            do_command([active_1.identity], flow=[FLOW_NEW])
-        else:
-            await run_cmd(do_command([active_1.identity], flow=[FLOW_NEW]))
+        await run_cmd(do_command([active_1.identity], flow=[FLOW_NEW]))
         assert active_1.flow_nums == {1, 2, 3}
 
         # -----(2. Test inactive tasks)-----
         if command == 'set':
             do_command = functools.partial(
-                schd.pool.set_prereqs_and_outputs, outputs=[], prereqs=['all']
+                set_prereqs_and_outputs,
+                schd,
+                outputs=[],
+                prerequisites=['all'],
             )
 
         # By default inactive tasks get all active flows.
-        if command == "set":
-            do_command(['1/a'], flow=[])
-        else:
-            await run_cmd(do_command(['1/a'], flow=[]))
+        await run_cmd(do_command(['1/a'], flow=[]))
         assert schd.pool._get_task_by_id('1/a').flow_nums == {1, 2, 3}
 
         # Else assign requested flows.
         # Run as no-flow:
-        from cylc.flow import LOG
-        LOG.critical("ZER")
-        if command == "set":
-            do_command(['1/b'], flow=[FLOW_NONE])
-        else:
-            await run_cmd(do_command(['1/b'], flow=[FLOW_NONE]))
-        LOG.critical("ONE")
+        await run_cmd(do_command(['1/b'], flow=[FLOW_NONE]))
         assert schd.pool._get_task_by_id('1/b').flow_nums == set()
 
-        if command == "set":
-            do_command(['1/c'], flow=[FLOW_NEW])
-        else:
-            await run_cmd(do_command(['1/c'], flow=[FLOW_NEW]))
+        await run_cmd(do_command(['1/c'], flow=[FLOW_NEW]))
         assert schd.pool._get_task_by_id('1/c').flow_nums == {4}
 
-        if command == "set":
-            do_command(['1/d'], flow=[])
-        else:
-            await run_cmd(do_command(['1/d'], flow=[]))
+        await run_cmd(do_command(['1/d'], flow=[]))
         assert schd.pool._get_task_by_id('1/d').flow_nums == {1, 2, 3, 4}
 
-        if command == "set":
-            do_command(['1/e'], flow=["7"])
-        else:
-            await run_cmd(do_command(['1/e'], flow=["7"]))
+        await run_cmd(do_command(['1/e'], flow=["7"]))
         assert schd.pool._get_task_by_id('1/e').flow_nums == {7}

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -37,9 +37,13 @@ from cylc.flow.commands import (
     set_prereqs_and_outputs,
 )
 from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_state import (
+    TASK_STATUS_FAILED,
+    TASK_STATUS_RUNNING,
+    TASK_STATUS_SUBMITTED,
+    TASK_STATUS_SUCCEEDED,
     TASK_STATUS_WAITING,
-    TASK_STATUS_RUNNING
 )
 
 
@@ -671,11 +675,11 @@ async def test_replay_outputs(flow, scheduler, start, complete, log_filter):
         # live during the forthcoming trigger operation.
 
         # Complete the a:started and k:kustom outputs.
-        schd.pool.set_prereqs_and_outputs(
-            ['1/a'], ['started'], [], []
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/a'], ['1'], ['started'], None)
         )
-        schd.pool.set_prereqs_and_outputs(
-            ['1/k'], ['kustom'], [], []
+        await run_cmd(
+            set_prereqs_and_outputs(schd, ['1/k'], ['1'], ['kustom'], None)
         )
         # It should spawn b, l, and offg.
         for task in ['b', 'l', 'offg']:
@@ -752,3 +756,52 @@ async def test_trigger_with_sequential_task(flow, scheduler, run, log_filter):
                 if log_filter(contains='[2/foo/02:running] (received)failed'):
                     break
                 await asyncio.sleep(0)
+
+
+async def test_trigger_with_task_selector(flow, scheduler, start, monkeypatch):
+    """Test task matching with the trigger command.
+
+    This test is intended to extend the other integration tests for ID matching
+    with a real use case to ensure the code in cylc.flow.commands
+    (which parses and standardises IDs) is working correctly.
+    """
+    id_ = flow({
+        'scheduling': {
+            'graph': {
+                'R1': 'a & b & c & d & e & f & g'
+            }
+        }
+    })
+    schd: Scheduler = scheduler(id_)
+    async with start(schd):
+        trigger_calls = []
+
+        def _force_trigger_tasks(_schd, ids, *_, **__):
+            trigger_calls.append(
+                {id_.relative_id_with_selectors for id_ in ids}
+            )
+
+        monkeypatch.setattr(
+            'cylc.flow.commands._force_trigger_tasks', _force_trigger_tasks
+        )
+
+        schd.pool._get_task_by_id('1/a').state_reset(TASK_STATUS_SUBMITTED)
+        schd.pool._get_task_by_id('1/b').state_reset(TASK_STATUS_RUNNING)
+        schd.pool._get_task_by_id('1/c').state_reset(TASK_STATUS_SUCCEEDED)
+        schd.pool._get_task_by_id('1/d').state_reset(TASK_STATUS_FAILED)
+
+        await run_cmd(force_trigger_tasks(schd, ['*:submitted'], []))
+        assert trigger_calls == [{'1/a'}]
+        trigger_calls.clear()
+
+        await run_cmd(force_trigger_tasks(schd, ['*:running'], []))
+        assert trigger_calls == [{'1/b'}]
+        trigger_calls.clear()
+
+        await run_cmd(force_trigger_tasks(schd, ['*:succeeded'], []))
+        assert trigger_calls == [{'1/c'}]
+        trigger_calls.clear()
+
+        await run_cmd(force_trigger_tasks(schd, ['*:failed'], []))
+        assert trigger_calls == [{'1/d'}]
+        trigger_calls.clear()

--- a/tests/integration/test_id_match.py
+++ b/tests/integration/test_id_match.py
@@ -1,0 +1,220 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Set, Tuple, cast, TYPE_CHECKING
+
+from cylc.flow import commands
+from cylc.flow.id import Tokens
+from cylc.flow.scheduler import Scheduler
+
+if TYPE_CHECKING:
+    from cylc.flow.id import TaskTokens
+
+
+async def test_id_match(flow, scheduler, start, caplog):
+    id_ = flow({
+        'scheduling': {
+            'cycling mode': 'integer',
+            'initial cycle point': '1',
+            'final cycle point': '3',
+            'graph': {
+                'P2': '''
+                    a1 => b1 => c1
+                    a2 => b2 => c2
+
+                    b1[-P1] => b1
+                    b2[-P1] => b2
+                ''',
+            },
+        },
+        'runtime': {
+            'a1, a2': {'inherit': 'A'},
+            'A': {},
+            'b1, b2': {'inherit': 'B'},
+            'B': {},
+            'c1, c2': {},
+        },
+    })
+    schd: Scheduler = scheduler(id_)
+
+    def match(*ids: str) -> Tuple[Set[str], Set[str]]:
+        matched, unmatched = schd.pool.id_match(
+            {cast('TaskTokens', Tokens(id_, relative=True)) for id_ in ids},
+        )
+        return {id_.relative_id for id_ in matched}, {
+            id_.relative_id_with_selectors for id_ in unmatched
+        }
+
+    async with start(schd):
+        await commands.run_cmd(
+            commands.set_prereqs_and_outputs(
+                schd, ['1/a2'], ['1'], ['succeeded'], None
+            )
+        )
+        await commands.run_cmd(
+            commands.set_prereqs_and_outputs(
+                schd, ['1/b2'], ['1'], ['failed'], None
+            )
+        )
+
+        # task pool state:
+        # * cycle 1
+        #   * n=0 a1 waiting
+        #   * n=1 b1 waiting
+        #   * n=2 c1 waiting
+        #   * n=1 a2 succeeded
+        #   * n=0 b2 failed
+        #   * n=1 c2 waiting
+        # * cycle 2
+        #   * n=0 a1 waiting
+        #   * n=1 b1 waiting
+        #   * n=2 c1 waiting
+        #   * n=0 a2 waiting
+        #   * n=1 b2 waiting
+        #   * n=2 c2 waiting
+
+        # check the n=0 window matches expecations before proceeding
+        assert {
+            itask.tokens.relative_id for itask in schd.pool.get_tasks()
+        } == {'1/a1', '1/b2', '3/a1', '3/a2'}
+
+        # test active task selection: waiting selector
+        assert (
+            match('*:waiting')
+            == match('*/root:waiting')
+            == match('*/*:waiting')
+            == match('*/A:waiting')
+            == match('*/a*:waiting')
+            == match('1/a1:waiting', '3/a1:waiting', '3/a2:waiting')
+            == match('^/a1:waiting', '3/a1:waiting', '$/a2:waiting')
+            == ({'1/a1', '3/a1', '3/a2'}, set())
+        )
+
+        # test active task selection: failed selector
+        assert (
+            match('*:failed')
+            == match('*/root:failed')
+            == match('*/*:failed')
+            == match('*/B:failed')
+            == match('*/b*:failed')
+            == match('1/b2:failed')
+            == match('^/b2:failed')
+            == ({'1/b2'}, set())
+        )
+
+        # test active task selection: failed selector
+        assert (
+            match('1/b1:failed', '1/b2:failed')
+            == match('1/B:failed', '1/b1:failed')
+            == match('*:failed', '1/B:failed', '1/b1:failed')
+            == ({'1/b2'}, {'1/b1:failed'})
+        )
+
+        # test active task selection: submit-failed selector
+        assert match('*:submit-failed') == (set(), {'*:submit-failed'})
+
+        # test globs, cycle and family matching
+        assert (
+            match('*')
+            == match('*/*')
+            == match('*/root')
+            == match('*/A', '*/B', '*/c1', '*/c2')
+            == match('*/a*', '*/b*', '*/c*')
+            == (
+                {
+                    '1/a1',
+                    '1/a2',
+                    '1/b1',
+                    '1/b2',
+                    '1/c1',
+                    '1/c2',
+                    '3/a1',
+                    '3/a2',
+                    '3/b1',
+                    '3/b2',
+                    '3/c1',
+                    '3/c2',
+                },
+                set(),
+            )
+        )
+
+        # test globs, cycle and family matching
+        assert (
+            match('1/A')
+            == match('1/a*')
+            == match('^/a*')
+            == match('1/a1', '1/a2')
+            == ({'1/a1', '1/a2'}, set())
+        )
+        assert match('1/X') == (set(), {'1/X'})
+        assert match('5:waiting') == (set(), {'5:waiting'})
+
+        # test invalid IDs
+        assert match('not-a-cycle/*', '*/not_a_task', '*:not-a-state') == (
+            set(),
+            {'not-a-cycle/*', '*/not_a_task', '*:not-a-state'},
+        )
+        # test invalid cycle point in combination with a selector
+        assert match('x/y:succeeded') == (set(), {'x/y:succeeded'})
+
+        # ensure that off-sequence IDs are filtered out
+        # NOTE: cycle 2 is not on sequence for task a1
+        assert match('1/a1', '2/a1', '3/a1') == ({'1/a1', '3/a1'}, {'2/a1'})
+
+        # ensure warnings are raised for off-sequence tasks if the user
+        # explcitly specified them
+        # NOTE: 2/a1 should result in a warning (because the user asked for
+        # this exact combination), however, "2/a*" should not (because there
+        # may be a combination of tasks which are or are not valid at the given
+        # cycle(s) which match the task name pattern)
+        caplog.clear()
+        assert match('2/a1', '2/a*') == (set(), {'2/a1', '2/a*'})
+        assert caplog.messages == ['Invalid cycle point for task: a1, 2']
+
+
+async def test_match_removed_task(flow, scheduler, run, complete):
+    """It should match and operate on tasks no longer in the config."""
+    config = {
+        'scheduling': {
+            'graph': {'R1': 'foo & bar'},
+        },
+    }
+    id_ = flow(config)
+    schd = scheduler(id_, paused_start=False)
+
+    def list_tasks():
+        return {
+            itask.tokens.relative_id for itask in schd.pool.get_tasks()
+        }
+
+    async with run(schd):
+        # workflow starts with "foo" and "bar" in the pool
+        assert list_tasks() == {'1/foo', '1/bar'}
+
+        # remove "bar" from the config and reload
+        config['scheduling']['graph']['R1'] = 'x => foo'
+        flow(config, name=id_)
+        await commands.run_cmd(commands.reload_workflow(schd))
+
+        # both "foo" and "bar" are still in the pool ("bar" is orphaned)
+        assert list_tasks() == {'1/foo', '1/bar'}
+
+        # remove all tasks from the workflow
+        await commands.run_cmd(commands.remove_tasks(schd, {'*'}, ['1']))
+
+        # this should match the orphaned task "bar"
+        assert list_tasks() == set()

--- a/tests/integration/test_optional_outputs.py
+++ b/tests/integration/test_optional_outputs.py
@@ -32,6 +32,7 @@ from cylc.flow.commands import (
 )
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
+from cylc.flow.id import TaskTokens
 from cylc.flow.network.resolvers import TaskMsg
 from cylc.flow.task_events_mgr import (
     TaskEventsManager,
@@ -148,7 +149,7 @@ async def test_task_completion(
         }:
             # set the combination of outputs
             schd.pool.set_prereqs_and_outputs(
-                ['1/a'],
+                {TaskTokens('1', 'a')},
                 combination,
                 [],
                 ['1'],
@@ -164,7 +165,7 @@ async def test_task_completion(
         for combination in completion_outputs:
             # set the combination of outputs
             schd.pool.set_prereqs_and_outputs(
-                ['1/a'],
+                {TaskTokens('1', 'a')},
                 combination,
                 [],
                 ['1'],

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -29,6 +29,7 @@ from cylc.flow.commands import (
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
 from cylc.flow.exceptions import XtriggerConfigError
+from cylc.flow.id import TaskTokens
 from cylc.flow.scheduler import Scheduler
 
 
@@ -124,7 +125,7 @@ async def test_set_outputs(sequential, start):
         sequential.pool.get_task(ISO8601Point('2000'), 'foo')
         # set foo:succeeded it should spawn next instance
         sequential.pool.set_prereqs_and_outputs(
-            ["2000/foo"], ["succeeded"], [], [])
+            {TaskTokens('2000', 'foo')}, ["succeeded"], [], [])
 
         assert list_cycles(sequential) == ['2001']
 
@@ -137,7 +138,7 @@ async def test_set_prereqs(sequential, start):
         sequential.pool.get_task(ISO8601Point('2000'), 'foo')
         # satisfy foo's xtriggers - it should spawn next instance
         sequential.pool.set_prereqs_and_outputs(
-            ["2000/foo"], [], ['xtrigger/all:succeeded'], [])
+            {TaskTokens('2000', 'foo')}, [], ['xtrigger/all:succeeded'], [])
         sequential.pool.spawn_parentless_sequential_xtriggers()
 
         assert list_cycles(sequential) == ['2000', '2001']

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -24,6 +24,7 @@ from typing import (
     List,
     Tuple,
     Union,
+    cast,
 )
 
 import pytest
@@ -38,6 +39,7 @@ from cylc.flow.cycling.iso8601 import ISO8601Point
 from cylc.flow.data_messages_pb2 import PbPrerequisite
 from cylc.flow.data_store_mgr import TASK_PROXIES
 from cylc.flow.flow_mgr import FLOW_NONE
+from cylc.flow.id import TaskTokens, Tokens
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
     TASK_OUTPUT_FAILED,
@@ -59,6 +61,7 @@ from cylc.flow.task_state import (
 if TYPE_CHECKING:
     from cylc.flow.cycling import PointBase
     from cylc.flow.scheduler import Scheduler
+
 
 # NOTE: foo and bar have no parents so at start-up (even with the workflow
 # paused) they get spawned out to the runahead limit. 2/pub spawns
@@ -180,121 +183,38 @@ async def mod_example_flow_2(
 
 
 @pytest.mark.parametrize(
-    'items, expected_task_ids, expected_bad_items, expected_warnings',
+    'ids, expected_tasks_to_hold_ids',
     [
         param(
-            ['*/foo'], ['1/foo', '2/foo', '3/foo', '4/foo', '5/foo'], [], [],
-            id="Point glob"
+            ['1/foo', '3/asd'],
+            ['1/foo', '3/asd'],
+            id="Active & inactive tasks",
         ),
         param(
-            ['1/*'],
-            ['1/foo', '1/bar'], [], [],
-            id="Name glob"
+            ['1/FAM', '2/FAM', '6/FAM'],
+            ['1/bar', '2/bar', '6/bar'],
+            id="Family names hold active and future tasks",
         ),
         param(
-            ['1/FAM'], ['1/bar'], [], [],
-            id="Family name"
-        ),
-        param(
-            ['*:waiting'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
-             '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
-            id="Task state"
-        ),
-        param(
-            ['8/foo', '3/asd'], [], ['8/foo', '3/asd'],
-            [f"No active tasks matching: {x}" for x in ['8/foo', '3/asd']],
-            id="Task not yet spawned"
-        ),
-        param(
-            ['1/foo', '8/bar'], ['1/foo'], ['8/bar'],
-            ["No active tasks matching: 8/bar"],
-            id="Multiple items"
-        ),
-        param(
-            ['1/grogu', '*/grogu'], [], ['1/grogu', '*/grogu'],
-            [f"No active tasks matching: {x}" for x in ['1/grogu', '*/grogu']],
-            id="No such task"
-        ),
-        param(
-            ['*'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
-             '4/foo', '4/bar', '5/foo', '5/bar'], [], [],
-            id="Glob everything"
-        )
-    ]
-)
-async def test_filter_task_proxies(
-    items: List[str],
-    expected_task_ids: List[str],
-    expected_bad_items: List[str],
-    expected_warnings: List[str],
-    mod_example_flow: 'Scheduler',
-    caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test TaskPool.filter_task_proxies().
-
-    The NOTE before EXAMPLE_FLOW_CFG above explains which tasks should be
-    expected for the tests here.
-
-    Params:
-        items: Arg passed to filter_task_proxies().
-        expected_task_ids: IDs of the TaskProxys that are expected to be
-            returned.
-        expected_bad_items: Expected to be returned.
-        expected_warnings: Expected to be logged.
-    """
-    caplog.set_level(logging.WARNING, CYLC_LOG)
-    task_pool = mod_example_flow.pool
-    itasks, _, bad_items = task_pool.filter_task_proxies(items)
-    task_ids = [itask.identity for itask in itasks]
-    assert sorted(task_ids) == sorted(expected_task_ids)
-    assert sorted(bad_items) == sorted(expected_bad_items)
-    assert_expected_log(caplog, expected_warnings)
-
-
-@pytest.mark.parametrize(
-    'items, expected_tasks_to_hold_ids, expected_warnings',
-    [
-        param(
-            ['1/foo', '3/asd'], ['1/foo', '3/asd'], [],
-            id="Active & inactive tasks"
-        ),
-        param(
-            ['1/*', '2/*', '3/*', '6/*'],
-            ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar'],
-            ["No active tasks matching: 6/*"],
-            id="Name globs hold active tasks only"  # (active means n=0 here)
-        ),
-        param(
-            ['1/FAM', '2/FAM', '6/FAM'], ['1/bar', '2/bar', '6/bar'],
+            ['1/grogu', 'H/foo', '20/foo', '1/pub'],
             [],
-            id="Family names hold active and future tasks"
+            id="Non-existent task name or invalid cycle point",
         ),
         param(
-            ['1/grogu', 'H/foo', '20/foo', '1/pub'], [],
-            ["No matching tasks found: grogu",
-             "H/foo - invalid cycle point: H",
-             "Invalid cycle point for task: foo, 20",
-             "Invalid cycle point for task: pub, 1"],
-            id="Non-existent task name or invalid cycle point"
-        ),
-        param(
-            ['1/foo:waiting', '1/foo:failed', '6/bar:waiting'], ['1/foo'],
-            ["No active tasks matching: 1/foo:failed",
-             "No active tasks matching: 6/bar:waiting"],
+            ['1/foo:waiting', '1/foo:failed', '6/bar:waiting'],
+            ['1/foo'],
             id=(
                 "Specifying task state works for active tasks,"
                 " not inactive tasks"
-            )
-        )
-    ]
+            ),
+        ),
+    ],
 )
 async def test_hold_tasks(
-    items: List[str],
+    ids: List[str],
     expected_tasks_to_hold_ids: List[str],
-    expected_warnings: List[str],
-    example_flow: 'Scheduler', caplog: pytest.LogCaptureFixture,
+    example_flow: 'Scheduler',
+    caplog: pytest.LogCaptureFixture,
     db_select: Callable
 ) -> None:
     """Test TaskPool.hold_tasks().
@@ -311,16 +231,15 @@ async def test_hold_tasks(
     expected_tasks_to_hold_ids = sorted(expected_tasks_to_hold_ids)
     caplog.set_level(logging.WARNING, CYLC_LOG)
     task_pool = example_flow.pool
-    n_warnings = task_pool.hold_tasks(items)
+    task_pool.hold_tasks(
+        {cast('TaskTokens', Tokens(id_, relative=True)) for id_ in ids}
+    )
 
     for itask in task_pool.get_tasks():
         hold_expected = itask.identity in expected_tasks_to_hold_ids
         assert itask.state.is_held is hold_expected
 
     assert get_task_ids(task_pool.tasks_to_hold) == expected_tasks_to_hold_ids
-
-    logged_warnings = assert_expected_log(caplog, expected_warnings)
-    assert n_warnings == len(logged_warnings)
 
     db_held_tasks = db_select(example_flow, True, 'tasks_to_hold')
     assert get_task_ids(db_held_tasks) == expected_tasks_to_hold_ids
@@ -341,7 +260,13 @@ async def test_release_held_tasks(
     # Setup
     task_pool = example_flow.pool
     expected_tasks_to_hold_ids = sorted(['1/foo', '1/bar', '3/asd'])
-    task_pool.hold_tasks(expected_tasks_to_hold_ids)
+    task_pool.hold_tasks(
+        {
+            TaskTokens('1', 'foo'),
+            TaskTokens('1', 'bar'),
+            TaskTokens('3', 'asd'),
+        }
+    )
     for itask in task_pool.get_tasks():
         hold_expected = itask.identity in expected_tasks_to_hold_ids
         assert itask.state.is_held is hold_expected
@@ -350,7 +275,9 @@ async def test_release_held_tasks(
     assert get_task_ids(db_tasks_to_hold) == expected_tasks_to_hold_ids
 
     # Test
-    task_pool.release_held_tasks(['1/foo', '3/asd'])
+    task_pool.release_held_tasks(
+        {TaskTokens('1', 'foo'), TaskTokens('3', 'asd')}
+    )
     for itask in task_pool.get_tasks():
         assert itask.state.is_held is (itask.identity == '1/bar')
 
@@ -364,14 +291,40 @@ async def test_release_held_tasks(
 @pytest.mark.parametrize(
     'hold_after_point, expected_held_task_ids',
     [
-        (0, ['1/foo', '1/bar', '2/foo', '2/bar', '2/pub', '3/foo', '3/bar',
-             '4/foo', '4/bar', '5/foo', '5/bar']),
-        (1, ['2/foo', '2/bar', '2/pub', '3/foo', '3/bar', '4/foo',
-             '4/bar', '5/foo', '5/bar'])
-    ]
+        (
+            '0',
+            [
+                '1/foo',
+                '1/bar',
+                '2/foo',
+                '2/bar',
+                '2/pub',
+                '3/foo',
+                '3/bar',
+                '4/foo',
+                '4/bar',
+                '5/foo',
+                '5/bar',
+            ],
+        ),
+        (
+            '1',
+            [
+                '2/foo',
+                '2/bar',
+                '2/pub',
+                '3/foo',
+                '3/bar',
+                '4/foo',
+                '4/bar',
+                '5/foo',
+                '5/bar',
+            ],
+        ),
+    ],
 )
 async def test_hold_point(
-    hold_after_point: int,
+    hold_after_point: str,
     expected_held_task_ids: List[str],
     example_flow: 'Scheduler', db_select: Callable
 ) -> None:
@@ -421,22 +374,21 @@ async def test_trigger_states(
     status: str, should_trigger: bool, one: 'Scheduler', start: Callable
 ):
     """It should only trigger tasks in compatible states."""
-
     async with start(one):
-        task = one.pool.filter_task_proxies(['1/one'])[0][0]
+        itask = one.pool.get_task(IntegerPoint('1'), 'one')
 
         # reset task a to the provided state
-        task.state.reset(status)
+        itask.state.reset(status)
 
         # try triggering the task
         await commands.run_cmd(
             commands.force_trigger_tasks(one, ['1/one'], []))
 
         # retrieve the task again - the original may have been removed
-        task = one.pool.filter_task_proxies(['1/one'])[0][0]
+        itask = one.pool.get_task(IntegerPoint('1'), 'one')
 
         # check whether the task triggered
-        assert task.is_manual_submit == should_trigger
+        assert itask.is_manual_submit == should_trigger
 
 
 async def test_preparing_tasks_on_restart(one_conf, flow, scheduler, start):
@@ -453,21 +405,21 @@ async def test_preparing_tasks_on_restart(one_conf, flow, scheduler, start):
     # start the workflow, reset a task to preparing
     one = scheduler(id_)
     async with start(one):
-        task = one.pool.filter_task_proxies(['*'])[0][0]
-        task.state.reset(TASK_STATUS_PREPARING)
+        itask = one.pool.get_tasks()[0]
+        itask.state.reset(TASK_STATUS_PREPARING)
 
     # when we restart the task should have been reset to waiting
     one = scheduler(id_)
     async with start(one):
-        task = one.pool.filter_task_proxies(['*'])[0][0]
-        assert task.state(TASK_STATUS_WAITING)
-        task.state.reset(TASK_STATUS_SUCCEEDED)
+        itask = one.pool.get_tasks()[0]
+        assert itask.state(TASK_STATUS_WAITING)
+        itask.state.reset(TASK_STATUS_SUCCEEDED)
 
     # whereas if we reset the task to succeeded the state is not reset
     one = scheduler(id_)
     async with start(one):
-        task = one.pool.filter_task_proxies(['*'])[0][0]
-        assert task.state(TASK_STATUS_SUCCEEDED)
+        itask = one.pool.get_tasks()[0]
+        assert itask.state(TASK_STATUS_SUCCEEDED)
 
 
 async def test_reload_stopcp(
@@ -1020,7 +972,7 @@ async def test_no_flow_tasks_dont_spawn(
 
         # Set as completed: should not spawn children.
         schd.pool.set_prereqs_and_outputs(
-            [task_a.identity], [], [], [FLOW_NONE]
+            {task_a.tokens}, [], [], [FLOW_NONE]
         )
         assert not schd.pool.get_tasks()
 
@@ -1243,7 +1195,7 @@ async def test_set_failed_complete(
             regex="failed.* did not complete the required outputs")
 
         # Set failed task complete via default "set" args.
-        schd.pool.set_prereqs_and_outputs([one.identity], [], [], [])
+        schd.pool.set_prereqs_and_outputs({one.tokens}, [], [], [])
 
         assert log_filter(
             contains=f'[{one}] removed from the n=0 window: completed')
@@ -1304,8 +1256,10 @@ async def test_set_prereqs(
 
         # try to set an invalid prereq of qux
         schd.pool.set_prereqs_and_outputs(
-            ["20400101T0000Z/qux"], [],
-            ["20400101T0000Z/foo:a", "xtrigger/x"], []
+            {TaskTokens('20400101T0000Z', 'qux')},
+            [],
+            ["20400101T0000Z/foo:a", "xtrigger/x"],
+            [],
         )
         assert log_filter(
             contains=(
@@ -1330,10 +1284,10 @@ async def test_set_prereqs(
         assert bar.state.prerequisites_all_satisfied()
         assert not bar.state.xtriggers_all_satisfied()
         schd.pool.set_prereqs_and_outputs(
-            ["20400101T0000Z/bar"],
+            {TaskTokens('20400101T0000Z', 'bar')},
             [],
             ["xtrigger/x:succeeded"],
-            []
+            [],
         )
         assert bar.state.xtriggers_all_satisfied()
         assert log_filter(
@@ -1341,17 +1295,17 @@ async def test_set_prereqs(
 
         # set xtrigger in the wrong task
         schd.pool.set_prereqs_and_outputs(
-            ["20400101T0000Z/baz"],
+            {TaskTokens('20400101T0000Z', 'baz')},
             [],
             ["xtrigger/x:succeeded"],
-            []
+            [],
         )
         assert log_filter(
             contains='20400101T0000Z/baz does not depend on xtrigger "x"')
 
         # set one prereq of inactive task 20400101T0000Z/qux
         schd.pool.set_prereqs_and_outputs(
-            ["20400101T0000Z/qux"],
+            {TaskTokens('20400101T0000Z', 'qux')},
             [],
             ["20400101T0000Z/foo:succeeded"],
             [])
@@ -1371,7 +1325,11 @@ async def test_set_prereqs(
         # set its other prereqs (test implicit "succeeded" and "succeed")
         # and truncated cycle point
         schd.pool.set_prereqs_and_outputs(
-            ["2040/qux"], [], ["2040/bar", "2040/baz:succeed"], [])
+            {TaskTokens('20400101T0000Z', 'qux')},
+            [],
+            ["2040/bar", "2040/baz:succeed"],
+            [],
+        )
 
         assert log_filter(
             contains=('prerequisite force-satisfied: 20400101T0000Z/bar'))
@@ -1383,7 +1341,7 @@ async def test_set_prereqs(
 
         # set one again
         schd.pool.set_prereqs_and_outputs(
-            ["2040/qux"], [], ["2040/bar"], [])
+            {TaskTokens('20400101T0000Z', 'qux')}, [], ["2040/bar"], [])
 
         assert log_filter(
             contains=('prerequisite already satisfied: 20400101T0000Z/bar'))
@@ -1410,7 +1368,7 @@ async def test_set_bad_prereqs(
     def set_prereqs(prereqs):
         """Shorthand so only variable under test given as arg"""
         schd.pool.set_prereqs_and_outputs(
-            ["2040/bar"], [], prereqs, [])
+            {TaskTokens('2040', 'bar')}, [], prereqs, [])
 
     async with start(schd):
         # Invalid: task name wildcard:
@@ -1465,7 +1423,9 @@ async def test_set_outputs_live(
         schd.pool.task_events_mgr.process_message(foo, 1, 'failed')
 
         # set foo:x: it should spawn bar but not baz
-        schd.pool.set_prereqs_and_outputs(["1/foo"], ["x"], [], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'foo')}, ["x"], [], []
+        )
         assert schd.pool.get_task_ids() == {"1/bar", "1/foo"}
         # Foo should have been removed from the queue:
         assert '1/foo' not in [
@@ -1474,7 +1434,8 @@ async def test_set_outputs_live(
         ]
         # set foo:succeed: it should spawn baz but foo remains incomplete.
         schd.pool.set_prereqs_and_outputs(
-            ["1/foo"], ["succeeded"], [], [])
+            {TaskTokens('1', 'foo')}, ["succeeded"], [], []
+        )
         assert schd.pool.get_task_ids() == {"1/bar", "1/baz", "1/foo"}
 
         # it should complete implied outputs (submitted, started) too
@@ -1482,7 +1443,7 @@ async def test_set_outputs_live(
         assert log_filter(contains="setting implied output: started")
 
         # set foo (default: all required outputs) to complete y.
-        schd.pool.set_prereqs_and_outputs(["1/foo"], [], [], [])
+        schd.pool.set_prereqs_and_outputs({TaskTokens('1', 'foo')}, [], [], [])
         assert log_filter(contains="output 1/foo:succeeded completed")
         assert schd.pool.get_task_ids() == {"1/bar", "1/baz"}
 
@@ -1511,7 +1472,7 @@ async def test_set_outputs_live2(
     schd: Scheduler = scheduler(id_)
 
     async with start(schd):
-        schd.pool.set_prereqs_and_outputs(["1/foo"], [], [], [])
+        schd.pool.set_prereqs_and_outputs({TaskTokens('1', 'foo')}, [], [], [])
         assert not log_filter(
             contains="did not complete required outputs: ['a', 'b']"
         )
@@ -1552,11 +1513,11 @@ async def test_set_outputs_future(
 
         # setting inactive task b succeeded should spawn c but not b
         schd.pool.set_prereqs_and_outputs(
-            ["1/b"], ["succeeded"], [], [])
+            {TaskTokens('1', 'b')}, ["succeeded"], [], [])
         assert schd.pool.get_task_ids() == {"1/a", "1/c"}
 
         schd.pool.set_prereqs_and_outputs(
-            items=["1/a"],
+            items={TaskTokens('1', 'a')},
             outputs=["x", "y", "cheese"],
             prereqs=[],
             flow=[]
@@ -1614,7 +1575,7 @@ async def test_set_outputs_from_skip_settings(
         # setting 1/a output to skip should set output x, but not
         # y (because y is optional).
         schd.pool.set_prereqs_and_outputs(
-            ['1/a'], ['skip'], [], [])
+            {TaskTokens('1', 'a')}, ['skip'], [], [])
         assert schd.pool.get_task_ids() == {
             '1/after_asucceeded',
             '1/after_ax',
@@ -1627,7 +1588,7 @@ async def test_set_outputs_from_skip_settings(
 
         # You should be able to set skip as part of a list of outputs:
         schd.pool.set_prereqs_and_outputs(
-            ['2/a'], ['skip', 'y'], [], [])
+            {TaskTokens('2', 'a')}, ['skip', 'y'], [], [])
         assert schd.pool.get_task_ids() == {
             '1/after_asucceeded',
             '1/after_ax',
@@ -1668,7 +1629,9 @@ async def test_prereq_satisfaction(
         # it should start up with just 1/a
         assert schd.pool.get_task_ids() == {"1/a"}
         # spawn b
-        schd.pool.set_prereqs_and_outputs(["1/a"], ["x"], [], [])
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'a')}, ["x"], [], []
+        )
         assert schd.pool.get_task_ids() == {"1/a", "1/b"}
 
         b = schd.pool.get_task(IntegerPoint("1"), "b")
@@ -1678,7 +1641,9 @@ async def test_prereq_satisfaction(
         # set valid and invalid prerequisites, by label and message.
         schd.pool.set_prereqs_and_outputs(
             prereqs=["1/a:xylophone", "1/a:y", "1/a:w", "1/a:z"],
-            items=["1/b"], outputs=[], flow=[]
+            items={TaskTokens('1', 'b')},
+            outputs=[],
+            flow=[],
         )
         assert log_filter(contains="1/a:z not found")
         assert log_filter(contains="1/a:w not found")
@@ -2105,19 +2070,26 @@ async def test_set_future_flow(flow, scheduler, start, log_filter):
 
         # set b, c1, c2 succeeded in flow 1
         schd.pool.set_prereqs_and_outputs(
-            ['1/b', '1/c1', '1/c2'], prereqs=[], outputs=[], flow=[1]
+            {
+                TaskTokens('1', 'b'),
+                TaskTokens('1', 'c1'),
+                TaskTokens('1', 'c2'),
+            },
+            prereqs=[],
+            outputs=[],
+            flow=['1'],
         )
         schd.workflow_db_mgr.process_queued_ops()
 
         # set task c1:succeeded in flow 2
         schd.pool.set_prereqs_and_outputs(
-            ['1/c1'], prereqs=[], outputs=[], flow=[2]
+            {TaskTokens('1', 'c1')}, prereqs=[], outputs=[], flow=['2']
         )
         schd.workflow_db_mgr.process_queued_ops()
 
         # set b:succeeded in flow 2 and check downstream spawning
         schd.pool.set_prereqs_and_outputs(
-            ['1/b'], prereqs=[], outputs=[], flow=[2]
+            {TaskTokens('1', 'b')}, prereqs=[], outputs=[], flow=['2']
         )
         assert schd.pool.get_task(IntegerPoint("1"), "c1") is None, (
             '1/c1 (flow 2) should not be spawned after 1/b:succeeded'
@@ -2260,7 +2232,10 @@ async def test_expire_dequeue_with_retries(
         method = lambda schd: schd.pool.clock_expire_tasks()
     else:
         method = lambda schd: schd.pool.set_prereqs_and_outputs(
-            ['2000/foo'], prereqs=[], outputs=['expired'], flow=['1']
+            {TaskTokens('20000101T0000Z', 'foo')},
+            prereqs=[],
+            outputs=['expired'],
+            flow=['1'],
         )
 
     id_ = flow(conf)
@@ -2374,7 +2349,6 @@ async def test_start_tasks(
     flow,
     scheduler,
     start,
-    log_filter,
     capture_submission,
 ):
     """Check starting from "start-tasks" with and without clock-triggers.
@@ -2420,12 +2394,12 @@ async def test_start_tasks(
         # - no qux instances (not listed as a start-task)
         itasks = schd.pool.get_tasks()
         assert (
-            set(itask.identity for itask in itasks) == set([
+            set(itask.identity for itask in itasks) == {
                 "2050/foo",
                 "2051/foo",
                 "2050/bar",
                 "2050/baz",
-            ])
+            }
         )
 
         # Check xtriggers
@@ -2439,11 +2413,11 @@ async def test_start_tasks(
         # It should submit 2050/foo, 2051/foo, 2050/baz
         # It should not submit 2050/bar (waiting on clock trigger)
         assert (
-            set(itask.identity for itask in submitted_tasks) == set([
+            set(itask.identity for itask in submitted_tasks) == {
                 "2050/foo",
                 "2051/foo",
                 "2050/baz",
-            ])
+            }
         )
 
 

--- a/tests/integration/test_xtrigger_mgr.py
+++ b/tests/integration/test_xtrigger_mgr.py
@@ -23,6 +23,7 @@ from typing import cast, Iterable
 from cylc.flow import commands
 from cylc.flow.data_messages_pb2 import PbTaskProxy
 from cylc.flow.data_store_mgr import FAMILY_PROXIES, TASK_PROXIES
+from cylc.flow.id import TaskTokens
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.subprocctx import SubFuncContext
@@ -242,7 +243,7 @@ async def test_set_xtrig_prereq_restart(flow, start, scheduler, db_select):
     async with start(schd):
         # artificially set dependence of foo on x0
         schd.pool.set_prereqs_and_outputs(
-            ['1/foo'], [], ['xtrigger/x0:succeeded'], []
+            {TaskTokens('1', 'foo')}, [], ['xtrigger/x0:succeeded'], []
         )
 
     # the satisfied x0 prerequisite should be written to the DB
@@ -388,7 +389,7 @@ async def test_set_xtrig_prereq_reload(flow, start, scheduler, db_select):
     async with start(schd):
         # artificially set dependence of foo on x0
         schd.pool.set_prereqs_and_outputs(
-            ['1/foo'], [], ['xtrigger/x0:succeeded'], []
+            {TaskTokens('1', 'foo')}, [], ['xtrigger/x0:succeeded'], []
         )
 
         # reload the workflow

--- a/tests/integration/tui/test_app.py
+++ b/tests/integration/tui/test_app.py
@@ -21,6 +21,7 @@ import pytest
 import urwid
 
 from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.id import TaskTokens
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.task_state import (
     TASK_STATUS_EXPIRED,
@@ -486,7 +487,7 @@ async def test_auto_expansion(flow, scheduler, start, rakiura):
             )
             for task in ('a', 'b'):
                 schd.pool.set_prereqs_and_outputs(
-                    items=[f"1/{task}"],
+                    items={TaskTokens('1', task)},
                     outputs=[TASK_OUTPUT_SUCCEEDED],
                     prereqs=[],
                     flow=[]

--- a/tests/unit/test_command_validation.py
+++ b/tests/unit/test_command_validation.py
@@ -14,15 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 import pytest
 
 from cylc.flow.command_validation import (
     ERR_OPT_FLOW_COMBINE,
     ERR_OPT_FLOW_VAL_INT_NEW_NONE,
     flow_opts,
+    is_tasks,
 )
+from cylc.flow.cycling.loader import ISO8601_CYCLING_TYPE
 from cylc.flow.exceptions import InputError
 from cylc.flow.flow_mgr import FLOW_NEW, FLOW_NONE
+from cylc.flow.id import TaskTokens
 
 
 @pytest.mark.parametrize('flow_strs, expected_msg', [
@@ -37,3 +42,56 @@ async def test_trigger_invalid(flow_strs, expected_msg):
     with pytest.raises(InputError) as exc_info:
         flow_opts(flow_strs, False)
     assert str(exc_info.value) == expected_msg
+
+
+async def test_is_tasks(set_cycling_type):
+    set_cycling_type(ISO8601_CYCLING_TYPE)
+
+    # tokens should be parsed
+    assert is_tasks({'20000101T0000Z/a', '20010101T0000Z/b'}) == {
+        TaskTokens('20000101T0000Z', 'a'),
+        TaskTokens('20010101T0000Z', 'b'),
+    }
+
+    # cycle points should be standardised unless they are globs
+    assert is_tasks({'2000/a', '20010101/b', '*/c', '[23]000/d'}) == {
+        TaskTokens('20000101T0000Z', 'a'),
+        TaskTokens('20010101T0000Z', 'b'),
+        TaskTokens('*', 'c'),
+        TaskTokens('[23]000', 'd'),
+    }
+
+    # the namespace should default to "root" unless provided
+    assert is_tasks({'*', '2000'}) == {
+        TaskTokens('*', 'root'),
+        TaskTokens('20000101T0000Z', 'root'),
+    }
+
+    # invalid IDs result in errors
+    with pytest.raises(InputError, match='Invalid ID: //, ///, ////'):
+        is_tasks({'//', '///', '////', '2000/a'})  # last ID is valid
+
+    # invalid cycle points result in errors
+    with pytest.raises(
+        InputError,
+        match=re.escape('Invalid cycle point: (42)/answer, 2000Z, abc'),
+    ):
+        is_tasks({'(42)/answer', '2000Z', 'abc', '2000/a'})  # last ID is valid
+
+    # job IDs reuslt in errors
+    with pytest.raises(
+        InputError,
+        match=re.escape('This command does not take job IDs: */b/02, 1/a/01'),
+    ):
+        is_tasks({'1/a/01', '*/b/02'})
+
+    # combinations of errors are reported
+    with pytest.raises(
+        InputError,
+        match=(
+            re.escape('Invalid ID: ///, ////')
+            + re.escape('\nInvalid cycle point: 200Z, abc')
+            + re.escape('\nThis command does not take job IDs: */b/02, 1/a/01')
+        ),
+    ):
+        is_tasks({'///', '////', '200Z', 'abc', '1/a/01', '*/b/02'})

--- a/tests/unit/test_id_match.py
+++ b/tests/unit/test_id_match.py
@@ -14,376 +14,262 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import TYPE_CHECKING, Callable
-from unittest.mock import create_autospec
+from textwrap import dedent
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Set, Tuple, cast
 
 import pytest
 
-from cylc.flow.id import IDTokens, Tokens
-from cylc.flow.id_match import filter_ids, point_match
-from cylc.flow.task_pool import Pool
-from cylc.flow.cycling.integer import IntegerPoint, CYCLER_TYPE_INTEGER
-from cylc.flow.cycling.iso8601 import ISO8601Point
-from cylc.flow.task_proxy import TaskProxy
-from cylc.flow.taskdef import TaskDef
+from cylc.flow.id import Tokens
+from cylc.flow.id_match import id_match
+from cylc.flow.config import WorkflowConfig
 
 if TYPE_CHECKING:
-    from cylc.flow.cycling import PointBase
+    from cylc.flow.id_match import TaskTokens
 
 
-def get_task_id(itask: TaskProxy) -> str:
-    return f"{itask.tokens.relative_id}:{itask.state.status}"
+def to_tokens(*ids):
+    return cast('Set[TaskTokens]', {Tokens(id_, relative=True) for id_ in ids})
+
+
+def to_string_ids(*ids):
+    return {id_.relative_id for id_ in ids}
+
+
+def to_string_ids_with_selectors(*ids):
+    return {id_.relative_id_with_selectors for id_ in ids}
 
 
 @pytest.fixture
-def task_pool(set_cycling_type: Callable):
-    def _task_proxy(id_, hier):
-        tokens = Tokens(id_, relative=True)
-        hier = hier.get(tokens['task'], [])
-        hier.append('root')
-        tdef = create_autospec(TaskDef, namespace_hierarchy=hier)
-        tdef.name = tokens['task']
-        tdef.expiration_offset = None
-        return TaskProxy(
-            Tokens('~user/workflow'),
-            tdef,
-            start_point=IntegerPoint(tokens['cycle']),
-            status=tokens['task_sel'],
-        )
+def test_config(tmp_path):
+    path = tmp_path / 'flow.cylc'
+    with open(path, 'w+') as flow_cylc:
+        flow_cylc.write(dedent('''
+            [scheduler]
+                allow implicit tasks = True
 
-    def _task_pool(pool, hier) -> 'Pool':
-        return {
-            IntegerPoint(cycle): {
-                id_.split(':')[0]: _task_proxy(id_, hier)
-                for id_ in ids
-            }
-            for cycle, ids in pool.items()
-        }
+            [scheduling]
+                cycling mode = integer
+                initial cycle point = 1
+                [[graph]]
+                    P1 = a => b => c => d
+                    P3 = z
+        '''))
 
-    set_cycling_type(CYCLER_TYPE_INTEGER)
-    return _task_pool
+    return WorkflowConfig('test', str(path), SimpleNamespace())
+
+
+def _id_match(
+    config: 'WorkflowConfig',
+    pool: 'Set[TaskTokens]',
+    ids: 'Set[TaskTokens]',
+    only_match_pool: bool = False,
+) -> 'Tuple[Set[str], Set[str]]':
+    """Convenience function for testing, converts strings to tokens."""
+    matched, unmatched = id_match(
+        config,
+        pool,
+        to_tokens(*ids),
+        only_match_pool=only_match_pool,
+    )
+    return (
+        to_string_ids(*matched),
+        to_string_ids_with_selectors(*unmatched),
+    )
 
 
 @pytest.mark.parametrize(
-    'ids,matched,not_matched',
+    'ids,matched,unmatched',
     [
         (
-            ['1'],
-            ['1/a:x', '1/b:x', '1/c:x'],
-            []
+            {'1'},
+            {'1/a', '1/b', '1/c'},
+            set(),
         ),
         (
-            ['2'],
-            [],
-            ['2']
+            {'2'},
+            set(),
+            {'2'}
         ),
         (
-            ['*'],
-            ['1/a:x', '1/b:x', '1/c:x'],
-            []
+            {'*'},
+            {'1/a', '1/b', '1/c'},
+            set(),
         ),
         (
-            ['1/*'],
-            ['1/a:x', '1/b:x', '1/c:x'],
-            []
+            {'1/*'},
+            {'1/a', '1/b', '1/c'},
+            set(),
         ),
         (
-            ['2/*'],
-            [],
-            ['2/*']
+            {'2/*'},
+            set(),
+            {'2/*'}
         ),
         (
-            ['*/*'],
-            ['1/a:x', '1/b:x', '1/c:x'],
-            []
+            {'*/*'},
+            {'1/a', '1/b', '1/c'},
+            set(),
         ),
         (
-            ['*/a'],
-            ['1/a:x'],
-            []
+            {'*/a'},
+            {'1/a'},
+            set(),
         ),
         (
-            ['*/z'],
-            [],
-            ['*/z']
+            {'*/z'},
+            set(),
+            {'*/z'}
         ),
         (
-            ['*/*:x'],
-            ['1/a:x', '1/b:x', '1/c:x'],
-            [],
+            {'*/*:x'},
+            {'1/a', '1/b', '1/c'},
+            set(),
         ),
         (
-            ['*/*:y'],
-            [],
-            ['*/*:y'],
+            {'*/*:y'},
+            set(),
+            {'*/*:y'},
         ),
     ]
 )
-def test_filter_ids_task_mode(task_pool, ids, matched, not_matched):
-    """Ensure tasks are returned in task mode."""
-    pool = task_pool(
-        {
-            1: ['1/a:x', '1/b:x', '1/c:x']
-        },
-        {}
-    )
-
-    _matched, _not_matched, _invalid = filter_ids(
+def test_match_task(test_config, ids, matched, unmatched):
+    """It should match task IDs."""
+    pool = to_tokens('1/a:x', '1/b:x', '1/c:x')
+    _matched, _unmatched = _id_match(
+        test_config,
         pool,
         ids,
-        IntegerPoint('1'),
-        IntegerPoint('1'),
+        only_match_pool=True,
     )
-    assert [get_task_id(itask) for itask in _matched] == matched
-    assert _not_matched == not_matched
-    assert not _invalid
+    assert _matched == matched
+    assert _unmatched == unmatched
 
 
 @pytest.mark.parametrize(
-    'ids,matched,not_matched',
+    'ids,matched,unmatched',
     [
         (
-            ['1/a'],
-            [1],
-            [],
+            {'1/a'},
+            {'1/a'},
+            set(),
         ),
         (
-            ['1/*'],
-            [1],
-            [],
+            {'1/*'},
+            {'1/a', '1/b'},
+            set(),
         ),
         (
-            ['1/*:x'],
-            [1],
-            [],
+            {'1/*:x'},
+            {'1/a', '1/b'},
+            set(),
         ),
         (
-            ['1/*:y'],
-            [],
-            ['1/*:y'],
+            {'1/*:y'},
+            set(),
+            {'1/*:y'},
         ),
         (
-            ['*/*:x'],
-            [1],
-            [],
+            {'*/*:x'},
+            {'1/a', '1/b', '2/a'},
+            set(),
         ),
         (
-            ['1/z'],
-            [],
-            ['1/z'],
+            {'1/z'},
+            set(),
+            {'1/z'},
         ),
         (
-            ['1'],
-            [1],
-            [],
+            {'1'},
+            {'1/a', '1/b'},
+            set(),
         ),
         (
-            ['3'],
-            [],
-            ['3'],
+            {'3'},
+            set(),
+            {'3'},
         ),
     ]
 )
-def test_filter_ids_cycle_mode(task_pool, ids, matched, not_matched):
-    """Ensure cycle poinds are returned in cycle mode."""
-    pool = task_pool(
-        {
-            1: ['1/a:x', '1/b:x'],
-            2: ['1/a:x'],
-            3: [],
-        },
-        {}
-    )
-
-    _matched, _not_matched, _invalid = filter_ids(
+def test_match_cycle(test_config, ids, matched, unmatched):
+    """It should match cycle IDs."""
+    pool = to_tokens('1/a:x', '1/b:x', '2/a:x')
+    assert _id_match(
+        test_config,
         pool,
         ids,
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        out=IDTokens.Cycle,
-    )
-    assert _matched == [IntegerPoint(i) for i in matched]
-    assert _not_matched == not_matched
-    assert not _invalid
-
-
-def test_filter_ids_invalid(caplog):
-    """Ensure invalid IDs are handled elegantly."""
-    _matched, _not_matched, _invalid = filter_ids(
-        {},
-        ['#'],
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-    )
-    assert _matched == []
-    assert _not_matched == ['#']
-    assert not _invalid
-    assert caplog.record_tuples == [
-        ('cylc', 30, 'No active tasks matching: #'),
-    ]
-
-    caplog.clear()
-    _matched, _not_matched, _invalid = filter_ids(
-        {},
-        ['#'],
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        warn=False,
-    )
-    assert caplog.record_tuples == []
-    assert not _invalid
-
-
-def test_filter_ids_pattern_match_off(task_pool):
-    """Ensure filtering works when pattern matching is turned off."""
-    pool = task_pool(
-        {
-            1: ['1/a:x'],
-        },
-        {}
-    )
-
-    _matched, _not_matched, _invalid = filter_ids(
-        pool,
-        ['1/a'],
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        out=IDTokens.Task,
-        pattern_match=False,
-    )
-    assert [get_task_id(itask) for itask in _matched] == ['1/a:x']
-    assert _not_matched == []
-    assert not _invalid
-
-
-def test_filter_ids_toggle_pattern_matching(task_pool, caplog):
-    """Ensure pattern matching can be toggled on and off."""
-    pool = task_pool(
-        {
-            1: ['1/a:x'],
-        },
-        {}
-    )
-
-    ids = ['*/*']
-
-    # ensure pattern matching works
-    _matched, _not_matched, _invalid = filter_ids(
-        pool,
-        ids,
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        out=IDTokens.Task,
-        pattern_match=True,
-    )
-    assert [get_task_id(itask) for itask in _matched] == ['1/a:x']
-    assert _not_matched == []
-    assert not _invalid
-
-    # ensure pattern matching can be disabled
-    caplog.clear()
-    _matched, _not_matched, _invalid = filter_ids(
-        pool,
-        ids,
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        out=IDTokens.Task,
-        pattern_match=False,
-    )
-    assert [get_task_id(itask) for itask in _matched] == []
-    assert _not_matched == ['*/*']
-    assert not _invalid
-
-    # ensure the ID is logged
-    assert len(caplog.record_tuples) == 1
-    assert '*/*' in caplog.record_tuples[0][2]
+        only_match_pool=True,
+    ) == (matched, unmatched)
 
 
 @pytest.mark.parametrize(
-    'ids,matched,not_matched',
+    'ids,matched,unmatched',
     [
-        (['1/A'], ['1/a:x'], []),
-        (['1/B'], ['1/b1:x', '1/b2:x'], []),
-        (['1/C'], [], ['1/C']),
-        (['1/root'], ['1/a:x', '1/b1:x', '1/b2:x'], []),
+        (
+            {'1/root'},
+            {'1/a', '1/b', '1/c', '1/d', '1/z'},
+            set(),
+        ),
+        (
+            {'2/root'},
+            {'2/a', '2/b', '2/c', '2/d'},  # 1/z isn't in cycle 2
+            set(),
+        ),
+        (
+            {'*/root'},
+            # should match all active cycles (i.e. cycles 1 and 2)
+            {'1/a', '1/b', '1/c', '1/d', '1/z', '2/a', '2/b', '2/c', '2/d'},
+            set(),
+        ),
+        (
+            {'1/[ad]'},
+            {'1/a', '1/d'},
+            set(),
+        ),
+        (
+            {'1/[!ad]'},
+            {'1/b', '1/c', '1/z'},
+            set(),
+        ),
     ]
 )
-def test_filter_ids_namespace_hierarchy(task_pool, ids, matched, not_matched):
-    """Ensure matching includes namespaces."""
-    pool = task_pool(
-        {
-            1: ['1/a:x', '1/b1:x', '1/b2:x']
-        },
-        {
-            'a': ['A'],
-            'b1': ['B'],
-            'b2': ['B'],
-        },
-    )
-
-    _matched, _not_matched, _invalid = filter_ids(
-        pool,
+def test_match_inactive(test_config, ids, matched, unmatched):
+    """It should match non-pool tasks"""
+    assert _id_match(
+        test_config,
+        to_tokens('1/a:running', '2/a:waiting'),  # active cycles are 1 and 2
         ids,
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        pattern_match=False,
-    )
-
-    assert [get_task_id(itask) for itask in _matched] == matched
-    assert _not_matched == not_matched
-    assert not _invalid
-
-
-def test_filter_ids_out_format():
-    filter_ids(
-        {},
-        [],
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-        out=IDTokens.Cycle,
-    )
-    with pytest.raises(ValueError):
-        filter_ids(
-            {},
-            [],
-            IntegerPoint('1'),
-            IntegerPoint('1'),
-            out=IDTokens.Job,
-        )
-
-
-def test_filter_ids_log_errors(caplog):
-    *_, _invalid = filter_ids(
-        {},
-        ['/////'],
-        IntegerPoint('1'),
-        IntegerPoint('1'),
-    )
-    assert _invalid == ['/////']
-    assert caplog.record_tuples == [('cylc', 30, 'Invalid ID: /////')]
+    ) == (matched, unmatched)
 
 
 @pytest.mark.parametrize(
-    'point, value, pattern_match, expected',
+    'ids,matched,unmatched',
     [
-        (IntegerPoint('23'), '23', True, True),
-        (IntegerPoint('23'), '23', False, True),
-        (IntegerPoint('23'), '2*', True, True),
-        (IntegerPoint('23'), '2*', False, False),
-        (IntegerPoint('23'), '2a', True, False),
-        (ISO8601Point('2049-01-01T00:00Z'), '2049', True, True),
-        (ISO8601Point('2049-01-01T00:00Z'), '2049', False, True),
-        (ISO8601Point('2049-03-01T00:00Z'), '2049', True, False),
-        (ISO8601Point('2049-03-01T00:00Z'), '2049*', True, True),
-        (ISO8601Point('2049-03-01T00:00Z'), '2049*', False, False),
-        (ISO8601Point('2049-01-01T00:00Z'), '20490101T00Z', False, True),
-        (ISO8601Point('2049-01-01T00:00Z'), '20490101T03+03', False, True),
-        (ISO8601Point('2049-01-01T00:00Z'), '2049a', True, False),
+        ({'1/A'}, {'1/a'}, set()),
+        ({'1/B'}, {'1/b1', '1/b2'}, set()),
+        ({'1/C'}, set(), {'1/C'}),
+        ({'1/root'}, {'1/a', '1/b1', '1/b2'}, set()),
     ]
 )
-def test_point_match(
-    point: 'PointBase', value: str, pattern_match: bool, expected: bool,
-    set_cycling_type: Callable
-):
-    set_cycling_type(point.TYPE, time_zone='Z')
-    assert point_match(point, value, pattern_match) is expected
+def test_match_family(tmp_path, ids, matched, unmatched):
+    """It should match family IDs."""
+    pool = to_tokens('1/a:x', '1/b1:x', '1/b2:x')
+
+    path = tmp_path / 'flow.cylc'
+    with open(path, 'w+') as flow_cylc:
+        flow_cylc.write(dedent('''
+            [scheduling]
+                cycling mode = integer
+                initial cycle point = 1
+                [[graph]]
+                    P1 = a & b1 & b2
+            [runtime]
+                [[a]]
+                    inherit = A
+                [[b1, b2]]
+                    inherit = B
+                [[A, B]]
+        '''))
+    config = WorkflowConfig('test', str(path), SimpleNamespace())
+
+    assert _id_match(config, pool, ids) == (matched, unmatched)


### PR DESCRIPTION
* Implement a single task ID matching interface which will satisfy all currently documented use cases / requirements.
* Closes #5827. Allow IDs including families or globs to match against inactive tasks.
* Closes #5750. Only match tasks to release against the "pool" of tasks which are actually held.
* Addresses #4357 & #5677 Abstract task matching from task pool objects. This simplifies its logic, but also unlocks the ability to add a command / GraphQL interface for listing IDs that match provided patterns. The remaining work required for this is outlined in https://github.com/cylc/cylc-uiserver/issues/720.
* Additionally:
  * Standardise task ID parsing, validation and standardisation and perform it upfront in `cylc.flow.commands` to ensure validation is not required in internal interfaces and sanitisation errors cannot occur there.
  * Add a subclass `TaskTokens(Tokens)` type which enforces the presence of cycle and task fields. This makes it easier to use `Tokens` objects in typed code.
  * Fix a `__hash__` computation error for `Tokens` objects which caused erroneous inequality.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/867
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.