### PR TITLE
Remove unnecessary logging of duplicate xtriggers

### DIFF
--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2437,8 +2437,6 @@ class WorkflowConfig:
         for tdef in self.taskdefs.values():
             tdef.tweak_outputs()
 
-        self.xtrigger_collator.report_duplicates()
-
     def check_terminal_outputs(self, terminals: Iterable[str]) -> None:
         """Check that task outputs have been registered with tasks.
 

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -14,10 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import (
-    Counter,
-    defaultdict
-)
 from contextlib import suppress
 from enum import Enum
 from inspect import signature
@@ -53,12 +49,6 @@ if TYPE_CHECKING:
     from cylc.flow.scheduler import Scheduler
     from cylc.flow.subprocctx import SubFuncContext
     from cylc.flow.task_proxy import TaskProxy
-
-
-XTRIG_DUP_WARNING = (
-    "Duplicate xtrigger prerequisites get satisfied naturally at"
-    " once, but they can be satisfied separately with `cylc set`."
-)
 
 
 class TemplateVariables(Enum):
@@ -244,22 +234,6 @@ class XtriggerCollator:
 
         if fctx.func_name == "wall_clock":
             self.wall_clock_labels.add(label)
-
-    def report_duplicates(self):
-        """Report labels that point to the same xtrigger signature."""
-
-        counts = Counter([v.get_signature() for v in self.functx_map.values()])
-        dups = defaultdict(list)
-        for label, fctx in self.functx_map.items():
-            sig = fctx.get_signature()
-            if counts[sig] < 2:
-                continue
-            dups[sig].append(label)
-
-        for sig, labels in dups.items():
-            LOG.info(f"Duplicate xtriggers: {', '.join(labels)} = {sig}")
-        if dups:
-            LOG.warning(XTRIG_DUP_WARNING)
 
     @classmethod
     def _validate(

--- a/tests/unit/test_xtrigger_mgr.py
+++ b/tests/unit/test_xtrigger_mgr.py
@@ -26,7 +26,6 @@ from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.taskdef import TaskDef
 from cylc.flow.xtrigger_mgr import (
     RE_STR_TMPL,
-    XTRIG_DUP_WARNING,
     XtriggerCollator
 )
 
@@ -320,43 +319,3 @@ def test_callback(xtrigger_mgr):
     xtrigger_mgr.callback(get_name)
     # this means that the xtrigger was satisfied
     assert xtrigger_mgr.sat_xtrig
-
-
-def test_report_duplicates(
-    caplog: pytest.LogCaptureFixture
-):
-    x1 = SubFuncContext(
-        label="x1",
-        func_name="echo",
-        func_args=[],
-        func_kwargs={"succeed": False}
-    )
-    x2 = SubFuncContext(
-        label="x2",
-        func_name="echo",
-        func_args=[],
-        func_kwargs={"succeed": False}
-    )
-    y = SubFuncContext(
-        label="y",
-        func_name="echo",
-        func_args=["arg1"],
-        func_kwargs={"succeed": False}
-    )
-
-    # x1 and x2 both have the same function signature.
-
-    xtriggers = XtriggerCollator()
-    xtriggers.functx_map = {
-        'x1': x1,
-        'x2': x2,
-        'y': y
-    }
-
-    caplog.set_level(logging.INFO, CYLC_LOG)
-    xtriggers.report_duplicates()
-
-    assert caplog.messages == [
-        "Duplicate xtriggers: x1, x2 = echo(succeed=False)",
-        XTRIG_DUP_WARNING
-    ]


### PR DESCRIPTION
See https://github.com/cylc/cylc-flow/issues/6747#issuecomment-4624104048

This logging was introduced in https://github.com/cylc/cylc-flow/pull/6695, possibly as a stop-gap measure until #6753 was implemented.

I don't think this logging serves any useful purpose (anymore); it seems more confusing than helpful.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests, changelog or docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
