### PR TITLE
task_events_mgr: task events should not be able to re-wind task state.

### DIFF
--- a/cylc/flow/task_events_mgr.py
+++ b/cylc/flow/task_events_mgr.py
@@ -120,6 +120,7 @@ from cylc.flow.task_state import (
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_WAITING,
     TASK_STATUSES_ACTIVE,
+    TASK_STATUSES_FINAL,
 )
 from cylc.flow.wallclock import (
     get_current_time_string,
@@ -786,9 +787,7 @@ class TaskEventsManager():
             )
 
         if message == self.EVENT_STARTED:
-            if flag == self.FLAG_RECEIVED and itask.state.is_gt(
-                TASK_STATUS_RUNNING
-            ):
+            if itask.state.is_gt(TASK_STATUS_RUNNING):
                 # Already running.
                 return True
             self._process_message_started(itask, event_time, forced)
@@ -803,10 +802,8 @@ class TaskEventsManager():
             self.spawn_children(itask, TASK_OUTPUT_EXPIRED, forced)
 
         elif task_output == self.EVENT_FAILED:
-            if flag == self.FLAG_RECEIVED and itask.state.is_gt(
-                TASK_STATUS_FAILED
-            ):
-                # Already failed.
+            if itask.state(*TASK_STATUSES_FINAL):
+                # Already in a final state
                 return True
             msg = self.JOB_FAILED
             if run_signal is not None:
@@ -829,10 +826,8 @@ class TaskEventsManager():
                 self.spawn_children(itask, TASK_OUTPUT_FAILED, forced)
 
         elif message == self.EVENT_SUBMIT_FAILED:
-            if flag == self.FLAG_RECEIVED and itask.state.is_gt(
-                TASK_STATUS_SUBMIT_FAILED
-            ):
-                # Already submit-failed
+            if itask.state(*TASK_STATUSES_FINAL):
+                # Already in a final state
                 return True
             if forced or self._process_message_submit_failed(
                 itask, event_time
@@ -840,9 +835,7 @@ class TaskEventsManager():
                 self.spawn_children(itask, TASK_OUTPUT_SUBMIT_FAILED, forced)
 
         elif message == self.EVENT_SUBMITTED:
-            if flag == self.FLAG_RECEIVED and itask.state.is_gte(
-                TASK_STATUS_SUBMITTED
-            ):
+            if itask.state.is_gte(TASK_STATUS_SUBMITTED):
                 # Already submitted.
                 return True
             if not forced:

--- a/tests/integration/test_task_events_mgr.py
+++ b/tests/integration/test_task_events_mgr.py
@@ -29,11 +29,14 @@ from cylc.flow.run_modes import RunMode
 from cylc.flow.scheduler import Scheduler
 from cylc.flow.task_events_mgr import (
     EventKey,
+    TaskEventsManager,
     TaskJobLogsRetrieveContext,
 )
+from cylc.flow.task_outputs import TASK_OUTPUT_STARTED
 from cylc.flow.task_state import (
     TASK_STATUS_PREPARING,
     TASK_STATUS_SUBMIT_FAILED,
+    TASK_STATUS_SUCCEEDED,
 )
 
 from cylc.flow.network.resolvers import TaskMsg
@@ -368,3 +371,42 @@ async def test_event_email_body(
     assert f'host: {mod_one.host}' in email_body
     assert f'port: {mod_one.server.port}' in email_body
     assert f'owner: {mod_one.owner}' in email_body
+
+
+@pytest.mark.parametrize(
+    'message_flag',
+    (
+        TaskEventsManager.FLAG_POLLED,
+        TaskEventsManager.FLAG_INTERNAL,
+        TaskEventsManager.FLAG_RECEIVED,
+    ),
+)
+async def test_delayed_event_notification(
+    message_flag,
+    one_conf,
+    flow,
+    scheduler,
+    run,
+    complete,
+):
+    """Delated event notification should not cause task state to rewind.
+
+    One a task reaches a state, it should not be possible for that state to
+    re-wind as the result of a subsequent event.
+
+    In this test, a task succeeds naturally, a "started" event is then sent
+    using one of the configured flags. The task state should not re-wind as a
+    result.
+
+    See https://github.com/cylc/cylc-flow/issues/7269
+    """
+    id_ = flow(one_conf)
+    schd = scheduler(id_, paused_start=False)
+    async with run(schd):
+        itask = schd.pool.get_tasks()[0]
+        await complete(schd, itask.tokens.relative_id)
+        assert itask.state.status == TASK_STATUS_SUCCEEDED
+        schd.task_events_mgr.process_message(
+            itask, 'INFO', TASK_OUTPUT_STARTED, flag=message_flag
+        )
+        assert itask.state.status == TASK_STATUS_SUCCEEDED


### PR DESCRIPTION
* Closes #7269
* This fixes a bug where a delayed poll notification could cause a final-state task to re-wind to submitted/running.

This fixes the bug, however, it does so by reverting a long-standing behaviour introduced in https://github.com/cylc/cylc-flow/pull/2638 (we've been doing it this way ever since we dropped the poll-to-confirm approach).

I'm not sure why we would want to allow task state to re-wind in the event of `FLAG_POLLED` but not `FLAG_RECEIVED`, `FLAG_INTERNAL` might make sense, however, due to implied task state changes, the message will already have been processed and the children spawned, so it's not clear that this logic was required in any case?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.