### PR TITLE
Fix test

### DIFF
--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -53,7 +53,6 @@ jobs:
         run: pip install .[all]
 
       - name: run tutorial workflow
-        timeout-minutes: 6
         run: |
           mkdir -p "${HOME}/cylc-run"
           etc/bin/run-validate-tutorials

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1718,7 +1718,6 @@ class Scheduler:
                 self.is_restart_timeout_wait = False
 
         if has_updated or self.data_store_mgr.updates_pending:
-            # Update the datastore.
             await self.update_data_structure()
 
         if has_updated:

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -2442,20 +2442,13 @@ async def test_clock_expire_with_sequential_xtriggers(
 async def test_downstream_complete_before_upstream(
     flow, scheduler, start, db_select
 ):
-    """It should handle an upstream task completing before a downstream task.
+    """A downstream task that completes - in the same main loop iteration as
+    its upstream task - does not get re-spawned.
 
     See https://github.com/cylc/cylc-flow/issues/6315
     """
-    id_ = flow(
-        {
-            'scheduling': {
-                'graph': {
-                    'R1': 'a => b',
-                },
-            },
-        }
-    )
-    schd = scheduler(id_)
+    id_ = flow('a => b')
+    schd: Scheduler = scheduler(id_)
     async with start(schd):
         # 1/a should be pre-spawned (parentless)
         a_1 = schd.pool.get_task(IntegerPoint('1'), 'a')
@@ -2472,7 +2465,8 @@ async def test_downstream_complete_before_upstream(
         # 1/b should be removed from the pool (completed)
         assert schd.pool.get_tasks() == [a_1]
 
-        # as a side effect the DB should have been updated
+        # as a side effect the DB should have been updated (not waiting for
+        # the main loop to do it)
         assert (
             TASK_OUTPUT_SUCCEEDED
             in db_select(

--- a/tests/integration/test_task_pool.py
+++ b/tests/integration/test_task_pool.py
@@ -16,6 +16,7 @@
 
 from json import loads
 import logging
+import re
 from typing import (
     TYPE_CHECKING,
     AsyncGenerator,
@@ -29,7 +30,6 @@ from typing import (
 
 import pytest
 from pytest import param
-import re
 
 from cylc.flow import (
     CYLC_LOG,
@@ -41,7 +41,10 @@ from cylc.flow.data_messages_pb2 import PbPrerequisite
 from cylc.flow.data_store_mgr import TASK_PROXIES
 from cylc.flow.exceptions import WorkflowConfigError
 from cylc.flow.flow_mgr import FLOW_NONE
-from cylc.flow.id import TaskTokens, Tokens
+from cylc.flow.id import (
+    TaskTokens,
+    Tokens,
+)
 from cylc.flow.run_modes import RunMode
 from cylc.flow.task_events_mgr import TaskEventsManager
 from cylc.flow.task_outputs import (
@@ -910,25 +913,28 @@ async def test_db_update_on_removal(
     See: https://github.com/cylc/cylc-flow/issues/5598
     """
     id_ = flow({
-        'scheduler': {
-            'allow implicit tasks': 'true',
-        },
         'scheduling': {
             'graph': {
                 'R1': 'a',
             },
         },
+        'runtime': {
+            'root': {
+                'simulation': {
+                    # Avoid instant task success for this test
+                    'default run length': 'PT2S',
+                },
+            },
+        },
     })
-    schd = scheduler(id_)
+    schd: Scheduler = scheduler(id_)
     async with start(schd):
         task_a = schd.pool.get_tasks()[0]
 
         # set the task to running
         schd.pool.task_events_mgr.process_message(task_a, 1, 'started')
 
-        # update the db
-        await schd.update_data_structure()
-        schd.workflow_db_mgr.process_queued_ops()
+        await schd._main_loop()
 
         # the task should appear in the DB
         assert list_pool_from_db(schd) == [
@@ -939,9 +945,7 @@ async def test_db_update_on_removal(
         schd.pool.task_events_mgr.process_message(task_a, 1, 'succeeded')
         schd.pool.remove_if_complete(task_a)
 
-        # update the DB, note no new tasks have been added to the pool
-        await schd.update_data_structure()
-        schd.workflow_db_mgr.process_queued_ops()
+        await schd._main_loop()
 
         # the task should be gone from the DB
         assert list_pool_from_db(schd) == []


### PR DESCRIPTION
Follow-up to https://github.com/cylc/cylc-flow/pull/5619

This test had drifted out of sync with what the main loop is now doing. Calling `schd.update_data_structure()` directly in the test is no longer valid. We need to check that the main loop is doing the right thing. 


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Is tests; no changelog or docs needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
