### PR TITLE
Validate and list command: list unused namespaces.

### DIFF
--- a/changes.d/7395.feat.md
+++ b/changes.d/7395.feat.md
@@ -1,0 +1,1 @@
+New `cylc list` option, and validation, to list unused runtime namespaces.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -590,6 +590,7 @@ class WorkflowConfig:
             self.cfg, self.taskdefs, self.MAX_WARNING_LINES)
 
         self._check_implicit_tasks()
+        self._check_unused_namespaces()
         self._check_sequence_bounds()
         self.validate_namespace_names()
 
@@ -924,6 +925,27 @@ class WorkflowConfig:
                 self.stop_point = None
             stopcp_str = str(self.stop_point) if self.stop_point else None
             self.cfg['scheduling']['stop after cycle point'] = stopcp_str
+
+    def _check_unused_namespaces(self):
+        """Check for runtime namespaces not used by the graph."""
+        not_task_in_graph = [  # unused tasks, and all family names
+            name for name in self.cfg['runtime'] if
+            name not in self.taskdefs
+        ]
+        unused = [
+            name for name in not_task_in_graph
+            # unused tasks:
+            if name not in self.runtime['descendants']
+            # families not inherited by any used tasks:
+            or self.runtime['descendants'][name].isdisjoint(
+                self.taskdefs.keys()
+            )
+        ]
+        if unused:
+            LOG.info(
+                "There are runtime namespaces not used by the workflow:"
+                f"\n* {'\n* '.join(unused)}"
+            )
 
     def _check_implicit_tasks(self) -> None:
         """Raise WorkflowConfigError if implicit tasks are found in graph or

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -583,6 +583,7 @@ class WorkflowConfig:
             self.cfg, self.taskdefs, self.MAX_WARNING_LINES)
 
         self._check_implicit_tasks()
+        self._check_unused_namespaces()
         self._check_sequence_bounds()
         self.validate_namespace_names()
 
@@ -914,6 +915,27 @@ class WorkflowConfig:
                 self.stop_point = None
             stopcp_str = str(self.stop_point) if self.stop_point else None
             self.cfg['scheduling']['stop after cycle point'] = stopcp_str
+
+    def _check_unused_namespaces(self):
+        """Check for runtime namespaces not used by the graph."""
+        not_task_in_graph = [  # unused tasks, and all family names
+            name for name in self.cfg['runtime'] if
+            name not in self.taskdefs
+        ]
+        unused = [
+            name for name in not_task_in_graph
+            # unused tasks:
+            if name not in self.runtime['descendants']
+            # families not inherited by any used tasks:
+            or self.runtime['descendants'][name].isdisjoint(
+                self.taskdefs.keys()
+            )
+        ]
+        if unused:
+            LOG.info(
+                "There are runtime namespaces not used by the workflow:"
+                f"\n* {'\n* '.join(unused)}"
+            )
 
     def _check_implicit_tasks(self) -> None:
         """Raise WorkflowConfigError if implicit tasks are found in graph or

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -583,7 +583,14 @@ class WorkflowConfig:
             self.cfg, self.taskdefs, self.MAX_WARNING_LINES)
 
         self._check_implicit_tasks()
-        self._check_unused_namespaces()
+
+        if getattr(self.options, 'is_validate', False):
+            unused = self._check_unused_namespaces()
+            if unused:
+                LOG.info(
+                    "There are runtime namespaces not used by the workflow:"
+                    f"\n* {'\n* '.join(unused)}"
+                )
         self._check_sequence_bounds()
         self.validate_namespace_names()
 
@@ -922,7 +929,7 @@ class WorkflowConfig:
             name for name in self.cfg['runtime'] if
             name not in self.taskdefs
         ]
-        unused = [
+        return {
             name for name in not_task_in_graph
             # unused tasks:
             if name not in self.runtime['descendants']
@@ -930,12 +937,7 @@ class WorkflowConfig:
             or self.runtime['descendants'][name].isdisjoint(
                 self.taskdefs.keys()
             )
-        ]
-        if unused:
-            LOG.info(
-                "There are runtime namespaces not used by the workflow:"
-                f"\n* {'\n* '.join(unused)}"
-            )
+        }
 
     def _check_implicit_tasks(self) -> None:
         """Raise WorkflowConfigError if implicit tasks are found in graph or
@@ -1705,6 +1707,9 @@ class WorkflowConfig:
                 if ns not in self.runtime['descendants']:
                     # tasks have no descendants
                     names.append(ns)
+        elif which == "unused namespaces":
+            names = self._check_unused_namespaces()
+
         result = {}
         for ns in names:
             result[ns] = self.cfg['runtime'][ns]['meta'].get(

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -925,19 +925,20 @@ class WorkflowConfig:
 
     def _check_unused_namespaces(self):
         """Check for runtime namespaces not used by the graph."""
-        not_task_in_graph = [  # unused tasks, and all family names
-            name for name in self.cfg['runtime'] if
-            name not in self.taskdefs
-        ]
         return {
-            name for name in not_task_in_graph
-            # unused tasks:
-            if name not in self.runtime['descendants']
-            # families not inherited by any used tasks:
-            or self.runtime['descendants'][name].isdisjoint(
-                self.taskdefs.keys()
+            name
+            for name in self.cfg['runtime']
+            if name not in self.taskdefs
+            and (
+                # unused tasks:
+                name not in self.runtime['descendants']
+                # families not inherited by any used tasks:
+                or self.runtime['descendants'][name].isdisjoint(
+                    self.taskdefs.keys()
+                )
             )
         }
+
 
     def _check_implicit_tasks(self) -> None:
         """Raise WorkflowConfigError if implicit tasks are found in graph or

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -927,7 +927,9 @@ class WorkflowConfig:
         """Check for runtime namespaces not used by the graph."""
         return {
             name
+            # all runtime namespaces:
             for name in self.cfg['runtime']
+            # that are not used in the graph:
             if name not in self.taskdefs
             and (
                 # unused tasks:
@@ -938,7 +940,6 @@ class WorkflowConfig:
                 )
             )
         }
-
 
     def _check_implicit_tasks(self) -> None:
         """Raise WorkflowConfigError if implicit tasks are found in graph or

--- a/cylc/flow/scripts/list.py
+++ b/cylc/flow/scripts/list.py
@@ -74,6 +74,11 @@ def get_option_parser():
         action="store_true", default=False, dest="all_namespaces")
 
     parser.add_option(
+        "-u", "--unused-namespaces",
+        help="Print any runtime namespaces not used in the graph.",
+        action="store_true", default=False, dest="unused_namespaces")
+
+    parser.add_option(
         "-m", "--mro",
         help="Print the linear \"method resolution order\" for each namespace "
              "(the multiple-inheritance precedence order as determined by the "
@@ -165,8 +170,17 @@ async def _main(options: 'Values', workflow_id: str) -> None:
     )
     template_vars = get_template_vars(options)
 
-    if options.all_tasks and options.all_namespaces:
-        raise InputError("Choose either -a or -n")
+    if len(
+        [
+            opt for opt in
+            [
+                options.all_tasks,
+                options.all_namespaces,
+                options.unused_namespaces
+            ] if opt is not False
+        ]
+    ) not in {0, 1}:
+        raise InputError("Choose either -a or -n or -u")
     if (options.all_tasks or options.all_namespaces) and options.prange:
         raise InputError(
             '--points cannot be used with --all-tasks or --all-namespaces'
@@ -178,6 +192,8 @@ async def _main(options: 'Values', workflow_id: str) -> None:
         which = "all tasks"
     elif options.all_namespaces:
         which = "all namespaces"
+    elif options.unused_namespaces:
+        which = "unused namespaces"
     elif options.prange:
         which = "prange"
         if options.prange == ",":

--- a/tests/integration/scripts/test_list.py
+++ b/tests/integration/scripts/test_list.py
@@ -111,6 +111,11 @@ async def test_plain(cylc_list, supports_utf8, capsys):
         'root',
     ]
 
+    assert await cylc_list(capsys, unused_namespaces=True) == [
+        'B',
+        'b1',
+    ]
+
     with pytest.raises(InputError):
         await cylc_list(capsys, all_tasks=True, all_namespaces=True)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1736,6 +1736,31 @@ def test_check_task_event_names(item, tmp_flow_config, log_filter):
     ))
 
 
+def test_check_unused_namespaces(tmp_flow_config):
+    """"Any invalid task handler events are warned about."""
+    flow_file = tmp_flow_config('foo', """
+        [scheduler]
+            allow implicit tasks = True
+        [scheduling]
+            [[graph]]
+                R1 = "a & FAM_1 & f"
+        [runtime]
+            [[a]]
+            [[e]]
+            [[FAM_1]]
+            [[b, c, d]]
+               inherit = FAM_1
+            [[FAM_2]]
+            [[k]]
+               inherit = FAM_2
+    """)
+    assert (
+        WorkflowConfig(
+            'foo', str(flow_file), ValidateOptions()
+        )._check_unused_namespaces() == {'e', 'FAM_2', 'k'}
+    )
+
+
 def test_jinja2_lib_python(tmp_flow_config):
     """Modules in lib/python are available in custom Jinja2."""
     flow_file: Path = tmp_flow_config((id_ := 'wflow'), r"""


### PR DESCRIPTION
Close #7392 

Validation, and `cylc list` option to print all unused (i.e., not in the graph) runtime namespaces.

Example: task `f` is implicit, tasks `e`, `k` and `FAM_2` are not used by the graph. (`FAM_2` is inherited only by `k` which is not used): 
```cylc
[scheduling]
    [[graph]]
        R1 = "a & FAM_1 & f"
[runtime]
    [[a, e, f]]
    [[FAM_1]]
    [[b, c, d]]
       inherit = FAM_1
    [[FAM_2]]
    [[k]]
       inherit = FAM_2
```
Validation:
```console
$ cylc val .
INFO - There are runtime namespaces not used by the workflow:
    * e
    * FAM_2
    * k
```

List command:
```console
$ cylc list --unused-namespaces
FAM_2
e
k
```

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
