### PR TITLE
Jobs shouldn't be reloaded while preparing 

### DIFF
--- a/changes.d/7353.fix.md
+++ b/changes.d/7353.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug causing preparing jobs to be reloaded.

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -529,7 +529,7 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
     # flush out preparing tasks before attempting reload
     schd.reload_pending = 'waiting for pending tasks to submit'
     while schd.release_tasks_to_run() or any(
-        itask.waiting_on_job_prep
+        itask.waiting_on_job_prep or itask.state(TASK_STATUS_PREPARING)
         for itask in schd.pool.get_tasks()
     ):
         # Run the subset of main-loop functionality required to push

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -528,7 +528,10 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
 
     # flush out preparing tasks before attempting reload
     schd.reload_pending = 'waiting for pending tasks to submit'
-    while schd.release_tasks_to_run():
+    while schd.release_tasks_to_run() or any(
+        itask.waiting_on_job_prep
+        for itask in schd.pool.get_tasks()
+    ):
         # Run the subset of main-loop functionality required to push
         # preparing through the submission pipeline and keep the workflow
         # responsive (e.g. to the `cylc stop` command).

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -387,6 +387,13 @@ async def test_reload_waits_for_preparing_tasks_in_remote_init(
     proc_pool.process() to advance these operations) rather than exiting
     prematurely.
 
+    Test works by simulating a task taking longer than one reload flush
+    loop to complete remote-init, catching the situation where
+    release_tasks_to_run() returns False (because all tasks started submission)
+    but the task is still waiting_on_job_prep or in the preparing state.
+    The reload flush loop should continue to iterate until the task has
+    actually submitted.
+
     https://github.com/cylc/cylc-flow/issues/7296
     """
     # speed up the test

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -380,13 +380,6 @@ async def test_reload_waits_for_preparing_tasks_in_remote_init(
 ):
     """Reload should wait for preparing tasks stuck in remote-init.
 
-    When tasks have entered the preparing state but are waiting for
-    asynchronous operations (e.g. remote-init or file-install) to complete,
-    submit_task_jobs returns an empty list because no submissions can be made
-    yet. The reload flush loop must continue to iterate (calling
-    proc_pool.process() to advance these operations) rather than exiting
-    prematurely.
-
     Test works by simulating a task taking longer than one reload flush
     loop to complete remote-init, catching the situation where
     release_tasks_to_run() returns False (because all tasks started submission)

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -382,10 +382,10 @@ async def test_reload_waits_for_preparing_tasks_in_remote_init(
 
     Test works by simulating a task taking longer than one reload flush
     loop to complete remote-init, catching the situation where
-    release_tasks_to_run() returns False (because all tasks started submission)
-    but the task is still waiting_on_job_prep or in the preparing state.
-    The reload flush loop should continue to iterate until the task has
-    actually submitted.
+    release_tasks_to_run() returns False (because no tasks are ready
+    for submission) but the task is still waiting_on_job_prep or in the
+    preparing state. The reload flush loop should continue to iterate
+    until the task has actually submitted.
 
     https://github.com/cylc/cylc-flow/issues/7296
     """

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -372,6 +372,78 @@ async def test_orphan_reload(
         )
 
 
+async def test_reload_waits_for_preparing_tasks_in_remote_init(
+    flow,
+    scheduler,
+    start,
+    monkeypatch,
+):
+    """Reload should wait for preparing tasks stuck in remote-init.
+
+    When tasks have entered the preparing state but are waiting for
+    asynchronous operations (e.g. remote-init or file-install) to complete,
+    submit_task_jobs returns an empty list because no submissions can be made
+    yet. The reload flush loop must continue to iterate (calling
+    proc_pool.process() to advance these operations) rather than exiting
+    prematurely.
+
+    https://github.com/cylc/cylc-flow/issues/7296
+    """
+    # speed up the test
+    monkeypatch.setattr('cylc.flow.scheduler.sleep', lambda *_: None)
+
+    id_ = flow('foo')
+    schd: Scheduler = scheduler(id_, paused_start=False)
+
+    async with start(schd):
+        foo = schd.pool.get_tasks()[0]
+
+        # Track how many times submit_task_jobs is called to simulate
+        # a task going through remote-init (returns empty list) before
+        # eventually submitting.
+        call_count = 0
+
+        def submit_task_jobs(itasks, *a, **k):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                # Simulate tasks stuck in remote-init: submit_task_jobs
+                # returns an empty list because remote-init hasn't completed
+                # yet, but the task is still waiting_on_job_prep.
+                # On the first call, set state to PREPARING (as the real
+                # prep_submit_task_jobs would do).
+                if not foo.state(TASK_STATUS_PREPARING):
+                    foo.submit_num += 1
+                    foo.state_reset(TASK_STATUS_PREPARING)
+                return []
+            else:
+                # Remote-init done, task actually submits now.
+                foo.waiting_on_job_prep = False
+                foo.state_reset(TASK_STATUS_SUBMITTED)
+                return [foo]
+
+        monkeypatch.setattr(
+            schd.task_job_mgr, 'submit_task_jobs', submit_task_jobs
+        )
+
+        # Put the task into the preparing state
+        schd.release_tasks_to_run()
+        assert foo.state(TASK_STATUS_PREPARING)
+        assert foo.waiting_on_job_prep
+
+        # Reload the workflow - this should wait for the task to submit
+        await commands.run_cmd(commands.reload_workflow(schd))
+
+        # The task should have been flushed through to submitted
+        assert foo.state(TASK_STATUS_SUBMITTED), (
+            "Reload proceeded before preparing task finished submitting"
+        )
+        assert not foo.waiting_on_job_prep
+        # submit_task_jobs should have been called multiple times
+        # (not just once before the loop exited)
+        assert call_count == 4
+
+
 async def test_data_store_tproxy(flow, scheduler, start):
     """Check N>0 task proxy in data store has correct info on reload.
 

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -444,7 +444,6 @@ async def test_orphan_reload(
         )
 
 
-
 async def test_data_store_tproxy(flow, scheduler, start):
     """Check N>0 task proxy in data store has correct info on reload.
 

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -111,6 +111,78 @@ async def test_reload_waits_for_pending_tasks(
         )
 
 
+async def test_reload_waits_for_preparing_tasks_in_remote_init(
+    flow,
+    scheduler,
+    start,
+    monkeypatch,
+):
+    """Reload should wait for preparing tasks stuck in remote-init.
+
+    Test works by simulating a task taking longer than one reload flush
+    loop to complete remote-init, catching the situation where
+    release_tasks_to_run() returns False (because no tasks are ready
+    for submission) but the task is still waiting_on_job_prep or in the
+    preparing state. The reload flush loop should continue to iterate
+    until the task has actually submitted.
+
+    https://github.com/cylc/cylc-flow/issues/7296
+    """
+    # speed up the test
+    monkeypatch.setattr('cylc.flow.scheduler.sleep', lambda *_: None)
+
+    id_ = flow('foo')
+    schd: Scheduler = scheduler(id_, paused_start=False)
+
+    async with start(schd):
+        foo = schd.pool.get_tasks()[0]
+
+        # Track how many times submit_task_jobs is called to simulate
+        # a task going through remote-init (returns empty list) before
+        # eventually submitting.
+        call_count = 0
+
+        def submit_task_jobs(itasks, *a, **k):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                # Simulate tasks stuck in remote-init: submit_task_jobs
+                # returns an empty list because remote-init hasn't completed
+                # yet, but the task is still waiting_on_job_prep.
+                # On the first call, set state to PREPARING (as the real
+                # prep_submit_task_jobs would do).
+                if not foo.state(TASK_STATUS_PREPARING):
+                    foo.submit_num += 1
+                    foo.state_reset(TASK_STATUS_PREPARING)
+                return []
+            else:
+                # Remote-init done, task actually submits now.
+                foo.waiting_on_job_prep = False
+                foo.state_reset(TASK_STATUS_SUBMITTED)
+                return [foo]
+
+        monkeypatch.setattr(
+            schd.task_job_mgr, 'submit_task_jobs', submit_task_jobs
+        )
+
+        # Put the task into the preparing state
+        schd.release_tasks_to_run()
+        assert foo.state(TASK_STATUS_PREPARING)
+        assert foo.waiting_on_job_prep
+
+        # Reload the workflow - this should wait for the task to submit
+        await commands.run_cmd(commands.reload_workflow(schd))
+
+        # The task should have been flushed through to submitted
+        assert foo.state(TASK_STATUS_SUBMITTED), (
+            "Reload proceeded before preparing task finished submitting"
+        )
+        assert not foo.waiting_on_job_prep
+        # submit_task_jobs should have been called multiple times
+        # (not just once before the loop exited)
+        assert call_count == 4
+
+
 async def test_reload_failure(
     flow,
     one_conf,
@@ -371,77 +443,6 @@ async def test_orphan_reload(
             contains=('Reload completed')
         )
 
-
-async def test_reload_waits_for_preparing_tasks_in_remote_init(
-    flow,
-    scheduler,
-    start,
-    monkeypatch,
-):
-    """Reload should wait for preparing tasks stuck in remote-init.
-
-    Test works by simulating a task taking longer than one reload flush
-    loop to complete remote-init, catching the situation where
-    release_tasks_to_run() returns False (because no tasks are ready
-    for submission) but the task is still waiting_on_job_prep or in the
-    preparing state. The reload flush loop should continue to iterate
-    until the task has actually submitted.
-
-    https://github.com/cylc/cylc-flow/issues/7296
-    """
-    # speed up the test
-    monkeypatch.setattr('cylc.flow.scheduler.sleep', lambda *_: None)
-
-    id_ = flow('foo')
-    schd: Scheduler = scheduler(id_, paused_start=False)
-
-    async with start(schd):
-        foo = schd.pool.get_tasks()[0]
-
-        # Track how many times submit_task_jobs is called to simulate
-        # a task going through remote-init (returns empty list) before
-        # eventually submitting.
-        call_count = 0
-
-        def submit_task_jobs(itasks, *a, **k):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 3:
-                # Simulate tasks stuck in remote-init: submit_task_jobs
-                # returns an empty list because remote-init hasn't completed
-                # yet, but the task is still waiting_on_job_prep.
-                # On the first call, set state to PREPARING (as the real
-                # prep_submit_task_jobs would do).
-                if not foo.state(TASK_STATUS_PREPARING):
-                    foo.submit_num += 1
-                    foo.state_reset(TASK_STATUS_PREPARING)
-                return []
-            else:
-                # Remote-init done, task actually submits now.
-                foo.waiting_on_job_prep = False
-                foo.state_reset(TASK_STATUS_SUBMITTED)
-                return [foo]
-
-        monkeypatch.setattr(
-            schd.task_job_mgr, 'submit_task_jobs', submit_task_jobs
-        )
-
-        # Put the task into the preparing state
-        schd.release_tasks_to_run()
-        assert foo.state(TASK_STATUS_PREPARING)
-        assert foo.waiting_on_job_prep
-
-        # Reload the workflow - this should wait for the task to submit
-        await commands.run_cmd(commands.reload_workflow(schd))
-
-        # The task should have been flushed through to submitted
-        assert foo.state(TASK_STATUS_SUBMITTED), (
-            "Reload proceeded before preparing task finished submitting"
-        )
-        assert not foo.waiting_on_job_prep
-        # submit_task_jobs should have been called multiple times
-        # (not just once before the loop exited)
-        assert call_count == 4
 
 
 async def test_data_store_tproxy(flow, scheduler, start):


### PR DESCRIPTION
Closes #7296
Added a test to reproduce the bug as well as a fix. 
The bug is that the reload flush loop's while condition depends on submit_task_jobs() returning a non-empty list, but tasks in remote-init can hit a continue branch that skips adding them to the return list, causing the loop to exit while tasks are potentially still preparing due to async operations.  

The fix is to also check tasks reported state and waiting_on_job_prep status before exiting the reload flush loop.

The test works by simulating a task taking longer than one reload flush loop to complete remote-init, catching the situation where release_tasks_to_run() returns False (because there were no tasks ready for submission) but a task is still waiting_on_job_prep or in the preparing state. 

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
