### PR TITLE
graph: add --flatten-icp option

### DIFF
--- a/changes.d/7417.feat.md
+++ b/changes.d/7417.feat.md
@@ -1,0 +1,1 @@
+Add `cylc graph --flatten-icp` option for simplifying graphs with inter-cycle dependencies.

--- a/cylc/flow/config.py
+++ b/cylc/flow/config.py
@@ -2066,6 +2066,7 @@ class WorkflowConfig:
         start_point_str=None,
         stop_point_str=None,
         grouping=None,
+        flatten_icp_dependence=False,
         sort=True,
     ):
         """Return concrete graph edges between specified cycle points.
@@ -2073,6 +2074,11 @@ class WorkflowConfig:
         Return a family-collapsed graph if the grouping arg is not None:
           * ['FAM1', 'FAM2']: group (collapse) specified families
           * ['<all>']: group (collapse) all families above root
+
+        The "flatten_icp_dependence" option detects ICP dependencies
+        (e.g. "start[^] => foo") and prefixes the cycle point on the left
+        side of the edge with "R1.". This allows graph visualisation tools
+        to handle these nodes differently.
 
         For validation, return non-suicide edges with left and right nodes.
         """
@@ -2177,7 +2183,22 @@ class WorkflowConfig:
                             cache[offset] = l_point
                     else:
                         l_point = point
-                    l_id = (name, l_point)
+
+                    if (
+                        flatten_icp_dependence
+                        and point != self.initial_point
+                        and offset
+                        and offset_is_from_icp
+                        and get_interval_cls()(offset)
+                        == get_interval_cls().get_null()
+                    ):
+                        # this is an R1 dependency (e.g, start[^] => foo). When
+                        # "collapse_icp = True", we prefix the point with "R1."
+                        # so graph visualization tools can apply special logic.
+                        l_id = (name, f'R1.{point}')
+                        # print('%', str(l_id))
+                    else:
+                        l_id = (name, l_point)
 
                     if actual_first_point > l_point:
                         # Check that l_id is not earlier than start time.

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -71,9 +71,11 @@ def sort_integer_node(id_):
     Example:
         >>> sort_integer_node('11/foo')
         ('foo', 11)
+        >>> sort_integer_node('R1.1/prep')
+        ('prep', 1)
 
     """
-    tokens = Tokens(id_, relative=True)
+    tokens = Tokens(id_.removeprefix("R1."), relative=True)
     return (tokens['task'], int(tokens['cycle']))
 
 

--- a/cylc/flow/scripts/graph.py
+++ b/cylc/flow/scripts/graph.py
@@ -128,6 +128,7 @@ def get_nodes_and_edges(
             stop,
             grouping=opts.grouping,
             show_suicide=opts.show_suicide,
+            flatten_icp_dependence=opts.flatten_icp_dependence,
         )
     return nodes, edges
 
@@ -138,12 +139,14 @@ def _get_graph_nodes_edges(
     stop_point_str=None,
     grouping=None,
     show_suicide=False,
+    flatten_icp_dependence=False,
 ) -> Tuple[List[Node], List[Edge]]:
     """Return nodes and edges for a workflow graph."""
     graph = config.get_graph_raw(
         start_point_str,
         stop_point_str,
-        grouping
+        grouping,
+        flatten_icp_dependence=flatten_icp_dependence,
     )
     if not graph:
         return [], []
@@ -249,7 +252,8 @@ def format_graphviz(
         else:
             indent = '  '
         for cycle, tasks in cycles.items():
-            if opts.cycles:
+            r1 = cycle.startswith('R1')
+            if opts.cycles and not r1:
                 dot_lines.extend(
                     [
                         f'  subgraph "cluster_{cycle}" {{ ',
@@ -257,11 +261,16 @@ def format_graphviz(
                         '    style="dashed"',
                     ]
                 )
+            if r1:
+                cycle_label = 'R1'
+            else:
+                cycle_label = cycle
+
             dot_lines.extend(
-                rf'{indent}"{cycle}/{task}" [label="{task}\n{cycle}"]'
+                rf'{indent}"{cycle}/{task}" [label="{task}\n{cycle_label}"]'
                 for task in tasks
             )
-            if opts.cycles:
+            if opts.cycles and not r1:
                 dot_lines.append('  }')
             dot_lines.append('')
 
@@ -524,6 +533,21 @@ def get_option_parser() -> COP:
         '--show-suicide',
         help='Show suicide triggers. Not shown by default.',
         action='store_true', default=False, dest='show_suicide')
+
+    parser.add_option(
+        '--flatten-icp',
+        help=(
+            'Flatten dependence on tasks at the initial cycle point.'
+            ' Workflows often contain repeated dependencies between the'
+            ' initial cycle point and subsequent cycles.'
+            ' This option "snips" the arrows between the R1 and subsequent'
+            ' cycles for a cleaner graph. The R1 tasks and their dependencies'
+            ' are still shown, but their inter-cycle dependency is omitted.'
+        ),
+        action='store_true',
+        default=False,
+        dest='flatten_icp_dependence',
+    )
 
     parser.add_option(icp_option)
 

--- a/tests/integration/scripts/test_graph.py
+++ b/tests/integration/scripts/test_graph.py
@@ -45,3 +45,69 @@ async def test_blank_graph(one, disable_graph_open, capsys):
     out, err = capsys.readouterr()
     assert 'No tasks to display' in err
     assert 'Try changing the start and stop values' in err
+
+
+async def test_flatten_icp(flow, tmp_path):
+    """It should flatten out absolute dependencies in the ICP.
+
+    Tests the "--flatten-icp" flag.
+    """
+    id_ = flow({
+        'scheduler': {
+            'cycle point format': 'CCYY',
+        },
+        'scheduling': {
+            'initial cycle point': '2000',
+            'final cycle point': '2004',
+            'graph': {
+                'R1': 'start',
+                'P1Y': 'start[^] => foo => bar',  # ICP dep (^)
+                'R1/2003': 'foo[2001] => pub',  # non-ICP ABS dep (2001)
+            },
+        },
+    })
+    graph_file = tmp_path / 'graph.dot'
+
+    # test default behaviour (expanded ICP deps):
+    await _main(
+        Opts(output=str(graph_file), flatten_icp_dependence=False),
+        id_,
+        '2000',
+        '2003',
+    )
+    with open(graph_file, 'r') as graph_file_:
+        edges = {line.strip() for line in graph_file_ if '->' in line}
+
+    assert edges == {
+        '"2000/foo" -> "2000/bar"',
+        '"2000/start" -> "2000/foo"',  # NOTE: inter-cycle ICP dep
+        '"2000/start" -> "2001/foo"',  # NOTE: ICP dep
+        '"2000/start" -> "2002/foo"',  # NOTE: ICP dep
+        '"2000/start" -> "2003/foo"',  # NOTE: ICP dep
+        '"2001/foo" -> "2001/bar"',
+        '"2001/foo" -> "2003/pub"',
+        '"2002/foo" -> "2002/bar"',
+        '"2003/foo" -> "2003/bar"',
+    }
+
+    # test "--flatten-icp" behaviour:
+    await _main(
+        Opts(output=str(graph_file), flatten_icp_dependence=True),
+        id_,
+        '2000',
+        '2003',
+    )
+    with open(graph_file, 'r') as graph_file_:
+        edges = {line.strip() for line in graph_file_ if '->' in line}
+
+    assert edges == {
+        '"2000/foo" -> "2000/bar"',
+        '"2000/start" -> "2000/foo"',
+        '"2001/foo" -> "2001/bar"',
+        '"2001/foo" -> "2003/pub"',  # NOTE: not flattened (non-ICP abs dep)
+        '"2002/foo" -> "2002/bar"',
+        '"2003/foo" -> "2003/bar"',
+        '"R1.2001/start" -> "2001/foo"',  # NOTE: ICP dep flattened
+        '"R1.2002/start" -> "2002/foo"',  # NOTE: ICP dep flattened
+        '"R1.2003/start" -> "2003/foo"',  # NOTE: ICP dep flattened
+    }

--- a/tests/unit/scripts/test_graph.py
+++ b/tests/unit/scripts/test_graph.py
@@ -294,13 +294,15 @@ def test_null(null_config):
     opts = SimpleNamespace(
         namespaces=False,
         grouping=False,
-        show_suicide=False
+        show_suicide=False,
+        flatten_icp_dependence=False,
     )
     assert get_nodes_and_edges(opts, None, 1, 2, '') == ([], [])
 
     opts = SimpleNamespace(
         namespaces=True,
         grouping=False,
-        show_suicide=False
+        show_suicide=False,
+        flatten_icp_dependence=False,
     )
     assert get_nodes_and_edges(opts, None, 1, 2, '') == ([], [])


### PR DESCRIPTION
Add a `cylc graph --flatten-icp` option for "snipping" edges from R1 cycles for graph simplification.

This is the trivial idea mentioned in previous discussions around isolated startup graphs.

This preserves the ICP dependence (i.e, there's no information missing from the graph), it just duplicates the R1 dependent tasks into their respective cycles (but outside of the dotted cycle boxes which appear with the `-c` option) to flatten out these inter-cycles.

<br />

**Without this option** (present behaviour / default):

<img width="50%" alt="graph-expanded" src="https://github.com/user-attachments/assets/977d3d81-c775-43e0-a1eb-1b112d0fe9d2" />


<br /><br />

**With this option**:

<img width="40%" alt="graph-flatten" src="https://github.com/user-attachments/assets/41ffafc5-2e35-47ef-b4fc-e3e030184875" />

<br /><br />

The `R1` label is completely optional, have done it this way for clarity, but could replace with the actual cycle point, or template, whatever. Just let me know what the preference is.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.