### PR TITLE
Fix scheduler crash after broadcasting `run mode = skip`

### DIFF
--- a/changes.d/6940.fix.md
+++ b/changes.d/6940.fix.md
@@ -1,0 +1,1 @@
+Fixed a scheduler crash that could occur after re-running a task in skip mode.

--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -1952,6 +1952,11 @@ class TaskEventsManager():
         >>> this([], 10, [5])
         [15, 5]
 
+        # There are no execution time limit polling intervals set - just
+        # repeat the execution polling interval until the time limit:
+        >>> this([10], 25, None)
+        [10, 10]
+
         # We have a list of execution time limit polling intervals,
         >>> this([10], 25, [5, 6, 7, 8])
         [10, 10, 10, 6, 7, 8]
@@ -1968,17 +1973,19 @@ class TaskEventsManager():
             size = int((time_limit - sum(delays)) / delays[-1])
             delays.extend([delays[-1]] * size)
 
-        # After the last delay before the execution time limit add the
-        # delay to get to the execution_time_limit
-        if len(time_limit_polling_intervals) == 1:
-            time_limit_polling_intervals.append(
-                time_limit_polling_intervals[0]
-            )
-        time_limit_polling_intervals[0] += time_limit - sum(delays)
+        if time_limit_polling_intervals:
+            # After the last delay before the execution time limit add the
+            # delay to get to the execution_time_limit
+            if len(time_limit_polling_intervals) == 1:
+                time_limit_polling_intervals.append(
+                    time_limit_polling_intervals[0]
+                )
+            time_limit_polling_intervals[0] += time_limit - sum(delays)
 
-        # After the execution time limit poll at execution time limit polling
-        # intervals.
-        delays += time_limit_polling_intervals
+            # After the execution time limit, poll at the
+            # execution time limit polling intervals.
+            delays += time_limit_polling_intervals
+
         return delays
 
     def add_event_timer(self, id_key: EventKey, event_timer) -> None:


### PR DESCRIPTION
### Bug

```cylc
[scheduling]
    [[graph]]
        R1 = foo
[runtime]
    [[foo]]
        script = false
        execution time limit = PT1M
```

1. Play the workflow and wait for `foo` to fail
2. Broadcast `run mode = skip` to `1/root`
3. Trigger `foo`
4. Scheduler crashes
```
Traceback (most recent call last):
  File "~/cylc-flow/cylc/flow/scheduler.py", line 703, in run_scheduler
    await self._main_loop()
  File "~/cylc-flow/cylc/flow/scheduler.py", line 1654, in _main_loop
    self.release_tasks_to_run()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/cylc-flow/cylc/flow/scheduler.py", line 1374, in release_tasks_to_run
    return self.start_job_submission(pre_prep_tasks)
            ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "~/cylc-flow/cylc/flow/scheduler.py", line 1391, in start_job_submission
    submitted = self.submit_task_jobs(itasks)
  File "~/cylc-flow/cylc/flow/scheduler.py", line 1418, in submit_task_jobs
    return self.task_job_mgr.submit_task_jobs(itasks, self.get_run_mode())
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/cylc-flow/cylc/flow/task_job_mgr.py", line 289, in submit_task_jobs
    itasks, submitted_nonlive_tasks = self.submit_nonlive_task_jobs(
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        itasks, run_mode
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "~/cylc-flow/cylc/flow/task_job_mgr.py", line 1108, in submit_nonlive_task_jobs
    if submit_func and submit_func(self, itask, rtconfig, now):
                        ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/cylc-flow/cylc/flow/run_modes/skip.py", line 97, in submit_task_job
    task_job_mgr.task_events_mgr.process_message(itask, INFO, output)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "~/cylc-flow/cylc/flow/task_events_mgr.py", line 754, in process_message
    self._process_message_started(itask, event_time, forced)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/cylc-flow/cylc/flow/task_events_mgr.py", line 1400, in _process_message_started
    self._reset_job_timers(itask)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "~/cylc-flow/cylc/flow/task_events_mgr.py", line 1881, in _reset_job_timers
    delays = self.process_execution_polling_intervals(
        execution_polling_intervals,
        time_limit,
        time_limit_polling_intervals
    )
  File "~/cylc-flow/cylc/flow/task_events_mgr.py", line 1975, in process_execution_polling_intervals
    if len(time_limit_polling_intervals) == 1:
        ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```


### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] Docs PR not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
