### PR TITLE
Add future final-incomplete tasks to n=0 for visibility.

### DIFF
--- a/changes.d/7248.feat.md
+++ b/changes.d/7248.feat.md
@@ -1,0 +1,1 @@
+Spawn future final-incomplete tasks into n=0 for visibility.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2218,6 +2218,15 @@ class TaskPool:
             itask.state_reset(is_runahead=False, is_queued=False)
             self.task_queue_mgr.remove_task(itask)
 
+        if (
+            itask.state(*TASK_STATUSES_FINAL)
+            and not itask.state.outputs.is_complete()
+        ):
+            # Add future final-incomplete tasks to the pool for visibility.
+            # (See https://github.com/cylc/cylc-flow/issues/6383).
+            self.add_to_pool(itask)
+            LOG.debug(f"[{itask}] adding future incomplete task to n=0.")
+
         if no_op:
             return False
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2217,15 +2217,21 @@ class TaskPool:
             # Can't be runahead limited or queued.
             itask.state_reset(is_runahead=False, is_queued=False)
             self.task_queue_mgr.remove_task(itask)
+            # If we skipped over runahead release and this tasks parentless
+            # it's next parentless instance might need to be spawned.
+            if itask.flow_nums and not itask.is_xtrigger_sequential:
+                self.spawn_next_parentless(itask)
 
         if (
             itask.state(*TASK_STATUSES_FINAL)
             and not itask.state.outputs.is_complete()
         ):
             # Add future final-incomplete tasks to the pool for visibility.
-            # (See https://github.com/cylc/cylc-flow/issues/6383).
-            self.add_to_pool(itask)
+            # See https://github.com/cylc/cylc-flow/issues/6383.
             LOG.debug(f"[{itask}] adding future incomplete task to n=0.")
+            self.add_to_pool(itask)
+            # (The transient used for spawning outputs is now not transient.)
+            itask.transient = False
 
         if no_op:
             return False

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -2217,8 +2217,8 @@ class TaskPool:
             # Can't be runahead limited or queued.
             itask.state_reset(is_runahead=False, is_queued=False)
             self.task_queue_mgr.remove_task(itask)
-            # If we skipped over runahead release and this tasks parentless
-            # it's next parentless instance might need to be spawned.
+            # If we skipped over runahead release (when parentless spawning
+            # happens) the next parentless instance might need to be spawned.
             if itask.flow_nums and not itask.is_xtrigger_sequential:
                 self.spawn_next_parentless(itask)
 

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -1496,7 +1496,10 @@ async def test_set_outputs_future(
         {
             'scheduling': {
                 'graph': {
-                    'R1': "a:x & a:y => b => c"
+                    'R1': """
+                        a:x & a:y => b => c
+                        a:y => f
+                    """
                 }
             },
             'runtime': {
@@ -1520,6 +1523,12 @@ async def test_set_outputs_future(
         schd.pool.set_prereqs_and_outputs(
             {TaskTokens('1', 'b')}, ["succeeded"], [], [])
         assert schd.pool.get_task_ids() == {"1/a", "1/c"}
+
+        # setting inactive task f failed should add it to n=0 as final
+        # incomplete - see https://github.com/cylc/cylc-flow/pull/7248
+        schd.pool.set_prereqs_and_outputs(
+            {TaskTokens('1', 'f')}, ["failed"], [], [])
+        assert schd.pool.get_task_ids() == {"1/a", "1/c", "1/f"}
 
         schd.pool.set_prereqs_and_outputs(
             items={TaskTokens('1', 'a')},


### PR DESCRIPTION
Close #6383
Close #7413 (commit 4 3b177dd6465bc4b04ef56d2a7727abe730e61d0e fixed this bug)

Add final-incomplete tasks created by `cylc set`ting a future task to the `n=0` window, for visibility.

<!--
Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
