### PR TITLE
runahead limit: fix possible mode of failure

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -442,12 +442,11 @@ class TaskPool:
             self._prev_runahead_sequence_points = sequence_points
             self._prev_runahead_base_point = base_point
 
-        if count_cycles:
-            if not sequence_points:
-                limit_point = base_point
-            else:
-                # (len(list) may be less than ilimit due to sequence end)
-                limit_point = sorted(sequence_points)[:ilimit + 1][-1]
+        if not sequence_points:
+            limit_point = base_point
+        elif count_cycles:
+            # (len(list) may be less than ilimit due to sequence end)
+            limit_point = sorted(sequence_points)[:ilimit + 1][-1]
         else:
             limit_point = max(sequence_points)
 


### PR DESCRIPTION
* Closes #6855
* Fix a possible scenario where there are no sequence points to choose from.

I haven't actually reproduced this, however, the logical flaw seems obvious.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.