### PR TITLE
fix issue with natural_sort

### DIFF
--- a/changes.d/7218.fix.md
+++ b/changes.d/7218.fix.md
@@ -1,0 +1,1 @@
+Fix issue which could break the ability to list log files in the GUI.

--- a/cylc/flow/util.py
+++ b/cylc/flow/util.py
@@ -45,7 +45,7 @@ BOOL_SYMBOLS: Dict[bool, str] = {
     True: '✓'
 }
 
-_NAT_SORT_SPLIT = re.compile(r'([\d\.]+)')
+_NAT_SORT_SPLIT = re.compile(r'(\d+(?:\.\d+)?)')
 
 
 def uniq(iterable):
@@ -117,7 +117,17 @@ def natural_sort_key(key: str, fcns=(int, str)) -> List[Any]:
         >>> natural_sort_key('a1.23b', fcns=(float, str))
         ['a', 1.23, 'b']
         >>> natural_sort_key('a.b')
-        ['a', '.', 'b']
+        ['a.b']
+        >>> natural_sort_key('a0.b')
+        ['a', 0, '.b']
+
+        # Default type casting
+        >>> natural_sort_key('a0.1b')
+        ['a', '0.1', 'b']
+
+        # Custom type casting
+        >>> natural_sort_key('a0.1b', fcns=(int, float, str))
+        ['a', 0.1, 'b']
 
     """
     ret = []
@@ -146,6 +156,11 @@ def natural_sort(items: List[str], fcns=(int, str)) -> None:
         >>> natural_sort(lst)
         >>> lst
         ['1a', 'a1']
+
+        >>> lst = ['a0.b', 'a0b']
+        >>> natural_sort(lst)
+        >>> lst
+        ['a0.b', 'a0b']
 
     """
     items.sort(key=partial(natural_sort_key, fcns=fcns))


### PR DESCRIPTION
Fix natural sort algorithm against edge case.

Currently, attempting to sort this will result in traceback:

```
    0.c
    0c
```

This was spotted in cylc-uiserver where job log files with these name patterns can cause file listing to fail.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users 
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.