### PR TITLE
Backport Cylc review compatibility with UIS

### DIFF
--- a/cylc/flow/etc/cylc
+++ b/cylc/flow/etc/cylc
@@ -78,7 +78,7 @@
 # for selection using CYLC_VERSION. e.g. ln -s cylc-8.0.1-1 cylc-next
 #
 # Legacy Cylc 7 and Rose 2019.01 versions can also be installed into environments
-# in the ROOT location. The legacy support for rose edit, rosie and cylc review
+# in the ROOT location. The legacy support for rose edit and rosie
 # requires cylc-7 and rose-2019.01 symlinks to be created to the preferred
 # environments.
 # e.g.    ln -s cylc-7.9.5 cylc-7
@@ -158,13 +158,6 @@ if [[ ${0##*/} =~ ^ros ]]; then
         # If CYLC_HOME was set externally, use ROSE_HOME if it is set
         CYLC_HOME="${ROSE_HOME:-$CYLC_HOME}"
     fi
-fi
-
-# Legacy support for cylc review
-if [[ ${0##*/} == "cylc" && ${1:-} == "review" && \
-      ! ${CYLC_ENV_NAME:-} =~ ^cylc-7 ]]; then
-    # Cylc 8: Use Cylc 7 to run "review"
-    CYLC_HOME="${CYLC_HOME_ROOT}/cylc-7"
 fi
 
 if [[ ! -x "${CYLC_HOME}/bin/${0##*/}" ]]; then

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -293,9 +293,6 @@ DEAD_ENDS = {
         'cylc set-outputs (cylc 8.0-8.2) has been replaced by cylc set',
     'restart':
         'cylc run & cylc restart have been replaced by cylc play',
-    'review':
-        'cylc review has been removed; the latest Cylc 7 version is forward'
-        ' compatible with Cylc 8.',
     'suite-state':
         'cylc suite-state has been replaced by cylc workflow-state',
     'run':

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -580,9 +580,13 @@ def pycoverage(cmd_args):  # pragma: no cover
     import cylc.flow
     import coverage
     from pathlib import Path
+    import signal
 
     # the cylc working directory
-    cylc_wc = Path(cylc.flow.__file__).parents[2]
+    if 'CYLC_COVERAGE_BASE' in os.environ:
+        cylc_wc = Path(os.environ['CYLC_COVERAGE_BASE'])
+    else:
+        cylc_wc = Path(cylc.flow.__file__).parents[2]
 
     # initiate coverage
     try:
@@ -604,13 +608,7 @@ def pycoverage(cmd_args):  # pragma: no cover
             '\n\n*****************************\n\n'
         ) from exc
 
-    # start the coverage running
-    cov.start()
-    try:
-        # yield control back to cylc, return once the command exits
-        yield
-    finally:
-        # stop the coverage and save the data
+    def cov_stop(*a, **k):
         cov.stop()
         cov.save()
         if cylc_coverage == '2':
@@ -618,6 +616,16 @@ def pycoverage(cmd_args):  # pragma: no cover
                 ccc.write(
                     '$ cylc ' + (' '.join(cmd_args) + '\n'),
                 )
+
+    # start the coverage running
+    cov.start()
+    signal.signal(signal.SIGINT, cov_stop)
+    try:
+        # yield control back to cylc, return once the command exits
+        yield
+    finally:
+        # stop the coverage and save the data
+        cov_stop()
 
 
 def get_arg_parser():


### PR DESCRIPTION
Cylc 8.7 got delayed.

This PR backports the changes required for cylc-review to 8.6.x to allow us to release cylc-uiserver as a sibling to 8.6.x.

* https://github.com/cylc/cylc-flow/pull/7068
* https://github.com/cylc/cylc-flow/pull/7232

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry not needed as this simply unlocks UIS feature
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.