### PR TITLE
reinstate no-spawn option for remove

### DIFF
--- a/changes.d/7134.feat.md
+++ b/changes.d/7134.feat.md
@@ -1,0 +1,1 @@
+Remove without spawning option, needed for parentless tasks, has been reinstated.

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2185,6 +2185,21 @@ class Remove(Mutation, TaskMutation):
                 By default, tasks will be removed from all flows.
             ''')
         )
+        no_spawn = Boolean(
+            default_value=False,
+            description=sstrip('''
+                "Do not spawn successors before removal."
+
+                This usually only applies to parentless tasks whose next
+                instance(s) are either spawned automatically to the runahead
+                limit or sequentially on xtrigger satisfaction.
+
+                If `false` the scheduler will spawn the next task instance
+                as normal (default).
+
+                If `true` the scheduler will not spawn the next task instance.
+            ''')
+        )
 
 
 class SetPrereqsAndOutputs(Mutation, TaskMutation):

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -71,11 +71,13 @@ mutation (
   $wFlows: [WorkflowID]!,
   $tasks: [NamespaceIDGlob]!,
   $flow: [Flow!],
+  $noSpawn: Boolean,
 ) {
   remove (
     workflows: $wFlows,
     tasks: $tasks,
-    flow: $flow
+    flow: $flow,
+    noSpawn: $noSpawn
   ) {
     result
   }
@@ -91,7 +93,12 @@ def get_option_parser() -> COP:
         multiworkflow=True,
         argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
+
     add_flow_opts_for_remove(parser)
+    parser.add_option(
+        "--no-spawn",
+        help="Do not spawn successors before removal.",
+        action="store_true", default=False, dest="no_spawn")
     return parser
 
 
@@ -107,6 +114,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
                 for tokens in tokens_list
             ],
             'flow': options.flow,
+            'noSpawn': options.no_spawn,
         }
     }
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -888,7 +888,7 @@ class TaskPool:
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
 
-        if itask.state.is_runahead and itask.flow_nums:
+        if itask.state.is_runahead and itask.flow_nums and not itask.no_spawn:
             # If removing a parentless runahead-limited task
             # auto-spawn its next instance first.
             self.spawn_if_parentless(
@@ -2436,6 +2436,7 @@ class TaskPool:
                 itask.identity not in
                 self.xtrigger_mgr.sequential_has_spawned_next
             )
+            and not itask.no_spawn
         ):
             self.xtrigger_mgr.sequential_has_spawned_next.add(
                 itask.identity

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -166,6 +166,9 @@ class TaskProxy:
         .removed:
             A flag to indicate this task has been removed by command (used
             e.g. to disable failed/submit-failed event handlers).
+        .no_spawn:
+            A flag to indicate whether this task should spawn a successor
+            (usually only applies to parentless tasks).
 
     Args:
         tdef: The definition object of this task.
@@ -212,6 +215,7 @@ class TaskProxy:
         'transient',
         'is_xtrigger_sequential',
         'removed',
+        'no_spawn',
     )
 
     def __init__(
@@ -288,6 +292,7 @@ class TaskProxy:
         self.is_late = is_late
         self.waiting_on_job_prep = False
         self.removed: bool = False
+        self.no_spawn: bool = False
 
         self.state = TaskState(tdef, self.point, status, is_held)
 


### PR DESCRIPTION
At present there's no way to remove parentless tasks from the scheduler and not have them spawn their next instance.

This is not ideal, and at ESNZ I've run into this problem many times while adding new tasks to a workflow and them being spawned in at the distant past (i.e. the ICP), and then the only way to fix the workflow is to spawn them forward one cycle at a time to the desired cycle point.

Also, in general, perhaps you wish not to run an isolate/branch for a gap then introduce again at some future cycle point.

This PR fixes the problem by reinstating `--no-spawn` option to `cylc remove`..

Example:
```
[scheduling]
    initial cycle point = 20260101T0000Z
    [[graph]]
        P1D = """
            @wall_clock => a => b => c
            d
        """

[runtime]
    [[root]]
        script = sleep 5
    [[a,b,c,d]]
```
running shows:
<img width="310" height="211" alt="image" src="https://github.com/user-attachments/assets/dd2033bf-f2b8-4689-8b89-3be36af5f1c3" />
Removing `d` normally (`$ cylc remove couple/run1//20260106T0000Z/d`) spawns it into the next cycle:
<img width="306" height="206" alt="image" src="https://github.com/user-attachments/assets/e756b1a6-5272-43f4-ba10-f9b63ee88239" />
With `--no-spawn`:
<img width="305" height="162" alt="image" src="https://github.com/user-attachments/assets/256838d9-903f-47bc-a66a-4a7df669682f" />

And of course removing the sequentially spawned `a` (`cylc remove --no-spawn couple/run1//20260101T0000Z/a`), with this option, gives:
<img width="317" height="138" alt="image" src="https://github.com/user-attachments/assets/7334f3af-f765-45e6-822d-e89acde3f890" />
(as expected)

Code changes were made in such a way that they should be conflict-free with #7132 

Seems our forms are smart enough at the UI end:
<img width="490" height="447" alt="image" src="https://github.com/user-attachments/assets/2a77b548-d491-4a27-8d6a-2abdcc85aa7b" />


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX. (not needed I think, [docs](https://cylc.github.io/cylc-doc/stable/html/user-guide/interventions/index.html#remove-tasks) aren't that detailed about removal and options are explained in UI/CLI info)
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
