### PR TITLE
Add a wait if we are rate limited

### DIFF
--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Linkcheck
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pytest -m linkcheck -rs --dist=load --color=yes -n 10 tests/unit/test_links.py
+        run: pytest -m linkcheck -ra --dist=load --color=yes -n 10 tests/unit/test_links.py
 
   codecov:
     needs: test

--- a/tests/unit/test_links.py
+++ b/tests/unit/test_links.py
@@ -36,6 +36,7 @@ EXCLUDE = [
     r'*//www.gnu.org/licenses/',
     r'*//my-site.com/*',
     r'*//ahost/%(owner)s/notes/%(workflow)s',
+    r'*//www.h2g2.com/*',
     r'*//web.archive.org/*'
 ]
 


### PR DESCRIPTION
We are experiencing a lot of rate limiting at the moment, causing our test suite to fail.
This PR changes how the tests behave. They will now for a while and try again a few times. 
If the site continues to rate limit us, the tests will "pass".
This is a best effort attempt at checking the links, a rate limit failure isn't an error from our perspective, as the link is still probably good, we just can't prove it.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
