### PR TITLE
Fixing tutorials due to an order change which didn't quite work.

### DIFF
--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -1,3 +1,4 @@
+#!jinja2
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
     # * previous(T-00) takes the current time ignoring minutes and seconds.

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -84,7 +84,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process_exeter]]
-        # Generate a forecast for Exeter 300 minutes in the future.
+        # Generate a weather report for Exeter 300 minutes in the future.
         script = post-process exeter 300
         [[[environment]]]
             # The dimensions of each grid cell in degrees.

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -1,4 +1,3 @@
-#!jinja2
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
     # * previous(T-00) takes the current time ignoring minutes and seconds.

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -84,8 +84,8 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process_exeter]]
-        # Generate a forecast for Exeter 60 minutes in the future.
-        script = post-process exeter 60
+        # Generate a forecast for Exeter 300 minutes in the future.
+        script = post-process exeter 300
         [[[environment]]]
             # The dimensions of each grid cell in degrees.
             RESOLUTION = 0.2

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -1,4 +1,5 @@
 #!jinja2
+
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
     # * previous(T-00) takes the current time ignoring minutes and seconds.

--- a/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
+++ b/cylc/flow/etc/tutorial/consolidation-tutorial/flow.cylc
@@ -1,7 +1,4 @@
 #!jinja2
-
-{% set RESOLUTION = 0.2 %}
-
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
     # * previous(T-00) takes the current time ignoring minutes and seconds.
@@ -55,7 +52,7 @@
         script = consolidate-observations
         [[[environment]]]
             # The dimensions of each grid cell in degrees.
-            RESOLUTION = {{ RESOLUTION }}
+            RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
             DOMAIN = -12,46,12,61  # Do not change!
 
@@ -63,7 +60,7 @@
         script = get-rainfall
         [[[environment]]]
             # The dimensions of each grid cell in degrees.
-            RESOLUTION = {{ RESOLUTION }}
+            RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
             DOMAIN = -12,46,12,61  # Do not change!
 
@@ -71,7 +68,7 @@
         script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # The dimensions of each grid cell in degrees.
-            RESOLUTION = {{ RESOLUTION }}
+            RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
             DOMAIN = -12,46,12,61  # Do not change!
             # The path to the files containing wind data (the {variables} will
@@ -91,7 +88,7 @@
         script = post-process exeter 60
         [[[environment]]]
             # The dimensions of each grid cell in degrees.
-            RESOLUTION = {{ RESOLUTION }}
+            RESOLUTION = 0.2
             # The area to generate forecasts for (lng1, lat1, lng2, lat2)
             DOMAIN = -12,46,12,61  # Do not change!
 

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -87,8 +87,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        # Generate a forecast for the location <site>
-        # {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future
+        #  Generate a forecast {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
         script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -87,7 +87,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        #  Generate a forecast {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
+        # Generate a weather report for {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
         script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -1,9 +1,14 @@
 #!jinja2
+
+{# Generate 5 forecasts at 60 minute intervals. #}
+{% set FORECAST_LENGTH = 60 %}
+{% set FORECAST_COUNT = 5 %}
+
 [task parameters]
     # A list of the weather stations we will be fetching observations from.
-    station = camborne, heathrow, shetland, aldergrove
+    station = aldergrove, camborne, heathrow, shetland
     # A list of the sites we will be generating forecasts for.
-    site = exeter
+    site = exeter, edinburgh
 
 [scheduling]
     # Start the workflow 7 hours before now ignoring minutes and seconds
@@ -67,7 +72,7 @@
         script = get-rainfall
 
     [[forecast]]
-        script = forecast 60 5  # Generate 5 forecasts at 60 minute intervals.
+        script = forecast {{ FORECAST_LENGTH }} {{ FORECAST_COUNT }}  # Generate 5 forecasts at 60 minute intervals.
         [[[environment]]]
             # The path to the files containing wind data (the {variables} will
             # get substituted in the forecast script).
@@ -82,7 +87,8 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        # Generate a forecast for the location <site> 60 minutes in the future.
-        script = post-process $CYLC_TASK_PARAM_site 60
+        # Generate a forecast for the location <site>
+        # {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future
+        script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}

--- a/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
+++ b/cylc/flow/etc/tutorial/cylc-forecasting-workflow/flow.cylc
@@ -87,7 +87,7 @@
             MAP_TEMPLATE = "$CYLC_WORKFLOW_RUN_DIR/lib/template/map.html"
 
     [[post_process<site>]]
-        # Generate a weather report for {{ FORECAST_LENGTH * FORECAST_COUNT }} minutes in the future for <site>
+        # Generate a weather report for [length * count] minutes in the future for <site>
         script = post-process $CYLC_TASK_PARAM_site {{ FORECAST_LENGTH * FORECAST_COUNT }}
 
 {% include 'etc/python-job.settings' %}


### PR DESCRIPTION
Relates to https://github.com/cylc/cylc-doc/issues/924 but doesn't close it until https://github.com/cylc/cylc-doc/pull/909 is also merged. 
Reverted https://github.com/cylc/cylc-flow/pull/7238 as order of tutorials has changed again.
Will also need to slightly re-do the JinJa2 and Parameters tutorials to work in the new (old) order.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
