### PR TITLE
fix broadcast cancel error

### DIFF
--- a/changes.d/6952.fix.md
+++ b/changes.d/6952.fix.md
@@ -1,0 +1,1 @@
+Fixed `cylc broadcast` failing when cancelling `[events]` settings.

--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -2043,13 +2043,20 @@ with Conf(
                 ''')
 
 
-def upg(cfg, descr):
+def upg(cfg, descr, for_cancel_broadcast=False):
     """Upgrade old workflow configuration.
 
     NOTE: We are silencing deprecation (and only deprecation) warnings
     when in Cylc 7 compat mode to help support Cylc 7/8 compatible workflows
     (which would loose Cylc 7 compatibility if users were to follow the
     warnings and upgrade the syntax).
+
+    Args:
+        for_cancel_broadcast:
+            If True, extra validation steps which inspect configuration values
+            will be skipped. This is used for "cylc broadcast --cancel" where
+            the values are not known.
+            See https://github.com/cylc/cylc-flow/issues/6950.
 
     """
     u = upgrader(cfg, descr)
@@ -2255,11 +2262,11 @@ def upg(cfg, descr):
     )
     u.upgrade()
 
-    upgrade_graph_section(cfg, descr)
-    upgrade_param_env_templates(cfg, descr)
-
-    warn_about_depr_platform(cfg)
-    warn_about_depr_event_handler_tmpl(cfg)
+    if not for_cancel_broadcast:
+        upgrade_graph_section(cfg, descr)
+        upgrade_param_env_templates(cfg, descr)
+        warn_about_depr_platform(cfg)
+        warn_about_depr_event_handler_tmpl(cfg)
 
     return u
 

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -167,7 +167,7 @@ def get_padding(settings, level=0, padding=0):
     return padding
 
 
-def get_rdict(left, right=None):
+def get_rdict(left, right=None, for_cancel_broadcast=False):
     """Check+transform left=right into a nested dict.
 
     left can be key, [key], [key1]key2, [key1][key2], [key1][key2]key3, etc.
@@ -193,7 +193,11 @@ def get_rdict(left, right=None):
             # item = right
             cur_dict[tail.strip()] = right
             tail = None
-    upg({'runtime': {'__MANY__': rdict}}, 'test')
+    upg(
+        {'runtime': {'__MANY__': rdict}},
+        'test',
+        for_cancel_broadcast=for_cancel_broadcast,
+    )
     # Perform validation, but don't coerce the original (deepcopy).
     cylc_config_validate(deepcopy(rdict), SPEC['runtime']['__MANY__'])
     return rdict
@@ -433,7 +437,7 @@ async def run(options: 'Values', workflow_id):
                 raise InputError(
                     "--cancel=[SEC]ITEM does not take a value")
             option_item = option_item.strip()
-            setting = get_rdict(option_item)
+            setting = get_rdict(option_item, for_cancel_broadcast=True)
             settings.append(setting)
         files_to_settings(settings, options.cancel_files, options.cancel)
         mutation_kwargs['variables'].update(


### PR DESCRIPTION
* Closes #6950
* Disable an upgrader-patched validation check which is incompatible with `cylc broadcast --cancel`.

So `cylc broadcast` runs config fragments via `cylc.flow.cfgspec.workflow` in order to run them through the upgraders.

Cute, means you can still broadcast deprecated settings, not sure why we support that though?

We have patched some validation stuff into the upgrader (naughty) which is incompatible with this usage.

**Check List**

- [X] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.