### PR TITLE
Catch xtriggers from orphaned tasks on reload

### DIFF
--- a/changes.d/7349.fix.md
+++ b/changes.d/7349.fix.md
@@ -1,0 +1,1 @@
+Fixed a crash that could occur when removing an xtriggered task from the graph in a reload.

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -786,6 +786,10 @@ class XtriggerManager:
         Ignores xtriggers not valid for itask.
         (However, these are now weeded out by the caller).
 
+        xtriggers without an entry in itask.state.xtriggers.functx_map
+        are force satisfied directly, without context lookup. This covers
+        the case where an xtrigger's definition was removed during reload.
+
         Args:
             itask: task proxy
             xtriggers: xtrigger prerequisites to un/satisfy

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -786,10 +786,6 @@ class XtriggerManager:
         Ignores xtriggers not valid for itask.
         (However, these are now weeded out by the caller).
 
-        xtriggers without an entry in itask.state.xtriggers.functx_map
-        are force satisfied directly, without context lookup. This covers
-        the case where an xtrigger's definition was removed during reload.
-
         Args:
             itask: task proxy
             xtriggers: xtrigger prerequisites to un/satisfy

--- a/cylc/flow/xtrigger_mgr.py
+++ b/cylc/flow/xtrigger_mgr.py
@@ -802,6 +802,12 @@ class XtriggerManager:
             if label not in itask.state.xtriggers:
                 continue
 
+            if label not in self.xtriggers.functx_map:
+                # This xtrigger's definition was removed (e.g. by reload).
+                # Just satisfy it directly without context lookup.
+                itask.state.xtriggers[label] = satisfied
+                continue
+
             ctx = self.get_xtrig_ctx(itask, label)
             sig = ctx.get_signature()
 

--- a/tests/integration/test_xtrigger_mgr.py
+++ b/tests/integration/test_xtrigger_mgr.py
@@ -760,3 +760,55 @@ async def test_xtrigger_modifiers(flow, scheduler, start):
         assert ds_fproxy.is_retry is False
         assert ds_fproxy.is_wallclock is False
         assert ds_fproxy.is_xtriggered is False
+
+
+async def test_remove_orphaned_xtrigger_on_reload(
+    flow, start, scheduler, log_filter
+):
+    """
+    Removing a task with an xtrigger dependency and reloading should not
+    crash.
+    """
+    id_ = flow({
+        'scheduling': {
+            'xtriggers': {
+                'my_xtrig': 'xrandom(0)',
+            },
+            'graph': {
+                'R1': '''
+                    @my_xtrig => foo
+                    bar
+                '''
+            },
+        },
+    })
+    schd: Scheduler = scheduler(id_)
+    async with start(schd):
+        # confirm the task with the xtrigger is in the pool
+        assert schd.pool._get_task_by_id('1/foo') is not None
+
+        # remove task with xtrigger dependency
+        flow(
+            {
+                'scheduling': {
+                    'xtriggers': {
+                        'my_xtrig': 'xrandom(0)',
+                    },
+                    'graph': {
+                        'R1': '''
+                            bar
+                        '''
+                    },
+                },
+            },
+            workflow_id=id_,
+        )
+
+        # reload should not crash
+        await commands.run_cmd(commands.reload_workflow(schd))
+
+        # the orphaned task should have been removed
+        assert schd.pool._get_task_by_id('1/foo') is None
+
+        # the reload should have completed successfully
+        assert log_filter(contains='Reload completed')

--- a/tests/integration/test_xtrigger_mgr.py
+++ b/tests/integration/test_xtrigger_mgr.py
@@ -769,7 +769,7 @@ async def test_remove_orphaned_xtrigger_on_reload(
     Removing a task with an xtrigger dependency and reloading should not
     crash.
     """
-    id_ = flow({
+    conf = {
         'scheduling': {
             'xtriggers': {
                 'my_xtrig': 'xrandom(0)',
@@ -781,28 +781,16 @@ async def test_remove_orphaned_xtrigger_on_reload(
                 '''
             },
         },
-    })
+    }
+    id_ = flow(conf)
     schd: Scheduler = scheduler(id_)
     async with start(schd):
         # confirm the task with the xtrigger is in the pool
         assert schd.pool._get_task_by_id('1/foo') is not None
 
-        # remove task with xtrigger dependency
-        flow(
-            {
-                'scheduling': {
-                    'xtriggers': {
-                        'my_xtrig': 'xrandom(0)',
-                    },
-                    'graph': {
-                        'R1': '''
-                            bar
-                        '''
-                    },
-                },
-            },
-            workflow_id=id_,
-        )
+        # remove task with xtrigger dependency (no foo in R1)
+        conf['scheduling']['graph']['R1'] = 'bar'
+        flow(conf, workflow_id=id_)
 
         # reload should not crash
         await commands.run_cmd(commands.reload_workflow(schd))

--- a/tests/integration/test_xtrigger_mgr.py
+++ b/tests/integration/test_xtrigger_mgr.py
@@ -762,11 +762,10 @@ async def test_xtrigger_modifiers(flow, scheduler, start):
         assert ds_fproxy.is_xtriggered is False
 
 
-async def test_remove_orphaned_xtrigger_on_reload(
+async def test_orphaned_task_with_xtrigger_on_reload(
     flow, start, scheduler, log_filter
 ):
-    """
-    Removing a task with an xtrigger dependency and reloading should not
+    """Removing a task with an xtrigger dependency and reloading should not
     crash.
     """
     conf = {


### PR DESCRIPTION
Closes #7323. Added a guard clause to catch xtriggers on orphaned tasks and force satisfy without trying to look up context (which doesn't exist).

#### Steps to reproduce

```cylc
[scheduler]
    allow implicit tasks = True
[scheduling]
    initial cycle point = 2026-01-01
    [[xtriggers]]
        my_clock = wall_clock(PT1M)
    [[graph]]
        R1 = """
            @my_clock => foo  # remove this line after starting
            bar
        """
```

1. ``cylc install .``
2. ``cylc play --pause workflowID``
3. Comment out ``@my_clock => foo`` from the graph
4. ``cylc reinstall workflowID``
5. ``cylc reload workflowID``
6. Look in schedular log for success or Error.

While my fix does prevent the bug, I am not sure I understand downstream dependencies well enough to know if this will cause problems elsewhere.  Having tried to follow the logic, it seems like it shouldn't be a problem as orphaned tasks are removed as dependencies of downstream tasks but I'm not sure.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
