### PR TITLE
Ensure `cylc remote-init` exits non-zero when failing

### DIFF
--- a/changes.d/7316.fix.md
+++ b/changes.d/7316.fix.md
@@ -1,0 +1,1 @@
+Ensure `cylc remote-init` exits non-zero when it fails.

--- a/cylc/flow/scripts/remote_init.py
+++ b/cylc/flow/scripts/remote_init.py
@@ -29,15 +29,21 @@ configured in the global.flow.
 
 Return:
     0:
-        On success or if initialisation not required:
-        - Print task_remote_cmd.REMOTE_INIT_DONE
+        On success or if initialisation not required (REMOTE_INIT_DONE)
     1:
-        On failure.
+        Error occurred when symlinking.
+    2:
+        Unexpected authentication keys exist.
+    3:
+        Any other unexpected error occurred.
 """
+
+import sys
 
 from cylc.flow.option_parsers import CylcOptionParser as COP
 from cylc.flow.task_remote_cmd import remote_init
 from cylc.flow.terminal import cli_function
+
 
 INTERNAL = True
 
@@ -60,9 +66,10 @@ def get_option_parser() -> COP:
 
 @cli_function(get_option_parser)
 def main(parser, options, install_target, rund, *dirs_to_be_symlinked):
-
-    remote_init(
-        install_target,
-        rund,
-        *dirs_to_be_symlinked
+    sys.exit(
+        remote_init(
+            install_target,
+            rund,
+            *dirs_to_be_symlinked,
+        )
     )

--- a/cylc/flow/task_remote_cmd.py
+++ b/cylc/flow/task_remote_cmd.py
@@ -19,21 +19,27 @@ import os
 import re
 import sys
 import tarfile
+from typing import TYPE_CHECKING
+
 import zmq
 
 import cylc.flow.flags
-from cylc.flow.workflow_files import (
-    KeyInfo,
-    KeyOwner,
-    KeyType,
-    WorkflowFiles
-)
 from cylc.flow.pathutil import make_symlink_dir
 from cylc.flow.resources import get_resources
 from cylc.flow.task_remote_mgr import (
     REMOTE_INIT_DONE,
-    REMOTE_INIT_FAILED
+    REMOTE_INIT_FAILED,
 )
+from cylc.flow.workflow_files import (
+    KeyInfo,
+    KeyOwner,
+    KeyType,
+    WorkflowFiles,
+)
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def remove_keys_on_client(srvd, install_target, full_clean=False):
@@ -83,7 +89,9 @@ def create_client_keys(srvd, install_target):
     os.umask(old_umask)
 
 
-def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
+def remote_init(
+    install_target: str, rund: 'Path | str', *dirs_to_symlink: str
+) -> int:
     """cylc remote-init
 
     Arguments:
@@ -104,7 +112,7 @@ def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
             print(REMOTE_INIT_FAILED)
             print(f'Error occurred when symlinking.'
                   f' {target} contains an invalid environment variable.')
-            return
+            return 1
         make_symlink_dir(path, target)
     srvd = os.path.join(rund, WorkflowFiles.Service.DIRNAME)
     os.makedirs(srvd, exist_ok=True)
@@ -126,16 +134,16 @@ def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
         print(f"Unexpected key directory exists: {client_key_dir}"
               " Check global.cylc install target is configured correctly "
               "for this platform.")
-        return
+        return 2
     pattern = re.compile(r"^client_\S*key$")
     for filepath in os.listdir(srvd):
         if pattern.match(filepath) and f"{install_target}" not in filepath:
             # client key for a different install target exists
             print(REMOTE_INIT_FAILED)
-            print(f"Unexpected authentication key \"{filepath}\" exists. "
+            print(f"Unexpected authentication key '{filepath}' exists. "
                   "Check global.cylc install target is configured correctly "
                   "for this platform.")
-            return
+            return 2
     try:
         remove_keys_on_client(srvd, install_target)
         create_client_keys(srvd, install_target)
@@ -143,7 +151,7 @@ def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
         # Catching all exceptions as need to fail remote init if any problems
         # with key generation.
         print(REMOTE_INIT_FAILED)
-        return
+        return 3
     oldcwd = os.getcwd()
     os.chdir(rund)
     # Extract job.sh from library, for use in job scripts.
@@ -162,7 +170,7 @@ def remote_init(install_target: str, rund: str, *dirs_to_symlink: str) -> None:
     with open(client_pub_keyinfo.full_key_path) as keyfile:
         print(keyfile.read(), end='KEYEND')
     print(REMOTE_INIT_DONE)
-    return
+    return 0
 
 
 def remote_tidy(install_target, rund):

--- a/tests/unit/test_task_remote_cmd.py
+++ b/tests/unit/test_task_remote_cmd.py
@@ -17,10 +17,11 @@
 
 from pathlib import Path
 from unittest.mock import patch
+
 from pytest import CaptureFixture
 
-from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.task_remote_cmd import remote_init
+from cylc.flow.workflow_files import WorkflowFiles
 
 
 def test_existing_key_raises_error(tmp_path: Path, capsys: CaptureFixture):
@@ -31,10 +32,10 @@ def test_existing_key_raises_error(tmp_path: Path, capsys: CaptureFixture):
     srvdir.mkdir(parents=True)
     (srvdir / 'client_wrong.key').touch()
 
-    remote_init('test_install_target', str(rundir))
+    assert remote_init('test_install_target', str(rundir))
     assert capsys.readouterr().out == (
         "REMOTE INIT FAILED\nUnexpected authentication key"
-        " \"client_wrong.key\" exists. Check global.cylc install target is"
+        " 'client_wrong.key' exists. Check global.cylc install target is"
         " configured correctly for this platform.\n")
 
 
@@ -44,7 +45,7 @@ def test_unexpandable_symlink_env_var_returns_failed(
     """Test unexpandable symlinks return REMOTE INIT FAILED"""
     mocked_expandvars.side_effect = ['some/rund/path', '$blah']
 
-    remote_init('test_install_target', 'some_rund', 'run=$blah')
+    assert remote_init('test_install_target', 'some_rund', 'run=$blah')
     assert capsys.readouterr().out == (
         "REMOTE INIT FAILED\nError occurred when symlinking."
         " $blah contains an invalid environment variable.\n")
@@ -59,7 +60,7 @@ def test_existing_client_key_dir_raises_error(
     keydir = rundir / WorkflowFiles.Service.DIRNAME / "client_public_keys"
     keydir.mkdir(parents=True)
 
-    remote_init('test_install_target', rundir)
+    assert remote_init('test_install_target', rundir)
     assert capsys.readouterr().out == (
         f"REMOTE INIT FAILED\nUnexpected key directory exists: {keydir}"
         " Check global.cylc install target is configured correctly for this"


### PR DESCRIPTION
Fixes a confusing behaviour not recorded in an issue.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included
- [x] Changelog entry included 
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
