### PR TITLE
Coverage performance issues on Python 3.14 - pin to lower version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,8 @@ tests =
     aiosmtpd
     async_generator
     bandit>=1.7.0
-    coverage>=5.0.0
+    # https://github.com/coveragepy/coveragepy/issues/2082
+    coverage>=5.0.0,<7.11.1
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0


### PR DESCRIPTION
https://github.com/coveragepy/coveragepy/issues/2082

Apart from irrelevant linkcheck fail, all the functional test jobs should pass on this PR (not time out) if the workaround has worked.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Tests dependency changes only apply to `setup.cfg`
- [x] Tests, docs, changelog not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
