### PR TITLE
Fix cat-log test timing out

### DIFF
--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -83,8 +83,10 @@ def get_proc_ancestors():
 def watch_and_kill(proc):
     """Kill proc if my PPID (etc.) changed - e.g. ssh connection dropped."""
     gpa = get_proc_ancestors()
+    # Allow customising the interval to allow tests to run faster:
+    interval = float(os.getenv('CYLC_PROC_POLL_INTERVAL', 60))
     while True:
-        sleep(60)
+        sleep(interval)
         if proc.poll() is not None:
             break
         if get_proc_ancestors() != gpa:

--- a/tests/functional/cylc-cat-log/12-delete-kill.t
+++ b/tests/functional/cylc-cat-log/12-delete-kill.t
@@ -33,6 +33,8 @@ __EOF__
 log_file="${WORKFLOW_RUN_DIR}/log/foo.log"
 echo "Hello, Mr. Thompson" > "$log_file"
 
+export CYLC_PROC_POLL_INTERVAL=0.5
+
 TEST_NAME="${TEST_NAME_BASE}-delete"
 cylc cat-log --mode=tail "$WORKFLOW_NAME" -f foo.log 2>&1 &
 cat_log_pid="$!"


### PR DESCRIPTION
Follow-up to #6871

When cat-log is run in tail mode, and the log file is deleted or the tail process is killed, cat-log exits after 60s since #6871.

However, the test `tests/functional/cylc-cat-log/12-delete-kill.t` is waiting 60s for the cat-log process to exit so the test has become slow + flaky.

This fix allows customising the interval for watching the tail process via an env var so that the test can be made to run quickly.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are updated
- [x] Changelog entry not needed
- [x] Docs PR not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
