### PR TITLE
resolvers: catch object leak

### DIFF
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -629,6 +629,8 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
                     del delta_queues[w_id][sub_id]
             if sub_id in self.delta_store:
                 del self.delta_store[sub_id]
+            if sub_id in self.delta_processing_flows:
+                del self.delta_processing_flows[sub_id]
             yield None
 
     async def flow_delta_processed(self, context, op_id):


### PR DESCRIPTION
Fix a memory leak found in the resolver code.

`cylc.flow.network.resolvers.BaseResolvers.delta_processing_flows` is added to for each subscription. However, it seems never to be removed from.

There is the `BaseResolvers.flow_delta_processed` method (called from the UIS side) which housekeeps things within each entry. I'm not sure if this was intended to remove the entry for each subscription too. But I'm also not sure if this method would get called in the event of an exception, namely `GeneratorExit`.

#### Reproducible Example

```diff
diff --git a/cylc/flow/network/resolvers.py b/cylc/flow/network/resolvers.py
index 77e602d26..d24e0d450 100644
--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -516,6 +516,8 @@ class BaseResolvers(metaclass=ABCMeta):  # noqa: SIM119
         yielded GraphQL subscription objects.
 
         """
+        print('#', len(self.delta_processing_flows))
+
         # NOTE: we don't expect workflows to be returned in definition order
         # so it is ok to use `set` here
         workflow_ids = set(args.get('workflows', args.get('ids', ())))
```

```python
# ~/.cylc/uiserver/jupyter_config.py

c.ServerApp.websocket_ping_interval = 3
c.ServerApp.websocket_ping_timeout = 0.000001
```

Before (objects not cleaned up):

```console
$ cylc gui --new  # let it open to the Dashboard page
# 0
# 1
# 2
# 3
...
```

After (objects cleaned up):

```console
$ cylc gui --new  # let it open to the Dashboard page
# 0
# 0
# 0
# 0
...
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.