### PR TITLE
cylc wrapper: Set PATH to allow cylc graph to find Graphviz

### DIFF
--- a/cylc/flow/etc/cylc
+++ b/cylc/flow/etc/cylc
@@ -173,7 +173,8 @@ if [[ ! -x "${CYLC_HOME}/bin/${0##*/}" ]]; then
 fi
 
 # Set PATH when running cylc hub so that configurable-http-proxy can find node
-if [[ ${0##*/} == "cylc" && ${1:-} == "hub" ]]; then
+# and when running cylc graph so that it can find Graphviz
+if [[ ${0##*/} == "cylc" && ${1:-} =~ ^(graph|hub)$ ]]; then
     PATH=${PATH}:${CYLC_HOME}/bin
 fi
 


### PR DESCRIPTION
Graphviz is installed in the Conda environment but wasn't being found by `cylc graph` (it was relying on it being installed with the OS).