### PR TITLE
Fix wrong prereq point for `[special tasks]sequential` tasks

### DIFF
--- a/changes.d/7342.fix.md
+++ b/changes.d/7342.fix.md
@@ -1,0 +1,1 @@
+Fixed bugs relating to incorrect previous instances of `[special tasks]sequential` tasks.

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -501,7 +501,7 @@ class ISO8601Sequence(SequenceBase):
                 break
             recurrence_cycle_point = ISO8601Point(str(recurrence_iso_point))
             if self.exclusions and recurrence_cycle_point in self.exclusions:
-                break
+                continue
             prev_cycle_point = recurrence_cycle_point
 
         if prev_cycle_point is None:
@@ -511,9 +511,6 @@ class ISO8601Sequence(SequenceBase):
                 self.recurrence, WorkflowSpecifics.DUMP_FORMAT,
                 prev_cycle_point, point
             )
-        # Check all exclusions
-        if self.exclusions and prev_cycle_point in self.exclusions:
-            return self.get_prev_point(prev_cycle_point)
         return prev_cycle_point
 
     def get_next_point(self, point):

--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -1130,28 +1130,29 @@ class DataStoreMgr:
                     # Parents/upstream nodes
                     np_ids = set()
                     if not p_done:
-                        for items in generate_graph_parents(
-                            tdef,
-                            get_point(node_tokens['cycle']),
-                            taskdefs
-                        ).values():
-                            for parent_name, parent_point, _ in items:
-                                if final_point and parent_point > final_point:
-                                    continue
-                                parent_tokens = self.id_.duplicate(
-                                    cycle=str(parent_point),
-                                    task=parent_name,
-                                )
-                                self.generate_ghost_task(
-                                    parent_tokens,
-                                    parent_point,
-                                    True,
-                                    None,
-                                    n_depth
-                                )
-                                # reverse for parent
-                                self.generate_edge(parent_tokens, node_tokens)
-                                np_ids.add(parent_tokens.id)
+                        for (
+                            parent_name,
+                            parent_point,
+                            _,
+                        ) in generate_graph_parents(
+                            tdef, get_point(node_tokens['cycle']), taskdefs
+                        ):
+                            if final_point and parent_point > final_point:
+                                continue
+                            parent_tokens = self.id_.duplicate(
+                                cycle=str(parent_point),
+                                task=parent_name,
+                            )
+                            self.generate_ghost_task(
+                                parent_tokens,
+                                parent_point,
+                                True,
+                                None,
+                                n_depth
+                            )
+                            # reverse for parent
+                            self.generate_edge(parent_tokens, node_tokens)
+                            np_ids.add(parent_tokens.id)
 
                     # Register new walk
                     if node_id not in all_walks:

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -140,7 +140,7 @@ def generate_graph_parents(
                 prevs.append(prev)
         if prevs:
             graph_parents.setdefault(seq, []).append(
-                TaskTuple(tdef.name, min(prevs), False)
+                TaskTuple(tdef.name, max(prevs), False)
             )
 
     return graph_parents

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -94,13 +94,13 @@ def generate_graph_children(
 
 
 def generate_graph_parents(
-    tdef: 'TaskDef', point: 'PointBase', taskdefs: Dict[str, 'TaskDef']
-) -> Dict['SequenceBase', List[TaskTuple]]:
+    tdef: 'TaskDef', point: 'PointBase', taskdefs: dict[str, 'TaskDef']
+) -> list[TaskTuple]:
     """Determine concrete graph parents of task tdef at point.
 
     Infer parents by reversing upstream triggers that lead to point/task.
     """
-    graph_parents: Dict['SequenceBase', List[TaskTuple]] = {}
+    graph_parents: list[TaskTuple] = []
 
     for seq, triggers in tdef.graph_parents.items():
         if not seq.is_valid(point):
@@ -109,7 +109,6 @@ def generate_graph_parents(
             #   T06 = "waz[-PT6H] => foo"
             # here waz[-PT6H] is a parent of T06/foo but not of T12/foo.
             continue
-        graph_parents[seq] = []
         for parent_name, trigger in triggers:
             parent_point = trigger.get_parent_point(point)
             if (
@@ -126,20 +125,19 @@ def generate_graph_parents(
                 # TODO ideally validation would flag this as an error.
                 continue
             is_abs = trigger.offset_is_absolute or trigger.offset_is_from_icp
-            graph_parents[seq].append(
+            graph_parents.append(
                 TaskTuple(parent_name, parent_point, is_abs)
             )
 
     if tdef.sequential:
         # Add implicit previous-instance parent.
-        prevs = []
-        for seq in tdef.sequences:
-            prev = seq.get_prev_point(point)
-            if prev is not None:
-                # Within sequence bounds.
-                prevs.append(prev)
+        prevs = {
+            prev
+            for seq in tdef.sequences
+            if (prev := seq.get_prev_point(point)) is not None
+        }
         if prevs:
-            graph_parents.setdefault(seq, []).append(
+            graph_parents.append(
                 TaskTuple(tdef.name, max(prevs), False)
             )
 

--- a/cylc/flow/taskdef.py
+++ b/cylc/flow/taskdef.py
@@ -131,14 +131,17 @@ def generate_graph_parents(
 
     if tdef.sequential:
         # Add implicit previous-instance parent.
-        prevs = {
-            prev
-            for seq in tdef.sequences
-            if (prev := seq.get_prev_point(point)) is not None
-        }
-        if prevs:
+        closest_prev_point: PointBase | None = max(
+            (
+                prev
+                for seq in tdef.sequences
+                if (prev := seq.get_prev_point(point)) is not None
+            ),
+            default=None,
+        )
+        if closest_prev_point is not None:
             graph_parents.append(
-                TaskTuple(tdef.name, max(prevs), False)
+                TaskTuple(tdef.name, closest_prev_point, False)
             )
 
     return graph_parents

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -601,6 +601,20 @@ def test_multiple_exclusions_extensive(set_cycling_type):
     assert sequence.get_prev_point(point_4) == point_1
 
 
+def test_get_nearest_prev_point_exclusions(set_cycling_type):
+    """Another test for get_nearest_prev_point() for sequences with exclusions.
+
+    https://github.com/cylc/cylc-flow/issues/7268
+    """
+    set_cycling_type(ISO8601_CYCLING_TYPE)
+    P = ISO8601Point
+    seq = ISO8601Sequence('T00 ! 2025-01-01T00Z', '2025-01-01T00Z')
+    assert seq.get_nearest_prev_point(P('2025-01-01T09Z')) is None
+    assert seq.get_nearest_prev_point(P('2025-01-02T09Z')) == P(
+        '2025-01-02T00Z'
+    )
+
+
 def test_exclusion_zero_duration_warning(set_cycling_type, caplog, log_filter):
     """It should not log zero-duration warnings for exclusion points.
 

--- a/tests/unit/test_taskdef.py
+++ b/tests/unit/test_taskdef.py
@@ -20,7 +20,7 @@ from pytest import param
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.cycling.integer import IntegerPoint
 from cylc.flow.cycling.iso8601 import ISO8601Point
-from cylc.flow.taskdef import generate_graph_parents
+from cylc.flow.taskdef import TaskTuple, generate_graph_parents
 
 
 def test_generate_graph_parents_1(tmp_flow_config):   # noqa: F811
@@ -97,6 +97,34 @@ def test_generate_graph_parents_2(tmp_flow_config):   # noqa: F811
                 IntegerPoint('1'),
                 False
             )
+        ]
+    ]
+
+
+def test_generate_graph_parents__sequential(tmp_flow_config):
+    """It chooses the latest previous point when using old-style sequential."""
+    flow_file = tmp_flow_config(
+        id_ := 'gargle-blaster',
+        """
+            [scheduler]
+                allow implicit tasks = True
+            [scheduling]
+                initial cycle point = 2010-01-01
+                [[special tasks]]
+                    sequential = foo
+                [[graph]]
+                    P1D = foo
+                    P1M = foo
+        """
+    )
+    cfg = WorkflowConfig(workflow=id_, fpath=flow_file, options=None)
+
+    parents = generate_graph_parents(
+        cfg.taskdefs['foo'], ISO8601Point('2010-02-01'), cfg.taskdefs
+    )
+    assert list(parents.values()) == [
+        [
+            TaskTuple('foo', ISO8601Point('2010-01-31'), False),
         ]
     ]
 

--- a/tests/unit/test_taskdef.py
+++ b/tests/unit/test_taskdef.py
@@ -50,17 +50,10 @@ def test_generate_graph_parents_1(tmp_flow_config):   # noqa: F811
         ISO8601Point('20230101T03'),
         ISO8601Point('20230101T06')
     ]:
-        parents = generate_graph_parents(
+        assert generate_graph_parents(
             cfg.taskdefs['every_cycle'], point, cfg.taskdefs
-        )
-        assert list(parents.values()) == [
-            [
-                (
-                    "run_once_at_midnight",
-                    ISO8601Point('20230101T0000Z'),
-                    False
-                )
-            ]
+        ) == [
+            ("run_once_at_midnight", ISO8601Point('20230101T0000Z'), False),
         ]
 
 
@@ -81,23 +74,14 @@ def test_generate_graph_parents_2(tmp_flow_config):   # noqa: F811
     cfg = WorkflowConfig(workflow=id_, fpath=flow_file, options=None)
 
     # Each instance of every_cycle should have a parent only at T00.
-    parents = generate_graph_parents(
+    assert generate_graph_parents(
         cfg.taskdefs['foo'], IntegerPoint("1"), cfg.taskdefs
-    )
-    assert list(parents.values()) == [[]]  # No parents at first point.
+    ) == []  # No parents at first point.
 
-    parents = generate_graph_parents(
+    assert generate_graph_parents(
         cfg.taskdefs['foo'], IntegerPoint("2"), cfg.taskdefs
-    )
-
-    assert list(parents.values()) == [
-        [
-            (
-                "foo",
-                IntegerPoint('1'),
-                False
-            )
-        ]
+    ) == [
+        ("foo", IntegerPoint('1'), False),
     ]
 
 
@@ -122,10 +106,8 @@ def test_generate_graph_parents__sequential(tmp_flow_config):
     parents = generate_graph_parents(
         cfg.taskdefs['foo'], ISO8601Point('2010-02-01'), cfg.taskdefs
     )
-    assert list(parents.values()) == [
-        [
-            TaskTuple('foo', ISO8601Point('2010-01-31'), False),
-        ]
+    assert list(parents) == [
+        TaskTuple('foo', ISO8601Point('2010-01-31'), False),
     ]
 
 


### PR DESCRIPTION
Update: now also fixes #7268

---

Fixes a data store bug where the UI would show a prereq with the wrong cycle point for an old-style `[special tasks]sequential` task.

E.g.

```cylc
[scheduler]
    allow implicit tasks = True
[scheduling]
    initial cycle point = 2010-01-01
    [[special tasks]]
        sequential = foo
    [[graph]]
        P1D = foo
        P1M = foo
```

You would see in the UI

```mermaid
graph TD
  subgraph after
  direction TD
  a1[2010-01-31/foo] --> a2[2010-02-01/foo]
  style a1 fill:#ecffed
  end
  subgraph before
  direction TD
  b1[2010-01-01/foo] --> b2[2010-02-01/foo]
  style b1 fill:#ffecec
  end
```

---

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included 
- [x] Changelog entry included if this is a change that can affect users
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
