### PR TITLE
Improve logging of warnings from Jinja2 processing

### DIFF
--- a/changes.d/7365.feat.md
+++ b/changes.d/7365.feat.md
@@ -1,1 +1,1 @@
-Python warnings raised in users' custom jinja2 filters, globals and tests are now logged.
+Python warnings raised during Jinja2 preprocessing are now logged.

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -513,6 +513,13 @@ def read_and_proc(
                 flines = jinja2process(
                     fpath, flines, fdir, template_vars
                 )
+            for w in warns:
+                if w.filename.endswith(os.path.join('jinja2', 'lexer.py')):
+                    # Warning originating from lexing of a jinja2 template.
+                    # Unfortunately, we can't know exactly where it originated,
+                    # so just set the config filename and vague line "number":
+                    w.filename = fpath
+                    w.lineno = '<jinja2 template>'  # type: ignore
             if warns:
                 LOG.warning(
                     "The following warnings were raised during Jinja2 "

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -125,6 +125,8 @@ EXTRA_VARS_TEMPLATE: dict[str, Any] = {
     TEMPLATING_DETECTED: None
 }
 
+_J2_WARN_LOCS = re.compile(rf'jinja2{re.escape(os.sep)}(lexer|runtime)\.py$')
+
 
 def get_cylc_env_vars() -> dict[str, str]:
     """Return a restricted dict of CYLC_ environment variables for templating.
@@ -514,8 +516,8 @@ def read_and_proc(
                     fpath, flines, fdir, template_vars
                 )
             for w in warns:
-                if w.filename.endswith(os.path.join('jinja2', 'lexer.py')):
-                    # Warning originating from lexing of a jinja2 template.
+                if _J2_WARN_LOCS.search(w.filename):
+                    # Warning originating from processing of a jinja2 template.
                     # Unfortunately, we can't know exactly where it originated,
                     # so just set the config filename and vague line "number":
                     w.filename = fpath

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import re
 import sqlite3
 from tempfile import NamedTemporaryFile
+from textwrap import dedent
 from types import SimpleNamespace
 import warnings
 
@@ -480,6 +481,28 @@ def test_read_and_proc_jinja2_warnings(
             rf"{__file__}:\d+: DeprecationWarning: {msg}"
         ),
         rec.message,
+    )
+
+
+def test_read_and_proc_jinja2_warnings_invalid_escape(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """When a warning comes from a j2 template expression, it should be logged
+    with the cylc config filepath."""
+    (fpath := tmp_path / 'flow.cylc').write_text(
+        dedent(r"""
+            #!jinja2
+            {% from 'warnings' import warn %}
+            {% do warn('Mock warning') %}
+        """).lstrip()
+    )
+    read_and_proc(
+        fpath=str(fpath),
+        viewcfg={'jinja2': True, 'contin': False, 'inline': False},
+    )
+
+    assert (
+        f"{fpath}:<jinja2 template>: UserWarning: Mock warning" in caplog.text
     )
 
 


### PR DESCRIPTION
Follow-up to #7365

Changes the apparent source of some warnings raised during jinja2 processing from the jinja2 source code to the Cylc config file

### Repro

```cylc
#!jinja2
{% set x = '\${HOME}/foo/bar' %}
[scheduler]
    allow implicit tasks = True
[scheduling]
    [[graph]]
        R1 = foo
```

#### Before

```console
$ cylc validate wflow
WARNING - The following warnings were raised during Jinja2 preprocessing (note: any Jinja 3.1 deprecations will break at Cylc 8.7):
    .../lib/python3.14/site-packages/jinja2/lexer.py:654: DeprecationWarning: "\$" is an invalid escape sequence. Such sequences will not work in the future.
      .decode("unicode-escape")
```

#### After

```console
$ cylc validate wflow
WARNING - The following warnings were raised during Jinja2 preprocessing (note: any Jinja 3.1 deprecations will break at Cylc 8.7):
    ~/cylc-run/wflow/flow.cylc:<jinja2 template>: DeprecationWarning: "\$" is an invalid escape sequence. Such sequences will not work in the future.
```

### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] No tests included as minor
- [x] Changelog entry not needed as follow-up to unreleased PR
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
