### PR TITLE
No spawn on manual remove of parentless RH and/or SX tasks

### DIFF
--- a/changes.d/7340.feat.md
+++ b/changes.d/7340.feat.md
@@ -1,0 +1,1 @@
+Parentless run-ahead and sequential xtriggered tasks no longer spawn their next instance on manual removal.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -184,7 +184,8 @@ def _remove_matched_tasks(
                 continue
             removed[itask.tokens.task] = fnums_to_remove
             if fnums_to_remove == itask.flow_nums:
-                schd.pool.remove(itask, 'request')
+                # Need to remove the task from the pool.
+                schd.pool.remove(itask, 'request', spawn=False)
                 to_kill.append(itask)
                 itask.removed = True
             itask.flow_nums.difference_update(fnums_to_remove)

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -870,7 +870,11 @@ class TaskPool:
             if ntask is not None and not is_in_pool:
                 self.add_to_pool(ntask)
 
-    def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:
+    def remove(
+        self, itask: 'TaskProxy',
+        reason: Optional[str] = None,
+        spawn: Optional[bool] = True
+    ) -> None:
         """Remove a task from the pool."""
         # the held state is no longer relevant -> remove it
         self.release_held_active_task(itask)
@@ -878,8 +882,12 @@ class TaskPool:
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
 
-        if itask.flow_nums and (
-            itask.state.is_runahead or itask.is_xtrigger_sequential
+        if (
+            itask.flow_nums
+            and spawn
+            and (
+                itask.state.is_runahead or itask.is_xtrigger_sequential
+            )
         ):
             # If removing a parentless runahead-limited task
             # auto-spawn its next instance first.

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -21,7 +21,7 @@
 
 . "$(dirname "$0")/test_header"
 
-set_test_number 7
+set_test_number 6
 
 # Test workflow uses built-in 'echo' xtrigger.
 init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
@@ -79,15 +79,10 @@ cylc remove "${WORKFLOW_NAME}//3001/b"
 
 poll_grep_workflow_log 'Command "remove_tasks" actioned.'
 
-cylc show "${WORKFLOW_NAME}//3002/b" | grep -E 'state: ' > 3002.b.log
-cylc show "${WORKFLOW_NAME}//3003/b" 2>&1 >/dev/null | grep -E 'No matching' > 3003.b.log
+cylc show "${WORKFLOW_NAME}//3002/b" 2>&1 >/dev/null | grep -E 'No matching' > 3002.b.log
 
-# 3002/b should be only at 3002.
 cmp_ok 3002.b.log - <<__END__
-state: waiting
-__END__
-cmp_ok 3003.b.log - <<__END__
-No matching active tasks found: 3003/b
+No matching active tasks found: 3002/b
 __END__
 
 cylc show "${WORKFLOW_NAME}//3002/c" | grep -E 'state: ' > 3002.c.log

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -545,3 +545,44 @@ async def test_remove_triggered(flow, scheduler, start):
         )
         assert not schd.pool.get_tasks()
         assert not schd.pool.tasks_to_trigger_now
+
+
+async def test_remove_spawn(flow, scheduler, start):
+    """Test the no-spawn removal of parentless tasks."""
+    schd: Scheduler = scheduler(
+        flow({
+            'scheduler': {
+                'cycle point format': 'CCYY',
+            },
+            'scheduling': {
+                'initial cycle point': '2000',
+                'runahead limit': 'P0',
+                'graph': {
+                    'R3//P1Y': '''
+                        @wall_clock => a
+                        b
+                        c
+                    ''',
+                },
+            },
+        })
+    )
+    async with start(schd):
+        assert schd.pool.get_task_ids() == {
+            '2000/a',
+            '2000/b',
+            '2000/c',
+            '2001/b',
+            '2001/c',
+        }
+
+        # Removal of parentless runahead and sequential xtrigger (PSX) spawned.
+        await run_cmd(remove_tasks(schd, ['2000/a', '2001/c', '2001/b'], []))
+        assert schd.pool.get_task_ids() == {
+            '2000/b',
+            '2000/c',
+        }
+
+        # empty the workflow
+        await run_cmd(remove_tasks(schd, ['2000/b', '2000/c'], []))
+        assert schd.pool.get_task_ids() == set()

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -58,17 +58,68 @@ def sequential(flow, scheduler):
 
 
 async def test_remove(sequential: Scheduler, start):
-    """It should spawn the next instance when a task is removed.
+    """It should not spawn the next instance when a task is removed.
 
-    Ensure that removing a task with a sequential xtrigger does not break the
-    chain causing future instances to be removed from the workflow.
+    Ensure that manually removing a task with a sequential xtrigger does not
+    spawn the next, while internal removal does.
     """
     async with start(sequential):
         # starts with the first task in the first cycle
         assert list_cycles(sequential) == ['2000']
+
         # removing it should spawn the next sequential instance
-        await run_cmd(remove_tasks(sequential, ['2000'], ["1"]))
+        # internal remove should spawn the next cycle
+        sequential.pool.remove(
+            sequential.pool.get_task(ISO8601Point('2000'), 'foo'),
+            reason='because'
+        )
         assert list_cycles(sequential) == ['2001']
+
+        # this sequentially spawns out to the runahead limit
+        for year in range(2001, 2010):
+            foo = sequential.pool.get_task(ISO8601Point(f'{year}'), 'foo')
+            if foo.state(is_runahead=True):
+                break
+            sequential.xtrigger_mgr.call_xtriggers_async(foo)
+
+        # for some reason this doesn't work in the loop
+        await sequential._main_loop()
+        await sequential._main_loop()
+        await sequential._main_loop()
+
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+            '2003',
+            '2004',
+        ]
+
+        # internal remove of RH PSX should spawn the next cycle
+        foo = sequential.pool.get_task(ISO8601Point('2004'), 'foo')
+        sequential.pool.remove(foo)
+        assert '2005' in list_cycles(sequential)
+
+        # remove command should not spawn next RH task
+        await run_cmd(remove_tasks(sequential, ['2005'], ["1"]))
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+            '2003',
+        ]
+
+        # and internal remove of already xtrigger spawned task should
+        # not spawn the next either.
+        foo = sequential.pool.get_task(ISO8601Point('2003'), 'foo')
+        sequential.pool.remove(foo)
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+        ]
+
+        # Now, let's just command/manual remove all tasks in the pool
+        await run_cmd(remove_tasks(sequential, ['*'], ["1"]))
+        # the workflow should be empty
+        assert not list_cycles(sequential)
 
 
 async def test_trigger(sequential, start):


### PR DESCRIPTION
supersedes #7134 

This change makes the default spawning behavior on manual (command) remove of parentless runahead (RH) and sequential xtriggered (SX) tasks.. They no longer spawn their next instance.

Users can always use `cylc set --pre=all . . .` to reintroduce the tasks.
And of course, not `remove` but, `set` (xtrig or outputs) or skip to spawn forward otherwise

This removes the need to reinstate the `--no-spawn` option in #7134

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
