### PR TITLE
Add dump command full-ids option.

### DIFF
--- a/changes.d/7335.feat
+++ b/changes.d/7335.feat
@@ -1,0 +1,2 @@
+New `cylc dump` command option to print full task IDs for easy cut-and-paste
+to other commands.

--- a/cylc/flow/flags.py
+++ b/cylc/flow/flags.py
@@ -27,3 +27,4 @@ DEPRECATED:
 
 # verbosity (<0=quiet, 0=normal, >0=verbose, >1=debug)
 verbosity: int = 0
+cylc7_back_compat = False

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -164,6 +164,12 @@ def get_option_parser():
         "-t", "--tasks", help="Task states only.",
         action="store_const", const="tasks", dest="disp_form")
     parser.add_option(
+        "-i", "--full-ids",
+        help="With -t/--tasks (task states only)"
+             " print full workflow//cycle/name IDs"
+             " for easy cut-and-paste to other commands.",
+        action="store_true", default=False, dest="full_ids")
+    parser.add_option(
         "-l", "--legacy", help="Tasks states only; use legacy format.",
         action="store_true", default=False, dest="legacy_format")
     parser.add_option(
@@ -301,6 +307,7 @@ async def dump(workflow_id, options, write=print):
                 else:
                     for item in summary['taskProxies']:
                         result = (
+                            f"{workflow_id + '//' if options.full_ids else ''}"
                             f"{item['cyclePoint']}/{item['name']}"
                             f":{item['state']}"
                         )

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -163,6 +163,12 @@ def get_option_parser():
         "-t", "--tasks", help="Task states only.",
         action="store_const", const="tasks", dest="disp_form")
     parser.add_option(
+        "-i", "--full-ids",
+        help="With -t/--tasks (task states only)"
+             " print full workflow//cycle/name IDs"
+             " for easy cut-and-paste to other commands.",
+        action="store_true", default=False, dest="full_ids")
+    parser.add_option(
         "-l", "--legacy", help="Tasks states only; use legacy format.",
         action="store_true", default=False, dest="legacy_format")
     parser.add_option(
@@ -300,6 +306,7 @@ async def dump(workflow_id, options, write=print):
                 else:
                     for item in summary['taskProxies']:
                         result = (
+                            f"{workflow_id + '//' if options.full_ids else ''}"
                             f"{item['cyclePoint']}/{item['name']}"
                             f":{item['state']}"
                         )

--- a/cylc/flow/scripts/dump.py
+++ b/cylc/flow/scripts/dump.py
@@ -166,7 +166,7 @@ def get_option_parser():
     parser.add_option(
         "-i", "--full-ids",
         help="With -t/--tasks (task states only)"
-             " print full workflow//cycle/name IDs"
+             " print full workflow//cycle/name IDs without other attributes"
              " for easy cut-and-paste to other commands.",
         action="store_true", default=False, dest="full_ids")
     parser.add_option(
@@ -306,21 +306,22 @@ async def dump(workflow_id, options, write=print):
                         write(', '.join(values))
                 else:
                     for item in summary['taskProxies']:
-                        result = (
-                            f"{workflow_id + '//' if options.full_ids else ''}"
-                            f"{item['cyclePoint']}/{item['name']}"
-                            f":{item['state']}"
-                        )
+                        result = ""
                         attrs = []
-                        if item['isHeld']:
-                            attrs.append("held")
-                        if item['isQueued']:
-                            attrs.append("queued")
-                        if item['isRunahead']:
-                            attrs.append("runahead")
+                        if options.full_ids:
+                            result = f"{workflow_id}//"
+                        result += f"{item['cyclePoint']}/{item['name']}"
+                        if not options.full_ids:
+                            result += f":{item['state']}"
+                            if item['isHeld']:
+                                attrs.append("held")
+                            if item['isQueued']:
+                                attrs.append("queued")
+                            if item['isRunahead']:
+                                attrs.append("runahead")
                         if attrs:
                             result += " (" + ",".join(attrs) + ")"
-                        if options.show_flows:
+                        if options.show_flows and not options.full_ids:
                             result += (
                                 f" flows={item['flowNums'].replace(' ', '')}"
                             )

--- a/tests/integration/scripts/test_dump.py
+++ b/tests/integration/scripts/test_dump.py
@@ -59,24 +59,33 @@ async def test_dump_tasks(flow, scheduler, start):
 
 
 @pytest.mark.parametrize(
-    'attributes_bool, flow_nums, dump_str',
+    'attributes_bool, flow_nums, full_ids, dump_str',
     [
         pytest.param(
             True,
             [1, 2],
+            False,
             '1/a:waiting (held,queued,runahead) flows=[1,2]',
             id='1'
         ),
         pytest.param(
             False,
             [1, 2],
+            False,
             '1/a:waiting',
             id='2'
+        ),
+        pytest.param(
+            False,
+            [1, 2],
+            True,
+            '{workflow_id}//1/a:waiting',
+            id='3'
         )
     ]
 )
 async def test_dump_format(
-    flow, scheduler, start, attributes_bool, flow_nums, dump_str
+    flow, scheduler, start, attributes_bool, flow_nums, full_ids, dump_str
 ):
     """Check the new "cylc dump" output format, i.e. task IDs.
 
@@ -112,7 +121,11 @@ async def test_dump_format(
         ret = []
         await dump(
             id_,
-            DumpOptions(disp_form='tasks', show_flows=attributes_bool),
+            DumpOptions(
+                disp_form='tasks',
+                full_ids=full_ids,
+                show_flows=attributes_bool
+            ),
             write=ret.append
         )
-        assert ret == [dump_str]
+        assert ret == [dump_str.format(**{"workflow_id": id_})]

--- a/tests/integration/scripts/test_dump.py
+++ b/tests/integration/scripts/test_dump.py
@@ -58,24 +58,33 @@ async def test_dump_tasks(flow, scheduler, start):
 
 
 @pytest.mark.parametrize(
-    'attributes_bool, flow_nums, dump_str',
+    'attributes_bool, flow_nums, full_ids, dump_str',
     [
         pytest.param(
             True,
             [1, 2],
+            False,
             '1/a:waiting (held,queued,runahead) flows=[1,2]',
             id='1'
         ),
         pytest.param(
             False,
             [1, 2],
+            False,
             '1/a:waiting',
             id='2'
+        ),
+        pytest.param(
+            False,
+            [1, 2],
+            True,
+            '{workflow_id}//1/a:waiting',
+            id='3'
         )
     ]
 )
 async def test_dump_format(
-    flow, scheduler, start, attributes_bool, flow_nums, dump_str
+    flow, scheduler, start, attributes_bool, flow_nums, full_ids, dump_str
 ):
     """Check the new "cylc dump" output format, i.e. task IDs.
 
@@ -111,7 +120,11 @@ async def test_dump_format(
         ret = []
         await dump(
             id_,
-            DumpOptions(disp_form='tasks', show_flows=attributes_bool),
+            DumpOptions(
+                disp_form='tasks',
+                full_ids=full_ids,
+                show_flows=attributes_bool
+            ),
             write=ret.append
         )
-        assert ret == [dump_str]
+        assert ret == [dump_str.format(**{"workflow_id": id_})]

--- a/tests/integration/scripts/test_dump.py
+++ b/tests/integration/scripts/test_dump.py
@@ -76,10 +76,10 @@ async def test_dump_tasks(flow, scheduler, start):
             id='2'
         ),
         pytest.param(
-            False,
+            True,
             [1, 2],
             True,
-            '{workflow_id}//1/a:waiting',
+            '{workflow_id}//1/a',
             id='3'
         )
     ]


### PR DESCRIPTION
Small change to make `cylc dump --tasks` output easy to cut-and-paste to other commands, via a command option to print the full workflow ID.

Without the option:
```console
$ cylc dump -ts hello
3/baz:running
4/bar:running
5/bar:waiting
6/bar:waiting
7/foo:running
8/foo:waiting (runahead)
```

With the option: [UPDATE: amended to remove task state and attributes - see below]
```console
$ cylc dump -tsi hello
hello/run2//4/baz
hello/run2//5/bar
hello/run2//6/bar
hello/run2//7/bar
hello/run2//8/foo
hello/run2//9/foo
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
