### PR TITLE
standardise user name interface

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -92,7 +92,6 @@ class HostUtil:
         self._host_exs = {}  # host: socket.gethostbyname_ex(host), ...
         self._remote_hosts = {}  # host: is_remote, ...
         self.user_pwent = None
-        self.remote_users = {}
 
     @staticmethod
     def get_local_ip_address(target):
@@ -195,7 +194,6 @@ class HostUtil:
                 self.user_pwent = pwd.getpwnam(my_user_name)
             else:
                 self.user_pwent = pwd.getpwuid(os.getuid())
-            self.remote_users.update(((self.user_pwent.pw_name, False),))
         return self.user_pwent
 
     def is_remote_host(self, name):
@@ -221,22 +219,6 @@ class HostUtil:
                     self._remote_hosts[name] = (
                         host_info != self._get_host_info())
         return self._remote_hosts[name]
-
-    def is_remote_user(self, name):
-        """Return True if name is not a name of the current user.
-
-        Return False if name is None.
-        Return True if name is not in the password database.
-        """
-        if not name:
-            return False
-        if name not in self.remote_users:
-            try:
-                self.remote_users[name] = (
-                    pwd.getpwnam(name) != self._get_user_pwent())
-            except KeyError:
-                self.remote_users[name] = True
-        return self.remote_users[name]
 
     def _is_remote_platform(self, platform):
         """Return True if any job host in platform have different IP address
@@ -295,8 +277,3 @@ def is_remote_platform(platform):
 def is_remote_host(name):
     """Shorthand for HostUtil.get_inst().is_remote_host(name)."""
     return HostUtil.get_inst().is_remote_host(name)
-
-
-def is_remote_user(name):
-    """Return True if name is not a name of the current user."""
-    return HostUtil.get_inst().is_remote_user(name)

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -45,6 +45,7 @@ returning the IP address associated with this socket.
 """
 
 from contextlib import suppress
+import getpass
 import os
 import pwd
 import socket
@@ -91,7 +92,7 @@ class HostUtil:
         self._host = None  # preferred name of localhost
         self._host_exs = {}  # host: socket.gethostbyname_ex(host), ...
         self._remote_hosts = {}  # host: is_remote, ...
-        self.user_pwent = None
+        self._user_pwent = None
 
     @staticmethod
     def get_local_ip_address(target):
@@ -180,7 +181,9 @@ class HostUtil:
 
     def get_user(self):
         """Return name of current user."""
-        return self._get_user_pwent().pw_name
+        # NOTE: don't use pwnam
+        # see https://github.com/cylc/cylc-flow/issues/7240
+        return getpass.getuser()
 
     def get_user_home(self):
         """Return home directory of current user."""
@@ -188,13 +191,13 @@ class HostUtil:
 
     def _get_user_pwent(self):
         """Ensure self.user_pwent is set to current user's password entry."""
-        if self.user_pwent is None:
+        if self._user_pwent is None:
             my_user_name = os.environ.get('USER')
             if my_user_name:
-                self.user_pwent = pwd.getpwnam(my_user_name)
+                self._user_pwent = pwd.getpwnam(my_user_name)
             else:
-                self.user_pwent = pwd.getpwuid(os.getuid())
-        return self.user_pwent
+                self._user_pwent = pwd.getpwuid(os.getuid())
+        return self._user_pwent
 
     def is_remote_host(self, name):
         """Return True if name has different IP address than the current host.

--- a/tests/unit/test_hostuserutil.py
+++ b/tests/unit/test_hostuserutil.py
@@ -25,17 +25,10 @@ from cylc.flow.hostuserutil import (
     get_user,
     get_user_home,
     is_remote_host,
-    is_remote_user
 )
 
 
-def test_is_remote_user_on_current_user():
-    """is_remote_user with current user."""
-    assert not is_remote_user(None)
-    assert not is_remote_user(os.getenv('USER'))
-
-
-def test_is_remote_host_on_localhost(monkeypatch):
+def test_is_remote_host_on_localhost():
     """is_remote_host with localhost."""
     assert not is_remote_host(None)
     assert not is_remote_host('localhost')


### PR DESCRIPTION
[remote: remove unused remote_user interface](https://github.com/cylc/cylc-flow/commit/a1ac5a04c326dde173a85425516de6673c4e8fd4):

* Residual remains of the Cylc 7 remrun interface.

[remote: standardise user name interface](https://github.com/cylc/cylc-flow/commit/86c235df4d579b45bb4e90b76e05543e628836f5)

* Replace `pwd.getpwnam().pw_name` with `getpass.getuser()`.
* Closes https://github.com/cylc/cylc-flow/issues/7240
* This ensures consistency with other parts of Cylc which are already
  using the `getpass` interface.

This is targetting 8.7.0 as the change was judged a little risky for a bugfix release.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.