### PR TITLE
Fix severe id_match & get_itasks slow down 

### DIFF
--- a/changes.d/7306.fix.md
+++ b/changes.d/7306.fix.md
@@ -1,0 +1,1 @@
+Fixed a severe efficiency problem for large workflows.

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1047,7 +1047,6 @@ class DataStoreMgr:
                 locations = ['']
             # Explore/walk locations
             for location in locations:
-                walk_incomplete = True
                 if not location:
                     loc_nodes = {active_id}
                 else:
@@ -1183,6 +1182,8 @@ class DataStoreMgr:
                 p_ids.difference_update(active_walk['walk_ids'])
                 if p_ids:
                     active_locs.setdefault(p_loc, set()).update(p_ids)
+                if p_ids or c_ids:
+                    walk_incomplete = True
                 active_walk['walk_ids'].update(c_ids, p_ids)
                 active_walk['depths'][n_depth].update(c_ids, p_ids)
 

--- a/cylc/flow/id_match.py
+++ b/cylc/flow/id_match.py
@@ -176,8 +176,12 @@ def _match(
             })
         else:
             # filter for on-sequence task instances
+            # exclude pool IDs from filtering (they're already validated)
             _invalid = set()
-            for id__ in list(_matched):
+            for id__ in _matched.difference({
+                pool_task_id.duplicate(task_sel=None)
+                for pool_task_id in pool
+            }):
                 try:
                     taskdef = config.taskdefs[id__['task']]
                     if not taskdef.is_valid_point(get_point(id__['cycle'])):

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1003,10 +1003,11 @@ class TaskPool:
             A list of an active tasks matching these IDs.
 
         """
+        ids_ = {id_.relative_id for id_ in ids}
         return [
             itasks[id_]
             for itasks in self.active_tasks.values()
-            for id_ in itasks.keys() & {id_.relative_id for id_ in ids}
+            for id_ in ids_ & itasks.keys()
         ]
 
     def queue_task(self, itask: TaskProxy) -> None:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1005,9 +1005,10 @@ class TaskPool:
         """
         ids_ = {id_.relative_id for id_ in ids}
         return [
-            itasks[id_]
+            itask
             for itasks in self.active_tasks.values()
-            for id_ in ids_ & itasks.keys()
+            for id_, itask in itasks.items()
+            if id_ in ids_
         ]
 
     def queue_task(self, itask: TaskProxy) -> None:

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1547,8 +1547,14 @@ class TaskPool:
             if c_task is not None:
                 # Have child task, update its prerequisites.
                 if is_abs:
+                    # NOTE: Absolute triggers can have an infinite number of
+                    # graph children, so only the first match is listed. We
+                    # satisfy the prerequisite for all other tasks of the same
+                    # name in the pool, future task instances have their
+                    # prereqs satisfied from the DB at spawn-time.
                     matched, _unmatched = self.id_match(
-                        {TaskTokens(cycle='*', task=c_name)}
+                        {TaskTokens(cycle='*', task=c_name)},
+                        only_match_pool=True,
                     )
                     tasks = self.get_itasks(matched)
                     if c_task not in tasks:


### PR DESCRIPTION
partially addresses #7267 

reduces the slow-down of the example workflow from 10sec/task (at 500 out of 2154 tasks processed) to 0.28sec/task (at 2154 tasks) (on my VM), for the issue workflow. (`n=0`)
<img width="772" height="287" alt="image" src="https://github.com/user-attachments/assets/6bf87fc8-a8f2-430c-a9d6-9860ae144433" />

(`AT len` is the number of cycles of active tasks, `id_` is the number of id matches used in `pool.get_itasks`)


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes) **(one minor adjacent)**.
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Covered by existing tests.
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
