### PR TITLE
fix: don't configure CLI logging when auto_add is off

### DIFF
--- a/changes.d/7251.fix.md
+++ b/changes.d/7251.fix.md
@@ -1,0 +1,1 @@
+Fixed a crash in CLI scripts that create their option parser with `auto_add=False`.

--- a/cylc/flow/option_parsers.py
+++ b/cylc/flow/option_parsers.py
@@ -555,28 +555,31 @@ class CylcOptionParser(OptionParser):
                 options.templatevars_file)
             )
 
-        cylc.flow.flags.verbosity = options.verbosity
+        # The verbosity and log timestamp options are only defined when the
+        # standard options have been added, so only configure logging then.
+        if self.auto_add:
+            cylc.flow.flags.verbosity = options.verbosity
 
-        # Set up stream logging for CLI. Note:
-        # 1. On choosing STDERR: Log messages are diagnostics, so STDERR is the
-        #    better choice for the logging stream. This allows us to use STDOUT
-        #    for verbosity agnostic outputs.
-        # 2. Scheduler will remove this handler when it becomes a daemon.
-        LOG.setLevel(verbosity_to_log_level(options.verbosity))
-        # Remove NullHandler before add the StreamHandler
+            # Set up stream logging for CLI. Note:
+            # 1. On choosing STDERR: Log messages are diagnostics, so STDERR is
+            #    the better choice for the logging stream. This allows us to
+            #    use STDOUT for verbosity agnostic outputs.
+            # 2. Scheduler will remove this handler when it becomes a daemon.
+            LOG.setLevel(verbosity_to_log_level(options.verbosity))
+            # Remove NullHandler before add the StreamHandler
 
-        while LOG.handlers:
-            LOG.handlers[0].close()
-            LOG.removeHandler(LOG.handlers[0])
-        log_handler = logging.StreamHandler(sys.stderr)
-        log_handler.setFormatter(CylcLogFormatter(
-            timestamp=options.log_timestamp,
-            dev_info=(options.verbosity > 2)
-        ))
-        LOG.addHandler(log_handler)
+            while LOG.handlers:
+                LOG.handlers[0].close()
+                LOG.removeHandler(LOG.handlers[0])
+            log_handler = logging.StreamHandler(sys.stderr)
+            log_handler.setFormatter(CylcLogFormatter(
+                timestamp=options.log_timestamp,
+                dev_info=(options.verbosity > 2)
+            ))
+            LOG.addHandler(log_handler)
 
-        if self.segregated_log:
-            setup_segregated_log_streams(LOG, log_handler)
+            if self.segregated_log:
+                setup_segregated_log_streams(LOG, log_handler)
 
         return (options, args)
 

--- a/tests/unit/test_option_parsers.py
+++ b/tests/unit/test_option_parsers.py
@@ -106,6 +106,20 @@ def test_Options_std_opts():
     assert MyValues.verbosity == 1
 
 
+def test_parse_args_no_auto_add():
+    """parse_args should work when the standard options are not added.
+
+    The standard options define --verbose/--debug/--timestamp, so with
+    auto_add=False the logging setup must not read them.
+
+    See https://github.com/cylc/cylc-flow/issues/7251
+    """
+    parser = COP(USAGE_WITH_COMMENT, auto_add=False)
+    options, args = parser.parse_args([])
+    assert args == []
+    assert not hasattr(options, 'verbosity')
+
+
 # Add overlapping args tomorrow
 @pytest.mark.parametrize(
     'first, second, expect',


### PR DESCRIPTION
Closes #7251

`CylcOptionParser.parse_args()` unconditionally read `options.verbosity` and `options.log_timestamp` when setting up CLI stream logging, but those options only exist once `add_std_options()` has run — which is skipped for `auto_add=False`. Any script building its parser that way died with `AttributeError: 'Values' object has no attribute 'verbosity'`. The logging setup is now guarded on `self.auto_add`, the same flag that decides whether those options were added.

Regression test added in `tests/unit/test_option_parsers.py`; it fails with the original code (the reported AttributeError) and passes with the fix. `tests/unit/test_option_parsers.py` and `tests/unit/scripts/test_completion_server.py` are green (65 passed), flake8 clean.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
