### PR TITLE
Fix parentless spawning.

### DIFF
--- a/changes.d/7237.fix.md
+++ b/changes.d/7237.fix.md
@@ -1,0 +1,2 @@
+Fixed a bug that could cause premature shutdown or stall if a parented instance 
+of a sometimes parentless task ended up at the runahead limit.

--- a/changes.d/7237.fix.md
+++ b/changes.d/7237.fix.md
@@ -1,2 +1,1 @@
-Fixed a bug that could cause premature shutdown or stall if a parented instance 
-of a sometimes parentless task ended up at the runahead limit.
+Fixed stall or premature shutdown caused by parented tasks at the runahead limit that have no parents in some other cycles.

--- a/cylc/flow/clean.py
+++ b/cylc/flow/clean.py
@@ -446,8 +446,8 @@ def remote_clean(
             f"Remote clean failed for {id_} - could not clean on these "
             "install target(s):"
         )
-        for target, exc in failed_targets.items():
-            msg += f"\n[{target}]\n{exc}"
+        for target, excep in failed_targets.items():
+            msg += f"\n[{target}]\n{excep}"
         raise CylcError(msg)
 
 

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -180,10 +180,6 @@ def _remove_matched_tasks(
                 continue
             removed[itask.tokens.task] = fnums_to_remove
             if fnums_to_remove == itask.flow_nums:
-                # Need to remove the task from the pool.
-                # Spawn next occurrence of xtrigger sequential task (otherwise
-                # this would not happen after removing this occurrence):
-                schd.pool.check_spawn_psx_task(itask)
                 schd.pool.remove(itask, 'request')
                 to_kill.append(itask)
                 itask.removed = True

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1705,6 +1705,8 @@ class Scheduler:
         # Update state summary, database, and uifeed
         self.workflow_db_mgr.put_task_event_timers(self.task_events_mgr)
 
+        self.pool.release_runahead_tasks()
+
         # List of task whose states have changed.
         updated_task_list = [
             t for t in self.pool.get_tasks() if t.state.is_updated]

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -844,8 +844,12 @@ class Scheduler:
             flow=[FLOW_NEW],
             flow_descr=f"original flow from {self.options.starttask}"
         )
+        # Spawning to the runahead limit immediately is not strictly necessary
+        # as it would occur over several scheduler main loop iterations; we do
+        # it mainly for compatibility with integration tests pre PR #7237.
         self.pool.spawn_to_runahead_limit()
-        self.pool.queue_if_ready()
+        for itask in self.pool.get_tasks():
+            self.pool.queue_if_ready(itask)
 
     def _load_pool_from_point(self):
         """Load task pool for a cycle point, for a new run.
@@ -1656,10 +1660,7 @@ class Scheduler:
                 self.broadcast_mgr.check_ext_triggers(
                     itask, self.ext_trigger_queue)
 
-            if itask.is_ready_to_run() and not itask.is_manual_submit:
-                if itask.is_xtrigger_sequential:
-                    self.pool.spawn_next_parentless(itask)
-                self.pool.queue_task(itask)
+            self.pool.queue_if_ready(itask)
 
         if self.xtrigger_mgr.do_housekeeping:
             self.xtrigger_mgr.housekeep(self.pool.get_tasks())
@@ -1744,10 +1745,6 @@ class Scheduler:
 
         # Shutdown workflow if timeouts have occurred
         self.timeout_check()
-
-        # # Does the workflow need to shutdown on task failure?
-        # move up to top
-        # await self.workflow_shutdown()
 
         if self.options.profile_mode:
             self.update_profiler_logs(tinit)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -844,6 +844,8 @@ class Scheduler:
             flow=[FLOW_NEW],
             flow_descr=f"original flow from {self.options.starttask}"
         )
+        self.pool.spawn_to_runahead_limit()
+        self.pool.queue_if_ready()
 
     def _load_pool_from_point(self):
         """Load task pool for a cycle point, for a new run.
@@ -880,13 +882,6 @@ class Scheduler:
             self.xtrigger_mgr.load_xtrigger_for_restart)
         self.workflow_db_mgr.pri_dao.select_abs_outputs_for_restart(
             self.pool.load_abs_outputs_for_restart)
-
-        # Compute and release runahead tasks once after loading all tasks from
-        # the DB. This also causes spawning of parentless tasks out to the
-        # runahead limit, which may be necessary here if the stop point or
-        # runahead limit was changed for the restart.
-        self.pool.compute_runahead()
-        self.pool.release_runahead_tasks()
 
         self.pool.load_db_tasks_to_hold()
         self.pool.update_flow_mgr()
@@ -1622,7 +1617,12 @@ class Scheduler:
 
     async def _main_loop(self) -> None:
         """A single iteration of the main loop."""
+
         tinit = time()
+
+        self.pool.compute_runahead()
+        self.pool.release_runahead_tasks()
+        await self.workflow_shutdown()
 
         # Useful for debugging core scheduler issues:
         # import logging
@@ -1657,10 +1657,13 @@ class Scheduler:
                     itask, self.ext_trigger_queue)
 
             if itask.is_ready_to_run() and not itask.is_manual_submit:
+                if itask.is_xtrigger_sequential:
+                    self.pool.spawn_next_parentless(itask)
                 self.pool.queue_task(itask)
 
         if self.xtrigger_mgr.do_housekeeping:
             self.xtrigger_mgr.housekeep(self.pool.get_tasks())
+
         self.pool.clock_expire_tasks()
         self.release_tasks_to_run()
 
@@ -1717,11 +1720,10 @@ class Scheduler:
             await self.update_data_structure()
 
         if has_updated:
-            if not self.is_reloaded:
+            if not self.is_reloaded and self.is_stalled:
                 # (A reload cannot un-stall workflow by itself)
-                if self.is_stalled:
-                    self.is_stalled = False
-                    self.update_data_store()
+                self.is_stalled = False
+                self.update_data_store()
             self.is_reloaded = False
 
             # Reset workflow and task updated flags.
@@ -1743,8 +1745,9 @@ class Scheduler:
         # Shutdown workflow if timeouts have occurred
         self.timeout_check()
 
-        # Does the workflow need to shutdown on task failure?
-        await self.workflow_shutdown()
+        # # Does the workflow need to shutdown on task failure?
+        # move up to top
+        # await self.workflow_shutdown()
 
         if self.options.profile_mode:
             self.update_profiler_logs(tinit)

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1655,6 +1655,7 @@ class Scheduler:
                 self.broadcast_mgr.check_ext_triggers(
                     itask, self.ext_trigger_queue)
 
+            self.pool.spawn_psx_task(itask)
             self.pool.queue_if_ready(itask)
 
         if self.xtrigger_mgr.do_housekeeping:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1620,6 +1620,7 @@ class Scheduler:
 
         self.pool.compute_runahead()
         self.pool.release_runahead_tasks()
+        # If applicable, set stop mode or shutdown on task failure:
         await self.workflow_shutdown()
 
         # Useful for debugging core scheduler issues:

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -844,12 +844,6 @@ class Scheduler:
             flow=[FLOW_NEW],
             flow_descr=f"original flow from {self.options.starttask}"
         )
-        # Spawning to the runahead limit immediately is not strictly necessary
-        # as it would occur over several scheduler main loop iterations; we do
-        # it mainly for compatibility with integration tests pre PR #7237.
-        self.pool.spawn_to_runahead_limit()
-        for itask in self.pool.get_tasks():
-            self.pool.queue_if_ready(itask)
 
     def _load_pool_from_point(self):
         """Load task pool for a cycle point, for a new run.
@@ -1704,8 +1698,6 @@ class Scheduler:
 
         # Update state summary, database, and uifeed
         self.workflow_db_mgr.put_task_event_timers(self.task_events_mgr)
-
-        self.pool.release_runahead_tasks()
 
         # List of task whose states have changed.
         updated_task_list = [

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -262,8 +262,7 @@ class TaskPool:
 
         """
         if (
-            itask.state(TASK_STATUS_WAITING)
-            and not itask.state.is_queued
+            not itask.state.is_queued
             and not itask.state.is_runahead
             and not itask.is_manual_submit
             and itask.is_ready_to_run()
@@ -867,10 +866,6 @@ class TaskPool:
                 self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)
             )
             if ntask is not None and not is_in_pool:
-                LOG.debug(
-                    f"Next parentless instance of {itask.identity}"
-                    f" is {ntask.identity}"
-                )
                 self.add_to_pool(ntask)
 
     def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -881,10 +881,8 @@ class TaskPool:
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
 
-        if (
-            itask.flow_nums and (
-                itask.state.is_runahead or itask.is_xtrigger_sequential
-            )
+        if itask.flow_nums and (
+            itask.state.is_runahead or itask.is_xtrigger_sequential
         ):
             # If removing a parentless runahead-limited task
             # auto-spawn its next instance first.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -268,8 +268,18 @@ class TaskPool:
             and itask.is_ready_to_run()
         ):
             self.queue_task(itask)
-            if itask.is_xtrigger_sequential:
-                self.spawn_next_parentless(itask)
+
+    def spawn_psx_task(self, itask: 'TaskProxy') -> None:
+        """Spawn a parentless sequential xtriggered task.
+
+        Do it when all of its sequential xtriggers are satisfied.
+
+        """
+        if (
+            itask.is_xtrigger_sequential
+            and self.xtrigger_mgr.all_task_seq_xtriggers_satisfied(itask)
+        ):
+            self.spawn_next_parentless(itask)
 
     def load_from_point(self):
         """Load the task pool for the workflow start point.
@@ -285,7 +295,7 @@ class TaskPool:
             tdef = self.config.get_taskdef(name)
             point = tdef.next_point_parentless(self.config.start_point)
             if point:
-                ntask, _, _ = self.get_or_spawn_task(point, tdef, flow_nums)
+                ntask, _ = self.get_or_spawn_task(point, tdef, flow_nums)
                 if ntask is not None:
                     self.add_to_pool(ntask)
         # Spawning to the runahead limit immediately is not strictly necessary
@@ -806,11 +816,11 @@ class TaskPool:
         tdef: 'TaskDef',
         flow_nums: 'FlowNums',
         flow_wait: bool = False
-    ) -> 'Tuple[Optional[TaskProxy], bool, bool]':
+    ) -> 'Tuple[Optional[TaskProxy], bool]':
         """Return new or existing task point/name with merged flow_nums.
 
         Returns:
-            tuple - (itask, is_in_pool
+            tuple - (itask, is_in_pool)
 
             itask:
                 The requested task proxy, or None if task does not
@@ -848,7 +858,7 @@ class TaskPool:
         point = itask.tdef.next_point_parentless(
             self.config.start_point, itask.point)
         if point is not None:
-            ntask, is_in_pool, _ = (
+            ntask, is_in_pool = (
                 self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)
             )
             if ntask is not None and not is_in_pool:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -244,18 +244,48 @@ class TaskPool:
             self.active_tasks[itask.point][itask.identity] = itask
             self.active_tasks_changed = True
 
+    def spawn_to_runahead_limit(self):
+        """Spawn the task pool out to the runahead limit in one go.
+
+        Not strictly necessary, it will spawn ahead per main loop iteration,
+        but useful back-compat for tests that expect this prior to GH #....
+
+        """
+        self.compute_runahead()
+        while self.release_runahead_tasks():
+            pass
+
+    def queue_if_ready(self):
+        """Queue tasks that are ready to run."""
+        # TODO consolidate with same code in schd main loop.
+        for itask in self.get_tasks():
+            if (
+                not itask.state(TASK_STATUS_WAITING)
+                or itask.state.is_queued
+                or itask.state.is_runahead
+            ):
+                continue
+            if itask.is_ready_to_run() and not itask.is_manual_submit:
+                if itask.is_xtrigger_sequential:
+                    self.spawn_next_parentless(itask)
+                self.queue_task(itask)
+
     def load_from_point(self):
         """Load the task pool for the workflow start point.
 
-        Add every parentless task out to the runahead limit.
+        Spawn the first instance of every parentless task.
+
         """
         flow_num = self.flow_mgr.get_flow(
             meta=f"original flow from {self.config.start_point}")
-        self.compute_runahead()
         for name in self.task_name_list:
             tdef = self.config.get_taskdef(name)
             point = tdef.first_point(self.config.start_point)
-            self.spawn_to_rh_limit(tdef, point, {flow_num})
+            if point is not None:
+                self.spawn_this_or_next_parentless(tdef, point, {flow_num})
+
+        self.spawn_to_runahead_limit()
+        self.queue_if_ready()
 
     def db_add_new_flow_rows(self, itask: TaskProxy) -> None:
         """Add new rows to DB task tables that record flow_nums.
@@ -277,7 +307,7 @@ class TaskPool:
             return None
         self.active_tasks[itask.point][itask.identity] = itask
         self.active_tasks_changed = True
-        LOG.debug(f"[{itask}] added to the n=0 window")
+        LOG.info(f"[{itask}] added to the n=0 window")  # TODO debug
 
         self.create_data_store_elements(itask)
 
@@ -310,6 +340,7 @@ class TaskPool:
 
         released = False
 
+        # TODO: is this still needed?
         # An intermediate list is needed here: auto-spawning of parentless
         # tasks can cause the task pool to change size during iteration.
         release_me = [
@@ -321,13 +352,10 @@ class TaskPool:
         ]
 
         for itask in release_me:
-            self.rh_release_and_queue(itask)
+            if itask.state_reset(is_runahead=False):
+                self.data_store_mgr.delta_task_state(itask)
             if itask.flow_nums and not itask.is_xtrigger_sequential:
-                self.spawn_to_rh_limit(
-                    itask.tdef,
-                    itask.tdef.next_point(itask.point),
-                    itask.flow_nums
-                )
+                self.spawn_next_parentless(itask)
             released = True
 
         return released
@@ -660,8 +688,10 @@ class TaskPool:
                     TASK_STATUS_EXPIRED
                 )
                 or itask.is_manual_submit
+            ) and (
+                itask.state_reset(is_runahead=False)
             ):
-                self.rh_release_and_queue(itask)
+                self.data_store_mgr.delta_task_state(itask)
 
     def load_db_task_action_timers(self, row_idx: int, row: Iterable) -> None:
         """Load a task action timer, e.g. event handlers, retry states."""
@@ -761,18 +791,6 @@ class TaskPool:
             self.workflow_db_mgr.pri_dao.select_tasks_to_hold()
         )
 
-    def rh_release_and_queue(self, itask) -> None:
-        """Release a task from runahead limiting, and queue it if ready.
-
-        Check the task against the RH limit before calling this method (in
-        forced triggering we need to release even if beyond the limit).
-        """
-        if itask.state_reset(is_runahead=False):
-            self.data_store_mgr.delta_task_state(itask)
-        if itask.is_ready_to_run():
-            # (otherwise waiting on xtriggers etc.)
-            self.queue_task(itask)
-
     def get_or_spawn_task(
         self,
         point: 'PointBase',
@@ -825,60 +843,40 @@ class TaskPool:
         # ntask may still be None
         return ntask, is_in_pool, is_xtrig_sequential
 
-    def spawn_to_rh_limit(
-        self,
-        tdef: 'TaskDef',
-        point: Optional['PointBase'],
-        flow_nums: 'FlowNums',
-    ) -> None:
-        """Spawn parentless task instances from point to runahead limit.
-
-        Sequentially checked xtriggers will spawn the next occurrence of their
-        corresponding tasks. These tasks will keep spawning until they depend
-        on any unsatisfied xtrigger of the same sequential behavior, are no
-        longer parentless, and/or hit the runahead limit.
-
-        """
+    def spawn_next_parentless(self, itask: 'TaskProxy') -> None:
+        """Spawn next parentless instance of this task."""
         if (
-            not flow_nums  # Force-triggered no-flow task
-            or point is None  # Reached end of sequence?
-            or point < self.config.start_point  # Warm start
+            not itask.flow_nums  # Force-triggered no-flow task
+            or itask.point < self.config.start_point  # Warm start
         ):
             return
-        if self.runahead_limit_point is None:
-            self.compute_runahead()
-            if self.runahead_limit_point is None:
-                return
-
-        is_xtrig_sequential = False
-        while point is not None and (point <= self.runahead_limit_point):
-            if tdef.is_parentless(point, cutoff=self.config.start_point):
-                ntask, is_in_pool, is_xtrig_sequential = (
-                    self.get_or_spawn_task(point, tdef, flow_nums)
-                )
-                if ntask is not None:
-                    if not is_in_pool:
-                        self.add_to_pool(ntask)
-                    self.rh_release_and_queue(ntask)
-                if is_xtrig_sequential:
-                    break
-            point = tdef.next_point(point)
-
-        # Once more for the runahead-limited task (don't release it).
-        if not is_xtrig_sequential:
-            self.spawn_if_parentless(tdef, point, flow_nums)
-
-    def spawn_if_parentless(self, tdef, point, flow_nums):
-        """Spawn a task if parentless, regardless of runahead limit."""
-        if (
-            flow_nums
-            and point is not None
-            and tdef.is_parentless(point, cutoff=self.config.start_point)
-        ):
-            ntask, is_in_pool, _ = self.get_or_spawn_task(
-                point, tdef, flow_nums
+        point = itask.tdef.next_point_parentless(
+            itask.point, self.config.start_point)
+        if point is not None:
+            ntask, is_in_pool, _ = (
+                self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)
             )
             if ntask is not None and not is_in_pool:
+                LOG.debug(
+                    f"Next parentless instance of {itask.identity}"
+                    f" is {ntask.identity}"
+                )
+                self.add_to_pool(ntask)
+
+    def spawn_this_or_next_parentless(
+        self, tdef: 'TaskDef', point: 'PointBase', flow_nums: 'FlowNums'
+    ) -> None:
+        """Spawn next parentless instance of this task."""
+        # this
+        if not tdef.is_parentless(point, self.config.start_point):
+            # next
+            point = tdef.next_point_parentless(point, self.config.start_point)
+        # spawn it
+        if point:
+            ntask, _, _ = (
+                self.get_or_spawn_task(point, tdef, flow_nums)
+            )
+            if ntask is not None:
                 self.add_to_pool(ntask)
 
     def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:
@@ -889,24 +887,19 @@ class TaskPool:
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
 
-        if itask.state.is_runahead and itask.flow_nums:
+        if (
+            itask.flow_nums and (
+                itask.state.is_runahead or itask.is_xtrigger_sequential
+            )
+        ):
             # If removing a parentless runahead-limited task
             # auto-spawn its next instance first.
-            self.spawn_if_parentless(
-                itask.tdef,
-                itask.tdef.next_point(itask.point),
-                itask.flow_nums
-            )
+            self.spawn_next_parentless(itask)
 
         msg = f"removed from the n=0 window: {reason or 'completed'}"
 
         # Mark as transient in case itask is still processed in other contexts.
         itask.transient = True
-
-        if itask.is_xtrigger_sequential:
-            self.xtrigger_mgr.sequential_has_spawned_next.discard(
-                itask.identity
-            )
 
         try:
             del self.active_tasks[itask.point][itask.identity]
@@ -950,10 +943,6 @@ class TaskPool:
             self.workflow_db_mgr.process_queued_ops()
 
             del itask
-
-            # removing this task could nudge the runahead limit forward
-            if self.compute_runahead():
-                self.release_runahead_tasks()
 
     def get_tasks(self) -> List[TaskProxy]:
         """Return a list of task proxies in the task pool."""
@@ -1112,6 +1101,7 @@ class TaskPool:
             ):
                 max_offset = itask.tdef.max_future_prereq_offset
         self.max_future_offset = max_offset
+        # TODO IS THIS NEEDED?
         if max_offset != orig and self.compute_runahead(force=True):
             self.release_runahead_tasks()
 
@@ -1212,18 +1202,10 @@ class TaskPool:
             self.config.runtime['descendants']
         )
 
-        if self.compute_runahead():
-            self.release_runahead_tasks()
-
         # Now queue all tasks that are ready to run
         for itask in self.get_tasks():
             # Recreate data store elements from task pool.
             self.create_data_store_elements(itask)
-            if itask.state.is_queued:
-                # Already queued
-                continue
-            if itask.is_ready_to_run() and not itask.state.is_runahead:
-                self.queue_task(itask)
 
     def set_stop_point(self, stop_point: 'PointBase') -> bool:
         """Set the workflow stop cycle point.
@@ -1572,12 +1554,6 @@ class TaskPool:
                     if not in_pool:
                         self.add_to_pool(t)
 
-                    if (
-                        self.runahead_limit_point is not None
-                        and t.point <= self.runahead_limit_point
-                    ):
-                        self.rh_release_and_queue(t)
-
                     # Event-driven suicide.
                     if (
                         t.state.suicide_prerequisites and
@@ -1634,9 +1610,6 @@ class TaskPool:
             if not itask.state(TASK_STATUS_FAILED, TASK_OUTPUT_SUBMIT_FAILED):
                 self.remove(itask)
                 ret = True
-            # Recompute runahead either way; failed tasks don't count in C7.
-            if self.compute_runahead():
-                self.release_runahead_tasks()
             return ret
 
         if not itask.state.outputs.is_complete():
@@ -1654,8 +1627,7 @@ class TaskPool:
             return False
 
         self.remove(itask)
-        if self.compute_runahead():
-            self.release_runahead_tasks()
+
         return True
 
     def spawn_on_all_outputs(
@@ -1705,11 +1677,6 @@ class TaskPool:
                     )
                     self.data_store_mgr.delta_task_prerequisite(c_task)
                 self.add_to_pool(c_task)
-                if (
-                    self.runahead_limit_point is not None
-                    and c_task.point <= self.runahead_limit_point
-                ):
-                    self.rh_release_and_queue(c_task)
 
     def can_be_spawned(self, name: str, point: 'PointBase') -> bool:
         """Return True if a point/name is within graph bounds."""
@@ -2106,8 +2073,6 @@ class TaskPool:
         """
         matched, _unmatched = self.id_match(set(items))
 
-        no_op = True
-
         # Clean and separate requested prerequisite and xtrigger specs.
         if prereqs != ['all']:
             set_all = False
@@ -2154,15 +2119,12 @@ class TaskPool:
                     self.merge_flows(itask, flow_nums)
                     self._set_prereqs_itask(
                         itask, valid_prereqs, valid_xtrigs, set_all)
-                    no_op = False
                 else:
                     # Outputs (may be empty list)
                     # Spawn as if seq xtrig of parentless task was satisfied,
                     # with associated task producing these outputs.
                     self.merge_flows(itask, flow_nums)
-                    self.check_spawn_psx_task(itask)
                     self._set_outputs_itask(itask, outputs)
-                    no_op = False
 
             else:
                 # set inactive task
@@ -2179,24 +2141,18 @@ class TaskPool:
                     self._set_prereqs_tdef(
                         icycle, tdef, valid_prereqs, valid_xtrigs, flow_nums,
                         flow_wait, set_all)
-                    no_op = False
                 else:
                     # Outputs (may be empty list)
                     trans = self._load_db_task_proxy(
                         icycle, tdef, flow_nums,
                         flow_wait=flow_wait, transient=True
                     )
-                    if trans and self._set_outputs_itask(trans, outputs):
-                        no_op = False
+                    if trans:
+                        self._set_outputs_itask(trans, outputs)
 
         if warnings_flow_none:
             msg = '\n  * '.join(warnings_flow_none)
             LOG.warning(f"Already active - ignoring no-flow set: \n  * {msg}")
-
-        if not no_op:
-            # for "cylc play --start-tasks" compute runahead after spawning
-            self.compute_runahead()
-            self.release_runahead_tasks()
 
     def _get_valid_prereqs(
         self, prereqs: Set[PrereqTuple], tdef: 'TaskDef', point: 'PointBase'
@@ -2338,17 +2294,6 @@ class TaskPool:
         # xtriggers, including "all"
         self.xtrigger_mgr.force_satisfy(itask, xtrigs)
 
-        if (
-            itask.state.is_runahead
-            and self.runahead_limit_point is not None
-            and itask.point <= self.runahead_limit_point
-        ):
-            self.spawn_to_rh_limit(
-                itask.tdef,
-                itask.tdef.next_point(itask.point),
-                itask.flow_nums
-            )
-
     def _set_prereqs_tdef(
         self,
         point: 'PointBase',
@@ -2412,14 +2357,7 @@ class TaskPool:
             # (could also be unhandled failed)
             self.data_store_mgr.delta_task_state(itask)
 
-        if itask.state_reset(is_runahead=False):
-            # Can force trigger runahead-limited tasks.
-            self.data_store_mgr.delta_task_state(itask)
-            self.spawn_to_rh_limit(
-                itask.tdef,
-                itask.tdef.next_point(itask.point),
-                itask.flow_nums
-            )
+        # TODO CHECK FORCE TRIGGER RUNAHEAD TASKS
 
         if not itask.state.is_queued:
             # queue it if limiting
@@ -2437,30 +2375,6 @@ class TaskPool:
             # If not queued now, record the task as ready to run.
             itask.waiting_on_job_prep = True
             self.tasks_to_trigger_now.add(itask)
-
-        # Task may be set running before xtrigger is satisfied,
-        # if so check/spawn if xtrigger sequential.
-        self.check_spawn_psx_task(itask)
-
-    def check_spawn_psx_task(self, itask: 'TaskProxy') -> None:
-        """Check and spawn parentless sequential xtriggered task (psx)."""
-        # Will spawn out to RH limit or next parentless clock trigger
-        # or non-parentless.
-        if (
-            itask.is_xtrigger_sequential
-            and (
-                itask.identity not in
-                self.xtrigger_mgr.sequential_has_spawned_next
-            )
-        ):
-            self.xtrigger_mgr.sequential_has_spawned_next.add(
-                itask.identity
-            )
-            self.spawn_to_rh_limit(
-                itask.tdef,
-                itask.tdef.next_point(itask.point),
-                itask.flow_nums
-            )
 
     def clock_expire_tasks(self):
         """Expire any tasks past their clock-expiry time."""
@@ -2515,9 +2429,6 @@ class TaskPool:
                 ):
                     # Don't spawn successor if the task is parentless.
                     self.remove(itask, "flow stopped")
-
-        if self.compute_runahead():
-            self.release_runahead_tasks()
 
     def log_task_pool(self, log_lvl=logging.DEBUG):
         """Log content of task pool, for debugging."""
@@ -2591,5 +2502,3 @@ class TaskPool:
             LOG.info(f"[{itask}] spawning on pre-merge outputs")
             itask.flow_wait = False
             self.spawn_on_all_outputs(itask, completed_only=True)
-            self.spawn_to_rh_limit(
-                itask.tdef, itask.next_point(), itask.flow_nums)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -248,7 +248,8 @@ class TaskPool:
         """Spawn the task pool out to the runahead limit in one go.
 
         Not strictly necessary, it will spawn ahead per main loop iteration,
-        but useful back-compat for tests that expect this prior to GH #....
+        but useful back-compat for tests that expect this prior to
+        https://github.com/cylc/cylc-flow/pull/7237
 
         """
         self.compute_runahead()

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -252,8 +252,10 @@ class TaskPool:
 
         """
         self.compute_runahead()
-        while self.release_runahead_tasks():
-            pass
+        # Arbitrary limit to avoid infinite loop if something goes wrong.
+        for _ in range(10):
+            if not self.release_runahead_tasks():
+                break
 
     def queue_if_ready(self, itask: 'TaskProxy') -> None:
         """Queue itask if it is ready to run.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -255,37 +255,46 @@ class TaskPool:
         while self.release_runahead_tasks():
             pass
 
-    def queue_if_ready(self):
-        """Queue tasks that are ready to run."""
-        # TODO consolidate with same code in schd main loop.
-        for itask in self.get_tasks():
-            if (
-                not itask.state(TASK_STATUS_WAITING)
-                or itask.state.is_queued
-                or itask.state.is_runahead
-            ):
-                continue
-            if itask.is_ready_to_run() and not itask.is_manual_submit:
-                if itask.is_xtrigger_sequential:
-                    self.spawn_next_parentless(itask)
-                self.queue_task(itask)
+    def queue_if_ready(self, itask: 'TaskProxy') -> None:
+        """Queue itask if it is ready to run.
+
+        Spawn next instance of sequential xtriggered tasks at this time too.
+
+        """
+        if (
+            itask.state(TASK_STATUS_WAITING)
+            and not itask.state.is_queued
+            and not itask.state.is_runahead
+            and not itask.is_manual_submit
+            and itask.is_ready_to_run()
+        ):
+            self.queue_task(itask)
+            if itask.is_xtrigger_sequential:
+                self.spawn_next_parentless(itask)
 
     def load_from_point(self):
         """Load the task pool for the workflow start point.
 
-        Spawn the first instance of every parentless task.
+        Spawn the first parentless instance (if any) of every task.
 
         """
-        flow_num = self.flow_mgr.get_flow(
-            meta=f"original flow from {self.config.start_point}")
+        flow_nums = {
+            self.flow_mgr.get_flow(
+                meta=f"original flow from {self.config.start_point}")
+        }
         for name in self.task_name_list:
             tdef = self.config.get_taskdef(name)
-            point = tdef.first_point(self.config.start_point)
-            if point is not None:
-                self.spawn_this_or_next_parentless(tdef, point, {flow_num})
-
+            point = tdef.next_point_parentless(self.config.start_point)
+            if point:
+                ntask, _, _ = self.get_or_spawn_task(point, tdef, flow_nums)
+                if ntask is not None:
+                    self.add_to_pool(ntask)
+        # Spawning to the runahead limit immediately is not strictly necessary
+        # as it would occur over several scheduler main loop iterations; we do
+        # it mainly for compatibility with integration tests pre PR #7237.
         self.spawn_to_runahead_limit()
-        self.queue_if_ready()
+        for itask in self.get_tasks():
+            self.queue_if_ready(itask)
 
     def db_add_new_flow_rows(self, itask: TaskProxy) -> None:
         """Add new rows to DB task tables that record flow_nums.
@@ -307,7 +316,7 @@ class TaskPool:
             return None
         self.active_tasks[itask.point][itask.identity] = itask
         self.active_tasks_changed = True
-        LOG.info(f"[{itask}] added to the n=0 window")  # TODO debug
+        LOG.debug(f"[{itask}] added to the n=0 window")
 
         self.create_data_store_elements(itask)
 
@@ -340,7 +349,6 @@ class TaskPool:
 
         released = False
 
-        # TODO: is this still needed?
         # An intermediate list is needed here: auto-spawning of parentless
         # tasks can cause the task pool to change size during iteration.
         release_me = [
@@ -352,8 +360,10 @@ class TaskPool:
         ]
 
         for itask in release_me:
+            # Release the task.
             if itask.state_reset(is_runahead=False):
                 self.data_store_mgr.delta_task_state(itask)
+            # Spawn the next parentless instance (if there is one) on release.
             if itask.flow_nums and not itask.is_xtrigger_sequential:
                 self.spawn_next_parentless(itask)
             released = True
@@ -851,7 +861,7 @@ class TaskPool:
         ):
             return
         point = itask.tdef.next_point_parentless(
-            itask.point, self.config.start_point)
+            self.config.start_point, itask.point)
         if point is not None:
             ntask, is_in_pool, _ = (
                 self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)
@@ -861,22 +871,6 @@ class TaskPool:
                     f"Next parentless instance of {itask.identity}"
                     f" is {ntask.identity}"
                 )
-                self.add_to_pool(ntask)
-
-    def spawn_this_or_next_parentless(
-        self, tdef: 'TaskDef', point: 'PointBase', flow_nums: 'FlowNums'
-    ) -> None:
-        """Spawn next parentless instance of this task."""
-        # this
-        if not tdef.is_parentless(point, self.config.start_point):
-            # next
-            point = tdef.next_point_parentless(point, self.config.start_point)
-        # spawn it
-        if point:
-            ntask, _, _ = (
-                self.get_or_spawn_task(point, tdef, flow_nums)
-            )
-            if ntask is not None:
                 self.add_to_pool(ntask)
 
     def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:
@@ -1101,9 +1095,8 @@ class TaskPool:
             ):
                 max_offset = itask.tdef.max_future_prereq_offset
         self.max_future_offset = max_offset
-        # TODO IS THIS NEEDED?
-        if max_offset != orig and self.compute_runahead(force=True):
-            self.release_runahead_tasks()
+        if max_offset != orig:
+            self.compute_runahead(force=True)
 
     def reload(self, config: 'WorkflowConfig') -> None:
         self.config = config   # store the updated config
@@ -1627,7 +1620,6 @@ class TaskPool:
             return False
 
         self.remove(itask)
-
         return True
 
     def spawn_on_all_outputs(
@@ -1648,7 +1640,7 @@ class TaskPool:
         if not itask.flow_nums:
             return
 
-        for _trigger, message, is_completed in itask.state.outputs:
+        for _, message, is_completed in itask.state.outputs:
             if completed_only and not is_completed:
                 continue
             try:
@@ -2356,8 +2348,6 @@ class TaskPool:
         if itask.state_reset(TASK_STATUS_WAITING):
             # (could also be unhandled failed)
             self.data_store_mgr.delta_task_state(itask)
-
-        # TODO CHECK FORCE TRIGGER RUNAHEAD TASKS
 
         if not itask.state.is_queued:
             # queue it if limiting

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -855,7 +855,8 @@ class TaskPool:
             or itask.point < self.config.start_point  # Warm start
         ):
             return
-        point = itask.tdef.next_point_parentless(itask.point)
+        point = itask.tdef.next_point_parentless(
+            self.config.start_point, itask.point)
         if point is not None:
             ntask, is_in_pool = (
                 self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -855,8 +855,7 @@ class TaskPool:
             or itask.point < self.config.start_point  # Warm start
         ):
             return
-        point = itask.tdef.next_point_parentless(
-            self.config.start_point, itask.point)
+        point = itask.tdef.next_point_parentless(itask.point)
         if point is not None:
             ntask, is_in_pool = (
                 self.get_or_spawn_task(point, itask.tdef, itask.flow_nums)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -810,22 +810,18 @@ class TaskPool:
         """Return new or existing task point/name with merged flow_nums.
 
         Returns:
-            tuple - (itask, is_in_pool, is_xtrig_sequential)
+            tuple - (itask, is_in_pool
 
             itask:
                 The requested task proxy, or None if task does not
                 exist or cannot spawn.
             is_in_pool:
                 Was the task found in a pool.
-            is_xtrig_sequential:
-                Is the next task occurrence spawned on xtrigger satisfaction,
-                or do all occurrence spawn out to the runahead limit.
 
         It does not add a spawned task proxy to the pool.
         """
         ntask = self.get_task(point, tdef.name)
         is_in_pool = False
-        is_xtrig_sequential = False
         if ntask is None:
             # ntask does not exist: spawn it in the flow.
             ntask = self.spawn_task(
@@ -834,23 +830,13 @@ class TaskPool:
             # if the task was found set xtrigger checking type.
             # otherwise find the xtrigger type if it can't spawn
             # for whatever reason.
-            if ntask is not None:
-                is_xtrig_sequential = ntask.is_xtrigger_sequential
-            elif any(
-                xtrig_label in (
-                    self.xtrigger_mgr.xtriggers.sequential_xtrigger_labels)
-                for sequence, xtrig_labels in tdef.xtrig_labels.items()
-                for xtrig_label in xtrig_labels
-                if sequence.is_valid(point)
-            ):
-                is_xtrig_sequential = True
         else:
             # ntask already exists (n=0): merge flows.
             is_in_pool = True
             self.merge_flows(ntask, flow_nums)
-            is_xtrig_sequential = ntask.is_xtrigger_sequential
+
         # ntask may still be None
-        return ntask, is_in_pool, is_xtrig_sequential
+        return ntask, is_in_pool
 
     def spawn_next_parentless(self, itask: 'TaskProxy') -> None:
         """Spawn next parentless instance of this task."""

--- a/cylc/flow/task_proxy.py
+++ b/cylc/flow/task_proxy.py
@@ -471,10 +471,6 @@ class TaskProxy:
         except (AttributeError, KeyError):
             return 0
 
-    def next_point(self):
-        """Return the next cycle point."""
-        return self.tdef.next_point(self.point)
-
     def is_ready_to_run(self) -> bool:
         """Is this task ready to run?
 

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -407,9 +407,7 @@ class TaskDef:
             point = min(adjusted)
         return point
 
-    def next_point_parentless(
-        self, cutoff: 'PointBase', point: 'PointBase | None' = None
-    ):
+    def next_point_parentless(self, point: 'PointBase | None' = None):
         """Return next cycle point for which I'm parentless.
 
         For a given recurrence, a task is either parented or parentless.
@@ -417,17 +415,15 @@ class TaskDef:
         If point is None, return the first parentless cycle; otherwise
         the first parentless cycle > point.
 
-        Cutoff is the start cycle point, prior to which we ignore parents.
-
         """
         adjusted = []
         for seq in self.sequences:
             next_point = (
-                seq.get_first_point(cutoff)
+                seq.get_first_point(self.start_point)
                 if point is None
                 else seq.get_next_point(point)
             )
-            if next_point and self.is_parentless(next_point, cutoff):
+            if next_point and self.is_parentless(next_point, self.start_point):
                 adjusted.append(next_point)
         if adjusted:
             return min(adjusted)

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -412,16 +412,16 @@ class TaskDef:
     ):
         """Return next cycle point for which I'm parentless.
 
+        For a given recurrence, a task is either parented or parentless.
+
         If point is None, return the first parentless cycle; otherwise
         the first parentless cycle > point.
 
         Cutoff is the start cycle point, prior to which we ignore parents.
 
         """
-        p_next = None
         adjusted = []
         for seq in self.sequences:
-            # (Tasks are parentless or not per sequence).
             next_point = (
                 seq.get_first_point(cutoff)
                 if point is None

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -407,28 +407,28 @@ class TaskDef:
             point = min(adjusted)
         return point
 
-    def next_point(self, point):
-        """Return the next cycle point after point."""
-        p_next = None
-        adjusted = []
-        for seq in self.sequences:
-            nxt = seq.get_next_point(point)
-            if nxt:
-                # may be None if beyond the sequence bounds
-                adjusted.append(nxt)
-        if adjusted:
-            p_next = min(adjusted)
-        return p_next
+    def next_point_parentless(
+        self, cutoff: 'PointBase', point: 'PointBase | None' = None
+    ):
+        """Return next cycle point for which I'm parentless.
 
-    def next_point_parentless(self, point: 'PointBase', cutoff: 'PointBase'):
-        """Return the next cycle point >= point where parentless."""
+        If point is None, return the first parentless cycle; otherwise
+        the first parentless cycle > point.
+
+        Cutoff is the start cycle point, prior to which we ignore parents.
+
+        """
         p_next = None
         adjusted = []
         for seq in self.sequences:
-            nxt = seq.get_next_point(point)
-            if nxt and self.is_parentless(nxt, cutoff):
-                # may be None if beyond the sequence bounds
-                adjusted.append(nxt)
+            # (Tasks are parentless or not per sequence).
+            pt = None
+            if point is None:
+                pt = seq.get_first_point(cutoff)
+            else:
+                pt = seq.get_next_point(point)
+            if pt and self.is_parentless(pt, cutoff):
+                adjusted.append(pt)
         if adjusted:
             p_next = min(adjusted)
         return p_next

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -407,7 +407,9 @@ class TaskDef:
             point = min(adjusted)
         return point
 
-    def next_point_parentless(self, point: 'PointBase | None' = None):
+    def next_point_parentless(
+        self, cutoff: 'PointBase', point: 'PointBase | None' = None
+    ):
         """Return next cycle point for which I'm parentless.
 
         For a given recurrence, a task is either parented or parentless.
@@ -415,15 +417,17 @@ class TaskDef:
         If point is None, return the first parentless cycle; otherwise
         the first parentless cycle > point.
 
+        Cutoff is the start cycle point, prior to which we ignore parents.
+
         """
         adjusted = []
         for seq in self.sequences:
             next_point = (
-                seq.get_first_point(self.start_point)
+                seq.get_first_point(cutoff)
                 if point is None
                 else seq.get_next_point(point)
             )
-            if next_point and self.is_parentless(next_point, self.start_point):
+            if next_point and self.is_parentless(next_point, cutoff):
                 adjusted.append(next_point)
         if adjusted:
             return min(adjusted)

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -430,8 +430,8 @@ class TaskDef:
             if next_point and self.is_parentless(next_point, cutoff):
                 adjusted.append(next_point)
         if adjusted:
-            p_next = min(adjusted)
-        return p_next
+            return min(adjusted)
+        return None
 
     def is_parentless(self, point: 'PointBase', cutoff: 'PointBase') -> bool:
         """Return True if task has no parents at the given point.

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -420,6 +420,19 @@ class TaskDef:
             p_next = min(adjusted)
         return p_next
 
+    def next_point_parentless(self, point: 'PointBase', cutoff: 'PointBase'):
+        """Return the next cycle point >= point where parentless."""
+        p_next = None
+        adjusted = []
+        for seq in self.sequences:
+            nxt = seq.get_next_point(point)
+            if nxt and self.is_parentless(nxt, cutoff):
+                # may be None if beyond the sequence bounds
+                adjusted.append(nxt)
+        if adjusted:
+            p_next = min(adjusted)
+        return p_next
+
     def is_parentless(self, point: 'PointBase', cutoff: 'PointBase') -> bool:
         """Return True if task has no parents at the given point.
 

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -422,13 +422,13 @@ class TaskDef:
         adjusted = []
         for seq in self.sequences:
             # (Tasks are parentless or not per sequence).
-            pt = None
-            if point is None:
-                pt = seq.get_first_point(cutoff)
-            else:
-                pt = seq.get_next_point(point)
-            if pt and self.is_parentless(pt, cutoff):
-                adjusted.append(pt)
+            next_point = (
+                seq.get_first_point(cutoff)
+                if point is None
+                else seq.get_next_point(point)
+            )
+            if next_point and self.is_parentless(next_point, cutoff):
+                adjusted.append(next_point)
         if adjusted:
             p_next = min(adjusted)
         return p_next

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -504,10 +504,6 @@ class XtriggerManager:
         # Signatures of active functions (waiting on callback).
         self.active: list = []
 
-        # A record of parentless sequential xtriggered tasks
-        # that have had their next occurrance spawned.
-        self.sequential_has_spawned_next: Set[str] = set()
-
         self.workflow_run_dir = workflow_run_dir
 
         # For function arg templating.

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -659,8 +659,6 @@ class XtriggerManager:
                 if sig in self.sat_xtrig:
                     # Already satisfied, just update the task
                     itask.state.xtriggers[label] = True
-                    if self.all_task_seq_xtriggers_satisfied(itask):
-                        self.schd.pool.check_spawn_psx_task(itask)
                 elif _wall_clock(*ctx.func_args, **ctx.func_kwargs):
                     # Newly satisfied
                     itask.state.xtriggers[label] = True
@@ -668,8 +666,6 @@ class XtriggerManager:
                     self.data_store_mgr.delta_xtrigger(sig, True)
                     self.workflow_db_mgr.put_xtriggers({sig: {}})
                     LOG.info('xtrigger succeeded: %s = %s', label, sig)
-                    if self.all_task_seq_xtriggers_satisfied(itask):
-                        self.schd.pool.check_spawn_psx_task(itask)
                     self.do_housekeeping = True
                 continue
             # General case: potentially slow asynchronous function call.
@@ -689,8 +685,6 @@ class XtriggerManager:
                             [itask.tdef.name],
                             xtrigger_env
                         )
-                    if self.all_task_seq_xtriggers_satisfied(itask):
-                        self.schd.pool.check_spawn_psx_task(itask)
                 continue
 
             # Call the function to check the xtrigger.
@@ -824,8 +818,6 @@ class XtriggerManager:
                 continue
 
             itask.state.xtriggers[label] = satisfied
-            if satisfied and self.all_task_seq_xtriggers_satisfied(itask):
-                self.schd.pool.check_spawn_psx_task(itask)
 
             self.data_store_mgr.delta_task_xtrigger(
                 itask, label, sig, satisfied)

--- a/tests/integration/run_modes/test_mode_overrides.py
+++ b/tests/integration/run_modes/test_mode_overrides.py
@@ -124,11 +124,11 @@ async def test_run_mode_skip_abides_by_held(flow, scheduler, run):
         # Hold task, check that it's held:
         schd.pool.hold_tasks({TaskTokens('1', 'foo')})
         assert foo.state.is_held
-        await schd._main_loop()
         assert foo.state(TASK_STATUS_WAITING)
 
         schd.pool.release_held_tasks({TaskTokens('1', 'foo')})
         assert not foo.state.is_held
+        await schd._main_loop()
         with pytest.raises(SchedulerStop):
             # Will shut down as foo has run
             await schd._main_loop()

--- a/tests/integration/scripts/test_set.py
+++ b/tests/integration/scripts/test_set.py
@@ -96,6 +96,7 @@ async def test_set_parentless_spawning(
             ['1'],
         )
 
+        schd.pool.spawn_to_runahead_limit()
         # the parentless task "a" should be spawned out to the runahead limit
         assert schd.pool.get_task_ids() == {'2/a', '3/a'}
 

--- a/tests/integration/test_compat_mode.py
+++ b/tests/integration/test_compat_mode.py
@@ -56,6 +56,9 @@ async def test_blocked_tasks_in_n0(flow, scheduler, run, complete):
     async with run(schd):
         # the workflow should run for three cycles, then runahead stall
         await complete(schd, *(f'{cycle}/bar' for cycle in range(1, 4)))
+
+        # (complete happens before stall test)
+        await schd._main_loop()
         assert schd.is_stalled
 
         # the "blocked" recover tasks should remain in the pool
@@ -92,6 +95,8 @@ async def test_blocked_tasks_in_n0(flow, scheduler, run, complete):
         for cycle in range(1, 4):
             itask = schd.pool.get_task(IntegerPoint(str(cycle)), 'recover')
             schd.pool.remove(itask, 'suicide-trigger')
+
+        schd.pool.spawn_to_runahead_limit()
         assert schd.pool.get_task_ids() == {
             '4/foo',
             '5/foo',
@@ -102,6 +107,7 @@ async def test_blocked_tasks_in_n0(flow, scheduler, run, complete):
         # the workflow continue into the next three cycles, then stall again
         # (i.e. the runahead limit should move forward after the removes)
         await complete(schd, *(f'{cycle}/bar' for cycle in range(4, 7)))
+        await schd._main_loop()
         assert schd.is_stalled
 
         assert {

--- a/tests/integration/test_force_trigger.py
+++ b/tests/integration/test_force_trigger.py
@@ -621,6 +621,7 @@ async def test_replay_outputs(flow, scheduler, start, complete, log_filter):
         await run_cmd(
             set_prereqs_and_outputs(schd, ['1/k'], ['1'], ['kustom'], None)
         )
+        await schd._main_loop()
         # It should spawn b, l, and offg.
         for task in ['b', 'l', 'offg']:
             assert log_filter(contains=msg_spawned.format(task))

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -341,7 +341,7 @@ async def test_prereqs(
 
         await run_cmd(remove_tasks(schd, ['1/a1'], []))
         assert not schd.pool.is_stalled()
-        assert len(schd.pool.task_queue_mgr.queues['default'].deque)
+
         # `cylc show` should reflect the now-unsatisfied condition:
         assert await cylc_show_prereqs(schd, '1/x') == [
             (True, {'1/a1': False, '1/a2': True, '1/b': True})
@@ -349,7 +349,6 @@ async def test_prereqs(
 
         await run_cmd(remove_tasks(schd, ['1/b'], []))
         # Should cause stall now because 1/c prereq is unsatisfied:
-        assert len(schd.pool.task_queue_mgr.queues['default'].deque) == 0
         assert schd.pool.is_stalled()
         assert log_filter(
             logging.WARNING,

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -24,7 +24,8 @@ import pytest
 from cylc.flow.commands import (
     run_cmd,
     force_trigger_tasks,
-    remove_tasks
+    remove_tasks,
+    set_prereqs_and_outputs
 )
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
@@ -62,31 +63,11 @@ async def test_remove(sequential: Scheduler, start):
     chain causing future instances to be removed from the workflow.
     """
     async with start(sequential):
-        # the scheduler starts with one task in the pool
+        # starts with the first task in the first cycle
         assert list_cycles(sequential) == ['2000']
-
-        # it sequentially spawns out to the runahead limit
-        for year in range(2000, 2010):
-            foo = sequential.pool.get_task(ISO8601Point(f'{year}'), 'foo')
-            if foo.state(is_runahead=True):
-                break
-            sequential.xtrigger_mgr.call_xtriggers_async(foo)
-        assert list_cycles(sequential) == [
-            '2000',
-            '2001',
-            '2002',
-            '2003',
-        ]
-
-        # remove all tasks in the pool
-        await run_cmd(remove_tasks(sequential, ['*'], ["1"]))
-
-        # the next cycle should be automatically spawned
-        assert list_cycles(sequential) == ['2004']
-
-        # NOTE: You won't spot this issue in a functional test because the
-        # re-spawned tasks are detected as completed and automatically removed.
-        # So ATM not dangerous, but potentially inefficient.
+        # removing it should spawn the next sequential instance
+        await run_cmd(remove_tasks(sequential, ['2000'], ["1"]))
+        assert list_cycles(sequential) == ['2001']
 
 
 async def test_trigger(sequential, start):
@@ -101,12 +82,18 @@ async def test_trigger(sequential, start):
     async with start(sequential):
         assert list_cycles(sequential) == ['2000']
 
-        foo = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
-        await run_cmd(force_trigger_tasks(sequential, [foo.identity], ["1"]))
-        foo.state_reset('succeeded')
-        sequential.pool.spawn_on_output(foo, 'succeeded')
+        foo1 = sequential.pool.get_task(ISO8601Point('2000'), 'foo')
+        await run_cmd(force_trigger_tasks(sequential, [foo1.identity], ["1"]))
 
-        assert list_cycles(sequential) == ['2000', '2001']
+        await sequential._main_loop()
+        assert list_cycles(sequential) == ['2001']
+
+        foo2 = sequential.pool.get_task(ISO8601Point('2001'), 'foo')
+        foo2.state_reset(is_runahead=False)
+        await run_cmd(
+            set_prereqs_and_outputs(sequential, [foo2.identity], ["1"]))
+
+        assert list_cycles(sequential) == ['2002']
 
 
 async def test_set_outputs(sequential, start):
@@ -138,6 +125,7 @@ async def test_set_prereqs(sequential, start):
         # satisfy foo's xtriggers - it should spawn next instance
         sequential.pool.set_prereqs_and_outputs(
             {TaskTokens('2000', 'foo')}, [], ['xtrigger/all:succeeded'], [])
+        await sequential._main_loop()
 
         assert list_cycles(sequential) == ['2000', '2001']
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1166,6 +1166,7 @@ async def test_future_trigger_final_point(
     async with start(schd):
         for itask in schd.pool.get_tasks():
             schd.pool.spawn_on_output(itask, "succeeded")
+        await schd._main_loop()
         assert log_filter(
             regex=(
                 ".*1/baz.*not spawned: a prerequisite is beyond"

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2579,20 +2579,14 @@ async def test_start_tasks(
             }
         )
 
-        # Check xtriggers
-        for itask in itasks:
-            schd.pool.xtrigger_mgr.call_xtriggers_async(itask)
-            schd.pool.rh_release_and_queue(itask)
+        await schd._main_loop()
 
-        # Release tasks that are ready to run.
-        schd.release_tasks_to_run()
-
-        # It should submit 2050/foo, 2051/foo, 2050/baz
+        # It should submit 2050/foo, 2050/baz
         # It should not submit 2050/bar (waiting on clock trigger)
+        # It should not submit 2051/foo (runahead limited)
         assert (
             set(itask.identity for itask in submitted_tasks) == {
                 "2050/foo",
-                "2051/foo",
                 "2050/baz",
             }
         )

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2683,3 +2683,29 @@ async def test_add_to_pool(
         schd.pool.add_to_pool(a_1)
 
         assert "1/a not added to n=0: already exists" in caplog.text
+
+
+async def test_parentless_spawning(flow, scheduler, run, complete):
+    """Check that parentless spawning works even if parented in some cycles.
+
+    Parentless spawning could be blocked if a parented cycle ended up at
+    the runahead limit. See https://github.com/cylc/cylc-flow/pull/7237.
+
+    """
+    cfg = {
+        'scheduling': {
+            'cycling mode': 'integer',
+            'initial cycle point': '1',
+            'runahead limit': 'P0',
+            'graph': {
+                'P1': 'b',
+                'R1/2/P0': 'a => b',
+            }
+        },
+    }
+    id_ = flow(cfg)
+    schd = scheduler(id_, paused_start=False)
+    async with run(schd):
+        await complete(schd, "2/b")
+        # The task pool should not be empty now.
+        assert schd.pool.get_tasks() != []

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2565,6 +2565,11 @@ async def test_start_tasks(
         submitted_tasks = capture_submission(schd)
         assert submitted_tasks == set()
 
+        # This test expects tasks to be spawned to the runahead limit for
+        # historical reasons - pre GitHub #7237. We can remove this call
+        # if we change test expectations below.
+        schd.pool.spawn_to_runahead_limit()
+
         # It should start up with:
         # - 2050/foo and 2051/foo (spawned to runahead limit)
         # - 2050/bar waiting on its (unsatisfied) clock-trigger

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2713,4 +2713,4 @@ async def test_parentless_spawning(flow, scheduler, run, complete):
     async with run(schd):
         await complete(schd, "2/b")
         # The task pool should not be empty now.
-        assert schd.pool.get_tasks() != []
+        assert len(schd.pool.get_tasks())

--- a/tests/integration/tui/test_app.py
+++ b/tests/integration/tui/test_app.py
@@ -495,6 +495,7 @@ async def test_auto_expansion(flow, scheduler, start, rakiura):
                     flow=[]
                 )
 
+            await schd._main_loop()
             await schd.update_data_structure()
             schd.update_data_store()
 
@@ -542,6 +543,7 @@ async def test_restart_reconnect(one_conf, flow, scheduler, start, rakiura):
         # 3- restart the workflow
         schd = scheduler(flow(one_conf, name='one'))
         async with start(schd):
+            await schd._main_loop()
             await schd.update_data_structure()
             rk.wait_until_loaded(schd.tokens.id)
             rk.compare_screenshot(

--- a/tests/integration/tui/test_mutations.py
+++ b/tests/integration/tui/test_mutations.py
@@ -268,6 +268,7 @@ async def test_set_mutation(
 
             # wait for the command to be received and run it
             await process_command(schd)
+            await schd._main_loop()
 
             # close the error dialogue
             # NOTE: This hides an asyncio error that does not occur outside of


### PR DESCRIPTION
Close #7235 
Close #5730

Premature shutdown or stall can result if a parented instance of a sometimes parentless task ends up at the runahead limit.

See https://github.com/cylc/cylc-flow/issues/7235#issuecomment-4079250720

The correct way to do this is: *for any task that is parentless in one or more recurrences, always spawn the next parentless instance* - which may lie beyond multiple parented instances and/or beyond the runahead limit. 

In effect, a parentless instance should always spawn the next parentless instance, at runahead release time. 

------------

NOTE my first attempt at this bug fix ran into trouble because the task pool spawning logic has gradually become too complicated to follow easily, so I bit the bullet and tried to rethink it. 

As a result: **this PR is a significant simplification of the scheduler core:**. E.g.  calls to `compute_runahead()` in the code: ~10 down to ~1;  and `git diff master cylc/flow`:  114 insertions(+), 218 deletions(-)

**On master:** every time anything happens to spawn a task, the task pool recomputes the runahead limit and spawns and releases and queues any parentless instances of that task all the way to the limit (which is recursive, within a single main loop iteration).

**On this branch:** the task pool only spawns the one instance, not downstream consequences of it. The main loop then computes the limit, releases instances below the limit, and (on release) spawns the single next parentless instance (if there is one).  ~However, I do a single spawn-to-rh-limit at startup (not necessary, but many current integration tests expect that).~

Note **zero functional tests broke despite the many changes to the scheduler guts here.**

The only consequences to be aware of are:
- If the runahead limit suddenly jumps multiple cycles ahead, the workflow will spawn out to it at one cycle per main loop iteration, instead of immediately (this really doesn't matter, but I could put a single spawn-to-rh-limit in the main loop if desired)
- Integration tests need to `await schd._main_loop()` and/or `schd.pool.spawn_to_runahead_limit()`  before checking downstream consequences (i.e. beyond immediate spawn) of operations such as `trigger` and `set` (note this actually didn't break very many existing integration tests, and they were easily fixed)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
