### PR TITLE
Remove extra double quotes and fix a typo from pydoc

### DIFF
--- a/cylc/flow/network/client_factory.py
+++ b/cylc/flow/network/client_factory.py
@@ -32,7 +32,7 @@ class CommsMeth(Enum):
 
 
 def get_comms_method() -> CommsMeth:
-    """"Return Communication Method from environment variable, default zmq"""
+    """Return Communication Method from environment variable, default zmq"""
     return CommsMeth(
         os.getenv('CYLC_TASK_COMMS_METHOD', CommsMeth.ZMQ.value)
     )

--- a/cylc/flow/scripts/cylc.py
+++ b/cylc/flow/scripts/cylc.py
@@ -259,7 +259,7 @@ DEAD_ENDS = {
     'conditions':
         'cylc conditions has been replaced by cylc help license',
     'documentation':
-        'Cylc documentation is now at http://cylc.org',
+        'Cylc documentation is now at https://cylc.org',
     'edit':
         'Command removed, please edit the workflow in source directory',
     'get-directory':
@@ -495,7 +495,7 @@ def list_plugins():
                 [],
             ).append(entry_point)
 
-    # list all the distriutions which provide Cylc entry points
+    # list all the distributions which provide Cylc entry points
     _plugins = []
     for dist in _dists:
         _plugins.append((
@@ -654,7 +654,7 @@ def main() -> None:  # pragma: no cover
 
 
 def _main(opts, cmd_args: list[str]) -> int:
-    """Implemnent the Cylc CLI.
+    """Implement the Cylc CLI.
 
     Returns the exit code as an integer.
     """

--- a/cylc/flow/task_state.py
+++ b/cylc/flow/task_state.py
@@ -176,13 +176,13 @@ TASK_STATE_MAP = {
 
 
 def status_leq(status_a, status_b):
-    """"Return True if status_a <= status_b"""
+    """Return True if status_a <= status_b"""
     return (TASK_STATUSES_ORDERED.index(status_a) <=
             TASK_STATUSES_ORDERED.index(status_b))
 
 
 def status_geq(status_a, status_b):
-    """"Return True if status_a >= status_b"""
+    """Return True if status_a >= status_b"""
     return (TASK_STATUSES_ORDERED.index(status_a) >=
             TASK_STATUSES_ORDERED.index(status_b))
 
@@ -436,12 +436,12 @@ class TaskState:
         return True
 
     def is_gt(self, status):
-        """"Return True if self.status > status."""
+        """Return True if self.status > status."""
         return (TASK_STATUSES_ORDERED.index(self.status) >
                 TASK_STATUSES_ORDERED.index(status))
 
     def is_gte(self, status):
-        """"Return True if self.status >= status."""
+        """Return True if self.status >= status."""
         return (TASK_STATUSES_ORDERED.index(self.status) >=
                 TASK_STATUSES_ORDERED.index(status))
 

--- a/tests/unit/parsec/test_fileparse.py
+++ b/tests/unit/parsec/test_fileparse.py
@@ -122,7 +122,7 @@ def test_addict_replace_value():
 
 
 def test_addict_replace_value_1():
-    """"Special case depending on key and parents, for
+    """Special case depending on key and parents, for
 
     - key is 'graph' AND parents['scheduling']['graph'] OR
     - len(parents)==3 AND parents['scheduling']['graph'][?]

--- a/tests/unit/plugins/test_pre_configure.py
+++ b/tests/unit/plugins/test_pre_configure.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-""""Test the pre_configure entry point."""
+"""Test the pre_configure entry point."""
 
 from random import random
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1715,7 +1715,7 @@ def test_val_wflow_event_names(item, tmp_flow_config, log_filter):
 
 @pytest.mark.parametrize('item', ['handler events', 'mail events'])
 def test_check_task_event_names(item, tmp_flow_config, log_filter):
-    """"Any invalid task handler events are warned about."""
+    """Any invalid task handler events are warned about."""
     flow_file = tmp_flow_config('foo', f"""
         [scheduling]
             [[graph]]

--- a/tests/unit/test_job_file.py
+++ b/tests/unit/test_job_file.py
@@ -227,7 +227,7 @@ def test_write(fixture_get_platform):
         )
     ], ids=["1", "2", "3", "4"])
 def test_write_directives(fixture_get_platform, job_conf: dict, expected: str):
-    """"Test the directives section of job script file is correctly
+    """Test the directives section of job script file is correctly
         written"""
     with io.StringIO() as fake_file:
         JobFileWriter()._write_directives(fake_file, job_conf)


### PR DESCRIPTION
Hi there. I'm rewriting Autosubmit cli parser (summer break project :grimacing:), and am looking at parts of Cylc code for reference. Found this extra double quote, but I think there are a few others. Will edit the commit as I created it from GH UI... :+1:  Cheers

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (pydoc change).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
