### PR TITLE
Fix server failing to stop if barrier broken at startup

### DIFF
--- a/changes.d/7426.fix.md
+++ b/changes.d/7426.fix.md
@@ -1,0 +1,1 @@
+Fixed a bug where the workflow server thread would hang on shutdown in the event of a rare `BrokenBarrierError`.

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -144,7 +144,6 @@ class WorkflowRuntimeServer:
     """Client public key directory, used by the ZMQ authenticator."""
 
     OPERATE_SLEEP_INTERVAL = 0.2
-    STOP_SLEEP_INTERVAL = 0.2
 
     def __init__(self, schd):
 
@@ -167,7 +166,6 @@ class WorkflowRuntimeServer:
 
         self.publish_queue: 'Queue[Iterable[tuple]]' = Queue()
         self._waiting_to_stop = False
-        self.stopped = True
 
         self.register_endpoints()
 
@@ -220,8 +218,6 @@ class WorkflowRuntimeServer:
         # wait for threads to setup socket ports before continuing
         barrier.wait()
 
-        self.stopped = False
-
         self.operate()
 
     def configure_curve(self) -> None:
@@ -229,21 +225,18 @@ class WorkflowRuntimeServer:
             domain='*', location=self.client_pub_key_dir
         )
 
-    async def stop(self, reason: Union[BaseException, str]) -> None:
+    async def stop(self, reason: BaseException | str) -> None:
         """Stop the TCP servers, and clean up authentication.
 
         This method must be called/awaited from a different thread to the
         server's self.thread in order to interrupt the self.operate() loop
         and wait for self.thread to terminate.
         """
-        if self.thread:
+        if self.thread and self.thread.is_alive():
+            # Tell self.operate() loop to stop:
             self._waiting_to_stop = True
-            # Wait for self.operate() loop to finish:
-            while self.thread.is_alive():
-                # Non-async sleep - yield to other threads rather than
-                # event loop (allows self.operate() running in different
-                # thread to return)
-                sleep(self.STOP_SLEEP_INTERVAL)
+            # Wait for the thread to terminate once the loop has stopped:
+            self.thread.join()
 
         if self.replier:
             self.replier.stop(stop_loop=False)
@@ -258,8 +251,6 @@ class WorkflowRuntimeServer:
             self.curve_auth.stop()  # stop the authentication thread
         if self.loop and self.loop.is_running():
             self.loop.stop()
-
-        self.stopped = True
 
     def operate(self) -> None:
         """Orchestrate the receive, send, publish of messages."""

--- a/cylc/flow/network/server.py
+++ b/cylc/flow/network/server.py
@@ -52,6 +52,8 @@ from cylc.flow.network.schema import schema
 
 
 if TYPE_CHECKING:
+    from threading import Thread
+
     from cylc.flow.network import ResponseDict
     from cylc.flow.scheduler import Scheduler
 
@@ -152,7 +154,7 @@ class WorkflowRuntimeServer:
         self.replier = None
         self.publisher = None
         self.loop = None
-        self.thread = None
+        self.thread: Thread | None = None
 
         self.schd: 'Scheduler' = schd
         self.resolvers = Resolvers(
@@ -164,13 +166,16 @@ class WorkflowRuntimeServer:
         ]
 
         self.publish_queue: 'Queue[Iterable[tuple]]' = Queue()
-        self.waiting_to_stop = False
+        self._waiting_to_stop = False
         self.stopped = True
 
         self.register_endpoints()
 
     def start(self, barrier):
-        """Start the TCP servers."""
+        """Start the TCP servers.
+
+        Note: this method is to be run in a separate thread.
+        """
         # set asyncio loop on thread
         try:
             self.loop = asyncio.get_running_loop()
@@ -231,10 +236,10 @@ class WorkflowRuntimeServer:
         server's self.thread in order to interrupt the self.operate() loop
         and wait for self.thread to terminate.
         """
-        self.waiting_to_stop = True
-        if self.thread and self.thread.is_alive():
+        if self.thread:
+            self._waiting_to_stop = True
             # Wait for self.operate() loop to finish:
-            while self.waiting_to_stop:
+            while self.thread.is_alive():
                 # Non-async sleep - yield to other threads rather than
                 # event loop (allows self.operate() running in different
                 # thread to return)
@@ -253,8 +258,6 @@ class WorkflowRuntimeServer:
             self.curve_auth.stop()  # stop the authentication thread
         if self.loop and self.loop.is_running():
             self.loop.stop()
-        if self.thread and self.thread.is_alive():
-            self.thread.join()  # Wait for processes to return
 
         self.stopped = True
 
@@ -263,13 +266,7 @@ class WorkflowRuntimeServer:
         # Note: this cannot be an async method because the response part
         # of the listener runs the event loop synchronously
         # (in graphql schema.execute_async)
-        while True:
-            if self.waiting_to_stop:
-                # The self.stop() method is waiting for us to signal that we
-                # have finished here
-                self.waiting_to_stop = False
-                return
-
+        while not self._waiting_to_stop:
             # Gather and respond to any requests.
             self.replier.listener()
             # Publish all requested/queued.

--- a/tests/integration/network/test_server.py
+++ b/tests/integration/network/test_server.py
@@ -16,12 +16,13 @@
 
 import asyncio
 import logging
+from threading import BrokenBarrierError
 from typing import Callable
 
 import pytest
 
 from cylc.flow import __version__ as CYLC_VERSION
-from cylc.flow.network.server import PB_METHOD_MAP
+from cylc.flow.network.server import PB_METHOD_MAP, WorkflowRuntimeServer
 from cylc.flow.scheduler import Scheduler
 
 
@@ -85,11 +86,42 @@ def test_pb_entire_workflow(myflow):
 async def test_stop(one: Scheduler, start):
     """Test stop."""
     async with start(one):
+        assert one.server.thread.is_alive()
+        assert one.server.publisher
+        assert one.server.curve_auth.is_alive()
         async with asyncio.timeout(2):
             # Wait for the server to consume the STOP signal.
             # If it doesn't, the test will fail with a asyncio.timeout error.
             await one.server.stop('TESTING')
-            assert one.server.stopped
+        assert not one.server.thread.is_alive()
+        assert not one.server.publisher
+        assert not one.server.curve_auth.is_alive()
+        assert not one.server.loop.is_running()
+
+
+@pytest.mark.filterwarnings(
+    r"ignore:.*:pytest.PytestUnhandledThreadExceptionWarning"
+)
+async def test_broken_barrier_shutdown(
+    one: Scheduler, start, monkeypatch: pytest.MonkeyPatch
+):
+    """Test that the server shuts down if the barrier is broken on startup.
+
+    Broken barrier has been observed to happen if the scheduler host is sickly
+    https://github.com/cylc/cylc-flow/issues/7425
+    """
+    class MockServer(WorkflowRuntimeServer):
+        def start(self, barrier):
+            barrier.abort()
+            super().start(barrier)
+
+    monkeypatch.setattr(
+        'cylc.flow.scheduler.WorkflowRuntimeServer', MockServer
+    )
+    with pytest.raises(BrokenBarrierError):
+        async with start(one):
+            pass
+    assert not one.server.thread.is_alive()
 
 
 async def test_receiver_basic(one: Scheduler, start, log_filter):


### PR DESCRIPTION
Partially addresses #7425

During scheduler start up, we create a threading barrier object to ensure the server (which runs a loop in a separate thread) and scheduler get to the same point before continuing:

https://github.com/cylc/cylc-flow/blob/0cfd6ed10cf525a35ad3db53bbd02d1216d51ecb/cylc/flow/scheduler.py#L779-L788

https://github.com/cylc/cylc-flow/blob/0cfd6ed10cf525a35ad3db53bbd02d1216d51ecb/cylc/flow/network/server.py#L207-L217

If the barrier is broken (e.g. due to the wait timing out), then the scheduler shutdown logic waits for the server to stop.

https://github.com/cylc/cylc-flow/blob/0cfd6ed10cf525a35ad3db53bbd02d1216d51ecb/cylc/flow/scheduler.py#L1907-L1908

But the server was getting caught in an infinite loop during its stop method

https://github.com/cylc/cylc-flow/blob/0cfd6ed10cf525a35ad3db53bbd02d1216d51ecb/cylc/flow/network/server.py#L236-L242

The solution is to simply wait for the thread to terminate, rather than relying on `self.waiting_to_stop` changing when the loop that would change it never started in the first place.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] No docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
