### PR TITLE
Fix lint traceback for .cylc directories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ requests_).
  - Christopher Bennett
  - Ryan Boult
  - Samuel Denton
+ - Vincent Gao
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/changes.d/7351.fix.md
+++ b/changes.d/7351.fix.md
@@ -1,0 +1,1 @@
+Prevent `cylc lint` from raising tracebacks for empty files and `.cylc` directories.

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -1168,7 +1168,7 @@ def check_cylc_file(
     modify: bool = False,
 ):
     """Check A Cylc File for Cylc 7 Config"""
-    if not file.is_file():
+    if file.is_dir():
         LOG.error(f'{file_rel} is not a file.')
         counter['E'] += 1
         return

--- a/cylc/flow/scripts/lint.py
+++ b/cylc/flow/scripts/lint.py
@@ -1168,6 +1168,11 @@ def check_cylc_file(
     modify: bool = False,
 ):
     """Check A Cylc File for Cylc 7 Config"""
+    if not file.is_file():
+        LOG.error(f'{file_rel} is not a file.')
+        counter['E'] += 1
+        return
+
     with open(file, 'r') as cylc_file:
         # generator which reads and lints one line at a time
         linter = lint(
@@ -1249,7 +1254,10 @@ def lint(
     """
     # get the first line
     line_no = 1
-    line = next(lines)
+    try:
+        line = next(lines)
+    except StopIteration:
+        return
     # check if it is a jinja2 shebang
     jinja_shebang = line.strip().lower() == JINJA2_SHEBANG
 

--- a/tests/unit/scripts/test_lint.py
+++ b/tests/unit/scripts/test_lint.py
@@ -31,6 +31,7 @@ from cylc.flow.scripts.lint import (
     LINT_SECTION,
     MANUAL_DEPRECATIONS,
     check_lowercase_family_names,
+    check_cylc_file,
     get_cylc_files,
     get_pyproject_toml,
     get_reference,
@@ -278,6 +279,15 @@ def test_check_cylc_file_line_no():
     assert ':2:' in lint.messages[0]
 
 
+def test_check_cylc_file_empty():
+    """It does not raise a traceback for an empty file."""
+    lint = lint_text('', ['style'])
+
+    assert lint.counter == Counter()
+    assert lint.messages == []
+    assert lint.outlines == []
+
+
 @pytest.mark.parametrize(
     'line',
     [
@@ -409,6 +419,18 @@ def test_get_cylc_files_get_all_rcs(tmp_path):
     # Run the test
     result = [(i.parent.name, i.name) for i in get_cylc_files(tmp_path)]
     assert sorted(result) == sorted(expect)
+
+
+def test_check_cylc_file_reports_directory(tmp_path, caplog):
+    """It reports .cylc directories instead of raising a traceback."""
+    path = tmp_path / 'another.cylc'
+    path.mkdir()
+    counter = Counter()
+
+    check_cylc_file(path, Path('another.cylc'), {}, counter)
+
+    assert counter == Counter({'E': 1})
+    assert 'another.cylc is not a file.' in caplog.messages
 
 
 def mock_parse_checks(*args, **kwargs):


### PR DESCRIPTION
Fixes #7344.

This prevents `cylc lint` from raising tracebacks for the issue reproduction where an empty `flow.cylc` exists alongside a directory named `*.cylc`.

Changes:
- Report matched non-files as lint errors instead of trying to open them.
- Treat empty lint inputs as having no lines to check.
- Add regression tests for empty files and `.cylc` directories.
- Add my name to the contributor list per `CONTRIBUTING.md`.

Verification:
- `.venv/bin/python -m pytest tests/unit/scripts/test_lint.py`
- `.venv/bin/python -m flake8 cylc/flow/scripts/lint.py tests/unit/scripts/test_lint.py`
- `git diff --check`
- Manual reproduction with `touch flow.cylc`, `mkdir another.cylc`, and `cylc lint --exit-zero`
