### PR TITLE
Speed up main loop in integration tests

### DIFF
--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1776,7 +1776,7 @@ class Scheduler:
         if (elapsed >= self.INTERVAL_MAIN_LOOP or
                 quick_mode and elapsed >= self.INTERVAL_MAIN_LOOP_QUICK):
             # Main loop has taken quite a bit to get through
-            # Still yield control to other threads by sleep(0.0)
+            # Still yield control to other async tasks by sleep(0)
             duration: float = 0
         elif quick_mode:
             duration = self.INTERVAL_MAIN_LOOP_QUICK - elapsed

--- a/tests/integration/utils/flow_tools.py
+++ b/tests/integration/utils/flow_tools.py
@@ -148,6 +148,9 @@ async def _start_flow(
 
     await schd.install()
 
+    # Speed up main loop
+    schd.INTERVAL_MAIN_LOOP = schd.INTERVAL_MAIN_LOOP_QUICK = 1e-4
+
     try:
         # Nested `try...finally` to ensure caplog always yielded even if
         # exception occurs in Scheduler
@@ -177,6 +180,9 @@ async def _run_flow(
         caplog.set_level(level, CYLC_LOG)
 
     await schd.install()
+
+    # Speed up main loop
+    schd.INTERVAL_MAIN_LOOP = schd.INTERVAL_MAIN_LOOP_QUICK = 1e-4
 
     task: Optional[asyncio.Task] = None
     try:


### PR DESCRIPTION
Reduce the main loop sleep to < 1 ms seconds in the integration tests.

Compared to a [reasonably fast recent run on 8.6.x](https://github.com/cylc/cylc-flow/actions/runs/32694013015), in [this run](https://github.com/cylc/cylc-flow/actions/runs/33641990705?pr=7437) it has sped up the integration tests by ~45%.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests, changelog, docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
