### PR TITLE
job log retrieval: remove duplicate logging

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1229,8 +1229,6 @@ class TaskEventsManager():
             or (proc_ctx.ret_code and proc_ctx.ret_code != 255)
         ):
             LOG.error(proc_ctx)
-        else:
-            LOG.debug(proc_ctx)
         id_key: EventKey
         for id_key in proc_ctx.cmd_kwargs["id_keys"]:
             try:

--- a/tests/unit/test_task_events_mgr.py
+++ b/tests/unit/test_task_events_mgr.py
@@ -15,49 +15,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
 from cylc.flow.broadcast_mgr import BroadcastMgr
-from cylc.flow.subprocctx import SubProcContext
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.taskdef import TaskDef
-
-
-@patch("cylc.flow.task_events_mgr.LOG")
-def test_log_error_on_error_exit_code(cylc_log):
-    """Test that an error log is emitted when the log retrieval command
-    exited with a code different than zero.
-
-    :param cylc_log: mocked cylc logger
-    :type cylc_log: mock.MagicMock
-    """
-    task_events_manager = TaskEventsManager(
-        None, None, None, None, None, None, None, None, None)
-    proc_ctx = SubProcContext(
-        cmd_key=None, cmd="error", ret_code=1, err="Error!", id_keys=[])
-    task_events_manager._job_logs_retrieval_callback(proc_ctx, None)
-    assert cylc_log.error.call_count == 1
-    assert cylc_log.error.call_args.contains("Error!")
-
-
-@patch("cylc.flow.task_events_mgr.LOG")
-def test_log_debug_on_noerror_exit_code(cylc_log):
-    """Test that a debug log is emitted when the log retrieval command
-    exited with an non-error code (i.e. 0).
-
-    :param cylc_log: mocked cylc logger
-    :type cylc_log: mock.MagicMock
-    """
-    task_events_manager = TaskEventsManager(
-        None, None, None, None, None, None, None, None, None)
-    proc_ctx = SubProcContext(
-        cmd_key=None, cmd="ls /tmp/123", ret_code=0, err="", id_keys=[])
-    task_events_manager._job_logs_retrieval_callback(proc_ctx, None)
-    assert cylc_log.debug.call_count == 1
-    assert cylc_log.debug.call_args.contains("ls /tmp/123")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
All subprocs are already logged at DEBUG level by the subprocpool:

https://github.com/cylc/cylc-flow/blob/3706f18bc49fe7a2d0cc40cd128cbd86278b1ac1/cylc/flow/subprocpool.py#L250-L252

So no need to repeat that just for job-log-retrieval.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed) - nope
- [x] Changelog entry included if this is a change that can affect users - irrelevant
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
