### PR TITLE
Fix BrokenPipeError traceback when piping CLI output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ requests_).
  - Christopher Bennett
  - Ryan Boult
  - Samuel Denton
+ - Matt Van Horn
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/changes.d/7247.fix.md
+++ b/changes.d/7247.fix.md
@@ -1,0 +1,1 @@
+Fixed an unwanted `BrokenPipeError` traceback when piping Cylc command output into a consumer that closes the pipe early (e.g. `less`, `grep -q`).

--- a/cylc/flow/terminal.py
+++ b/cylc/flow/terminal.py
@@ -326,6 +326,25 @@ def cli_function(
                         )
                         sys.exit(1)
                     raise
+            except BrokenPipeError:
+                # The output pipe was closed early by the consumer, e.g:
+                #   $ cylc config <flow> | less  # then quit less
+                #   $ cylc config <flow> | grep -q '\\w'
+                # A broken pipe is never user-actionable, so suppress the
+                # traceback at all verbosity levels and exit quietly.
+                # Redirect any remaining buffered stdout to /dev/null to
+                # avoid a second BrokenPipeError when Python flushes stdout
+                # during interpreter shutdown (see the Python docs note on
+                # handling BrokenPipeError).
+                try:
+                    devnull = os.open(os.devnull, os.O_WRONLY)
+                    os.dup2(devnull, sys.stdout.fileno())
+                except (OSError, ValueError):
+                    # stdout may not be backed by a real file descriptor
+                    # (e.g. it has been replaced with a buffer); nothing to
+                    # redirect in that case.
+                    pass
+                sys.exit(1)
             except UnicodeEncodeError as exc:
                 # this error can be raised from any code which attempts to
                 # write a UTF-8 character to a terminal which does not or is

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -30,6 +30,7 @@ from cylc.flow.terminal import (
 # this puts Exception in globals() where we can easily find it later
 Exception = Exception
 SystemExit = SystemExit
+BrokenPipeError = BrokenPipeError
 
 
 def get_option_parser():
@@ -156,6 +157,31 @@ def test_cli(
 
     if stderr is not None:
         assert capsys.readouterr()[1] == stderr
+
+
+@pytest.mark.parametrize('verbosity', [0, 2])
+def test_cli_broken_pipe(verbosity, monkeypatch, capsys):
+    """A BrokenPipeError should exit quietly without a traceback.
+
+    A broken pipe is raised when the consumer of a piped command closes the
+    pipe early, e.g. ``cylc config <flow> | less`` (then quit) or
+    ``cylc config <flow> | grep -q '\\w'``. This is never user-actionable so
+    the CLI wrapper should suppress the traceback at all verbosity levels and
+    exit with a non-zero return code, rather than dumping a Python traceback to
+    stderr.
+    """
+    monkeypatch.setattr('cylc.flow.flags.verbosity', verbosity)
+    monkeypatch.setattr('cylc.flow.terminal.supports_color', lambda: False)
+    # Under capsys, stdout is not backed by a real file descriptor, so the
+    # handler's stdout->/dev/null redirect is a no-op (handled gracefully).
+
+    with pytest.raises(SystemExit) as exc_ctx:
+        cli(BrokenPipeError.__name__)
+
+    # exits non-zero, not via a propagated traceback
+    assert exc_ctx.value.args[0] == 1
+    # no Python traceback dumped to stderr
+    assert 'Traceback' not in capsys.readouterr()[1]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a `BrokenPipeError` handler to the central CLI decorator (`cli_function` in `cylc/flow/terminal.py`) so that piping a Cylc command into a consumer that closes the pipe early exits quietly instead of dumping a Python traceback.

Fixes #7247

## Why this matters

As reported in #7247, running something like:

```
cylc config <flow> | less    # then quit less
cylc config <flow> | grep -q '\w'
```

prints an ugly `BrokenPipeError: [Errno 32] Broken pipe` traceback to stderr. It is harmless (the command still works) but looks broken, and it has existed since at least 8.3.5. The reporter confirmed it reproduces every time with `grep -q '\w'`. The root cause is that the central CLI wrapper, which already converts "known" errors into clean exits, did not handle `BrokenPipeError` raised when writing to a closed stdout pipe.

Putting the fix in `cli_function` means every Cylc subcommand benefits, not just `cylc config`.

## Changes

- `cylc/flow/terminal.py`: add `except BrokenPipeError` to the `cli_function` wrapper. It follows the standard-library-recommended pattern of redirecting the remaining stdout to `os.devnull` (to avoid a second `BrokenPipeError` when Python flushes buffered stdout at interpreter shutdown) and then exits with status `1`. The redirect is guarded so it degrades gracefully if stdout is not backed by a real file descriptor. A broken pipe is never user-actionable, so the traceback is suppressed at all verbosity levels (distinct from the "unknown error" path, which intentionally shows a traceback).
- `tests/unit/test_terminal.py`: add `test_cli_broken_pipe` verifying the wrapper converts `BrokenPipeError` into a clean `SystemExit(1)` with no traceback on stderr, at both normal and debug verbosity.
- `changes.d/7247.fix.md`: towncrier changelog fragment.
- `CONTRIBUTING.md`: add contributor name (CLA).

## Testing

- `pytest tests/unit/test_terminal.py` — all 16 cases pass (the 8 existing `test_cli` cases for `CylcError`/`ParsecError`/`Exception`/`SystemExit` are unaffected, plus the 2 new broken-pipe cases).
- `flake8 cylc/flow/terminal.py tests/unit/test_terminal.py` — clean.
- End-to-end: with a command that writes a large stream through `cli_function` piped into a reader that closes early, the unpatched code prints a multi-line `Traceback ... BrokenPipeError` to stderr; the patched code exits cleanly with no traceback.

### Check List

- [x] I have read [`CONTRIBUTING.md`](https://github.com/cylc/cylc-flow/blob/master/CONTRIBUTING.md) and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present). — N/A, no dependency changes.
- [x] Tests are included (or explain why this is not needed).
- [x] Changelog entry included (`changes.d/7247.fix.md`).
- [ ] CONTRIBUTING.md updated if it describes a relevant change to development workflow. — N/A.
