### PR TITLE
Retrying remote-init on failure from restart

### DIFF
--- a/changes.d/7379.fix.md
+++ b/changes.d/7379.fix.md
@@ -1,1 +1,1 @@
-Added retry logic for remote_init and file_install after restart
+Fixed bug where Cylc would not retry communicating with a remote job platform if the initial attempt failed.

--- a/changes.d/7379.fix.md
+++ b/changes.d/7379.fix.md
@@ -1,0 +1,1 @@
+Added retry logic for remote_init and file_install after restart

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -620,8 +620,12 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
         # Re-initialise data model on reload
         schd.data_store_mgr.initiate_data_model(schd.is_reloaded)
 
-        # Reset the remote init map to trigger fresh file installation
+        # Reset the remote init map to trigger fresh file installation.
+        # Also clear incomplete_ri_map (restart remote-init tracker) to
+        # keep it consistent - the normal submission path will redo
+        # remote-init for any platform no longer in remote_init_map.
         schd.task_job_mgr.task_remote_mgr.remote_init_map.clear()
+        schd.incomplete_ri_map.clear()
         schd.task_job_mgr.task_remote_mgr.is_reload = True
         schd.pool.reload(config)
         schd.data_store_mgr.apply_task_proxy_db_history()

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -622,7 +622,6 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
 
         # Reset the remote init map to trigger fresh file installation
         schd.task_job_mgr.task_remote_mgr.remote_init_map.clear()
-        schd.incomplete_ri_map.clear()
         schd.task_job_mgr.task_remote_mgr.is_reload = True
         schd.pool.reload(config)
         schd.data_store_mgr.apply_task_proxy_db_history()

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -620,10 +620,7 @@ async def reload_workflow(schd: 'Scheduler', reload_global: bool = False):
         # Re-initialise data model on reload
         schd.data_store_mgr.initiate_data_model(schd.is_reloaded)
 
-        # Reset the remote init map to trigger fresh file installation.
-        # Also clear incomplete_ri_map (restart remote-init tracker) to
-        # keep it consistent - the normal submission path will redo
-        # remote-init for any platform no longer in remote_init_map.
+        # Reset the remote init map to trigger fresh file installation
         schd.task_job_mgr.task_remote_mgr.remote_init_map.clear()
         schd.incomplete_ri_map.clear()
         schd.task_job_mgr.task_remote_mgr.is_reload = True

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -923,26 +923,25 @@ class Scheduler:
         * Starts file installation when Remote init is complete.
         * Retries remote init/file install on SSH failure (255).
         * Removes complete or fatally failed installations.
+        * The bad_hosts logic already handles unreachable hosts.
         """
         for install_target, platform in list(self.incomplete_ri_map.items()):
-            status = self.task_job_mgr.task_remote_mgr.remote_init_map[
-                install_target]
+            remote_mgr = self.task_job_mgr.task_remote_mgr
+            status = remote_mgr.remote_init_map[install_target]
             if status == REMOTE_INIT_DONE:
-                self.task_job_mgr.task_remote_mgr.file_install(platform)
+                remote_mgr.file_install(platform)
             elif status == REMOTE_INIT_255:
                 # Remote init failed due to unreachable host, retry.
-                del self.task_job_mgr.task_remote_mgr.remote_init_map[
-                    install_target]
-                self.task_job_mgr.task_remote_mgr.remote_init(platform)
+                del remote_mgr.remote_init_map[install_target]
+                remote_mgr.remote_init(platform)
             elif status == REMOTE_FILE_INSTALL_255:
                 # File install failed due to unreachable host, retry.
-                del self.task_job_mgr.task_remote_mgr.remote_init_map[
-                    install_target]
-                self.task_job_mgr.task_remote_mgr.file_install(platform)
+                del remote_mgr.remote_init_map[install_target]
+                remote_mgr.file_install(platform)
             elif status in [REMOTE_FILE_INSTALL_DONE,
                             REMOTE_INIT_FAILED,
                             REMOTE_FILE_INSTALL_FAILED]:
-                # Complete or fatally failed - remove install target.
+                # Complete or fatally failed, remove install target.
                 self.incomplete_ri_map.pop(install_target)
 
     def _load_task_run_times(self, row_idx, row):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -921,20 +921,28 @@ class Scheduler:
 
         * Called within the main loop.
         * Starts file installation when Remote init is complete.
-        * Removes complete installations or installations encountering SSH
-          error (remote init will take place on next job submission).
+        * Retries remote init/file install on SSH failure (255).
+        * Removes complete or fatally failed installations.
         """
         for install_target, platform in list(self.incomplete_ri_map.items()):
             status = self.task_job_mgr.task_remote_mgr.remote_init_map[
                 install_target]
             if status == REMOTE_INIT_DONE:
                 self.task_job_mgr.task_remote_mgr.file_install(platform)
-            if status in [REMOTE_FILE_INSTALL_DONE,
-                          REMOTE_INIT_255,
-                          REMOTE_FILE_INSTALL_255,
-                          REMOTE_INIT_FAILED,
-                          REMOTE_FILE_INSTALL_FAILED]:
-                # Remove install target
+            elif status == REMOTE_INIT_255:
+                # Remote init failed due to unreachable host, retry.
+                del self.task_job_mgr.task_remote_mgr.remote_init_map[
+                    install_target]
+                self.task_job_mgr.task_remote_mgr.remote_init(platform)
+            elif status == REMOTE_FILE_INSTALL_255:
+                # File install failed due to unreachable host, retry.
+                del self.task_job_mgr.task_remote_mgr.remote_init_map[
+                    install_target]
+                self.task_job_mgr.task_remote_mgr.file_install(platform)
+            elif status in [REMOTE_FILE_INSTALL_DONE,
+                            REMOTE_INIT_FAILED,
+                            REMOTE_FILE_INSTALL_FAILED]:
+                # Complete or fatally failed - remove install target.
                 self.incomplete_ri_map.pop(install_target)
 
     def _load_task_run_times(self, row_idx, row):

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -932,11 +932,9 @@ class Scheduler:
                 remote_mgr.file_install(platform)
             elif status == REMOTE_INIT_255:
                 # Remote init failed due to unreachable host, retry.
-                del remote_mgr.remote_init_map[install_target]
                 remote_mgr.remote_init(platform)
             elif status == REMOTE_FILE_INSTALL_255:
                 # File install failed due to unreachable host, retry.
-                del remote_mgr.remote_init_map[install_target]
                 remote_mgr.file_install(platform)
             elif status in [REMOTE_FILE_INSTALL_DONE,
                             REMOTE_INIT_FAILED,

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -492,7 +492,7 @@ async def test_manage_remote_init_retry_on_255(
         # tracked via incomplete_ri_map:
         schd.incomplete_ri_map[missing_target] = fake_platform
 
-        # --- REMOTE_INIT_255: should retry remote_init, NOT pop from map ---
+        # REMOTE_INIT_255: retry remote_init, pop from init map, NOT ri map
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_255
         schd.manage_remote_init()
         assert missing_target not in remote_mgr.remote_init_map, (
@@ -504,14 +504,14 @@ async def test_manage_remote_init_retry_on_255(
         )
         mock_remote_init.reset_mock()
 
-        # --- REMOTE_INIT_DONE: should trigger file_install ---
+        # REMOTE_INIT_DONE: should trigger file_install
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_DONE
         schd.manage_remote_init()
         mock_file_install.assert_called_once_with(fake_platform)
         assert missing_target in schd.incomplete_ri_map
         mock_file_install.reset_mock()
 
-        # --- REMOTE_FILE_INSTALL_255: should retry file_install ---
+        # REMOTE_FILE_INSTALL_255: should retry file_install
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_255
         schd.manage_remote_init()
         assert missing_target not in remote_mgr.remote_init_map
@@ -519,18 +519,18 @@ async def test_manage_remote_init_retry_on_255(
         assert missing_target in schd.incomplete_ri_map
         mock_file_install.reset_mock()
 
-        # --- REMOTE_FILE_INSTALL_DONE: should remove from map (success) ---
+        # REMOTE_FILE_INSTALL_DONE: should remove from ri map
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_DONE
         schd.manage_remote_init()
         assert missing_target not in schd.incomplete_ri_map
 
-        # --- REMOTE_INIT_FAILED: should remove from map (fatal) ---
+        # REMOTE_INIT_FAILED: should remove from ri map
         schd.incomplete_ri_map[missing_target] = fake_platform
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_FAILED
         schd.manage_remote_init()
         assert missing_target not in schd.incomplete_ri_map
 
-        # --- REMOTE_FILE_INSTALL_FAILED: should remove from map (fatal) ---
+        # REMOTE_FILE_INSTALL_FAILED: should remove from ri map
         schd.incomplete_ri_map[missing_target] = fake_platform
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_FAILED
         schd.manage_remote_init()

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -17,17 +17,27 @@
 import asyncio
 import logging
 from pathlib import Path
+import re
+from signal import (
+    SIGHUP,
+    SIGINT,
+    SIGTERM,
+)
+from typing import (
+    Any,
+    Callable,
+)
 from unittest.mock import Mock
 
 import pytest
-import re
-from signal import SIGHUP, SIGINT, SIGTERM
-from typing import Any, Callable
 
 from cylc.flow import commands
 from cylc.flow.exceptions import CylcError
 from cylc.flow.parsec.exceptions import ParsecError
-from cylc.flow.scheduler import Scheduler, SchedulerStop
+from cylc.flow.scheduler import (
+    Scheduler,
+    SchedulerStop,
+)
 from cylc.flow.task_remote_mgr import (
     REMOTE_FILE_INSTALL_255,
     REMOTE_FILE_INSTALL_DONE,
@@ -37,15 +47,17 @@ from cylc.flow.task_remote_mgr import (
     REMOTE_INIT_FAILED,
 )
 from cylc.flow.task_state import (
-    TASK_STATUS_SUCCEEDED,
-    TASK_STATUS_WAITING,
+    TASK_STATUS_FAILED,
+    TASK_STATUS_RUNNING,
     TASK_STATUS_SUBMIT_FAILED,
     TASK_STATUS_SUBMITTED,
-    TASK_STATUS_RUNNING,
-    TASK_STATUS_FAILED
+    TASK_STATUS_SUCCEEDED,
+    TASK_STATUS_WAITING,
 )
-
-from cylc.flow.workflow_status import AutoRestartMode, StopMode
+from cylc.flow.workflow_status import (
+    AutoRestartMode,
+    StopMode,
+)
 
 
 Fixture = Any

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -17,6 +17,8 @@
 import asyncio
 import logging
 from pathlib import Path
+from unittest.mock import Mock
+
 import pytest
 import re
 from signal import SIGHUP, SIGINT, SIGTERM
@@ -26,6 +28,15 @@ from cylc.flow import commands
 from cylc.flow.exceptions import CylcError
 from cylc.flow.parsec.exceptions import ParsecError
 from cylc.flow.scheduler import Scheduler, SchedulerStop
+from cylc.flow.task_remote_mgr import (
+    REMOTE_FILE_INSTALL_255,
+    REMOTE_FILE_INSTALL_DONE,
+    REMOTE_FILE_INSTALL_FAILED,
+    REMOTE_INIT_255,
+    REMOTE_INIT_DONE,
+    REMOTE_INIT_FAILED,
+    REMOTE_INIT_IN_PROGRESS,
+)
 from cylc.flow.task_state import (
     TASK_STATUS_SUCCEEDED,
     TASK_STATUS_WAITING,
@@ -454,3 +465,74 @@ async def test_set_stall_interaction(flow, scheduler, start):
             schd.data_store_mgr.data[schd.tokens.id]['workflow'].status_msg
             != 'stalled'
         )
+
+
+async def test_manage_remote_init_retry_on_255(
+    flow, scheduler, start, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that manage_remote_init retries remote init/file install on 255.
+
+    See https://github.com/cylc/cylc-flow/issues/7286
+
+    On restart, if remote-init fails with exit code 255 (SSH connection
+    failure), manage_remote_init should retry rather than silently dropping
+    the install target.
+    """
+    missing_target = 'Alderaan'
+    fake_platform = {'install target': missing_target, 'name': 'test_plat'}
+
+    schd: Scheduler = scheduler(flow('one'), run_mode='live')
+    async with start(schd):
+        remote_mgr = schd.task_job_mgr.task_remote_mgr
+        mock_remote_init = Mock()
+        monkeypatch.setattr(remote_mgr, 'remote_init', mock_remote_init)
+        mock_file_install = Mock()
+        monkeypatch.setattr(remote_mgr, 'file_install', mock_file_install)
+
+        # Simulate restart remote-init has been kicked off and is being
+        # tracked via incomplete_ri_map:
+        schd.incomplete_ri_map[missing_target] = fake_platform
+
+        # --- REMOTE_INIT_255: should retry remote_init, NOT pop from map ---
+        remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_255
+        schd.manage_remote_init()
+        assert missing_target not in remote_mgr.remote_init_map, (
+            "Stale 255 status should be deleted before retry"
+        )
+        mock_remote_init.assert_called_once_with(fake_platform)
+        assert missing_target in schd.incomplete_ri_map, (
+            "Install target should remain in incomplete_ri_map for tracking"
+        )
+        mock_remote_init.reset_mock()
+
+        # --- REMOTE_INIT_DONE: should trigger file_install ---
+        remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_DONE
+        schd.manage_remote_init()
+        mock_file_install.assert_called_once_with(fake_platform)
+        assert missing_target in schd.incomplete_ri_map
+        mock_file_install.reset_mock()
+
+        # --- REMOTE_FILE_INSTALL_255: should retry file_install ---
+        remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_255
+        schd.manage_remote_init()
+        assert missing_target not in remote_mgr.remote_init_map
+        mock_file_install.assert_called_once_with(fake_platform)
+        assert missing_target in schd.incomplete_ri_map
+        mock_file_install.reset_mock()
+
+        # --- REMOTE_FILE_INSTALL_DONE: should remove from map (success) ---
+        remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_DONE
+        schd.manage_remote_init()
+        assert missing_target not in schd.incomplete_ri_map
+
+        # --- REMOTE_INIT_FAILED: should remove from map (fatal) ---
+        schd.incomplete_ri_map[missing_target] = fake_platform
+        remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_FAILED
+        schd.manage_remote_init()
+        assert missing_target not in schd.incomplete_ri_map
+
+        # --- REMOTE_FILE_INSTALL_FAILED: should remove from map (fatal) ---
+        schd.incomplete_ri_map[missing_target] = fake_platform
+        remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_FAILED
+        schd.manage_remote_init()
+        assert missing_target not in schd.incomplete_ri_map

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -35,7 +35,6 @@ from cylc.flow.task_remote_mgr import (
     REMOTE_INIT_255,
     REMOTE_INIT_DONE,
     REMOTE_INIT_FAILED,
-    REMOTE_INIT_IN_PROGRESS,
 )
 from cylc.flow.task_state import (
     TASK_STATUS_SUCCEEDED,

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -504,42 +504,51 @@ async def test_manage_remote_init_retry_on_255(
         # tracked via incomplete_ri_map:
         schd.incomplete_ri_map[missing_target] = fake_platform
 
-        # REMOTE_INIT_255: retry remote_init
+        # REMOTE_INIT_255: retry remote_init (not file_install)
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_255
         schd.manage_remote_init()
         mock_remote_init.assert_called_once_with(fake_platform)
+        mock_file_install.assert_not_called()
         assert missing_target in schd.incomplete_ri_map, (
             "Install target should remain in incomplete_ri_map for tracking"
         )
         mock_remote_init.reset_mock()
 
-        # REMOTE_INIT_DONE: should trigger file_install
+        # REMOTE_INIT_DONE: should trigger file_install (not remote_init)
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_DONE
         schd.manage_remote_init()
         mock_file_install.assert_called_once_with(fake_platform)
+        mock_remote_init.assert_not_called()
         assert missing_target in schd.incomplete_ri_map
         mock_file_install.reset_mock()
 
-        # REMOTE_FILE_INSTALL_255: should retry file_install
+        # REMOTE_FILE_INSTALL_255: should retry file_install (not remote_init)
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_255
         schd.manage_remote_init()
         mock_file_install.assert_called_once_with(fake_platform)
+        mock_remote_init.assert_not_called()
         assert missing_target in schd.incomplete_ri_map
         mock_file_install.reset_mock()
 
         # REMOTE_FILE_INSTALL_DONE: should remove from ri map
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_DONE
         schd.manage_remote_init()
+        mock_remote_init.assert_not_called()
+        mock_file_install.assert_not_called()
         assert missing_target not in schd.incomplete_ri_map
 
         # REMOTE_INIT_FAILED: should remove from ri map
         schd.incomplete_ri_map[missing_target] = fake_platform
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_FAILED
         schd.manage_remote_init()
+        mock_remote_init.assert_not_called()
+        mock_file_install.assert_not_called()
         assert missing_target not in schd.incomplete_ri_map
 
         # REMOTE_FILE_INSTALL_FAILED: should remove from ri map
         schd.incomplete_ri_map[missing_target] = fake_platform
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_FAILED
         schd.manage_remote_init()
+        mock_remote_init.assert_not_called()
+        mock_file_install.assert_not_called()
         assert missing_target not in schd.incomplete_ri_map

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -504,12 +504,9 @@ async def test_manage_remote_init_retry_on_255(
         # tracked via incomplete_ri_map:
         schd.incomplete_ri_map[missing_target] = fake_platform
 
-        # REMOTE_INIT_255: retry remote_init, pop from init map, NOT ri map
+        # REMOTE_INIT_255: retry remote_init
         remote_mgr.remote_init_map[missing_target] = REMOTE_INIT_255
         schd.manage_remote_init()
-        assert missing_target not in remote_mgr.remote_init_map, (
-            "Stale 255 status should be deleted before retry"
-        )
         mock_remote_init.assert_called_once_with(fake_platform)
         assert missing_target in schd.incomplete_ri_map, (
             "Install target should remain in incomplete_ri_map for tracking"
@@ -526,7 +523,6 @@ async def test_manage_remote_init_retry_on_255(
         # REMOTE_FILE_INSTALL_255: should retry file_install
         remote_mgr.remote_init_map[missing_target] = REMOTE_FILE_INSTALL_255
         schd.manage_remote_init()
-        assert missing_target not in remote_mgr.remote_init_map
         mock_file_install.assert_called_once_with(fake_platform)
         assert missing_target in schd.incomplete_ri_map
         mock_file_install.reset_mock()


### PR DESCRIPTION
Closes #7286 
Added some re-try logic when remote-init failures are returned following a restart.
Ran isort

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
