### PR TITLE
polling: reset bad hosts on manual poll

### DIFF
--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -430,7 +430,7 @@ async def poll_tasks(schd: 'Scheduler', tasks: Iterable[str]):
     matched, unmatched = schd.pool.id_match(ids, only_match_pool=True)
     _report_unmatched(unmatched)
     itasks = schd.pool.get_itasks(matched)
-    schd.task_job_mgr.poll_task_jobs(itasks)
+    schd.task_job_mgr.poll_task_jobs(itasks, manual_request=True)
     yield len(unmatched)
 
 

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -223,7 +223,10 @@ class TaskJobManager:
         self._prep_submit_task_job_error(itask, '(killed in job prep)', '')
 
     def poll_task_jobs(
-        self, itasks: 'Iterable[TaskProxy]', msg: str | None = None
+        self,
+        itasks: 'Iterable[TaskProxy]',
+        msg: str | None = None,
+        manual_request: bool = False,
     ):
         """Poll jobs of specified tasks.
 
@@ -245,7 +248,8 @@ class TaskJobManager:
                     if itask.state.status != TASK_STATUS_WAITING
                 ],
                 self._poll_task_jobs_callback,
-                self._poll_task_jobs_callback_255
+                self._poll_task_jobs_callback_255,
+                continue_if_no_good_hosts=manual_request,
             )
 
     def prep_submit_task_jobs(
@@ -918,12 +922,33 @@ class TaskJobManager:
         log_task_job_activity(ctx, self.workflow, itask.point, itask.tdef.name)
 
     def _run_job_cmd(
-        self, cmd_key, itasks, callback, callback_255
+        self,
+        cmd_key,
+        itasks,
+        callback,
+        callback_255,
+        continue_if_no_good_hosts=False,
     ):
         """Run job commands, e.g. poll, kill, etc.
 
         Group itasks with their platform_name and host.
         Put a job command for each group to the multiprocess pool.
+
+        Args:
+            cmd_key:
+                Identifier for the command to run.
+            itasks:
+                List of task proxies to run the command against.
+            callback:
+                Callback to run on command completion.
+            callback_255:
+                Callback to run on SSH error.
+            continue_if_no_good_hosts:
+                If True, the bad hosts set will be reset in the event that
+                there are no "good hosts" to run the command on. This should
+                only be turned on for manual operations, e.g. manual poll. Use
+                of this option for automatic commands may result in feedback
+                loops between parallel opererations.
 
         """
         if not itasks:
@@ -960,36 +985,48 @@ class TaskJobManager:
             cmd.append("--")
             cmd.append(get_remote_workflow_run_job_dir(self.workflow))
             job_log_dirs = []
-            host = 'localhost'
 
-            ctx = SubProcContext(cmd_key, cmd, host=host)
-            if remote_mode:
-                try:
+            # select a host to run the operation on
+            host = None
+            with suppress(NoHostsError):
+                host = get_host_from_platform(
+                    platform, bad_hosts=self.bad_hosts
+                )
+
+            if not host and continue_if_no_good_hosts:
+                # no hosts available for this platform
+                # -> reset the bad hosts and try again
+                self.task_events_mgr.reset_bad_hosts()
+                with suppress(NoHostsError):
                     host = get_host_from_platform(
                         platform, bad_hosts=self.bad_hosts
                     )
-                    cmd = construct_ssh_cmd(
-                        cmd, platform, host
-                    )
-                except NoHostsError:
-                    ctx.err = f'No available hosts for {platform["name"]}'
-                    LOG.debug(ctx)
-                    callback_255(ctx, itasks)
-                    continue
-                else:
-                    ctx = SubProcContext(cmd_key, cmd, host=host)
 
-            for itask in sorted(itasks, key=lambda task: task.identity):
-                job_log_dirs.append(itask.job_tokens.relative_id)
-            cmd += job_log_dirs
-            LOG.debug(f'{cmd_key} for {platform["name"]} on {host}')
-            self.proc_pool.put_command(
-                ctx,
-                bad_hosts=self.bad_hosts,
-                callback=callback,
-                callback_args=[itasks],
-                callback_255=callback_255,
-            )
+            # construct SSH command if host is remote
+            if remote_mode:
+                cmd = construct_ssh_cmd(cmd, platform, host or 'None')
+
+            ctx = SubProcContext(cmd_key, cmd, host=host or 'None')
+            if not host:
+                # report host selection error
+                ctx.err = f'No available hosts for {platform["name"]}'
+                LOG.debug(ctx)
+                callback_255(ctx, itasks)
+                continue
+
+            else:
+                # perform operation
+                for itask in sorted(itasks, key=lambda task: task.identity):
+                    job_log_dirs.append(itask.job_tokens.relative_id)
+                cmd += job_log_dirs
+                LOG.debug(f'{cmd_key} for {platform["name"]} on {host}')
+                self.proc_pool.put_command(
+                    ctx,
+                    bad_hosts=self.bad_hosts,
+                    callback=callback,
+                    callback_args=[itasks],
+                    callback_255=callback_255,
+                )
 
     @staticmethod
     def _set_retry_timers(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -453,9 +453,7 @@ def capture_polling():
     def _disable_polling(schd: 'Scheduler') -> 'Set[TaskProxy]':
         polled_tasks: 'Set[TaskProxy]' = set()
 
-        def run_job_cmd(
-            _1, itasks, _3, _4=None
-        ):
+        def run_job_cmd(_, itasks, *__, **___):
             polled_tasks.update(itasks)
             return itasks
 

--- a/tests/integration/test_task_job_mgr.py
+++ b/tests/integration/test_task_job_mgr.py
@@ -21,11 +21,15 @@ from typing import Any as Fixture
 from unittest.mock import Mock
 
 from cylc.flow import CYLC_LOG
+from cylc.flow.commands import poll_tasks, run_cmd
 from cylc.flow.job_runner_mgr import JOB_FILES_REMOVED_MESSAGE
+from cylc.flow.platforms import get_platform
 from cylc.flow.scheduler import Scheduler
+from cylc.flow.task_job_mgr import TaskJobManager
 from cylc.flow.task_state import (
     TASK_STATUS_FAILED,
     TASK_STATUS_RUNNING,
+    TASK_STATUS_SUBMITTED,
 )
 
 
@@ -258,6 +262,67 @@ async def test_poll_job_deleted_log_folder(
     assert log_filter(
         logging.ERROR, f"job log directory {job_id} no longer exists"
     )
+
+
+async def test_manual_poll_resets_bad_hosts(
+    flow,
+    scheduler,
+    start,
+    mock_glbl_cfg,
+):
+    """Manual poll should be attempted even if all hosts are "bad".
+
+    Automated polling will be skipped in the event that all of a platform's
+    hosts are in the known "bad hosts" list.
+
+    Manual poll (similar to manual trigger), will reset the bad hosts list in
+    this eventuality in order to ensure the operation is attempted anyway.
+
+    See https://github.com/cylc/cylc-flow/issues/7029
+    """
+    mock_glbl_cfg(
+        'cylc.flow.platforms.glbl_cfg',
+        '''
+        [platforms]
+            [[my-remote]]
+                hosts = abc
+        ''',
+    )
+    id_ = flow({
+        'scheduling': {
+            'graph': {
+                'R1': 'foo',
+            },
+        },
+        'runtime': {
+            'foo': {
+                'platform': 'my-remote',
+            },
+        },
+    })
+    schd: 'Scheduler' = scheduler(id_, run_mode='live')
+    async with start(schd):
+        # make it look like the task is submitted
+        itask = schd.pool.get_tasks()[0]
+        itask.platform = get_platform('my-remote')
+        itask.state_reset(TASK_STATUS_SUBMITTED)
+
+        assert not len(schd.proc_pool.queuings)
+
+        # mark all of the hosts as bad hosts
+        schd.task_events_mgr.bad_hosts.update(itask.platform['hosts'])
+
+        # request a manual poll
+        await run_cmd(poll_tasks(schd, [itask.tokens.relative_id]))
+
+        # the bad hosts set should be empty
+        assert not schd.task_events_mgr.bad_hosts
+
+        # and a poll command should have been issued
+        assert len(schd.proc_pool.queuings) == 1
+        poll_ctx = schd.proc_pool.queuings.pop()[0]
+        assert poll_ctx.cmd_key == TaskJobManager.JOBS_POLL
+        assert poll_ctx.host == 'abc'
 
 
 async def test__prep_submit_task_job_impl_handles_all_old_platform_settings(


### PR DESCRIPTION
* Closes #7029
* This reduces the pressure on #7001 (polling is not attempted if a platform runs out of hosts until the next run of reset-bad hosts) by making it easier for operators to reset bad hosts and recover their workflow in the event of platform outages.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.