### PR TITLE
Revert errant version change from 8.6.x-sync

### DIFF
--- a/cylc/flow/__init__.py
+++ b/cylc/flow/__init__.py
@@ -53,7 +53,7 @@ def environ_init():
 
 environ_init()
 
-__version__ = '8.6.5.dev'
+__version__ = '8.7.0.dev'
 
 
 def iter_entry_points(entry_point_name):


### PR DESCRIPTION
This partially reverts commit 5fcd27b45677662b5a192018321f6d28c7a1fa02 (see https://github.com/cylc/cylc-flow/pull/7302#discussion_r3233394241)
