### PR TITLE
broadcast: reduce the broadcast expire limit

### DIFF
--- a/changes.d/6964.feat.md
+++ b/changes.d/6964.feat.md
@@ -1,0 +1,2 @@
+Automatic broadcast expiry is now delayed to make it easier to re-trigger
+tasks from the previous cycle.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2346,6 +2346,23 @@ class WorkflowConfig:
             # dependencies are checked in generate_triggers:
             self.check_terminal_outputs(parser.terminals)
 
+        # set of all cycling intervals containined within the workflow
+        cycling_intervals = {
+            sequence.get_interval()
+            for sequence in self.sequences
+        } | {
+            # add a null interval to handle async workflows
+            get_interval_cls().get_null()
+        }
+
+        # determine the longest cycling interval in the workflow
+        self.interval_of_longest_sequence: 'IntervalBase' = max({
+            interval for interval in cycling_intervals
+            # NOTE: None type sorts above a null interval for strange
+            # historical reasons so must be filtered out
+            if interval is not None
+        })
+
         self.set_required_outputs(task_output_opt)
 
         # Detect use of xtrigger names with '@' prefix (creates a task).

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -406,7 +406,11 @@ class ISO8601Sequence(SequenceBase):
                     exclusion_start_point,
                     exclusion_end_point)
 
-        self.step = ISO8601Interval(str(self.recurrence.duration))
+        self.step = (
+            ISO8601Interval(str(self.recurrence.duration))
+            if self.recurrence.duration
+            else ISO8601Interval.get_null()
+        )
         self.value = str(self.recurrence)
         # Concatenate the strings in exclusion list
         if self.exclusions:

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ testpaths =
     cylc/flow/
     tests/unit/
     tests/integration/
+    tests/conftest.py
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     ELLIPSIS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import logging
 import re
 from pathlib import Path
 from shutil import rmtree
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import pytest
 
@@ -175,9 +175,11 @@ def capcall(monkeypatch):
         function_string:
             The function to replace as it would be specified to
             monkeypatch.setattr.
-        substitute_function:
-            An optional function to replace it with, otherwise the captured
-            function will return None.
+        mock:
+            * If True, the function will be replaced by a "return None".
+            * If False, the oringal function will be run.
+            * If a Callable is provided, this will be run in place of the
+              original function.
 
     Returns:
         [(args: Tuple, kwargs: Dict), ...]
@@ -190,15 +192,80 @@ def capcall(monkeypatch):
 
     """
 
-    def _capcall(function_string, substitute_function=None):
+    def _capcall(function_string: str, mock: bool | Callable = True):
         calls = []
+
+        if mock is True:
+            fcn = lambda *args, **kwargs: None
+        elif mock is False:
+            fcn = import_object_from_string(function_string)
+        else:
+            fcn = mock
 
         def _call(*args, **kwargs):
             calls.append((args, kwargs))
-            if substitute_function:
-                return substitute_function(*args, **kwargs)
+            return fcn(*args, **kwargs)
 
         monkeypatch.setattr(function_string, _call)
         return calls
 
     return _capcall
+
+
+def import_object_from_string(string):
+    """Import a Python object from a string path.
+
+    The path may reference a module, function, class, method, whatever.
+
+    Examples:
+        # import a module
+        >>> import_object_from_string('os')
+        <module 'os' ...>
+
+        # import a function
+        >>> import_object_from_string('os.path.walk')
+        <function walk at ...>
+
+        # import a constant from a namespace package
+        >>> import_object_from_string('cylc.flow.LOG')
+        <Logger cylc (WARNING)>
+
+        # import a class
+        >>> import_object_from_string('pathlib.Path')
+        <class 'pathlib.Path'>
+
+        # import a method
+        >>> import_object_from_string('pathlib.Path.exists')
+        <function Path.exists ...>
+
+    """
+    head = string
+    tail = []
+    while True:
+        try:
+            # try and import the thing
+            module = __import__(head)
+        except ModuleNotFoundError:
+            # if it's not something we can import, lop the last item off the
+            # end of the string and repeat
+            if '.' in head:
+                head, _tail = head.rsplit('.', 1)
+                tail.append(_tail)
+            else:
+                # we definitely can't import this
+                raise
+        else:
+            # we managed to import something
+            if '(namespace)' in str(module):
+                # with namespace packages you have to pull the module out of
+                # the package yourself
+                for part in head.split('.')[1:]:
+                    module = getattr(module, part)
+            break
+
+    # extract the requested object from the module (if requested)
+    obj = module
+    for part in reversed(tail):
+        obj = getattr(obj, part)
+
+    return obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,7 +177,7 @@ def capcall(monkeypatch):
             monkeypatch.setattr.
         mock:
             * If True, the function will be replaced by a "return None".
-            * If False, the oringal function will be run.
+            * If False, the original function will be run.
             * If a Callable is provided, this will be run in place of the
               original function.
 

--- a/tests/flakyfunctional/xtriggers/01-workflow_state.t
+++ b/tests/flakyfunctional/xtriggers/01-workflow_state.t
@@ -68,14 +68,14 @@ __END__
 # set' ('+') and later '... INFO - Broadcast cancelled:' ('-') line, where we
 # use as a test case an arbitrary task where such setting & cancellation occurs:
 contains_ok "${WORKFLOW_LOG}" << __LOG_BROADCASTS__
-${LOG_INDENT}+ [2015/f1] [environment]upstream_workflow=${WORKFLOW_NAME_UPSTREAM}
-${LOG_INDENT}+ [2015/f1] [environment]upstream_task=foo
-${LOG_INDENT}+ [2015/f1] [environment]upstream_point=2015
-${LOG_INDENT}+ [2015/f1] [environment]upstream_trigger=data_ready
-${LOG_INDENT}- [2015/f1] [environment]upstream_workflow=${WORKFLOW_NAME_UPSTREAM}
-${LOG_INDENT}- [2015/f1] [environment]upstream_task=foo
-${LOG_INDENT}- [2015/f1] [environment]upstream_point=2015
-${LOG_INDENT}- [2015/f1] [environment]upstream_trigger=data_ready
+${LOG_INDENT}+ [2014/f1] [environment]upstream_workflow=${WORKFLOW_NAME_UPSTREAM}
+${LOG_INDENT}+ [2014/f1] [environment]upstream_task=foo
+${LOG_INDENT}+ [2014/f1] [environment]upstream_point=2014
+${LOG_INDENT}+ [2014/f1] [environment]upstream_trigger=data_ready
+${LOG_INDENT}- [2014/f1] [environment]upstream_workflow=${WORKFLOW_NAME_UPSTREAM}
+${LOG_INDENT}- [2014/f1] [environment]upstream_task=foo
+${LOG_INDENT}- [2014/f1] [environment]upstream_point=2014
+${LOG_INDENT}- [2014/f1] [environment]upstream_trigger=data_ready
 __LOG_BROADCASTS__
 # ... and 2) in the DB.
 TEST_NAME="${TEST_NAME_BASE}-check-broadcast-in-db"
@@ -88,14 +88,14 @@ sqlite3 "${DB_FILE}" \
     'SELECT change, point, namespace, key, value FROM broadcast_events
      ORDER BY time, change, point, namespace, key' >"${NAME}"
 contains_ok "${NAME}" << __DB_BROADCASTS__
-+|2015|f1|[environment]upstream_workflow|${WORKFLOW_NAME_UPSTREAM}
-+|2015|f1|[environment]upstream_task|foo
-+|2015|f1|[environment]upstream_point|2015
-+|2015|f1|[environment]upstream_trigger|data_ready
--|2015|f1|[environment]upstream_workflow|${WORKFLOW_NAME_UPSTREAM}
--|2015|f1|[environment]upstream_task|foo
--|2015|f1|[environment]upstream_point|2015
--|2015|f1|[environment]upstream_trigger|data_ready
++|2014|f1|[environment]upstream_workflow|${WORKFLOW_NAME_UPSTREAM}
++|2014|f1|[environment]upstream_task|foo
++|2014|f1|[environment]upstream_point|2014
++|2014|f1|[environment]upstream_trigger|data_ready
+-|2014|f1|[environment]upstream_workflow|${WORKFLOW_NAME_UPSTREAM}
+-|2014|f1|[environment]upstream_task|foo
+-|2014|f1|[environment]upstream_point|2014
+-|2014|f1|[environment]upstream_trigger|data_ready
 __DB_BROADCASTS__
 
 purge

--- a/tests/functional/broadcast/00-simple.t
+++ b/tests/functional/broadcast/00-simple.t
@@ -47,7 +47,6 @@ cmp_ok "${NAME}" <<'__SELECT__'
 +|*|m7|[environment]BCAST|M7
 +|*|m8|[environment]BCAST|M8
 +|*|m9|[environment]BCAST|M9
--|20100808T00|foo|[environment]BCAST|FOO
 __SELECT__
 
 NAME='select-broadcast-states.out'
@@ -62,6 +61,7 @@ cmp_ok "${NAME}" <<'__SELECT__'
 *|m8|[environment]BCAST|M8
 *|m9|[environment]BCAST|M9
 *|root|[environment]BCAST|ROOT
+20100808T00|foo|[environment]BCAST|FOO
 20100809T00|baz|[environment]BCAST|BAZ
 20100809T00|m2|[environment]BCAST|M2
 __SELECT__


### PR DESCRIPTION
* Partially addresses #6308
* Broadcasts for a cycle are expired when there are no more active tasks in the cycle.
* At Cylc 7, there was (almost) always a succeeded task in the pool one cycle behind each active task.
* So the broadcast expire limit was the oldest cycle with active tasks *minus* the duration of the longest cycling sequence.
* This commit restores the Cylc 7 broadcast expire limit which ensures that the broadcasts for the previous instance of any given task are preserved.
* This better satisfies the use case of winding back a workflow to the previous cycle (i.e. to retrigger a task, reflow from a task or warm restart).

### The originally proposed solution

The solution suggested in #6308 was:
* Don't expire broadcasts automatically.
* Maintain a window of broadcasts in memory.
* Go to the DB to retrieve broadcasts when this window changed.

Unfortunately, this turned out to be a right pig to implement. Unfortunately, because broadcasts are managed from the server thread, it is not possible to go to the DB. Working around this problem is a major refactor on top of the work itself, which was also a major refactor.

### The newly proposed solution

This is essentially a Cylc 7 -> 8 migration issue. Although it doesn't make sense to auto-expire broadcasts (except from a memory management perspective) this expiry didn't cause any issues before.

This PR reduces the broadcast expire limit back to more-or-less what it was at Cylc 7 resolving the the "issue" part of the problem.

Removing auto-expiry may still be a mid/long term goal, but this would need to be done with a large scale refactor of the broadcast code. The broadcast code has a few issues, so a refactor may well be in order:

* The CLI does validation (and upgrading) client side (fingers crossed the client is at the same version!), the GUI gets no validation or upgrading whatsoever (#6429).
* Broadcasts are performed in the server thread, but I don't think there's a good reason for this.
* Broadcasts can only be cleared/expired by reproducing the exact settings they were issued with (#6402).

So we can always come back to this.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at https://github.com/cylc/cylc-doc/pull/871.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.