### PR TITLE
Clarify install target docs.

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1368,11 +1368,15 @@ with Conf('global.cylc', desc='''
             .. versionadded:: 8.0.0
         """):
             with Conf('<install target>', desc=dedent("""
-                :ref:`Host <Install targets>` on which to create the symlinks.
+                :ref:`Label of the filesystem <Install targets>` on which to make
+                the symlinks.
+
+                Workflow setup, including symlinking, only needs to be done once
+                for all platforms that share the same install target.
 
                 .. versionadded:: 8.0.0
-
             """) + comma_sep_section_note(version_changed='8.4.0')):
+
                 Conf('run', VDR.V_STRING, None, desc="""
                     Alternative location for the run dir.
 
@@ -1878,8 +1882,13 @@ with Conf('global.cylc', desc='''
                    [<system>]job name length maximum``.
             ''')
             Conf('install target', VDR.V_STRING, desc='''
-                This defaults to the platform name. This will be used as the
-                target for remote file installation.
+                :ref:`Label representng a filesystem <Install targets>`.
+
+                Workflow setup and file installation only needs to be done once
+                for all platforms that share the same install target.
+
+                This defaults to the platform name.
+
                 For example, if Platform_A shares a file system with localhost:
 
                 .. code-block:: cylc

--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1882,7 +1882,7 @@ with Conf('global.cylc', desc='''
                    [<system>]job name length maximum``.
             ''')
             Conf('install target', VDR.V_STRING, desc='''
-                :ref:`Label representng a filesystem <Install targets>`.
+                :ref:`Label representing a filesystem <Install targets>`.
 
                 Workflow setup and file installation only needs to be done once
                 for all platforms that share the same install target.


### PR DESCRIPTION
Companion of https://github.com/cylc/cylc-doc/pull/929

Current docs are a bit misleading (IMO) on exactly what an `install target` is.

Question: can we also change `install target = localhost` in various example to something else, e.g. `local_cluster` to make it more obvious that an install target is not a hostname?

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
