### PR TITLE
log_vc_info: close files nicely

### DIFF
--- a/cylc/flow/pipe_poller.py
+++ b/cylc/flow/pipe_poller.py
@@ -69,4 +69,7 @@ def pipe_poller(proc, *files, chunk_size=4096):
     # double check the buffers now that the process has finished
     _read(timeout=0.01)
 
+    for file in files:
+        file.close()
+
     return tuple(_files.values())


### PR DESCRIPTION
* Closes #5989

This warning comes up several times whenever we install a workflow (if you enable Python warnings) and is driving me nuts.

To see the warning for yourself, try:

```
$ PYTHONWARNINGS=all cylc install
```

This may be a bug, but I expect those handles get closed as part of `__del__` cleanup somewhere, so likely harmless.

Not sure whether this should go in a bugfix release?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.