### PR TITLE
Give a clean error for invalid initial cycle point syntax

### DIFF
--- a/changes.d/7390.fix.md
+++ b/changes.d/7390.fix.md
@@ -1,0 +1,1 @@
+Invalid `initial cycle point` values such as `T, T` now give a clean error message instead of a traceback.

--- a/cylc/flow/cycling/iso8601.py
+++ b/cylc/flow/cycling/iso8601.py
@@ -699,7 +699,15 @@ def ingest_time(value: str, now: Optional[str] = None) -> str:
         timepoint = None
         is_truncated = None
     else:
-        timepoint = parser.parse(value)
+        try:
+            timepoint = parser.parse(value)
+        except ISO8601SyntaxError:
+            raise
+        except ValueError as exc:
+            # The parser can fail with a bare ValueError on some malformed
+            # input (e.g. "T, T"); convert it to a recognisable syntax error
+            # so callers report it cleanly instead of tracing back.
+            raise ISO8601SyntaxError('date-time', value) from exc
         # missing date-time components off the front (e.g. 01T00)
         is_truncated = timepoint.truncated
 

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -838,7 +838,7 @@ class CylcConfigValidator(ParsecValidator):
             for i in range(1, 101):
                 try:
                     TimePointParser(num_expanded_year_digits=i).parse(value)
-                except IsodatetimeError:
+                except (IsodatetimeError, ValueError):
                     continue
                 return value
             raise IllegalValueError('cycle point', keys, value)
@@ -866,6 +866,10 @@ class CylcConfigValidator(ParsecValidator):
                 details = {'exc': exc}
             raise IllegalValueError(
                 'cycle point', keys, value, **details
+            ) from None
+        except ValueError:
+            raise IllegalValueError(
+                'cycle point', keys, value, msg="Invalid cycle point"
             ) from None
         return value
 

--- a/tests/unit/cycling/test_iso8601.py
+++ b/tests/unit/cycling/test_iso8601.py
@@ -23,6 +23,7 @@ from cylc.flow.cycling.iso8601 import (
     ISO8601Interval,
     ISO8601Point,
     ISO8601Sequence,
+    ISO8601SyntaxError,
     ingest_time,
 )
 from cylc.flow.cycling.loader import ISO8601_CYCLING_TYPE
@@ -963,3 +964,17 @@ def test_validate_fails_comma_sep_offset_list(
     set_cycling_type(ISO8601_CYCLING_TYPE, "Z")
     with pytest.raises(Exception, match=errortext):
         ingest_time(_input)
+
+
+@pytest.mark.parametrize("_input", ("T, T", "T00, T18", "T00,T18"))
+def test_ingest_time_bad_syntax_raises_iso8601_error(_input, set_cycling_type):
+    """It raises ISO8601SyntaxError, not a bare ValueError, on bad syntax.
+
+    The isodatetime parser fails with an unhelpful "too many values to
+    unpack" ValueError on some malformed input, which reached the user as a
+    traceback rather than a clean error message. See
+    https://github.com/cylc/cylc-flow/issues/7390
+    """
+    set_cycling_type(ISO8601_CYCLING_TYPE, "Z")
+    with pytest.raises(ISO8601SyntaxError, match="Invalid ISO 8601"):
+        ingest_time(_input, "2010-08-08T15:41Z")

--- a/tests/unit/parsec/test_validate.py
+++ b/tests/unit/parsec/test_validate.py
@@ -785,3 +785,9 @@ def test_type_help_examples():
 )
 def test_broadcast_coerce_str(value: str, expected: str):
     assert BroadcastConfigValidator.coerce_str(value, ['whatever']) == expected
+
+
+@pytest.mark.parametrize('value', ['T, T', 'T00, T18', '+123456-01-01T00T00'])
+def test_malformed_cycle_point_reports_config_error(value):
+    with pytest.raises(IllegalValueError):
+        VDR.coerce_cycle_point(value, ['scheduling', 'initial cycle point'])


### PR DESCRIPTION
Closes #7390

Some malformed `initial cycle point` values (e.g. `T, T`, `T00, T18`) make the isodatetime parser fail with a bare `ValueError: too many values to unpack` instead of an `ISO8601SyntaxError`. `_parse_iso_cycle_point` only catches `IsodatetimeError`, so that escaped as a traceback rather than a clean `WorkflowConfigError`. `ingest_time` now converts an unrecognised `ValueError` from the parser into an `ISO8601SyntaxError`, which the existing error handling already reports readably.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
