### PR TITLE
daemonize: fix unclosed file handle

### DIFF
--- a/cylc/flow/daemonize.py
+++ b/cylc/flow/daemonize.py
@@ -16,6 +16,7 @@
 
 """Turn a cylc scheduler into a Unix daemon."""
 
+import atexit
 import json
 import os
 import sys
@@ -129,6 +130,6 @@ def daemonize(schd):
     # Note that simply reassigning the sys streams is not sufficient
     # if we import modules that write to stdin and stdout from C
     # code - evidently the subprocess module is in this category!
-    # TODO: close resource? atexit?
     dvnl = open(os.devnull, 'r')  # noqa: SIM115 (keep devnull open until exit)
     os.dup2(dvnl.fileno(), sys.stdin.fileno())
+    atexit.register(dvnl.close)


### PR DESCRIPTION
Fix an unclosed file handle by addressing an ancient `TODO`.

The unclosed file handle is reported as a Python warning, try running:

```console
$ PYTHONWARNINGS=all cylc vip
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users - no symptoms observed thus far
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.