### PR TITLE
docs: always specify an interval with `cpu_percent`

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1016,8 +1016,8 @@ with Conf('global.cylc', desc='''
 
                 .. code-block:: python
 
-                   # rank hosts by cpu_percent
-                   cpu_percent()
+                   # rank hosts by cpu_percent over a 1 second interval
+                   cpu_percent(1)  # Note: monitors CPU for 1 second
 
                    # rank hosts by 15min average of server load
                    getloadavg()[2]
@@ -1040,7 +1040,7 @@ with Conf('global.cylc', desc='''
                 .. code-block:: python
 
                    # filter out hosts with a CPU utilisation of 70% or above
-                   cpu_percent() < 70
+                   cpu_percent(1) < 70
 
                    # filter out hosts with less than 1GB of RAM available
                    virtual_memory().available > 1000000000
@@ -1057,14 +1057,14 @@ with Conf('global.cylc', desc='''
                 .. code-block:: python
 
                    # filter hosts
-                   cpu_percent() < 70
+                   cpu_percent(1) < 70
                    disk_usage('/').free > 1000000000
 
                    # rank hosts by CPU count
                    1 / cpu_count()
                    # if two hosts have the same CPU count
                    # then rank them by CPU usage
-                   cpu_percent()
+                   cpu_percent(1)
 
                 .. versionchanged:: 8.0.0
 

--- a/cylc/flow/host_select.py
+++ b/cylc/flow/host_select.py
@@ -185,14 +185,14 @@ def select_host(
 
                # only consider hosts with less than 70% cpu usage
                # and a server load of less than 5
-               cpu_percent() < 70
+               cpu_percent(1) < 70
                getloadavg()[0] < 5
 
             And or Python statements to rank hosts by e.g::
 
                # rank by used cpu, then by load average as a tie-break
                # (lower scores are better)
-               cpu_percent()
+               cpu_percent(1)
                getloadavg()
 
             Comments are allowed using `#` but not inline comments.


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-doc/issues/829
* `cpu_percent` typically returns `0.0` on the first call as the monitoring period elapses from module import.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.