### PR TITLE
`log_vc_info`: write new uncommitted diff file for new (re)installs

### DIFF
--- a/changes.d/7190.feat.md
+++ b/changes.d/7190.feat.md
@@ -1,0 +1,1 @@
+The uncommitted diff log file now rotates instead of appending on each (re)install.

--- a/cylc/flow/plugins/log_vc_info.py
+++ b/cylc/flow/plugins/log_vc_info.py
@@ -60,7 +60,6 @@ Any uncommitted changes will also be saved as a diff in
    Git does not include untracked files in the diff.
 """
 
-import os
 import json
 from pathlib import Path
 from subprocess import Popen, DEVNULL, PIPE

--- a/cylc/flow/plugins/log_vc_info.py
+++ b/cylc/flow/plugins/log_vc_info.py
@@ -60,6 +60,7 @@ Any uncommitted changes will also be saved as a diff in
    Git does not include untracked files in the diff.
 """
 
+import os
 import json
 from pathlib import Path
 from subprocess import Popen, DEVNULL, PIPE
@@ -76,6 +77,7 @@ from typing import (
     overload,
 )
 
+from cylc.flow.loggingutil import get_next_log_number, get_sorted_logs_by_time
 from cylc.flow import LOG as _LOG, LoggerAdaptor
 from cylc.flow.exceptions import CylcError
 import cylc.flow.flags
@@ -342,13 +344,26 @@ def write_diff(
         str(Path().cwd() / repo_path)
     )
 
-    diff_file = Path(
+    diff_location = Path(
         run_dir,
         WorkflowFiles.LogDir.DIRNAME,
         WorkflowFiles.LogDir.VERSION,
-        DIFF_FILENAME
     )
-    diff_file.parent.mkdir(exist_ok=True)
+    diff_location.mkdir(exist_ok=True)
+    install_location = Path(
+        run_dir,
+        WorkflowFiles.LogDir.DIRNAME,
+        WorkflowFiles.LogDir.INSTALL,
+    )
+    log_files = get_sorted_logs_by_time(str(install_location),
+                                        r'*install.log')
+    log_num = get_next_log_number(log_files[-1]) - 1 if log_files else 1
+
+    number = f"{log_num:02d}"
+    diff_file = Path(
+        diff_location,
+        number + '-' + DIFF_FILENAME
+    )
 
     with open(diff_file, 'a') as f:
         f.write(
@@ -361,6 +376,13 @@ def write_diff(
             _run_cmd(vcs, args, repo_path, stdout=f)
         except VCSMissingBaseError as exc:
             print(f"# No diff - {exc}", file=f)
+
+    try:
+        Path(str(diff_location), DIFF_FILENAME).symlink_to(diff_file)
+    except FileExistsError:
+        os.remove(str(diff_location) + "/" + DIFF_FILENAME)
+        Path(str(diff_location), DIFF_FILENAME).symlink_to(diff_file)
+
     return diff_file
 
 

--- a/cylc/flow/plugins/log_vc_info.py
+++ b/cylc/flow/plugins/log_vc_info.py
@@ -378,7 +378,7 @@ def write_diff(
 
     if (symlink_path := diff_location / DIFF_FILENAME).exists():
         symlink_path.unlink()
-    symlink_path.symlink_to(diff_file)
+    symlink_path.symlink_to(diff_file.relative_to(diff_location))
 
     return diff_file
 

--- a/cylc/flow/plugins/log_vc_info.py
+++ b/cylc/flow/plugins/log_vc_info.py
@@ -377,11 +377,9 @@ def write_diff(
         except VCSMissingBaseError as exc:
             print(f"# No diff - {exc}", file=f)
 
-    try:
-        Path(str(diff_location), DIFF_FILENAME).symlink_to(diff_file)
-    except FileExistsError:
-        os.remove(str(diff_location) + "/" + DIFF_FILENAME)
-        Path(str(diff_location), DIFF_FILENAME).symlink_to(diff_file)
+    if (symlink_path := diff_location / DIFF_FILENAME).exists():
+        symlink_path.unlink()
+    symlink_path.symlink_to(diff_file)
 
     return diff_file
 

--- a/tests/functional/cylc-install/05-check-logs-git.t
+++ b/tests/functional/cylc-install/05-check-logs-git.t
@@ -59,7 +59,7 @@ echo "Outside workflow" > test_file_outside_workflow
 # Carry out actual test with relpath:
 run_ok "${TEST_NAME_BASE}-install" \
     cylc install "./${WORKFLOW}" --workflow-name "${WORKFLOW_NAME}"
-DIFF_FILE="${WORKFLOW_RUN_DIR}/log/version/uncommitted.diff"
+DIFF_FILE="${WORKFLOW_RUN_DIR}/log/version/01-uncommitted.diff"
 grep_ok "Inside workflow" "$DIFF_FILE"
 grep_fail "Outside workflow" "$DIFF_FILE"
 

--- a/tests/functional/cylc-install/06-check-logs-svn.t
+++ b/tests/functional/cylc-install/06-check-logs-svn.t
@@ -59,7 +59,7 @@ echo "Outside workflow" > test_file_outside_workflow
 run_ok "${TEST_NAME_BASE}-install" \
     cylc install "./${WORKFLOW}" --no-run-name --workflow-name "${WORKFLOW_NAME}"
 
-DIFF_FILE="${WORKFLOW_RUN_DIR}/log/version/uncommitted.diff"
+DIFF_FILE="${WORKFLOW_RUN_DIR}/log/version/01-uncommitted.diff"
 grep_ok "Inside workflow" "$DIFF_FILE"
 grep_fail "Outside workflow" "$DIFF_FILE"
 

--- a/tests/functional/post-install/00-log-vc-info.t
+++ b/tests/functional/post-install/00-log-vc-info.t
@@ -22,7 +22,7 @@
 if ! command -v 'git' > /dev/null; then
     skip_all 'git not installed'
 fi
-set_test_number 4
+set_test_number 6
 
 make_rnd_workflow
 cd "${RND_WORKFLOW_SOURCE}" || exit 1
@@ -43,7 +43,12 @@ exists_ok "$VCS_INFO_FILE"
 # Basic check, unit tests cover this in more detail:
 grep_ok '"version control system": "git"' "$VCS_INFO_FILE" -F
 
-DIFF_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/uncommitted.diff"
+DIFF_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/01-uncommitted.diff"
+exists_ok "$DIFF_FILE"  # Expected to be empty but should exist
+
+run_ok "${TEST_NAME_BASE}-reinstall" cylc reinstall "${RND_WORKFLOW_NAME}/runN"
+
+DIFF_FILE="${RND_WORKFLOW_RUNDIR}/runN/log/version/02-uncommitted.diff"
 exists_ok "$DIFF_FILE"  # Expected to be empty but should exist
 
 purge_rnd_workflow

--- a/tests/unit/post_install/test_log_vc_info.py
+++ b/tests/unit/post_install/test_log_vc_info.py
@@ -205,8 +205,6 @@ def test_write_diff_git(git_source_repo: Tuple[str, str], tmp_path: Path):
                  "+        R1 = foobar"):
         assert line in diff_lines
 
-    flow_file.write_text(BASIC_FLOW_2)
-
 
 @require_git
 def test_main_git(git_source_repo: Tuple[str, str], tmp_run_dir: Callable):

--- a/tests/unit/post_install/test_log_vc_info.py
+++ b/tests/unit/post_install/test_log_vc_info.py
@@ -53,6 +53,11 @@ BASIC_FLOW_2 = """
         R1 = bar
 """
 
+BASIC_FLOW_3 = """
+[scheduling]
+    [[graph]]
+        R1 = foobar
+"""
 
 require_git = pytest.mark.skipif(
     shutil.which('git') is None,
@@ -171,13 +176,36 @@ def test_write_diff_git(git_source_repo: Tuple[str, str], tmp_path: Path):
     source_dir, _ = git_source_repo
     run_dir = tmp_path / 'run_dir'
     (run_dir / WorkflowFiles.LogDir.DIRNAME).mkdir(parents=True)
+    (run_dir / WorkflowFiles.LogDir.DIRNAME /
+     WorkflowFiles.LogDir.INSTALL).mkdir(exist_ok=True)
+    with open(run_dir / WorkflowFiles.LogDir.DIRNAME /
+              WorkflowFiles.LogDir.INSTALL / "01-install.log", "w") as _:
+        pass
     diff_file = write_diff('git', source_dir, run_dir)
+    assert diff_file.parts[-1] == "01-uncommitted.diff"
     diff_lines = diff_file.read_text().splitlines()
     assert diff_lines[0].startswith("# Auto-generated diff")
     for line in ("diff --git a/flow.cylc b/flow.cylc",
                  "-        R1 = foo",
                  "+        R1 = bar"):
         assert line in diff_lines
+
+    flow_file = Path(source_dir) / 'flow.cylc'
+    flow_file.write_text(BASIC_FLOW_3)
+
+    with open(run_dir / WorkflowFiles.LogDir.DIRNAME /
+              WorkflowFiles.LogDir.INSTALL / "02-reinstall.log", "w") as _:
+        pass
+    diff_file = write_diff('git', source_dir, run_dir)
+    assert diff_file.parts[-1] == "02-uncommitted.diff"
+    diff_lines = diff_file.read_text().splitlines()
+    assert diff_lines[0].startswith("# Auto-generated diff")
+    for line in ("diff --git a/flow.cylc b/flow.cylc",
+                 "-        R1 = foo",
+                 "+        R1 = foobar"):
+        assert line in diff_lines
+
+    flow_file.write_text(BASIC_FLOW_2)
 
 
 @require_git


### PR DESCRIPTION
Added code in log_vc_info to append new files for new uncommit diffs
closes #7190 
<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
