### PR TITLE
Change a method name, for clarity.

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -876,7 +876,7 @@ class TaskPool:
     def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:
         """Remove a task from the pool."""
         # the held state is no longer relevant -> remove it
-        self.release_held_active_task(itask)
+        self.release_held_task(itask)
 
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
@@ -1385,7 +1385,19 @@ class TaskPool:
         self.tasks_to_hold.add((itask.tdef.name, itask.point))
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
 
-    def release_held_active_task(self, itask: TaskProxy) -> None:
+    def release_held_task(self, itask: TaskProxy) -> None:
+        """Release a task from hold.
+
+        The given task proxy may be from the active pool, or a
+        transient representing a future task (targeted by `cylc set`
+        to set its outputs and thereby spawn children - and we release
+        held tasks if their outputs are set).
+
+        Note in the transient case the proxy will not be is_held but
+        this method removes it from the tasks_to_hold list below.
+        (This is a bit confused, could do with refactoring).
+
+        """
         if itask.state_reset(is_held=False):
             self.data_store_mgr.delta_task_state(itask)
             if (not itask.state.is_runahead) and itask.is_ready_to_run():
@@ -1436,7 +1448,7 @@ class TaskPool:
             itask = self._get_task_by_id(id_.relative_id)
             if itask:
                 # release active task
-                self.release_held_active_task(itask)
+                self.release_held_task(itask)
             else:
                 # release inactive task
                 self.data_store_mgr.delta_task_held(
@@ -1453,7 +1465,7 @@ class TaskPool:
         """Unset the workflow hold point and release all held active tasks."""
         self.hold_point = None
         for itask in self.get_tasks():
-            self.release_held_active_task(itask)
+            self.release_held_task(itask)
         self.tasks_to_hold.clear()
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
         self.workflow_db_mgr.put_workflow_hold_cycle_point(None)


### PR DESCRIPTION
A tiny non-functional code-tidy change for clarity.
 - change `release_held_active_task(itask)` to `release_held_task(itask)`
 - and add to the method's docstring

This method is not just called for active (n=0) tasks.

The task proxy argument can also be a transient (a temporary task proxy not intended to be added to the task pool, but used for other purposes) representing a future (n>0, non-active) task. 

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
