### PR TITLE
Fix a broken Rubric line in docs.

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1058,7 +1058,7 @@ with Conf(
 
                See :ref:`task namespace rules. <namespace-names>`
 
-            ..rubric:: Examples:
+            .. rubric:: Examples:
 
             - ``[foo]``
             - ``[foo, bar, baz]``


### PR DESCRIPTION
Docs built at internal server /doc/cylc/fix.rubric/html/reference/config/workflow.html

This is a very small internal docs fix.