### PR TITLE
data_store: optimise rtconfig serialisation

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -106,7 +106,7 @@ from cylc.flow.exceptions import WorkflowConfigError
 from cylc.flow.id import Tokens
 from cylc.flow.network import API
 from cylc.flow.parsec.util import (
-    listjoin,
+    fast_listjoin as listjoin,
     pdeepcopy,
     poverride,
 )

--- a/cylc/flow/parsec/util.py
+++ b/cylc/flow/parsec/util.py
@@ -113,11 +113,29 @@ def listjoin(lst, none_str=''):
     for item in lst:
         if item is None:
             items.append(none_str)
-        elif any(char in str(item) for char in ',#"\''):
-            items.append(repr(item))  # will be quoted
         else:
-            items.append(str(item))
+            string = str(item)
+            if any(char in string for char in ',#"\''):
+                items.append(repr(item))  # will be quoted
+            else:
+                items.append(string)
     return ', '.join(items)
+
+
+def fast_listjoin(lst, none_str=''):
+    """Faster variant of listjoin suitable in select cases.
+
+    Compared to listjoin, this does *not*:
+    * Rationalise and pretty-format integer lists.
+    * Intelligently quote arguments which need quoting.
+
+    Suitable for use in situations where you know the data type of the field
+    being joined and the above is of no concern.
+    """
+    return ', '.join((
+        none_str if item is None else str(item)
+        for item in lst or [None]
+    ))
 
 
 def printcfg(cfg, level=0, indent=0, prefix='', none_str='',

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -22,6 +22,7 @@ Coerce more value type from string (to time point, duration, xtriggers, etc.).
 Also provides default values from the spec as a nested dict.
 """
 
+from functools import lru_cache
 import re
 import shlex
 from collections import deque
@@ -655,11 +656,17 @@ def parsec_validate(cfg_root, spec_root):
     return ParsecValidator().validate(cfg_root, spec_root)
 
 
-class DurationFloat(float):
-    """Duration in floating point seconds, but stringify as ISO8601 format."""
-
-    def __str__(self):
+class _DurationFloat(float):
+    def _str(self):
         return str(Duration(seconds=self, standardize=True))
+
+    # NOTE: This object is immutable so we cache the value of __str__.
+    __str__ = lru_cache(1)(_str)
+
+
+# NOTE: Prevent duplicate DurationFloat objects being created for the same
+# duration value. This allows __str__ caching to be effective.
+DurationFloat = lru_cache(None)(_DurationFloat.__call__)
 
 
 class Range(tuple):

--- a/tests/unit/parsec/test_util.py
+++ b/tests/unit/parsec/test_util.py
@@ -22,6 +22,7 @@ from cylc.flow.parsec.OrderedDict import OrderedDictWithDefaults
 from cylc.flow.parsec.util import (
     SECTION_EXPAND_PATTERN,
     expand_many_section,
+    fast_listjoin,
     itemstr,
     listjoin,
     m_override,
@@ -31,15 +32,44 @@ from cylc.flow.parsec.util import (
     replicate,
     un_many,
 )
+from cylc.flow.parsec.validate import DurationFloat
 
 
-def test_listjoin():
-    assert listjoin(None) == ''
-    assert listjoin(None, 'test') == 'test'
-    assert listjoin([], 'test') == 'test'
-    assert listjoin([None], 'test') == 'test'
-    assert listjoin(['test', 'test']) == 'test, test'
-    assert listjoin(['test,', 'test']) == '\'test,\', test'
+@pytest.mark.parametrize('method', (listjoin, fast_listjoin))
+def test_listjoin(method):
+    assert method(None) == ''
+    assert method(None, 'test') == 'test'
+    assert method([]) == ''
+    assert method([], 'test') == 'test'
+    assert method([None], 'test') == 'test'
+    assert method(['test', 'test']) == 'test, test'
+    if method == listjoin:
+        # intelligent quoting
+        assert method(['a#', 'b,', "c'"]) == "'a#', 'b,', \"c'\""
+        assert method(['test,', 'test']) == '\'test,\', test'
+
+        # integer list rationalisation
+        assert method([10, 11, 12]) == '10..12'
+        assert method([10, 10, 10]) == '3*10'
+        assert method([10, 10, 10, 42]) == '3*10, 42'
+
+
+def test_duration_float():
+    """It should prevent the creation of duplicate instances."""
+    # these calls should only create two discrete instances of DurationFloat
+    a = DurationFloat(1.0)
+    b = DurationFloat(1.0)
+    c = DurationFloat(42.0)
+
+    # a and b should be no only equal but also the same instance
+    assert a == b
+    assert id(a) == id(b)
+    assert str(a) == 'PT1S'
+
+    # a and c should be unequal and different instances
+    assert a != c
+    assert id(a) != id(c)
+    assert str(c) == 'PT42S'
 
 
 # --- printcfg


### PR DESCRIPTION
Partially addresses the example which demonstrated the severe performance issues outlined in #7267

Improve the efficiency of some parsec methods to improve the performance of datastore runtime configuration serialisation.

(deliberating over 8.6.x vs master for this one)

#### Example

```cylc
[scheduler]
    [[events]]
        startup handlers = cylc set "%(workflow)s//1/a" && cylc stop "%(workflow)s"; echo

[task parameters]
    foo = 1..1000

[scheduling]
    [[graph]]
        R1 = a = > <foo> => b

[runtime]
    [[a, b]]
    [[<foo>]]
        execution retry delays = 1000*PT1S
```

This example is derived from the same workflow which prompted https://github.com/cylc/cylc-flow/issues/7267 which includes complex execution/submission retry delay configurations.

This example stresses different factors to the one outlined there and does not use any absolute dependencies.

#### Problem

When the data store creates each `<foo>` task proxy, it must serialise the runtime configuration. This results in the `PT1S` expression being evaluated 10 million times!

* 1000x: Once for each of the 1000 tasks.
* 1000x: Once for each of the 1000 `PT1S` expressions.
* 5x: Due to an inefficiency.
* 2x: Due to the way parsec / configs work.


#### Fixes

There are three optimisations here:

1. Fix the 5x inefficiency in `listjoin`.
2. Implement a more efficient version of `listjoin` for use in the data store.
3. Prevent duplicate `DurationFloat` objects being created for the same value and cache the value of `__str__`.

The third fix is the one which delivers the biggest boost.

#### Results.

| branch | time [1] | saving |
| --- | --- | --- |
| [8.6.x](http://github.com/cylc/cylc-flow/commit/816699ac8a8a3edd352130258575b855fbdcc71e) | 378.5 | 0% |
| #7313 | 59.31 | 84% |
| #7313 + [patches 1-4](https://github.com/cylc/cylc-flow/pull/7306#issuecomment-4479831685) |  58.50 | 85%|

[1] Cumulative time of the `_main_loop` method identified by cProfile.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.