### PR TITLE
Turn off flake8-simplify for Python≥3.14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,7 @@ tests =
     flake8-debugger>=4.0.0
     flake8-implicit-str-concat>=0.4
     flake8-mutable>=1.2.0
-    flake8-simplify>=0.14.0
+    flake8-simplify>=0.14.0; python_version<"3.14"
     flake8-type-checking
     flake8>=3.0.0
     mypy>=0.910


### PR DESCRIPTION
Upgrade of default Python on the job runner for linting has broken flake8-simplify.

According to flake8-simplify is isn't supported for Python≥3.9, but it works until 3.13. Someone has raised [a ticket](https://github.com/MartinThoma/flake8-simplify/issues/190), and there has been a [PR open since June](https://github.com/MartinThoma/flake8-simplify/pull/200) but they don't sound keen to support it. 

**Check List**
This is a request to remove a flake8 plugin dependency from Python >= 3.14, and therefore most of the usual checklist doesn't apply.