### PR TITLE
No spawn manual remove option

### DIFF
--- a/changes.d/7419.feat.md
+++ b/changes.d/7419.feat.md
@@ -1,0 +1,1 @@
+Remove option `--no-spawn` made available, so removal of parentless run-ahead and/or sequential xtriggered tasks will not spawn their next instance.

--- a/changes.d/7419.feat.md
+++ b/changes.d/7419.feat.md
@@ -1,1 +1,1 @@
-Remove option `--no-spawn` made available, so removal of parentless run-ahead and/or sequential xtriggered tasks will not spawn their next instance.
+Added a `--no-spawn` option for the `remove` command. On removing the leading instance of a parentless task, the next instance will not be spawned. 

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -184,7 +184,8 @@ def _remove_matched_tasks(
                 continue
             removed[itask.tokens.task] = fnums_to_remove
             if fnums_to_remove == itask.flow_nums:
-                schd.pool.remove(itask, 'request')
+                # Need to remove the task from the pool.
+                schd.pool.remove(itask, 'request', spawn=False)
                 to_kill.append(itask)
                 itask.removed = True
             itask.flow_nums.difference_update(fnums_to_remove)

--- a/cylc/flow/commands.py
+++ b/cylc/flow/commands.py
@@ -166,6 +166,7 @@ def _remove_matched_tasks(
     ids: Set[TaskTokens],
     flow_nums: 'FlowNums',
     warn_unremovable: bool = True,
+    no_spawn: bool = False,
 ):
     """Remove matched tasks."""
     # Mapping of *relative* task IDs to removed flow numbers:
@@ -185,7 +186,7 @@ def _remove_matched_tasks(
             removed[itask.tokens.task] = fnums_to_remove
             if fnums_to_remove == itask.flow_nums:
                 # Need to remove the task from the pool.
-                schd.pool.remove(itask, 'request', spawn=False)
+                schd.pool.remove(itask, 'request', no_spawn=no_spawn)
                 to_kill.append(itask)
                 itask.removed = True
             itask.flow_nums.difference_update(fnums_to_remove)
@@ -494,13 +495,17 @@ async def set_verbosity(schd: 'Scheduler', level: 'Enum'):
 
 @_command('remove_tasks')
 async def remove_tasks(
-    schd: 'Scheduler', tasks: Iterable[str], flow: List[str]
+    schd: 'Scheduler',
+    tasks: Iterable[str],
+    flow: List[str],
+    no_spawn: bool = False
 ):
     """Match and remove tasks (`cylc remove` command).
 
     Args:
         tasks: Relative IDs or globs to match.
         flow: flows to remove the tasks from.
+        no_spawn: Do not spawn successors before removal.
     """
     flow = back_compat_flow_all(flow)  # BACK COMPAT (see func def)
     ids = validate.is_tasks(tasks)
@@ -513,7 +518,8 @@ async def remove_tasks(
         _remove_matched_tasks(
             schd,
             matched,
-            schd.pool.flow_mgr.cli_to_flow_nums(flow)
+            schd.pool.flow_mgr.cli_to_flow_nums(flow),
+            no_spawn=no_spawn,
         )
 
 

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2170,6 +2170,26 @@ class Remove(Mutation, TaskMutation):
                 By default, tasks will be removed from all flows.
             ''')
         )
+        no_spawn = Boolean(
+            default_value=False,
+            description=sstrip('''
+                "Do not spawn successors before removal."
+
+                This usually only applies to parentless tasks whose next
+                instance(s) are either spawned automatically to the runahead
+                limit or sequentially on xtrigger satisfaction.
+
+                If `false` the scheduler will spawn the next task instance
+                as normal (default).
+
+                If `true` the scheduler will not spawn the next task instance.
+
+                Warning: This is a low-level intervention for targeting the
+                spawning of parentless tasks, and may result in emptying the
+                workflow(s) of associated sub-graph(s).
+
+            ''')
+        )
 
 
 class SetPrereqsAndOutputs(Mutation, TaskMutation):

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2176,14 +2176,10 @@ class Remove(Mutation, TaskMutation):
                 "Remove the leading instance of a parentless task without "
                 "spawning its next instance."
 
-                The --no-spawn option only affects the leading instances of
-                parentless tasks (i.e. tasks with no upstream task
-                prerequisites): normal parentless tasks waiting at the runahead
-                limit, and the leading instances of sequentia xtriggered
-                parentless tasks. This low-level intervention removes such
-                tasks without spawning their next instances (and hence any
-                dependent sub-graphs) into the workflow.
-                WARNING: this could cause your workflow to shut down
+                This only affects leading instances of parentless sequential
+                xtriggered tasks and parentless tasks waiting at the runahead-limit.
+                WARNING: this is a low-level intervention that cuts tasks from
+                the future graph; it could cause your workflow to shut down
                 prematurely as complete.
 
                 If `false` the scheduler will spawn the next task instance

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2173,8 +2173,8 @@ class Remove(Mutation, TaskMutation):
         no_spawn = Boolean(
             default_value=False,
             description=sstrip('''
-                "Remove the leading instance of a parentless task without "
-                "spawning its next instance."
+                Remove the leading instance of a parentless task without
+                spawning its next instance.
 
                 This only affects leading instances of parentless sequential
                 xtriggered tasks and parentless tasks waiting at the runahead-limit.

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2177,7 +2177,9 @@ class Remove(Mutation, TaskMutation):
                 spawning its next instance.
 
                 This only affects leading instances of parentless sequential
-                xtriggered tasks and parentless tasks waiting at the runahead-limit.
+                xtriggered tasks and parentless tasks waiting at the
+                runahead-limit.
+
                 WARNING: this is a low-level intervention that cuts tasks from
                 the future graph; it could cause your workflow to shut down
                 prematurely as complete.

--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -2173,20 +2173,23 @@ class Remove(Mutation, TaskMutation):
         no_spawn = Boolean(
             default_value=False,
             description=sstrip('''
-                "Do not spawn successors before removal."
+                "Remove the leading instance of a parentless task without "
+                "spawning its next instance."
 
-                This usually only applies to parentless tasks whose next
-                instance(s) are either spawned automatically to the runahead
-                limit or sequentially on xtrigger satisfaction.
+                The --no-spawn option only affects the leading instances of
+                parentless tasks (i.e. tasks with no upstream task
+                prerequisites): normal parentless tasks waiting at the runahead
+                limit, and the leading instances of sequentia xtriggered
+                parentless tasks. This low-level intervention removes such
+                tasks without spawning their next instances (and hence any
+                dependent sub-graphs) into the workflow.
+                WARNING: this could cause your workflow to shut down
+                prematurely as complete.
 
                 If `false` the scheduler will spawn the next task instance
                 as normal (default).
 
                 If `true` the scheduler will not spawn the next task instance.
-
-                Warning: This is a low-level intervention for targeting the
-                spawning of parentless tasks, and may result in emptying the
-                workflow(s) of associated sub-graph(s).
 
             ''')
         )

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -27,7 +27,7 @@ The primary use cases for this command are:
  * Erase the flow history of tasks to allow them to rerun without starting a
    new flow. (Note that `cylc trigger` now does this automatically, however).
 
-Tasks will be removed from ALL flows, by defaut.
+Tasks will be removed from ALL flows, by default.
 
 Tasks removed from all flows, and any waiting downstream tasks spawned by
 their outputs, will be recorded with no flow numbers and will not affect
@@ -38,9 +38,8 @@ remaining flows but will not affect the evolution of the removed flows.
 
 Removing a submitted or running task also kills it (see "cylc kill").
 
-Removing parentless xtrigger sequential and/or RH tasks with the flag
-`--no-spawn` prevents the spawning of the next instance, and possibly
-future propagation of associated sub-graph(s).
+If you need to stop parentless tasks from spawning into future cycles, see
+the "--no-spawn" option.
 
 Examples:
   # Remove a task that already ran.
@@ -102,11 +101,15 @@ def get_option_parser() -> COP:
     add_flow_opts_for_remove(parser)
     parser.add_option(
         "--no-spawn",
-        help="""Do not spawn successors before removal.
+        help="""This option only affects the leading instances of parentless
+tasks (i.e. tasks with no upstream task prerequisites): normal parentless tasks
+waiting at the runahead limit, and the leading instances of sequential
+xtriggered parentless tasks. This low-level intervention removes such tasks
+without spawning their next instances (and hence any dependent sub-graphs)
+into the workflow.
 
-                Warning: This is a low-level intervention for targeting the
-spawning of parentless tasks, and may result in emptying the workflow(s) of
-associated sub-graph(s).
+WARNING: this could cause your workflow to shut down
+prematurely as complete.
         """,
         action="store_true", default=False, dest="no_spawn")
     return parser

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -38,6 +38,10 @@ remaining flows but will not affect the evolution of the removed flows.
 
 Removing a submitted or running task also kills it (see "cylc kill").
 
+Removing parentless xtrigger sequential and/or RH tasks with the flag
+`--no-spawn` prevents the spawning of the next instance, and possibly
+future propagation of associated sub-graph(s).
+
 Examples:
   # Remove a task that already ran.
   # (Any downstream tasks that are already running or finished will be
@@ -72,11 +76,13 @@ mutation (
   $wFlows: [WorkflowID]!,
   $tasks: [NamespaceIDGlob]!,
   $flow: [Flow!],
+  $noSpawn: Boolean,
 ) {
   remove (
     workflows: $wFlows,
     tasks: $tasks,
-    flow: $flow
+    flow: $flow,
+    noSpawn: $noSpawn
   ) {
     result
   }
@@ -92,7 +98,17 @@ def get_option_parser() -> COP:
         multiworkflow=True,
         argdoc=[FULL_ID_MULTI_ARG_DOC],
     )
+
     add_flow_opts_for_remove(parser)
+    parser.add_option(
+        "--no-spawn",
+        help="""Do not spawn successors before removal.
+
+                Warning: This is a low-level intervention for targeting the
+spawning of parentless tasks, and may result in emptying the workflow(s) of
+associated sub-graph(s).
+        """,
+        action="store_true", default=False, dest="no_spawn")
     return parser
 
 
@@ -108,6 +124,7 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
                 for tokens in tokens_list
             ],
             'flow': options.flow,
+            'noSpawn': options.no_spawn,
         }
     }
 

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -56,6 +56,9 @@ from functools import partial
 import sys
 from typing import TYPE_CHECKING, Dict, Any
 
+from packaging.specifiers import SpecifierSet
+
+from cylc.flow.exceptions import InputError
 from cylc.flow.flow_mgr import add_flow_opts_for_remove
 from cylc.flow.network.client_factory import get_client
 from cylc.flow.network.multi import call_multi
@@ -162,7 +165,13 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
             'flow': options.flow,
         }
     }
-    if version_result["workflows"][0]["cylcVersion"] < '8.7.0':
+    target_version = version_result["workflows"][0]["cylcVersion"]
+    if f'{target_version}' in SpecifierSet('>=8, <8.7', prereleases=True):
+        if options.no_spawn:
+            raise InputError(
+                f"Option --no-spawn is not available ({workflow_id}: Cylc "
+                f"{target_version} < 8.7.0)."
+            )
         mutation_kwargs['request_string'] = BCOMPAT_MUTATION
     else:
         mutation_kwargs['request_string'] = MUTATION

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -54,7 +54,7 @@ Examples:
 
 from functools import partial
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Any
 
 from cylc.flow.flow_mgr import add_flow_opts_for_remove
 from cylc.flow.network.client_factory import get_client
@@ -68,6 +68,33 @@ from cylc.flow.terminal import cli_function
 
 if TYPE_CHECKING:
     from optparse import Values
+
+
+VERSION_QUERY = '''
+query ($wFlows: [ID]) {
+  workflows(ids: $wFlows) {
+    id
+    cylcVersion
+  }
+}
+'''
+
+
+BCOMPAT_MUTATION = '''
+mutation (
+  $wFlows: [WorkflowID]!,
+  $tasks: [NamespaceIDGlob]!,
+  $flow: [Flow!],
+) {
+  remove (
+    workflows: $wFlows,
+    tasks: $tasks,
+    flow: $flow,
+  ) {
+    result
+  }
+}
+'''
 
 
 MUTATION = '''
@@ -115,8 +142,17 @@ down prematurely as complete.
 async def run(options: 'Values', workflow_id: str, *tokens_list):
     pclient = get_client(workflow_id, timeout=options.comms_timeout)
 
-    mutation_kwargs = {
-        'request_string': MUTATION,
+    # BACK COMPAT: handle --no-spawn absence in earlier clients
+    # FROM: 8.0
+    # TO: 8.6.*
+    # REMOVE: 8.8
+    version_kwargs: Dict[str, Any] = {
+        'request_string': VERSION_QUERY,
+        'variables': {'wFlows': [workflow_id]}
+    }
+    version_result = await pclient.async_request('graphql', version_kwargs)
+
+    mutation_kwargs: Dict[str, Any] = {
         'variables': {
             'wFlows': [workflow_id],
             'tasks': [
@@ -124,9 +160,13 @@ async def run(options: 'Values', workflow_id: str, *tokens_list):
                 for tokens in tokens_list
             ],
             'flow': options.flow,
-            'noSpawn': options.no_spawn,
         }
     }
+    if version_result["workflows"][0]["cylcVersion"] < '8.7.0':
+        mutation_kwargs['request_string'] = BCOMPAT_MUTATION
+    else:
+        mutation_kwargs['request_string'] = MUTATION
+        mutation_kwargs['variables']['noSpawn'] = options.no_spawn
 
     return await pclient.async_request('graphql', mutation_kwargs)
 

--- a/cylc/flow/scripts/remove.py
+++ b/cylc/flow/scripts/remove.py
@@ -38,8 +38,8 @@ remaining flows but will not affect the evolution of the removed flows.
 
 Removing a submitted or running task also kills it (see "cylc kill").
 
-If you need to stop parentless tasks from spawning into future cycles, see
-the "--no-spawn" option.
+If you need to cut parentless tasks (and their dependent sub-graphs) from the
+future graph, see the "--no-spawn" option.
 
 Examples:
   # Remove a task that already ran.
@@ -101,15 +101,12 @@ def get_option_parser() -> COP:
     add_flow_opts_for_remove(parser)
     parser.add_option(
         "--no-spawn",
-        help="""This option only affects the leading instances of parentless
-tasks (i.e. tasks with no upstream task prerequisites): normal parentless tasks
-waiting at the runahead limit, and the leading instances of sequential
-xtriggered parentless tasks. This low-level intervention removes such tasks
-without spawning their next instances (and hence any dependent sub-graphs)
-into the workflow.
-
-WARNING: this could cause your workflow to shut down
-prematurely as complete.
+        help="""Remove the leading instance of a parentless task
+without spawning its next instance. This only affects leading instances
+of parentless sequential xtriggered tasks and parentless tasks waiting
+at the runahead-limit. WARNING: this is a low-level intervention that
+cuts tasks from the future graph; it could cause your workflow to shut
+down prematurely as complete.
         """,
         action="store_true", default=False, dest="no_spawn")
     return parser

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -833,7 +833,11 @@ class TaskPool:
             if ntask is not None and not is_in_pool:
                 self.add_to_pool(ntask)
 
-    def remove(self, itask: 'TaskProxy', reason: Optional[str] = None) -> None:
+    def remove(
+        self, itask: 'TaskProxy',
+        reason: Optional[str] = None,
+        spawn: Optional[bool] = True
+    ) -> None:
         """Remove a task from the pool."""
         # the held state is no longer relevant -> remove it
         self.release_held_active_task(itask)
@@ -841,8 +845,12 @@ class TaskPool:
         # xtriggers are no longer relevant -> remove them
         self.xtrigger_mgr.force_satisfy_all(itask, log=False)
 
-        if itask.flow_nums and (
-            itask.state.is_runahead or itask.is_xtrigger_sequential
+        if (
+            itask.flow_nums
+            and spawn
+            and (
+                itask.state.is_runahead or itask.is_xtrigger_sequential
+            )
         ):
             # If removing a parentless runahead-limited task
             # auto-spawn its next instance first.

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -836,7 +836,7 @@ class TaskPool:
     def remove(
         self, itask: 'TaskProxy',
         reason: Optional[str] = None,
-        spawn: Optional[bool] = True
+        no_spawn: Optional[bool] = False
     ) -> None:
         """Remove a task from the pool."""
         # the held state is no longer relevant -> remove it
@@ -847,7 +847,7 @@ class TaskPool:
 
         if (
             itask.flow_nums
-            and spawn
+            and not no_spawn
             and (
                 itask.state.is_runahead or itask.is_xtrigger_sequential
             )

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -21,7 +21,7 @@
 
 . "$(dirname "$0")/test_header"
 
-set_test_number 7
+set_test_number 6
 
 # Test workflow uses built-in 'echo' xtrigger.
 init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
@@ -79,15 +79,10 @@ cylc remove "${WORKFLOW_NAME}//3001/b"
 
 poll_grep_workflow_log 'Command "remove_tasks" actioned.'
 
-cylc show "${WORKFLOW_NAME}//3002/b" | grep -E 'state: ' > 3002.b.log
-cylc show "${WORKFLOW_NAME}//3003/b" 2>&1 >/dev/null | grep -E 'No matching' > 3003.b.log
+cylc show "${WORKFLOW_NAME}//3002/b" 2>&1 >/dev/null | grep -E 'No matching' > 3002.b.log
 
-# 3002/b should be only at 3002.
 cmp_ok 3002.b.log - <<__END__
-state: waiting
-__END__
-cmp_ok 3003.b.log - <<__END__
-No matching active tasks found: 3003/b
+No matching active tasks found: 3002/b
 __END__
 
 cylc show "${WORKFLOW_NAME}//3002/c" | grep -E 'state: ' > 3002.c.log

--- a/tests/functional/xtriggers/04-sequential.t
+++ b/tests/functional/xtriggers/04-sequential.t
@@ -21,7 +21,7 @@
 
 . "$(dirname "$0")/test_header"
 
-set_test_number 6
+set_test_number 7
 
 # Test workflow uses built-in 'echo' xtrigger.
 init_workflow "${TEST_NAME_BASE}" << '__FLOW_CONFIG__'
@@ -79,10 +79,15 @@ cylc remove "${WORKFLOW_NAME}//3001/b"
 
 poll_grep_workflow_log 'Command "remove_tasks" actioned.'
 
-cylc show "${WORKFLOW_NAME}//3002/b" 2>&1 >/dev/null | grep -E 'No matching' > 3002.b.log
+cylc show "${WORKFLOW_NAME}//3002/b" | grep -E 'state: ' > 3002.b.log
+cylc show "${WORKFLOW_NAME}//3003/b" 2>&1 >/dev/null | grep -E 'No matching' > 3003.b.log
 
+# 3002/b should be only at 3002.
 cmp_ok 3002.b.log - <<__END__
-No matching active tasks found: 3002/b
+state: waiting
+__END__
+cmp_ok 3003.b.log - <<__END__
+No matching active tasks found: 3003/b
 __END__
 
 cylc show "${WORKFLOW_NAME}//3002/c" | grep -E 'state: ' > 3002.c.log

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -545,3 +545,44 @@ async def test_remove_triggered(flow, scheduler, start):
         )
         assert not schd.pool.get_tasks()
         assert not schd.pool.tasks_to_trigger_now
+
+
+async def test_remove_spawn(flow, scheduler, start):
+    """Test the no-spawn removal of parentless tasks."""
+    schd: Scheduler = scheduler(
+        flow({
+            'scheduler': {
+                'cycle point format': 'CCYY',
+            },
+            'scheduling': {
+                'initial cycle point': '2000',
+                'runahead limit': 'P0',
+                'graph': {
+                    'R3//P1Y': '''
+                        @wall_clock => a
+                        b
+                        c
+                    ''',
+                },
+            },
+        })
+    )
+    async with start(schd):
+        assert schd.pool.get_task_ids() == {
+            '2000/a',
+            '2000/b',
+            '2000/c',
+            '2001/b',
+            '2001/c',
+        }
+
+        # Removal of parentless runahead and sequential xtrigger (PSX) spawned.
+        await run_cmd(remove_tasks(schd, ['2000/a', '2001/c', '2001/b'], []))
+        assert schd.pool.get_task_ids() == {
+            '2000/b',
+            '2000/c',
+        }
+
+        # empty the workflow
+        await run_cmd(remove_tasks(schd, ['2000/b', '2000/c'], []))
+        assert schd.pool.get_task_ids() == set()

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -576,13 +576,20 @@ async def test_remove_spawn(flow, scheduler, start):
             '2001/c',
         }
 
-        # Removal of parentless runahead and sequential xtrigger (PSX) spawned.
-        await run_cmd(remove_tasks(schd, ['2000/a', '2001/c', '2001/b'], []))
+        # Normal removal of parentless runahead and sequential xtrigger (PSX)
+        # spawned.
+        await run_cmd(remove_tasks(schd, ['2000/a', '2000/b', '2001/b'], []))
         assert schd.pool.get_task_ids() == {
-            '2000/b',
             '2000/c',
+            '2001/a',
+            '2001/c',
+            '2002/b',
         }
 
+        # no spawn removal
+        await run_cmd(remove_tasks(schd, ['2001/a', '2001/c'], [], True))
+        assert schd.pool.get_task_ids() == {'2000/c', '2002/b'}
+
         # empty the workflow
-        await run_cmd(remove_tasks(schd, ['2000/b', '2000/c'], []))
+        await run_cmd(remove_tasks(schd, ['2002/b', '2000/c'], [], True))
         assert schd.pool.get_task_ids() == set()

--- a/tests/integration/test_remove.py
+++ b/tests/integration/test_remove.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from functools import partial
 import logging
 
 import pytest
@@ -26,8 +27,11 @@ from cylc.flow.commands import (
     run_cmd,
 )
 from cylc.flow.cycling.integer import IntegerPoint
+from cylc.flow.data_store_mgr import WORKFLOW
 from cylc.flow.id import TaskTokens
+from cylc.flow.network.multi import call_multi_async
 from cylc.flow.scheduler import Scheduler
+from cylc.flow.scripts import remove
 from cylc.flow.task_outputs import TASK_OUTPUT_SUCCEEDED
 from cylc.flow.task_proxy import TaskProxy
 from cylc.flow.task_state import TASK_STATUS_FAILED
@@ -593,3 +597,61 @@ async def test_remove_spawn(flow, scheduler, start):
         # empty the workflow
         await run_cmd(remove_tasks(schd, ['2002/b', '2000/c'], [], True))
         assert schd.pool.get_task_ids() == set()
+
+
+async def test_remove_script(flow, scheduler, start):
+    """Test script and back-compat handling."""
+
+    parser = remove.get_option_parser()
+
+    conf = {
+        'scheduling': {
+            'graph': {
+                'R1': 'a & b'
+            },
+        },
+    }
+    schd: Scheduler = scheduler(flow(conf))
+    async with start(schd):
+        a, b = schd.pool.get_tasks()
+
+        # test script works
+        opts, args = parser.parse_args(
+            ['--no-spawn', a.tokens.id]
+        )
+        rets = await call_multi_async(
+            partial(remove.run, opts),
+            *args,
+        )
+        assert True in rets.values()
+        await schd._main_loop()
+        assert a not in schd.pool.get_tasks()
+
+        # test back-compat
+        schd.data_store_mgr.data[
+            b.tokens.workflow_id
+        ][WORKFLOW].cylc_version = '8.6.6'
+
+        # test old version with --no-spawn
+        opts, args = parser.parse_args(
+            ['--no-spawn', b.tokens.id]
+        )
+        rets = await call_multi_async(
+            partial(remove.run, opts),
+            *args,
+        )
+        assert False in rets.values()
+        await schd._main_loop()
+        assert b in schd.pool.get_tasks()
+
+        # test old version without --no-spawn
+        opts, args = parser.parse_args(
+            [b.tokens.id]
+        )
+        rets = await call_multi_async(
+            partial(remove.run, opts),
+            *args,
+        )
+        assert True in rets.values()
+        await schd._main_loop()
+        assert not schd.pool.get_tasks()

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -58,17 +58,69 @@ def sequential(flow, scheduler):
 
 
 async def test_remove(sequential: Scheduler, start):
-    """It should spawn the next instance when a task is removed.
+    """It should not spawn the next instance when a task is removed.
 
-    Ensure that removing a task with a sequential xtrigger does not break the
-    chain causing future instances to be removed from the workflow.
+    Ensure that manually removing a task with a sequential xtrigger does not
+    spawn the next, while internal removal does.
     """
     async with start(sequential):
         # starts with the first task in the first cycle
         assert list_cycles(sequential) == ['2000']
+
         # removing it should spawn the next sequential instance
-        await run_cmd(remove_tasks(sequential, ['2000'], ["1"]))
+        # internal remove should spawn the next cycle
+        sequential.pool.remove(
+            sequential.pool.get_task(ISO8601Point('2000'), 'foo'),
+            reason='because'
+        )
         assert list_cycles(sequential) == ['2001']
+
+        # this sequentially spawns out to the runahead limit
+        for year in range(2001, 2010):
+            foo = sequential.pool.get_task(ISO8601Point(f'{year}'), 'foo')
+            if foo.state(is_runahead=True):
+                break
+            sequential.xtrigger_mgr.call_xtriggers_async(foo)
+
+        # for some reason this doesn't work in the loop
+        await sequential._main_loop()
+        await sequential._main_loop()
+        await sequential._main_loop()
+        await sequential._main_loop()
+
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+            '2003',
+            '2004',
+        ]
+
+        # internal remove of RH PSX should spawn the next cycle
+        foo = sequential.pool.get_task(ISO8601Point('2004'), 'foo')
+        sequential.pool.remove(foo)
+        assert '2005' in list_cycles(sequential)
+
+        # remove command should not spawn next RH task
+        await run_cmd(remove_tasks(sequential, ['2005'], ["1"]))
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+            '2003',
+        ]
+
+        # and internal remove of already xtrigger spawned task should
+        # not spawn the next either.
+        foo = sequential.pool.get_task(ISO8601Point('2003'), 'foo')
+        sequential.pool.remove(foo)
+        assert list_cycles(sequential) == [
+            '2001',
+            '2002',
+        ]
+
+        # Now, let's just command/manual remove all tasks in the pool
+        await run_cmd(remove_tasks(sequential, ['*'], ["1"]))
+        # the workflow should be empty
+        assert not list_cycles(sequential)
 
 
 async def test_trigger(sequential, start):

--- a/tests/integration/test_sequential_xtriggers.py
+++ b/tests/integration/test_sequential_xtriggers.py
@@ -61,7 +61,7 @@ async def test_remove(sequential: Scheduler, start):
     """It should not spawn the next instance when a task is removed.
 
     Ensure that manually removing a task with a sequential xtrigger does not
-    spawn the next, while internal removal does.
+    spawn the next, while the default removal does.
     """
     async with start(sequential):
         # starts with the first task in the first cycle
@@ -95,30 +95,29 @@ async def test_remove(sequential: Scheduler, start):
             '2004',
         ]
 
-        # internal remove of RH PSX should spawn the next cycle
-        foo = sequential.pool.get_task(ISO8601Point('2004'), 'foo')
-        sequential.pool.remove(foo)
+        # default remove of RH PSX should spawn the next cycle
+        await run_cmd(remove_tasks(sequential, ['2004'], ["1"]))
         assert '2005' in list_cycles(sequential)
 
-        # remove command should not spawn next RH task
-        await run_cmd(remove_tasks(sequential, ['2005'], ["1"]))
+        # remove no-spawn should not spawn next RH task
+        await run_cmd(remove_tasks(sequential, ['2005'], ["1"], True))
         assert list_cycles(sequential) == [
             '2001',
             '2002',
             '2003',
         ]
 
-        # and internal remove of already xtrigger spawned task should
-        # not spawn the next either.
-        foo = sequential.pool.get_task(ISO8601Point('2003'), 'foo')
-        sequential.pool.remove(foo)
+        # Default remove of already xtrigger spawned task should
+        # spawn next again (because it's not tracked).
+        await run_cmd(remove_tasks(sequential, ['2003'], ["1"]))
         assert list_cycles(sequential) == [
             '2001',
             '2002',
+            '2004',
         ]
 
         # Now, let's just command/manual remove all tasks in the pool
-        await run_cmd(remove_tasks(sequential, ['*'], ["1"]))
+        await run_cmd(remove_tasks(sequential, ['*'], ["1"], True))
         # the workflow should be empty
         assert not list_cycles(sequential)
 


### PR DESCRIPTION
Partially addresses #7134, supersedes #7340
Closes #7340

This PR is essentially #7340, with the command option in #7134 added (easier then rebasing the latter).

CLI doc:
```
  --no-spawn            Do not spawn successors before removal.
                        Warning: This is a low-level intervention for
                        targeting the spawning of parentless tasks, and may
                        result in emptying the workflow(s) of associated sub-
                        graph(s).
```
WUI:
<img width="792" height="546" alt="image" src="https://github.com/user-attachments/assets/8d675830-9f66-40a8-bad1-8a56866638bc" />
<img width="627" height="286" alt="image" src="https://github.com/user-attachments/assets/832de308-2e7a-489b-8f88-51b903152399" />




**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
