### PR TITLE
job_runner_mgr: fix repeat path addition bug

### DIFF
--- a/changes.d/7333.fix.md
+++ b/changes.d/7333.fix.md
@@ -1,0 +1,1 @@
+Fix an issue where the `$PATH` variable passed to the job submission environment could grow between each submission in a batch when `max batch submit size` > 1 and `clean job submission environment = False`.

--- a/cylc/flow/job_runner_mgr.py
+++ b/cylc/flow/job_runner_mgr.py
@@ -602,7 +602,9 @@ class JobRunnerManager():
         if not self.clean_env:
             # Pass the whole environment to the job submit subprocess.
             # (Note this runs on the job host).
-            env = os.environ
+            # NOTE:: We modify this below so use a copy!
+            # See: https://github.com/cylc/cylc-flow/issues/7333
+            env = dict(os.environ)
         else:
             # $HOME is required by job.sh on the job host.
             env = {'HOME': os.environ.get('HOME', '')}


### PR DESCRIPTION
Fix a bizarre bug whereby the `$PATH` environment variable could grow between each submission in a batch.

Closes #7333

Repro and more details on the issue.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.