### PR TITLE
review BACK COMPAT code

### DIFF
--- a/cylc/flow/broadcast_mgr.py
+++ b/cylc/flow/broadcast_mgr.py
@@ -235,7 +235,7 @@ class BroadcastMgr:
     # to:
     #    8.1.x
     # remove at:
-    #    8.x
+    #    8.7
     def post_load_db_coerce(self):
         """Coerce DB loaded values to config objects, i.e. DurationFloat."""
         for namespaces in self.broadcasts.values():

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -114,7 +114,10 @@ if TYPE_CHECKING:
 COMMANDS: 'Dict[str, Command]' = {}
 
 
-# BACK COMPAT: handle --flow=all from pre-8.5 clients.
+# BACK COMPAT: handle --flow=all from earlier clients
+# FROM: 8.0
+# TO: 8.5.0
+# REMOVE AT: 8.8
 def back_compat_flow_all(flow: List[str]) -> List[str]:
     """From 8.5 the old --flow=all is just the default.
 
@@ -386,7 +389,7 @@ async def stop(
             #     versions
             # From: 8.4
             # To: 8.5
-            # Remove at: 8.x
+            # Remove at: 8.8
             mode = StopMode(mode.value) if mode else StopMode.REQUEST_CLEAN
         except ValueError:
             raise CommandFailedError(f"Invalid stop mode: '{mode}'") from None

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -114,7 +114,9 @@ if TYPE_CHECKING:
 COMMANDS: 'Dict[str, Command]' = {}
 
 
-# BACK COMPAT: handle --flow=all from pre-8.5 clients.
+# BACK COMPAT: handle --flow=all
+# FROM: 8.4 clients.
+# REMOVE AT: 8.8
 def back_compat_flow_all(flow: List[str]) -> List[str]:
     """From 8.5 the old --flow=all is just the default.
 
@@ -386,7 +388,7 @@ async def stop(
             #     versions
             # From: 8.4
             # To: 8.5
-            # Remove at: 8.x
+            # Remove at: 8.8
             mode = StopMode(mode.value) if mode else StopMode.REQUEST_CLEAN
         except ValueError:
             raise CommandFailedError(f"Invalid stop mode: '{mode}'") from None

--- a/cylc/flow/dbstatecheck.py
+++ b/cylc/flow/dbstatecheck.py
@@ -84,6 +84,8 @@ class CylcWorkflowDBChecker:
             self.c7_back_compat_mode = False
         except sqlite3.OperationalError as exc:
             # BACK COMPAT: Cylc 7 DB (see method below).
+            # FROM: 7.x
+            # REMOVE AT: 8.7
             try:
                 self.db_point_fmt = self._get_db_point_format_compat()
                 self.c7_back_compat_mode = True
@@ -194,7 +196,7 @@ class CylcWorkflowDBChecker:
         # to:
         #    8.1.x
         # remove at:
-        #    8.x
+        #    8.7
         for row in self.conn.execute(
             rf'''
                 SELECT

--- a/cylc/flow/network/resolvers.py
+++ b/cylc/flow/network/resolvers.py
@@ -680,7 +680,7 @@ class Resolvers(BaseResolvers):
         # url: https://github.com/cylc/cylc-flow/pull/6478
         # from: <8.5.0
         # to: >=8.5.0
-        # remove at: 8.x
+        # remove at: 8.9
         # For back compat, with gql-v3 None will not use default_value.
         if 'flow' in kwargs:
             kwargs['flow'] = (

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -1266,7 +1266,7 @@ class BroadcastConfigValidator(CylcConfigValidator):
     # to:
     #    8.1.x
     # remove at:
-    #    8.x
+    #    8.7
     @classmethod
     def coerce_interval(cls, value, keys):
         """Coerce an ISO 8601 interval into seconds.

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -1276,7 +1276,7 @@ class BroadcastConfigValidator(CylcConfigValidator):
     # to:
     #    8.1.x
     # remove at:
-    #    8.x
+    #    8.7
     @classmethod
     def coerce_interval(cls, value, keys):
         """Coerce an ISO 8601 interval into seconds.

--- a/cylc/flow/platforms.py
+++ b/cylc/flow/platforms.py
@@ -110,14 +110,6 @@ def get_platform(
     ...
 
 
-# BACK COMPAT: get_platform
-#     At Cylc 8.x remove all Cylc7 upgrade logic.
-# from:
-#     Cylc8
-# to:
-#     Cylc8.x
-# remove at:
-#     Cylc8.x
 def get_platform(
     task_conf: Union[str, dict, 'OrderedDictWithDefaults', None] = None,
     task_name: str = UNKNOWN_TASK,
@@ -608,6 +600,13 @@ def fail_if_platform_and_host_conflict(
             )
 
 
+# BACK COMPAT: get_platform_deprecated_settings
+# from:
+#     Cylc7
+# to:
+#     Cylc8
+# remove at:
+#     Cylc8.x
 def get_platform_deprecated_settings(
     task_conf: Union[dict, 'OrderedDictWithDefaults'],
     task_name: str = UNKNOWN_TASK

--- a/cylc/flow/rundb.py
+++ b/cylc/flow/rundb.py
@@ -219,7 +219,7 @@ class CylcWorkflowDAO:
     # xtriggers (and the `cylc workflow-state` command) to
     # work with Cylc 7 workflows.
     # url: https://github.com/cylc/cylc-flow/issues/5236
-    # remove at: 8.x
+    # remove at: 8.7
     TABLE_SUITE_PARAMS = "suite_params"
     TABLE_WORKFLOW_FLOWS = "workflow_flows"
     TABLE_WORKFLOW_TEMPLATE_VARS = "workflow_template_vars"

--- a/cylc/flow/scripts/broadcast.py
+++ b/cylc/flow/scripts/broadcast.py
@@ -112,7 +112,7 @@ if TYPE_CHECKING:
 
 
 RAW_DEPR_MSG = (
-    "DEPRECATED: the --raw option will be removed at Cylc 8.7; "
+    "DEPRECATED: the --raw option will be removed at Cylc 8.9; "
     "use --format=raw instead."
 )
 
@@ -347,7 +347,7 @@ def get_option_parser() -> COP:
     # BACK COMPAT: --raw
     # From: < 8.5.1
     # To: 8.5.1
-    # Remove at: 8.7.0
+    # Remove at: 8.9
     parser.add_option(
         "-r", "--raw",
         help=(

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -116,7 +116,7 @@ LINT_SECTION = '.'.join(LINT_TABLE)
 # to:
 #    8.3.0
 # remove at:
-#    8.4.0 ?
+#    8.7
 DEPR_LINT_SECTION = 'cylc-lint'
 
 IGNORE = 'ignore'

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -514,6 +514,7 @@ class TaskPool:
                 #   messages were stored in the DB as a list.
                 # from: 8.0.0
                 # to: 8.3.0
+                # remove at: 8.7
                 outputs: Union[
                     Dict[str, str], List[str]
                 ] = json.loads(task_outputs)
@@ -690,6 +691,7 @@ class TaskPool:
                         # BACK COMPAT: no-longer used ctx_type arg
                         # from: Cylc 7
                         # to: 8.3.0
+                        # remove at: 8.7
                         ctx_args.pop(1)
                     ctx: tuple = known_cls(*ctx_args)
                     break
@@ -1797,6 +1799,7 @@ class TaskPool:
                     #   messages were stored in the DB as a list.
                     # from: 8.0.0
                     # to: 8.3.0
+                    # remove at: 8.7
                     outputs: Union[
                         Dict[str, str], List[str]
                     ] = json.loads(outputs_str)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -514,6 +514,7 @@ class TaskPool:
                 #   messages were stored in the DB as a list.
                 # from: 8.0.0
                 # to: 8.3.0
+                # remove at: 8.7
                 outputs: Union[
                     Dict[str, str], List[str]
                 ] = json.loads(task_outputs)
@@ -690,6 +691,7 @@ class TaskPool:
                         # BACK COMPAT: no-longer used ctx_type arg
                         # from: Cylc 7
                         # to: 8.3.0
+                        # remove at: 8.7
                         ctx_args.pop(1)
                     ctx: tuple = known_cls(*ctx_args)
                     break
@@ -1805,6 +1807,7 @@ class TaskPool:
                     #   messages were stored in the DB as a list.
                     # from: 8.0.0
                     # to: 8.3.0
+                    # remove at: 8.7
                     outputs: Union[
                         Dict[str, str], List[str]
                     ] = json.loads(outputs_str)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1807,7 +1807,7 @@ class TaskPool:
                     #   messages were stored in the DB as a list.
                     # from: 8.0.0
                     # to: 8.3.0
-                    # remove at: 8.7
+                    # remove after: https://github.com/cylc/cylc-flow/issues/7339
                     outputs: Union[
                         Dict[str, str], List[str]
                     ] = json.loads(outputs_str)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1807,7 +1807,8 @@ class TaskPool:
                     #   messages were stored in the DB as a list.
                     # from: 8.0.0
                     # to: 8.3.0
-                    # remove after: https://github.com/cylc/cylc-flow/issues/7339
+                    # remove after:
+                    #     https://github.com/cylc/cylc-flow/issues/7339
                     outputs: Union[
                         Dict[str, str], List[str]
                     ] = json.loads(outputs_str)

--- a/cylc/flow/tui/data.py
+++ b/cylc/flow/tui/data.py
@@ -124,6 +124,8 @@ _COMPAT_QUERIES = (
     (
         # BACK COMPAT
         # isRetry, isWallclock and isXtriggered fields added at 8.5.0
+        # FROM 8.4
+        # REMOVE AT: 8.8
         SpecifierSet('>=8, <8.5'),
         _QUERY
         .replace('isRetry', '')

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -412,7 +412,7 @@ class XtriggerCollator:
     # BACK COMPAT: workflow_state_backcompat
     # from: 8.0.0
     # to: 8.3.0
-    # remove at: 8.x
+    # remove at: 8.7
     @classmethod
     def _try_workflow_state_backcompat(
         cls,

--- a/cylc/flow/xtriggers/workflow_state.py
+++ b/cylc/flow/xtriggers/workflow_state.py
@@ -168,7 +168,7 @@ def validate(args: Dict[str, Any]):
 # BACK COMPAT: workflow_state_backcompat
 # from: 8.0.0
 # to: 8.3.0
-# remove at: 8.x
+# remove at: 8.7
 def _workflow_state_backcompat(
     workflow: str,
     task: str,
@@ -233,7 +233,7 @@ def _workflow_state_backcompat(
 # BACK COMPAT: workflow_state_backcompat
 # from: 8.0.0
 # to: 8.3.0
-# remove at: 8.x
+# remove at: 8.7
 def _upgrade_workflow_state_sig(args: Dict[str, Any]) -> Dict[str, Any]:
     """Return upgraded args for workflow_state, given the deprecated args."""
     is_message = False
@@ -256,7 +256,7 @@ def _upgrade_workflow_state_sig(args: Dict[str, Any]) -> Dict[str, Any]:
 # BACK COMPAT: workflow_state_backcompat
 # from: 8.0.0
 # to: 8.3.0
-# remove at: 8.x
+# remove at: 8.7
 def _validate_backcompat(args: Dict[str, Any]):
     """Validate old workflow_state xtrigger function args.
     """

--- a/tests/functional/broadcast/14-display-format.t
+++ b/tests/functional/broadcast/14-display-format.t
@@ -70,7 +70,7 @@ __EOF__
 cmp_ok "${FOO_WORK_DIR}/raw2.stdout" "${FOO_WORK_DIR}/raw1.stdout"
 
 cmp_ok "${FOO_WORK_DIR}/raw2.stderr" << __EOF__
-DEPRECATED: the --raw option will be removed at Cylc 8.7; use --format=raw instead.
+DEPRECATED: the --raw option will be removed at Cylc 8.9; use --format=raw instead.
 __EOF__
 
 purge


### PR DESCRIPTION
We're dropping Cylc 7 compatibility mode in 8.7.0 - #6849

I've done some prelim work towards that goal. As part of this, we'll want to strip out some of the more ancient BACK COMPAT Cylc code (much of which goes back to Cylc 7).

This is a quick mini-review of `BACK COMPAT` code blocks to schedule their removal.

Here's my proposed schedule - a four version compatibility window:

* 8.7 would support 8.4+ (dropping 7.x, 8.0, 8.1, 8.2, 8.3)
* 8.8 would support 8.5+ (dropping 8.4)
* 8.9 would support 8.6+ (dropping 8.5)

This does **not** cover:
* Cylc 7 configurations (parsec upgraders).
* Cylc 7 `[remote]host` and `[job]batch system` -> `platform`.
* Deprecated environment variables.
* Deprecated template variables.

All of which to be decided on later for removal in 8.9 at the earliest.

Additionally, when a `BACK COMPAT` block is one version from removal, a critical error should be logged (where possible) naming the version at which support will be removed (follow-on work).

Removal to be completed in https://github.com/cylc/cylc-flow/issues/7275

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.