### PR TITLE
Disable ZMQ thread authenticator logging

### DIFF
--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -183,7 +183,7 @@ class WorkflowRuntimeServer:
         # And use of concurrent.futures.ThreadPoolExecutor?
         self.zmq_context = zmq.Context()
         # create an authenticator for the ZMQ context
-        self.curve_auth = ThreadAuthenticator(self.zmq_context, log=LOG)
+        self.curve_auth = ThreadAuthenticator(self.zmq_context)
         self.curve_auth.start()  # start the authentication thread
 
         # Setting the location means that the CurveZMQ auth will only


### PR DESCRIPTION
Enough of this:

<img width="1343" height="952" alt="image" src="https://github.com/user-attachments/assets/4ff85d80-bdae-4088-b15f-00abd6e17400" />

---

> [!NOTE]
> If there is a good reason to turn this back on, we should probably only do it as a child logger: https://github.com/cylc/cylc-flow/issues/7423

---

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are not needed
- [x] Changelog entry not needed as minor change
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
