### PR TITLE
Move paused start logic to before initiating data store and task pool

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -467,6 +467,9 @@ class Scheduler:
                     f" You can't restart it in {run_mode.value} mode."
                 )
 
+        if self.options.paused_start:
+            self.pause_workflow('Paused on start up')
+
         self.profiler.log_memory("scheduler.py: before load_flow_file")
         try:
             cfg = self.load_flow_file()
@@ -590,9 +593,6 @@ class Scheduler:
             holdcp = self.config.cfg['scheduling']['hold after cycle point']
         if holdcp is not None:
             await commands.run_cmd(commands.set_hold_point(self, holdcp))
-
-        if self.options.paused_start:
-            self.pause_workflow('Paused on start up')
 
         self.profiler.log_memory("scheduler.py: begin run while loop")
         self.is_updated = True

--- a/tests/integration/network/test_graphql.py
+++ b/tests/integration/network/test_graphql.py
@@ -463,9 +463,9 @@ async def test_subscription_deltas(one, start):
         assert aitem.data['deltas']['added']['workflow'] == {
             'id': one.id,
             'host': one.host,
-            'status': 'running',
+            'status': 'paused',
         }
-        # Workflow one is paused on start, but this hasn't been processed yet.
+        # Workflow one is paused on start
         await one.update_data_structure()
         assert (
             one.data_store_mgr.data[one.id]['workflow'].status
@@ -486,7 +486,6 @@ async def test_subscription_deltas(one, start):
         aitem = await subscription.__anext__()
         assert aitem.data['deltas']['updated']['workflow'] == {
             'id': one.id,
-            'status': get_workflow_status(one).value,
         }
         with suppress(GeneratorExit):
             await subscription.aclose()


### PR DESCRIPTION
This may be needed to avoid sending a delta with "running" status before "paused" status is applied.

I have seen on several occasions a workflow started with `--pause` appear as running for several seconds in the GUI before becoming paused, which is slightly alarming as it makes you think you might have forgotten the `--pause` option.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry not needed as minor
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
