### PR TITLE
Remove noisy runahead base point debug log message

### DIFF
--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -449,8 +449,6 @@ class TaskPool:
         if base_point is None:
             return False
 
-        LOG.debug(f"Runahead: base point {base_point}")
-
         if self._prev_runahead_base_point is None:
             self._prev_runahead_base_point = base_point
 


### PR DESCRIPTION
```
2026-07-14T17:23:33+01:00 WARNING - [1/a-task/01:failed] did not complete the required outputs:
    ⨯ ┆  succeeded
2026-07-14T17:23:34+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:35+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:36+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:37+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:38+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:39+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:40+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:41+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:42+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:43+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:44+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:45+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:46+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:47+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:48+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:49+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:50+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:51+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:52+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:53+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:54+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:55+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:56+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:57+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:58+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:23:59+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:00+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:01+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:02+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:03+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:04+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:05+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:06+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:07+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:08+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:09+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:10+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:11+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:12+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:13+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:14+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:15+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:16+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:17+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:18+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:19+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:20+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:21+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:22+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:23+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:24+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:25+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:26+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:27+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:28+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:29+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:30+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:31+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:32+01:00 DEBUG - Runahead: base point 1
2026-07-14T17:24:32+01:00 WARNING - stall timer timed out after PT1M
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests needed
- [x] Changelog entry not needed
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
