### PR TITLE
Clarify `execution time limit polling intervals`

### DIFF
--- a/cylc/flow/cfgspec/workflow.py
+++ b/cylc/flow/cfgspec/workflow.py
@@ -1414,13 +1414,13 @@ with Conf(
                 Set the execution (:term:`wallclock <wallclock time>`) time
                 limit of a job.
 
-                For ``background`` and ``at`` job runners Cylc runs the
-                job's script using the timeout command. For other job runners
+                For the ``background`` and ``at`` job runners, Cylc runs the
+                job's script using the timeout command. For other job runners,
                 Cylc will convert execution time limit to a :term:`directive`.
 
-                If a job exceeds its execution time limit Cylc can
-                poll the job multiple times. You can set polling
-                intervals using :cylc:conf:`global.cylc[platforms]
+                If a job exceeds its execution time limit, Cylc will
+                poll the job multiple times at the
+                intervals configured in :cylc:conf:`global.cylc[platforms]
                 [<platform name>]execution time limit polling intervals`
 
                 .. versionchanged:: 8.0.0


### PR DESCRIPTION
A user cannot configure `execution time limit polling intervals` on a per-task basis, which the previous wording implies

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests not needed
- [x] Changelog entry not needed as minor
- [x] No docs PR needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
