### PR TITLE
`job-activity.log`: log reason for submission failure when no hosts are reachable

### DIFF
--- a/changes.d/7320.fix.md
+++ b/changes.d/7320.fix.md
@@ -1,0 +1,1 @@
+Improved logging for submission failures when no hosts are reachable.

--- a/cylc/flow/subprocpool.py
+++ b/cylc/flow/subprocpool.py
@@ -603,10 +603,8 @@ class SubProcPool:
             log_platform_event(
                 # NOTE: the failure of the command should be logged elsewhere
                 (
-                    f'Could not connect to {ctx.host}.'
-                    f'\n* {ctx.host} has been added to the list of'
-                    ' unreachable hosts'
-                    f'\n* {cmd_key} will retry if another host is available.'
+                    f'Could not connect to {ctx.host}. '
+                    f'{cmd_key} will retry if another host is available.'
                 ),
                 platform or {'name': platform_name},
                 level='warning',

--- a/cylc/flow/task_job_mgr.py
+++ b/cylc/flow/task_job_mgr.py
@@ -590,7 +590,14 @@ class TaskJobManager:
         submit-failed."""
         itask.waiting_on_job_prep = False
         itask.local_job_file_path = None
-        self._prep_submit_task_job_error(itask, '(remote init)', '')
+        self._prep_submit_task_job_error(
+            itask,
+            '(remote init)',
+            PlatformError(
+                f"{PlatformError.MSG_INIT} (no hosts were reachable)",
+                itask.platform['name'],
+            ),
+        )
         # Now that all hosts on all platforms in platform
         # group selected in task config are exhausted we
         # clear bad_hosts for all the hosts we have
@@ -598,12 +605,6 @@ class TaskJobManager:
         self.bad_hosts -= set(itask.platform['hosts'])
         self.bad_hosts -= self.bad_hosts_to_clear
         self.bad_hosts_to_clear.clear()
-        LOG.critical(
-            PlatformError(
-                f"{PlatformError.MSG_INIT} (no hosts were reachable)",
-                itask.platform['name'],
-            )
-        )
 
     def _create_job_log_path(self, itask):
         """Create job log directory for a task job, etc.

--- a/tests/functional/intelligent-host-selection/00-mixedhost.t
+++ b/tests/functional/intelligent-host-selection/00-mixedhost.t
@@ -57,7 +57,7 @@ workflow_run_ok "${TEST_NAME_BASE}-run" \
 # produced by Intelligent Host Selection Logic have happened.
 
 named_grep_ok "unreachable host warning" \
-    'unreachable_host has been added to the list of unreachable hosts' \
+    'Could not connect to unreachable_host' \
     "${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 # Ensure that retrying in this context doesn't increment try number:

--- a/tests/functional/intelligent-host-selection/02-badhosts.t
+++ b/tests/functional/intelligent-host-selection/02-badhosts.t
@@ -23,7 +23,7 @@ export REQUIRE_PLATFORM='loc:remote fs:indep comms:tcp'
 . "$(dirname "$0")/test_header"
 
 #-------------------------------------------------------------------------------
-set_test_number 6
+set_test_number 7
 
 # Uses a fake background job runner to get around the single host restriction.
 
@@ -64,21 +64,20 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${WORKFLOW_NAME}"
 workflow_run_ok "${TEST_NAME_BASE}-run" \
     cylc play --debug --no-detach "${WORKFLOW_NAME}"
 
-LOGFILE="${WORKFLOW_RUN_DIR}/log/scheduler/log"
+workflow_log="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 
 # Check that badhosttask has submit failed, but not good or mixed
 named_grep_ok "badhost task submit failed" \
-    "1/badhosttask.* submit-failed" "${LOGFILE}"
+    "1/badhosttask.* submit-failed" "${workflow_log}"
 named_grep_ok "goodhost suceeded" \
-    "1/mixedhosttask.* succeeded" "${LOGFILE}"
+    "1/mixedhosttask.* succeeded" "${workflow_log}"
 named_grep_ok "mixedhost task suceeded" \
-    "1/goodhosttask.* succeeded" "${LOGFILE}"
+    "1/goodhosttask.* succeeded" "${workflow_log}"
 
-# Check that when a task fail badhosts associated with that task's platform
-# are removed from the badhosts set.
-named_grep_ok "remove task platform bad hosts after submit-fail" \
-    "initialisation did not complete (no hosts were reachable)" \
-    "${LOGFILE}"
+# Check for remote-init fail reason given in scheduler and job activity logs
+job_activity_log="${WORKFLOW_RUN_DIR}/log/job/1/badhosttask/01/job-activity.log"
+msg="initialisation did not complete (no hosts were reachable)"
+named_grep_ok "${msg:0:30}... (workflow log)" "$msg" "$workflow_log"
+named_grep_ok "${msg:0:30}... (job activity log)" "$msg" "$job_activity_log"
 
 purge
-exit 0

--- a/tests/functional/intelligent-host-selection/03-polling.t
+++ b/tests/functional/intelligent-host-selection/03-polling.t
@@ -76,7 +76,7 @@ LOGFILE="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 # are removed from the badhosts set.
 named_grep_ok \
     "job poll fails" \
-    "unreachable_host has been added to the list of unreachable hosts" \
+    "Could not connect to unreachable_host" \
     "${LOGFILE}"
 
 named_grep_ok "job poll retries & succeeds" \

--- a/tests/functional/intelligent-host-selection/04-kill.t
+++ b/tests/functional/intelligent-host-selection/04-kill.t
@@ -62,7 +62,7 @@ LOGFILE="${WORKFLOW_RUN_DIR}/log/scheduler/log"
 # Check that when a task fail badhosts associated with that task's platform
 # are removed from the badhosts set.
 named_grep_ok "job kill fails" \
-    "unreachable_host has been added to the list of unreachable hosts" \
+    "Could not connect to unreachable_host" \
     "${LOGFILE}"
 
 named_grep_ok "job kill retries & succeeds" \


### PR DESCRIPTION
Add more context to `job-activity.log`
```diff
 [jobs-submit cmd] (remote init)
 [jobs-submit ret_code] 1
+[jobs-submit err] platform: hpc - initialisation did not complete (no hosts were reachable)
```

Also shorten the warning messages for when an unreachable host is detected

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
