### PR TITLE
Removed target from cylc get resources example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ domains.
 conda install cylc-flow
 
 # extract an example to run
-cylc get-resources examples/2-integer-cycling ~/cylc-src/integer-cycling
+cylc get-resources examples/2-integer-cycling
 
 # install and run it
 cylc vip integer-cycling  # vip = validate, install and play


### PR DESCRIPTION
Closes #7166 

* Previous path would result in workflow being put in ~/cylc-src/integer-cycling/2-integer-cycling, so the vip command below wouldn't work.
* If second arg (target) is given, the leading 2 is not stripped which will cause Cylc install to fail.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Documentation only - no tests or changlog changes.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
