### PR TITLE
zmq client: cleanup sockets and contexts

### DIFF
--- a/cylc/flow/network/client.py
+++ b/cylc/flow/network/client.py
@@ -401,3 +401,6 @@ class WorkflowRuntimeClient(  # type: ignore[misc]
                     )
             }
         }
+
+    def __del__(self):
+        self.stop(stop_loop=False)


### PR DESCRIPTION
* Resolves Python warnings about unclosed sockets and contexts.
* Particularly important for commands which repeatably open clients such as `cylc scan --ping` and `cylc gui`.

To see the warning for yourself, try:

```
$ PYTHONWARNINGS=all cylc scan --ping # with at least one workflow running
```

It is possible that this may be a memory leak for Cylc GUI / Tui processes, although I can't confirm that, tracemalloc did identify some zmq entries during investigation of https://github.com/cylc/cylc-uiserver/issues/732, so it's possible.

I'm uncertain over whether this should go into a bugfix or not. It is a bugfix, however, it's not clear if this is causing issues ATM and the diff has the potential to cause issues if not tested thoroughly.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.