### PR TITLE
coverage: enable multiprocessing concurrency

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,7 @@
 [run]
 branch = True
 cover_pylib = False
-concurrency = thread
+concurrency = thread, multiprocessing
 data_file = .coverage
 disable_warnings =
     trace-changed


### PR DESCRIPTION
Configure coverage to track code coverage of routines called via Python's multiprocessing interface.

This should boost the coverage of the Tui updater.

Coverage docs: https://coverage.readthedocs.io/en/7.15.4/subprocess.html#multiprocessing


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.