### PR TITLE
Fix flake8 ISC004 violations.

### DIFF
--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -126,8 +126,10 @@ class HostUtil:
         if target is None:
             target = socket.getfqdn()
         if IS_MAC_OS and target in {
-            '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.'
-            '0.0.0.0.0.0.ip6.arpa',
+            (
+                '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.'
+                '0.0.0.0.0.0.ip6.arpa'
+            ),
             '1.0.0.127.in-addr.arpa',
         }:
             # Python's socket bindings don't play nicely with mac os

--- a/cylc/flow/hostuserutil.py
+++ b/cylc/flow/hostuserutil.py
@@ -126,10 +126,7 @@ class HostUtil:
         if target is None:
             target = socket.getfqdn()
         if IS_MAC_OS and target in {
-            (
-                '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.'
-                '0.0.0.0.0.0.ip6.arpa'
-            ),
+            f'1.{"0." * 31}ip6.arpa',
             '1.0.0.127.in-addr.arpa',
         }:
             # Python's socket bindings don't play nicely with mac os

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -790,8 +790,7 @@ class CylcConfigValidator(ParsecValidator):
             'xtrigger function signature',
             (
                 'A function signature similar to how it would be written in '
-                'Python.\n'
-                '``<function>(<arg>, <kwarg>=<value>):<interval>``'
+                'Python.\n``<function>(<arg>, <kwarg>=<value>):<interval>``'
             ),
             {
                 'mytrigger(42, cycle_point=%(point)):PT10S':

--- a/cylc/flow/parsec/validate.py
+++ b/cylc/flow/parsec/validate.py
@@ -140,9 +140,11 @@ class ParsecValidator:
         ),
         V_ABSOLUTE_HOST_LIST: (
             'absolute host list',
-            'A comma separated list of hostnames which does not contain '
-            'any self references '
-            f'(i.e. does not contain {", ".join(SELF_REFERENCE_PATTERNS)})',
+            (
+                'A comma separated list of hostnames which does not contain '
+                'any self references '
+                f'(i.e. does not contain {", ".join(SELF_REFERENCE_PATTERNS)})'
+            ),
             ['foo', 'bar', 'baz']
         )
     }
@@ -709,9 +711,11 @@ class CylcConfigValidator(ParsecValidator):
         ),
         V_CYCLE_POINT_FORMAT: (
             'cycle point format',
-            'An time format for date-time cycle points in ``isodatetime`` '
-            '"print" or "parse" format. '
-            'See ``isodatetime --help`` for more information.',
+            (
+                'A time format for date-time cycle points in ``isodatetime`` '
+                '"print" or "parse" format. '
+                'See ``isodatetime --help`` for more information.'
+            ),
             {
                 'CCYYMM': '``isodatetime`` print format.',
                 '%Y%m': '``isodatetime`` parse format.'
@@ -757,19 +761,22 @@ class CylcConfigValidator(ParsecValidator):
         ),
         V_INTERVAL_LIST: (
             'time interval list',
-            'A comma separated list of time intervals. '
-            'These can include multipliers.',
+            (
+                'A comma separated list of time intervals. '
+                'These can include multipliers.'
+            ),
             {
                 'P1Y, P2Y, P3Y': 'After 1, 2 and 3 years.',
-                'PT1M, 2*PT1H, P1D': 'After 1 minute, 1 hour, 1 hour and 1 '
-                'day'
+                'PT1M, 2*PT1H, P1D': 'After 1 minute, 1 hour, 1 hour and 1 day'
             },
             [('std:term', 'ISO8601 duration')]
         ),
         V_PARAMETER_LIST: (
             'parameter list',
-            'A comma separated list of Cylc parameter values. '
-            'This can include strings, integers and integer ranges.',
+            (
+                'A comma separated list of Cylc parameter values. '
+                'This can include strings, integers and integer ranges.'
+            ),
             {
                 'foo, bar, baz': 'List of string parameters.',
                 '1, 2, 3': 'List of integer parameters.',
@@ -781,9 +788,11 @@ class CylcConfigValidator(ParsecValidator):
         ),
         V_XTRIGGER: (
             'xtrigger function signature',
-            'A function signature similar to how it would be written in '
-            'Python.\n'
-            '``<function>(<arg>, <kwarg>=<value>):<interval>``',
+            (
+                'A function signature similar to how it would be written in '
+                'Python.\n'
+                '``<function>(<arg>, <kwarg>=<value>):<interval>``'
+            ),
             {
                 'mytrigger(42, cycle_point=%(point)):PT10S':
                     'Run function ``mytrigger`` every 10 seconds.'

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,8 @@ tests =
     flake8-builtins>=1.5.0
     flake8-comprehensions>=3.5.0
     flake8-debugger>=4.0.0
-    flake8-implicit-str-concat>=0.4
+    # https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/issues/82
+    flake8-implicit-str-concat>=0.4,!=0.7.0
     flake8-mutable>=1.2.0
     flake8-simplify>=0.14.0; python_version<"3.14"
     flake8-type-checking


### PR DESCRIPTION
New flake8 fails have appeared.

https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/releases/tag/0.7.0
> Add ISC004: unparenthesized implicit string concatenation in collection

> ISC004
> 
> Checks for implicitly concatenated strings inside list, tuple, and set literals.
> 
> In collection literals, implicit string concatenation is often the result of a missing comma between elements, which can silently merge items together.
> 
> If the concatenation is intentional, wrap it in parentheses to make it explicit


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
