### PR TITLE
6596 force remote retrieval

### DIFF
--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -66,7 +66,6 @@ from contextlib import suppress
 from glob import glob
 from pathlib import Path
 import shlex
-import logging
 from subprocess import Popen, PIPE, DEVNULL
 import sys
 from typing import TYPE_CHECKING
@@ -93,12 +92,12 @@ from cylc.flow.task_job_logs import (
     JOB_LOG_OUT, JOB_LOG_ERR, JOB_LOG_OPTS, NN, JOB_LOG_ACTIVITY)
 from cylc.flow.terminal import cli_function
 from cylc.flow.platforms import get_platform
+from cylc.flow import LOG
 
 
 if TYPE_CHECKING:
     from optparse import Values
 
-logger = logging.getLogger(__name__)
 
 WORKFLOW_LOG_OPTS = {
     'c': ('workflow configuration file (raw)', r'config/*-start-*.cylc'),
@@ -571,8 +570,10 @@ def _main(
         )
 
         job_log_present = (Path(local_log_dir) / "job.out").exists()
-        logger.debug("job_log_present: %s", job_log_present,
-                     " getting job log remotely)")
+        # For testing purposes
+        if not job_log_present:
+            LOG.debug("job.out not present, getting job log remotely")
+
         log_is_remote = (is_remote_platform(platform)
                          and (options.filename != JOB_LOG_ACTIVITY))
         log_is_retrieved = (platform['retrieve job logs']

--- a/tests/functional/cylc-cat-log/15-remote_when_no_local_log.t
+++ b/tests/functional/cylc-cat-log/15-remote_when_no_local_log.t
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "cylc cat-log" for remote tasks.
+export REQUIRE_PLATFORM='loc:remote'
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+set_test_number 4
+create_test_global_config "" "
+[platforms]
+   [[${CYLC_TEST_PLATFORM}]]
+       retrieve job logs = False"
+install_workflow "${TEST_NAME_BASE}" "${TEST_NAME_BASE}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-validate"
+run_ok "${TEST_NAME}" cylc validate "${WORKFLOW_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME="${TEST_NAME_BASE}-run"
+workflow_run_ok "${TEST_NAME}" \
+    cylc play --debug --no-detach \
+        -s "CYLC_TEST_PLATFORM='${CYLC_TEST_PLATFORM}'" "${WORKFLOW_NAME}"
+#-------------------------------------------------------------------------------
+TEST_NAME=${TEST_NAME_BASE}-task-job
+cylc cat-log -f j "${WORKFLOW_NAME}//1/a-task" >"${TEST_NAME}.out"
+contains_ok "${TEST_NAME}.out" - << __END__
+# SCRIPT:
+# Write to task stdout log
+echo "the quick brown fox"
+# Write to task stderr log
+echo "jumped over the lazy dog" >&2
+# Write to a custom log file
+echo "drugs and money" > \${CYLC_TASK_LOG_ROOT}.custom-log
+__END__
+#-------------------------------------------------------------------------------
+# remote
+TEST_NAME=${TEST_NAME_BASE}-no_log_remote
+cylc cat-log -f j "${WORKFLOW_NAME}//1/a-task" >"${TEST_NAME}.out"
+grep_ok "${WORKFLOW_NAME}/log/job/1/a-task/NN/job$" "${TEST_NAME}.out"
+#-------------------------------------------------------------------------------
+# Clean up the task host.
+purge
+exit

--- a/tests/functional/cylc-cat-log/15-remote_when_no_local_log/flow.cylc
+++ b/tests/functional/cylc-cat-log/15-remote_when_no_local_log/flow.cylc
@@ -1,0 +1,21 @@
+#!Jinja2
+[scheduler]
+   [[events]]
+       abort on stall timeout = True
+       stall timeout = PT1M
+[scheduling]
+    [[graph]]
+        R1 = a-task => b-task
+[runtime]
+    [[a-task]]
+        script = """
+# Write to task stdout log
+echo "the quick brown fox"
+# Write to task stderr log
+echo "jumped over the lazy dog" >&2
+# Write to a custom log file
+echo "drugs and money" > ${CYLC_TASK_LOG_ROOT}.custom-log
+"""
+        platform = {{CYLC_TEST_PLATFORM | default("localhost")}}
+    [[b-task]]
+        script = """rm ${CYLC_WORKFLOW_RUN_DIR}/log/${CYLC_TASK_CYCLE_POINT}/a-task/NN/job.out"""

--- a/tests/functional/cylc-cat-log/15-remote_when_no_local_log/flow.cylc
+++ b/tests/functional/cylc-cat-log/15-remote_when_no_local_log/flow.cylc
@@ -10,12 +10,8 @@
     [[a-task]]
         script = """
 # Write to task stdout log
-echo "the quick brown fox"
-# Write to task stderr log
-echo "jumped over the lazy dog" >&2
-# Write to a custom log file
-echo "drugs and money" > ${CYLC_TASK_LOG_ROOT}.custom-log
+echo "Master, Master! Where are those dreams that I've been after?"
 """
         platform = {{CYLC_TEST_PLATFORM | default("localhost")}}
     [[b-task]]
-        script = """rm ${CYLC_WORKFLOW_RUN_DIR}/log/${CYLC_TASK_CYCLE_POINT}/a-task/NN/job.out"""
+        script = """rm ${CYLC_WORKFLOW_RUN_DIR}/log/job/1/a-task/NN/job.out"""


### PR DESCRIPTION
This PR addresses the issue #6596.
There was an issue where if cat-log is ran in a small window of time between when a task finishes, but before the logs are copied locally, cat-log could display logs incorrectly. This change looks to see if the job.out log is present locally and if not, it defaults to remote retrieval.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
