### PR TITLE
set: remove state selection limitation

### DIFF
--- a/changes.d/7108.fix.md
+++ b/changes.d/7108.fix.md
@@ -1,0 +1,1 @@
+Allow use of task state selectors with the `cylc set` command.

--- a/cylc/flow/scripts/set.py
+++ b/cylc/flow/scripts/set.py
@@ -26,6 +26,9 @@ By default this command completes required outputs, plus the "submitted",
 Setting prerequisites promotes target tasks to the n=0 active window; setting
 outputs also sets the prerequisites of any tasks that depend on those outputs.
 
+Note: state selectors such as ":failed" determine which tasks to target, not
+the outputs to set - see examples below.
+
 Note: see `cylc trigger` command help if you want rerun a sub-graph of tasks.
 
 Setting Outputs:
@@ -117,6 +120,11 @@ Examples:
   # satisfy multiple prerequisites at once:
   $ cylc set --pre=3/foo:x --pre=3/foo:y,3/foo:z my_workflow//3/bar
 
+  # set required outputs of all failed tasks in the n=0 window at cycle 3:
+  $ cylc set my_workflow//3/*:failed
+
+  # set the succeeded output of all failed tasks in the n=0 window at cycle 3:
+  $ cylc set my_workflow//3/*:failed --output=succeeded
 """
 
 from functools import partial


### PR DESCRIPTION
Closes https://github.com/cylc/cylc-flow/issues/7104

@hjoliver, it would be useful to be able to select tasks by state when using the `cylc set` command.

However, this was purposefully disabled when the `cylc set` command was added. I think this was to prevent users accidentally running `cylc set <task>:out` when they meant `cylc set <task> --out=<out>`? However, this check was only ever added for the CLI, not the GUI.

Are you ok with removing this check?

---

This has randomly come up twice in the last two days.

One use case is mopping up failed/submit-failed tasks from otherwise expired cycles:

```
$ cylc set '//1/*:failed' --out=expired
```

The other, from opps, was setting failed tasks to succeeded where manually clicking them one-by-one was tedious.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed). - don't need a test to ensure we don't do something unusual
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.