### PR TITLE
Fix docker FROM AS/as error.

### DIFF
--- a/dockerfiles/cylc-dev/Dockerfile
+++ b/dockerfiles/cylc-dev/Dockerfile
@@ -21,7 +21,7 @@ RUN \
 # 2) The Cylc image
 #    This has the Cylc Mamba environment installed and activated by default in
 #    Bash shells. However, it does not have Mamba installed.
-FROM ubuntu:latest as cylc-dev
+FROM ubuntu:latest AS cylc-dev
 
 COPY --from=mamba /tmp/venv /venv
 COPY ./ /cylc


### PR DESCRIPTION
After swarm build failed in CI (for other reasons - slow download?):

```
 135.6 critical libmamba Could not solve for environment specs
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
Dockerfile:8
---------------
```

(Does that really matter? 🤣 )

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->
