### PR TITLE
Remove Suicide trigger check from Cylc lint

### DIFF
--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -122,6 +122,7 @@ DEPR_LINT_SECTION = 'cylc-lint'
 IGNORE = 'ignore'
 EXCLUDE = 'exclude'
 RULESETS = 'rulesets'
+WARN = 'warn'
 MAX_LINE_LENGTH = 'max-line-length'
 
 DEPRECATED_ENV_VARS = {
@@ -161,6 +162,10 @@ DEPRECATED_STRING_TEMPLATES = {
 
 
 LIST_ITEM = '\n    * '
+FUNCTION = 'function'
+
+# Don't remove deprecated check.
+REMOVED_CHECKS = ['U008']
 
 
 deprecated_string_templates = {
@@ -295,32 +300,6 @@ def check_dead_ends(line: str) -> bool:
     return any(
         f'cylc {dead_end}' in line for dead_end in DEAD_ENDS
     )
-
-
-def check_for_suicide_triggers(
-    line: str,
-    file: Path,
-    function: Callable,
-    **kwargs
-):
-    """Check for suicide triggers, if file is a .cylc file.
-
-    Examples:
-        >>> func = lambda line: line
-
-        # Suicide trigger in a *.cylc file:
-        >>> check_for_suicide_triggers(
-        ... 'x:fail => !y', function=func, file=Path('foo.cylc'))
-        'x:fail => !y'
-
-        # Suicide trigger in a suite.rc file:
-        >>> check_for_suicide_triggers(
-        ... 'x:fail => !y', function=func, file=Path('suite.rc'))
-        False
-    """
-    if file.name.endswith('.cylc'):
-        return function(line)
-    return False
 
 
 def check_for_deprecated_environment_variables(
@@ -510,8 +489,6 @@ def list_wrapper(line: str, check: Callable) -> Optional[Dict[str, str]]:
         return {'vars': '\n    * '.join(result)}
     return None
 
-
-FUNCTION = 'function'
 
 STYLE_GUIDE = (
     'https://cylc.github.io/cylc-doc/stable/html/workflow-design-guide/'
@@ -731,17 +708,6 @@ MANUAL_DEPRECATIONS = {
         ''',
         FUNCTION: re.compile(r'platform\s*=\s*\$\(\s*rose host-select').findall
     },
-    'U008': {
-        'short': 'Suicide triggers are not required at Cylc 8.',
-        'url': '''
-            https://cylc.github.io/cylc-doc/stable/html/7-to-8/major-changes/suicide-triggers.html
-        ''',
-        'kwargs': True,
-        FUNCTION: functools.partial(
-            check_for_suicide_triggers,
-            function=re.compile(r'=>\s*\!.*').findall
-        ),
-    },
     'U009': {
         'short': 'This line contains an obsolete Cylc CLI command.',
         'url': '',
@@ -848,8 +814,10 @@ EXTRA_TOML_VALIDATION = {
     IGNORE: {
         lambda x: re.match(r'[A-Z]\d\d\d', x):
             '{item} not valid: Ignore codes should be in the form X001',
-        lambda x: x in parse_checks(['728', 'style']):
-            '{item} is a not a known linter code.'
+        lambda x: x in parse_checks(['728', 'style']) or x in REMOVED_CHECKS:
+            '{item} is a not a known linter code.',
+        lambda x: WARN if x in REMOVED_CHECKS else True:
+            '{item} is a deprecated linter code',
     },
     RULESETS: {
         lambda item: item in ALL_RULESETS:
@@ -929,6 +897,8 @@ def validate_toml_items(tomldata):
                         raise CylcError(
                             message.format(item=item)
                         )
+                    elif check(item) == WARN:
+                        LOG.warning(message.format(item=item))
     return True
 
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -260,7 +260,9 @@ def test_check_cylc_file_7to8(number):
     """TEST File has one of each manual deprecation;"""
     lint = lint_text(TEST_FILE, ['728'])
     instances = EXPECT_INSTANCES_OF_ERR.get(number, None)
-    assert_contains(lint.messages, f'[U{number:03d}]', instances)
+    # U0008 Has been removed, but we don't want to change the numbering
+    if number != 8:
+        assert_contains(lint.messages, f'[U{number:03d}]', instances)
 
 
 def test_check_cylc_file_7to8_has_shebang():
@@ -386,7 +388,9 @@ def test_check_cylc_file_jinja2_comments_shell_arithmetic_not_warned():
 )
 def test_check_cylc_file_inplace(number):
     lint = lint_text(TEST_FILE, ['728', 'style'], modify=True)
-    assert_contains(lint.outlines, f'[U{number:03d}]')
+    # U0008 Has been removed, but we don't want to change the numbering
+    if number != 8:
+        assert_contains(lint.outlines, f'[U{number:03d}]')
 
 
 def test_get_cylc_files_get_all_rcs(tmp_path):
@@ -576,11 +580,11 @@ def test_get_pyproject_toml__depr(
 
 
 @pytest.mark.parametrize(
-    'input_, error',
+    'input_, output',
     [
         param(
             {'exclude': ['hey', 'there', 'Delilah']},
-            None,
+            True,
             id='it works'
         ),
         param(
@@ -612,16 +616,24 @@ def test_get_pyproject_toml__depr(
             {'ignore': ['R999']},
             'R999 is a not a known linter code.',
             id='it fails with non-existant checks ignored'
-        )
+        ),
+        param(
+            {'ignore': ['U008']},
+            'warn',
+            id='valid, but deprecated linter code'
+        ),
     ]
 )
-def test_validate_toml_items(input_, error):
+def test_validate_toml_items(input_, output, caplog):
     """It chucks out the wrong sort of items."""
-    if error is not None:
-        with pytest.raises(CylcError, match=error):
+    if output not in [True, 'warn']:
+        with pytest.raises(CylcError, match=output):
             validate_toml_items(input_)
-    else:
+    elif output is True:
+        assert validate_toml_items(input_) is output
+    elif output == 'warn':
         assert validate_toml_items(input_) is True
+        assert 'U008 is a deprecated linter code' in caplog.messages
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove the dubious [`U008`](https://cylc.github.io/cylc-doc/stable/html/user-guide/writing-workflows/configuration.html#id14) lint code.

The check claims "Suicide triggers are not required at Cylc 8", however, this has [never been quite true](https://cylc.github.io/cylc-doc/stable/html/user-guide/writing-workflows/suicide-triggers.html#remaining-use-case) and the lint message has driven folks to try and remove triggers in places where they shouldn't have.

We decided it would be better just to remove this rule.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
