### PR TITLE
data store: ensure set can clear the stalled message

### DIFF
--- a/changes.d/7158.fix.md
+++ b/changes.d/7158.fix.md
@@ -1,0 +1,3 @@
+Fix an issue where a workflow's status message (as displayed in the GUI
+toolbar) could erroneously report that the workflow is stalled after
+intervention is performed.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1712,7 +1712,9 @@ class Scheduler:
         if has_updated:
             if not self.is_reloaded:
                 # (A reload cannot un-stall workflow by itself)
-                self.is_stalled = False
+                if self.is_stalled:
+                    self.is_stalled = False
+                    self.update_data_store()
             self.is_reloaded = False
 
             # Reset workflow and task updated flags.
@@ -1824,10 +1826,9 @@ class Scheduler:
             return True
         if self.is_paused:  # cannot be stalled it's not even running
             return False
-        is_stalled = self.pool.is_stalled()
-        if is_stalled != self.is_stalled:
+        if self.pool.is_stalled():
+            self.is_stalled = True
             self.update_data_store()
-            self.is_stalled = is_stalled
         if self.is_stalled:
             LOG.critical("Workflow stalled")
             self.run_event_handlers(self.EVENT_STALL, 'workflow stalled')


### PR DESCRIPTION
* Closes https://github.com/cylc/cylc-flow/issues/7157
* Ensure that the `status_msg` field is updated when the workflow stall status changes.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.