### PR TITLE
job log retrieval: configurable success condition

### DIFF
--- a/changes.d/7052.feat.md
+++ b/changes.d/7052.feat.md
@@ -1,0 +1,2 @@
+Make the list of files used to determine the success of job log retrieval
+commands configurable.

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -160,6 +160,12 @@ LOG_RETR_SETTINGS = {
         logs appearing in their final location (due to the job runner)
         you can configure time intervals here to delay the first and
         subsequent retrieval attempts.
+
+        Job log retrieval will be retried until the expected job files have
+        been retried, see
+        :cylc:conf:`
+        global.cylc[platforms][<platform name>]retrieve job log expected files`
+        for details
     ''')
 }
 
@@ -1751,6 +1757,33 @@ with Conf('global.cylc', desc='''
                    retry delays``.
                    {replaces}
             ''')
+            Conf(
+                'retrieve job log expected files',
+                VDR.V_STRING_LIST,
+                '',
+                desc='''
+                Configure the log files that job log retrieval is expected to
+                return.
+
+                By default, job log retrieval is considered successful once
+                it has retrieved the "job.out" file, and additionally the
+                "job.err" file if the job failed.
+
+                Cylc will repeat job log retrieval according to the configured
+                :cylc:conf:`[..]retrieve job logs retry delays` until the
+                expected file(s) have been retrieved.
+
+                This configuration allows you to configure additional files
+                to add to this success condition.
+
+                The purpose of this configuration is to facilitate working with
+                files written asynchronously by job runners which may not be
+                created until after the job has succeeded. E.g, job report
+                or accounting files.
+
+                .. versionadded:: 8.7.0
+            ''',
+            )
             Conf('tail command template',
                  VDR.V_STRING, 'tail -n +1 --follow=name %(filename)s',
                  desc=f'''

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -586,7 +586,15 @@ def _main(
             workflow_id, point, task, submit_num
         )
 
-        job_log_present = (Path(local_log_dir) / "job.out").exists()
+        job_log_present = all(
+            (Path(local_log_dir) / file).exists()
+            for file in [
+                # the files which are used to indicate that job log retrieval
+                # has completed
+                'job.out',
+                *platform['retrieve job log expected files'],
+            ]
+        )
 
         log_is_remote = (is_remote_platform(platform)
                          and (options.filename != JOB_LOG_ACTIVITY))


### PR DESCRIPTION
* task events mgr: address possibly undefined variable warning
* job log retrieval: configurable success condition 
    * Presently, job log retrieval is considered successful when the
      `job.out` file appears, and additionally the `job.err` file if the job
      failed.
    * This commit adds a new configuration to allow additional files to be
      specified.
    * This will help with a MO platform where the job epilogue file is
      written asynchronously, so may only appear some time after the `job.out`
      file.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.