### PR TITLE
config: fix validation check for "[scheduler]install"

### DIFF
--- a/changes.d/7293.fix.md
+++ b/changes.d/7293.fix.md
@@ -1,0 +1,3 @@
+Fixed validation check for `[scheduler]install` which previously permitted some invalid values.
+See [the config reference](https://cylc.github.io/cylc-doc/stable/html/reference/config/workflow.html#flow.cylc[scheduler]install)
+for more information on valid values.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2692,15 +2692,23 @@ class WorkflowConfig:
     def get_validated_rsync_includes(self):
         """Validate and return items to be included in the file installation"""
         includes = self.cfg['scheduler']['install']
-        illegal_includes = []
+        illegal_includes = {}
         for include in includes:
-            if include.count("/") > 1:
-                illegal_includes.append(f"{include}")
+            include_path = Path(include)
+            if include_path.is_absolute():
+                illegal_includes[include] = 'Paths cannot be absolute'
+            elif len(include_path.parts) > 1:
+                illegal_includes[include] = (
+                    'Only top-level files/directories can be configured'
+                )
         if len(illegal_includes) > 0:
             raise WorkflowConfigError(
-                "Error in [scheduler] install. "
-                "Directories can only be from the top level, please "
-                "reconfigure:" + str(illegal_includes)[1:-1])
+                'Error in [scheduler]install:\n\t'
+                + '\n\t'.join(
+                    f'"{path}" - {message}.'
+                    for path, message in illegal_includes.items()
+                )
+            )
         return includes
 
     def process_metadata_urls(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1040,14 +1040,23 @@ def test_rsync_includes_will_not_accept_sub_directories(tmp_flow_config):
         [[dependencies]]
             graph = "blah => deeblah"
     [scheduler]
-        install = dir/, dir2/subdir2/, file1, file2
+        install = /, /foo, /foo/, foo/bar, foo/bar/
     """)
 
     with pytest.raises(WorkflowConfigError) as exc:
         WorkflowConfig(
             workflow=id_, fpath=flow_file, options=Values()
         )
-    assert "Directories can only be from the top level" in str(exc.value)
+    assert '"/" - Paths cannot be absolute.' in str(exc.value)
+    assert '"/foo" - Paths cannot be absolute.' in str(exc.value)
+    assert (
+        '"foo/bar" - Only top-level files/directories can be configured.'
+        in str(exc.value)
+    )
+    assert (
+        '"foo/bar/" - Only top-level files/directories can be configured.'
+        in str(exc.value)
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Spotted some issues with the validation of `[scheduler]install` in user-support today.

* Error message a bit cryptic.
* Permits `/`.
* Permits `/foo`.
* Permits `foo/bar` (but not `foo/bar/`).


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.