### PR TITLE
cyclers: remove deprecated interfaces

### DIFF
--- a/cylc/flow/cycling/__init__.py
+++ b/cylc/flow/cycling/__init__.py
@@ -322,8 +322,7 @@ class SequenceBase(metaclass=ABCMeta):
 
     Subclasses should provide values for TYPE and TYPE_SORT_KEY.
     They should also provide get_async_expr, get_interval,
-    get_offset & set_offset (deprecated), is_on_sequence,
-    get_nearest_prev_point, get_next_point,
+    is_on_sequence, get_nearest_prev_point, get_next_point,
     get_next_point_on_sequence, get_first_point
     get_start_point, and get_stop_point.
 
@@ -360,16 +359,6 @@ class SequenceBase(metaclass=ABCMeta):
     @abstractmethod
     def get_interval(self):
         """Return the cycling interval of this sequence."""
-        pass
-
-    @abstractmethod
-    def get_offset(self):
-        """Deprecated: return the offset used for this sequence."""
-        pass
-
-    @abstractmethod
-    def set_offset(self, i_offset):
-        """Deprecated: alter state to offset the entire sequence."""
         pass
 
     # NOTE: not using @abstractmethod because we need to

--- a/cylc/flow/cycling/integer.py
+++ b/cylc/flow/cycling/integer.py
@@ -421,36 +421,6 @@ class IntegerSequence(SequenceBase):
         # interval may be None (a one-off sequence)
         return self.i_step
 
-    def get_offset(self):
-        """Deprecated: return the offset used for this sequence."""
-        return self.i_offset
-
-    def set_offset(self, i_offset):
-        """Deprecated: alter state to offset the entire sequence."""
-        if not i_offset.value:
-            # no offset
-            return
-        if not self.i_step:
-            # this is a one-off sequence
-            self.p_start += i_offset
-            self.p_stop += i_offset
-            if self.p_start < self.p_context_start:
-                self.p_start = self.p_stop = None
-            return
-        if not int(i_offset) % int(self.i_step):
-            # offset is a multiple of step
-            return
-        # shift to 0 < offset < interval
-        i_offset = IntegerInterval.from_integer(
-            int(i_offset) % int(self.i_step))
-        self.i_offset = i_offset
-        self.p_start += i_offset  # can be negative
-        if self.p_start < self.p_context_start:
-            self.p_start += self.i_step
-        self.p_stop += i_offset
-        if self.p_stop > self.p_context_stop:
-            self.p_stop -= self.i_step
-
     def is_on_sequence(self, point):
         """Is point on-sequence, disregarding bounds?"""
         if self.exclusions and point in self.exclusions:

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -445,21 +445,6 @@ class ISO8601Sequence(SequenceBase):
         """Return the interval between points in this sequence."""
         return self.step
 
-    def get_offset(self):
-        """Deprecated: return the offset used for this sequence."""
-        return self.offset
-
-    def set_offset(self, i_offset):
-        """Deprecated: alter state to i_offset the entire sequence."""
-        self.recurrence += interval_parse(str(i_offset))
-        self._cached_first_point_values = {}
-        self._cached_next_point_values = {}
-        self._cached_valid_point_booleans = {}
-        self._cached_recent_valid_points = []
-        self.value = str(self.recurrence) + '!' + str(self.exclusions)
-        if self.exclusions:
-            self.value += '!' + str(self.exclusions)
-
     # lru_cache'd see __init__()
     def _is_on_sequence(self, point):
         """Return True if point is on-sequence."""

--- a/tests/unit/cycling/test_integer.py
+++ b/tests/unit/cycling/test_integer.py
@@ -187,13 +187,11 @@ def test_simple():
     assert [int(out) for out in output] == [10, 7, 4, 1]
 
     # Test sequence comparison
-    sequence1 = IntegerSequence('R/1/P2', 1, 10)
-    sequence2 = IntegerSequence('R/1/P2', 1, 10)
-    assert sequence1 == sequence2
-    sequence2.set_offset(IntegerInterval('-P2'))
-    assert sequence1 == sequence2
-    sequence2.set_offset(IntegerInterval('-P1'))
-    assert sequence1 != sequence2
+    assert IntegerSequence('R/1/P2', 1, 10) == IntegerSequence('R/1/P2', 1, 10)
+    assert IntegerSequence('R/1/P2', 1, 10) == IntegerSequence(
+        'R/-1/P2', 1, 10
+    )
+    assert IntegerSequence('R/1/P2', 1, 10) == IntegerSequence('R/1/P2', 1, 10)
 
 
 def test_interval_parsing_error():

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -641,7 +641,6 @@ def test_simple(set_cycling_type):
         str(p_start),
         str(p_stop),
     )
-    sequence.set_offset(-ISO8601Interval("PT10M"))
     point = sequence.get_next_point(ISO8601Point("20100808T0000"))
     assert point == ISO8601Point("20100808T0010")
     output = []


### PR DESCRIPTION
Spotted a couple of deprecated interfaces while looking into #7274

They are unused within cylc-flow so might as well kill em now.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.