### PR TITLE
Adding catch-except for invalid cylc message formats in scheduler.py

### DIFF
--- a/changes.d/7336.fix.md
+++ b/changes.d/7336.fix.md
@@ -1,0 +1,1 @@
+Adding code to catch invalid cylc message formats to report them instead of crashing

--- a/changes.d/7336.fix.md
+++ b/changes.d/7336.fix.md
@@ -1,1 +1,1 @@
-Adding code to catch invalid cylc message formats to report them instead of crashing
+Report invalid cylc message formats instead of crashing.

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -77,6 +77,7 @@ from cylc.flow.exceptions import (
     CommandFailedError,
     CylcError,
     InputError,
+    WorkflowConfigError,
 )
 import cylc.flow.flags
 from cylc.flow.flow_mgr import (
@@ -1003,7 +1004,12 @@ class Scheduler:
         warn = ""
         for tm in unprocessed_messages:
             job_tokens = self.tokens.duplicate(tm.job_id)
-            tdef = self.config.get_taskdef(job_tokens['task'])
+            try:
+                tdef = self.config.get_taskdef(job_tokens['task'])
+            except WorkflowConfigError as exc:
+                LOG.error(exc)
+                warn += f'\n  {tm.job_id}: {tm.severity} - "{tm.message}"'
+                continue
             if not self.task_events_mgr.process_job_message(
                 job_tokens, tdef, tm.message, tm.event_time
             ):

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -459,11 +459,12 @@ async def test_set_stall_interaction(flow, scheduler, start):
         )
 
 
+"""
 async def test_invalid_cylc_message(one, start, log_filter):
     async with start(one):
 
         tasky = TaskMsg(
-            Tokens("Invalid task!", relative=True),
+            Tokens("1/Invalid task!", relative=True),
             "6pm",  # event_time
             "INFO",  # severity
             'b')
@@ -484,3 +485,35 @@ async def test_valid_cylc_message(one, start, log_filter):
         one.message_queue.put(tasky)
         one.process_queued_task_messages()
         assert not log_filter(contains="Illegal task name: None")
+"""
+
+
+async def test_invalid_cylc_message(one, start, log_filter, caplog):
+    message = (
+        "20000101T0000Z",  # event_time
+        "INFO",  # severity
+        'some-message',  # message
+    )
+
+    async with start(one):
+        # send a message for an invalid task (task names cannot contain spaces)
+        one.message_queue.put(
+            TaskMsg(
+                Tokens("1/Invalid task", relative=True),
+                *message,
+            )
+        )
+        one.process_queued_task_messages()
+        assert log_filter(contains="Illegal task name: Invalid task")
+
+        # send a message for a valid task
+        caplog.clear()
+        one.message_queue.put(
+            TaskMsg(
+                Tokens("1/one", relative=True),
+                *message,
+            )
+        )
+        one.process_queued_task_messages()
+        assert not log_filter(contains="Illegal task name")
+        assert log_filter(contains='(received)some-message')

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -38,6 +38,9 @@ from cylc.flow.task_state import (
 from cylc.flow.workflow_status import AutoRestartMode, StopMode
 
 
+from cylc.flow.network.resolvers import TaskMsg
+from cylc.flow.id import Tokens
+
 Fixture = Any
 
 
@@ -454,3 +457,30 @@ async def test_set_stall_interaction(flow, scheduler, start):
             schd.data_store_mgr.data[schd.tokens.id]['workflow'].status_msg
             != 'stalled'
         )
+
+
+async def test_invalid_cylc_message(one, start, log_filter):
+    async with start(one):
+
+        tasky = TaskMsg(
+            Tokens("Invalid task!", relative=True),
+            "6pm",  # event_time
+            "INFO",  # severity
+            'b')
+
+        one.message_queue.put(tasky)
+        one.process_queued_task_messages()
+        assert log_filter(contains="Illegal task name: None")
+
+
+async def test_valid_cylc_message(one, start, log_filter):
+    async with start(one):
+        tasky = TaskMsg(
+            Tokens("1/one", relative=True),
+            "6pm",  # event_time
+            "INFO",  # severity
+            'b')
+
+        one.message_queue.put(tasky)
+        one.process_queued_task_messages()
+        assert not log_filter(contains="Illegal task name: None")

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -459,36 +459,7 @@ async def test_set_stall_interaction(flow, scheduler, start):
         )
 
 
-"""
-async def test_invalid_cylc_message(one, start, log_filter):
-    async with start(one):
-
-        tasky = TaskMsg(
-            Tokens("1/Invalid task!", relative=True),
-            "6pm",  # event_time
-            "INFO",  # severity
-            'b')
-
-        one.message_queue.put(tasky)
-        one.process_queued_task_messages()
-        assert log_filter(contains="Illegal task name: None")
-
-
-async def test_valid_cylc_message(one, start, log_filter):
-    async with start(one):
-        tasky = TaskMsg(
-            Tokens("1/one", relative=True),
-            "6pm",  # event_time
-            "INFO",  # severity
-            'b')
-
-        one.message_queue.put(tasky)
-        one.process_queued_task_messages()
-        assert not log_filter(contains="Illegal task name: None")
-"""
-
-
-async def test_invalid_cylc_message(one, start, log_filter, caplog):
+async def test_cylc_message(one, start, log_filter, caplog):
     message = (
         "20000101T0000Z",  # event_time
         "INFO",  # severity


### PR DESCRIPTION
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->
closes #7191
**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
