### PR TITLE
On restart, load all tasks from DB before trying to spawn runahead tasks

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -875,8 +875,7 @@ class Scheduler:
         self.broadcast_mgr.post_load_db_coerce()
         self.workflow_db_mgr.pri_dao.select_task_job_run_times(
             self._load_task_run_times)
-        self.workflow_db_mgr.pri_dao.select_task_pool_for_restart(
-            self.pool.load_db_task_pool_for_restart)
+        self.pool.load_db_task_pool_for_restart()
         self.workflow_db_mgr.pri_dao.select_jobs_for_restart(
             self.data_store_mgr.insert_db_job)
         self.workflow_db_mgr.pri_dao.select_task_action_timers(


### PR DESCRIPTION
On restart, instead of calling `pool.release_runahead_tasks()` every time we load a single task from the DB, call it once at the end of loading all tasks.

Closes https://github.com/cylc/cylc-flow/issues/7037

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
