### PR TITLE
Fix `--startcp` option for integer cycling

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -815,7 +815,8 @@ class WorkflowConfig:
             )
         if startcp:
             # Start from a point later than initial point.
-            self.options.startcp = _parse_iso_cycle_point(startcp)
+            if self.cycling_type == ISO8601_CYCLING_TYPE:
+                self.options.startcp = _parse_iso_cycle_point(startcp)
             self.start_point = get_point(self.options.startcp).standardise()
         elif starttask:
             # Start from designated task(s).


### PR DESCRIPTION
**Unreleased bug** - follow-up to #7024, which broke the `--startcp` option for integer cycling. Added a test to catch this.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry not needed as unreleased bug
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
