### PR TITLE
fix spelling

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -1496,7 +1496,7 @@ with Conf('global.cylc', desc='''
                      Configure the path to the cgroups filesystem.
 
                      The default value is the standard
-                     location for cgroups on linux and should work in
+                     location for cgroups on Linux and should work in
                      most circumstances
                      ''')
                 Conf('polling interval', VDR.V_INTERVAL,


### PR DESCRIPTION
Fix a docs build error by fixing the spelling of Linux (capital L -> proper noun).

Some bits of our code get auto-documented, the Cylc config reference is an example.

We have a (somewhat overzealous) spellcheck in cylc-doc which has to be placated.

Along with https://github.com/cylc/cylc-doc/pull/955 this should fix build errors.