### PR TITLE
Add Scott to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -60,3 +60,4 @@ Diquan Jabbour             <165976689+Diquan-BOM@users.noreply.github.com>
 Maxime Rio                 <maxime.rio@niwa.co.nz>
 Christopher Bennett        <christopher.bennett@metoffice.gov.uk> christopher.bennett <christopher.bennett@metoffice.gov.uk>
 Samuel Denton              <samuel.denton@metoffice.gov.uk>     samuel-denton       <samuel.denton@metoffice.gov.uk>
+Scott Owen James           <scott.james@metoffice.gov.uk>       Scott-Owen-James


### PR DESCRIPTION
[A check](https://github.com/cylc/cylc-flow/actions/runs/27547482013) is now failing due to a difference in usernames between different commits (possibly those made locally and those made on GitHub). To fix the check, I've added a mailmap entry that tells Git both of these are your username.

