### PR TITLE
Strip target to allow number stripping in Cylc get-resource to work

### DIFF
--- a/cylc/flow/etc/examples/1-hello-world/index.rst
+++ b/cylc/flow/etc/examples/1-hello-world/index.rst
@@ -1,12 +1,14 @@
 Hello World
 -----------
 
+.. n.b: get-resources will strip the number and install to ~/cylc-src
+
 .. admonition:: Get a copy of this example
    :class: hint
 
    .. code-block:: console
 
-      $ cylc get-resources examples/1-hello-world ~/cylc-src/hello-world
+      $ cylc get-resources examples/1-hello-world
 
 In the time honoured tradition, this is the minimal Cylc workflow:
 

--- a/cylc/flow/etc/examples/2-integer-cycling/index.rst
+++ b/cylc/flow/etc/examples/2-integer-cycling/index.rst
@@ -1,12 +1,14 @@
 Integer Cycling
 ===============
 
+.. n.b: get-resources will strip the number and install to ~/cylc-src
+
 .. admonition:: Get a copy of this example
    :class: hint
 
    .. code-block:: console
 
-      $ cylc get-resources examples/2-integer-cycling ~/cylc-src/integer-cycling
+      $ cylc get-resources examples/2-integer-cycling
 
 .. literalinclude:: flow.cylc
    :language: cylc

--- a/cylc/flow/etc/examples/3-datetime-cycling/index.rst
+++ b/cylc/flow/etc/examples/3-datetime-cycling/index.rst
@@ -1,12 +1,14 @@
 Datetime Cycling
 ================
 
+.. n.b: get-resources will strip the number and install to ~/cylc-src
+
 .. admonition:: Get a copy of this example
    :class: hint
 
    .. code-block:: console
 
-      $ cylc get-resources examples/3-datetime-cycling ~/cylc-src/datetime-cycling
+      $ cylc get-resources examples/3-datetime-cycling
 
 .. literalinclude:: flow.cylc
    :language: cylc


### PR DESCRIPTION
Closes #7166

Partially undoes changes from https://github.com/cylc/cylc-flow/pull/7109/changes which missed that without the target directory `cylc get-resources` will strip leading digits and put the workflow in `~/cylc-src`.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Doc change does not require changelog update, tests or `cylc-doc` change.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
