### PR TITLE
Feat.cylc review

### DIFF
--- a/cylc/flow/etc/cylc
+++ b/cylc/flow/etc/cylc
@@ -78,7 +78,7 @@
 # for selection using CYLC_VERSION. e.g. ln -s cylc-8.0.1-1 cylc-next
 #
 # Legacy Cylc 7 and Rose 2019.01 versions can also be installed into environments
-# in the ROOT location. The legacy support for rose edit, rosie and cylc review
+# in the ROOT location. The legacy support for rose edit and rosie
 # requires cylc-7 and rose-2019.01 symlinks to be created to the preferred
 # environments.
 # e.g.    ln -s cylc-7.9.5 cylc-7
@@ -158,13 +158,6 @@ if [[ ${0##*/} =~ ^ros ]]; then
         # If CYLC_HOME was set externally, use ROSE_HOME if it is set
         CYLC_HOME="${ROSE_HOME:-$CYLC_HOME}"
     fi
-fi
-
-# Legacy support for cylc review
-if [[ ${0##*/} == "cylc" && ${1:-} == "review" && \
-      ! ${CYLC_ENV_NAME:-} =~ ^cylc-7 ]]; then
-    # Cylc 8: Use Cylc 7 to run "review"
-    CYLC_HOME="${CYLC_HOME_ROOT}/cylc-7"
 fi
 
 if [[ ! -x "${CYLC_HOME}/bin/${0##*/}" ]]; then

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -293,9 +293,6 @@ DEAD_ENDS = {
         'cylc set-outputs (cylc 8.0-8.2) has been replaced by cylc set',
     'restart':
         'cylc run & cylc restart have been replaced by cylc play',
-    'review':
-        'cylc review has been removed; the latest Cylc 7 version is forward'
-        ' compatible with Cylc 8.',
     'suite-state':
         'cylc suite-state has been replaced by cylc workflow-state',
     'run':


### PR DESCRIPTION
Companion to https://github.com/cylc/cylc-uiserver/pull/755

* Remove `cylc review` inteception from the wrapper script.
* Remove dead ends interception of `cylc review`

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are *NOT* included: Use the companion UI Server branch to check this PR.
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] This is a feature to be raised against master
