### PR TITLE
Reload custom Jinja2 extensions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ requests_).
  - Christopher Bennett
  - Ryan Boult
  - Samuel Denton
+ - Sanjay Santhanam
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/changes.d/7387.fix.md
+++ b/changes.d/7387.fix.md
@@ -1,0 +1,1 @@
+Reload custom workflow Jinja2 filters, tests and globals when their source files change.

--- a/cylc/flow/parsec/jinja2support.py
+++ b/cylc/flow/parsec/jinja2support.py
@@ -189,7 +189,14 @@ def jinja2environment(dir_=None):
                 for name in glob(os.path.join(fdir, '*.py')):
                     fname = os.path.splitext(os.path.basename(name))[0]
                     # TODO - EXCEPTION HANDLING FOR LOADING CUSTOM FILTERS
-                    module = __import__(fname)
+                    module = sys.modules.get(fname)
+                    if module is None:
+                        module = importlib.import_module(fname)
+                    elif (
+                        (module_file := getattr(module, '__file__', None))
+                        and os.path.samefile(module_file, name)
+                    ):
+                        module = importlib.reload(module)
                     envnsp = getattr(env, namespace)
                     envnsp[fname] = getattr(module, fname)
 

--- a/tests/unit/parsec/test_jinja2support.py
+++ b/tests/unit/parsec/test_jinja2support.py
@@ -81,6 +81,26 @@ def test_jinja2environment(tmp_path: Path, custom_filter_global_and_test):
     assert env.tests['big'](5) is False
 
 
+def test_jinja2environment_reloads_custom_filter(tmp_path: Path):
+    filters_dir = tmp_path / 'Jinja2Filters'
+    filters_dir.mkdir()
+    filter_file = filters_dir / 'reload_filter.py'
+    filter_file.write_text(
+        "def reload_filter(value):\n    return 'old'\n"
+    )
+
+    assert jinja2environment(tmp_path).filters['reload_filter'](None) == 'old'
+
+    filter_file.write_text(
+        "def reload_filter(value):\n    return 'new-value'\n"
+    )
+
+    assert (
+        jinja2environment(tmp_path).filters['reload_filter'](None)
+        == 'new-value'
+    )
+
+
 def test_jinja2process(tmp_path, custom_filter_global_and_test):
     lines = [
         r"skipped",


### PR DESCRIPTION
Closes #7385

Custom workflow Jinja2 modules remained cached across reload, so edited filters, tests, and globals kept their old behavior. This reloads matching local modules when rebuilding the Jinja environment and adds a regression test.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
