### PR TITLE
fix no cfg xtrig broadcast delta shutdown

### DIFF
--- a/changes.d/6936.fix.md
+++ b/changes.d/6936.fix.md
@@ -1,0 +1,1 @@
+Fixes workflow shutdown on reload with orphaned xtriggered task.


### PR DESCRIPTION
So this occurred on workflow reload after xtrigger removal:
```
2025-08-24T09:54:16Z CRITICAL - An uncaught error caused Cylc to shut down.
    If you think this was an issue in Cylc, please report the following traceback to the developers.
    https://github.com/cylc/cylc-flow/issues/new?assignees=&labels=bug&template=bug.md&title=;
2025-08-24T09:54:16Z ERROR - 'cvt_nzlam_ps38_stats_sync'
    Traceback (most recent call last):
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/scheduler_cli.py", line 710, in cylc_play
        asyncio.get_running_loop()
    RuntimeError: no running event loop
    During handling of the above exception, another exception occurred:
    Traceback (most recent call last):
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/scheduler.py", line 703, in run_scheduler
        await self._main_loop()
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/scheduler.py", line 1636, in _main_loop
        self.xtrigger_mgr.call_xtriggers_async(itask)
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/xtrigger_mgr.py", line 722, in call_xtriggers_async
        self.broadcast_mgr.put_broadcast(
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/broadcast_mgr.py", line 381, in put_broadcast
        self.data_store_mgr.delta_broadcast()
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/data_store_mgr.py", line 2311, in delta_broadcast
        self._generate_broadcast_node_deltas(
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/data_store_mgr.py", line 2339, in _generate_broadcast_node_deltas
        cfg['runtime'][node.name]
      File "/opt/niwa/share/cylc/cylc-8.5.0/lib/python3.9/site-packages/cylc/flow/parsec/OrderedDict.py", line 38, in __getitem__
        return OrderedDict.__getitem__(self, key)
    KeyError: 'cvt_nzlam_ps38_stats_sync'
```

This could happen with an orphaned running task, to mitigate I've handled this and similar calls in the data-store to carry on with an empty runtime item.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
