### PR TITLE
Coverage: set core to ctrace to avoid performance issues with sysmon

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,7 +19,8 @@ omit =
     cylc/flow/scripts/report_timings.py
 parallel = True
 source = ./cylc
-timid = False
+# https://github.com/coveragepy/coveragepy/issues/2082:
+core = ctrace
 
 [report]
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,8 +96,7 @@ tests =
     aiosmtpd
     async_generator
     bandit>=1.7.0
-    # https://github.com/coveragepy/coveragepy/issues/2082
-    coverage>=5.0.0,<7.11.1
+    coverage>=7.9.0
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0


### PR DESCRIPTION
Further investigation in https://github.com/coveragepy/coveragepy/issues/2082 has revealed that we can remove the upper pin on coverage as long as we configure it to use ctrace 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Dependency changes do not apply to conda file
- [x] No tests etc. needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
