### PR TITLE
pause: fix trigger whilst paused logic

### DIFF
--- a/changes.d/7054.fix.md
+++ b/changes.d/7054.fix.md
@@ -1,0 +1,3 @@
+Fix an issue where job submission could fail with the message
+`No such file or directory` when tasks were triggered while the workflow was
+paused.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1354,7 +1354,7 @@ class Scheduler:
                 # finish processing preparing tasks
                 pre_prep_tasks.update({
                     itask for itask in self.pool.get_tasks()
-                    if itask.state(TASK_STATUS_PREPARING)
+                    if itask.waiting_on_job_prep
                 })
             else:
                 # release queued tasks


### PR DESCRIPTION
I think this one is fairly simple, just a subtle error.

* Closes #7016
* The wrong indicator was being used to list tasks for job preparation resulting in duplicate preparation calls.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.