### PR TITLE
Tests: fix TUI test speedup not working

### DIFF
--- a/cylc/flow/tui/app.py
+++ b/cylc/flow/tui/app.py
@@ -197,7 +197,7 @@ class TuiNode(urwid.ParentNode):
 
 
 @contextmanager
-def updater_subproc(filters, client_timeout):
+def updater_subproc(updater: 'Updater', filters):
     """Runs the Updater in its own process.
 
     The updater provides the data for Tui to render. Running the updater
@@ -205,12 +205,10 @@ def updater_subproc(filters, client_timeout):
     it to remain responsive whilst updates are being gathered as well as
     decoupling the application update logic from the data update logic.
     """
-    # start the updater
-    updater = Updater(client_timeout=client_timeout)
     p = Process(target=updater.start, args=(filters,))
     try:
         p.start()
-        yield updater
+        yield
     finally:
         updater.terminate()
         p.join(4)  # timeout of 4 seconds
@@ -292,6 +290,8 @@ class TuiApp:
         id_filter=None,
         interactive=True,
         client_timeout=3,
+        *,
+        _is_tests=False,
     ):
         """Start the Tui app.
 
@@ -306,9 +306,17 @@ class TuiApp:
         """
         self.set_initial_filters(w_id, id_filter)
 
-        with updater_subproc(self.filters, client_timeout) as updater:
-            self.updater = updater
+        self.updater = Updater(client_timeout=client_timeout)
 
+        if _is_tests:
+            # make the update and scan intervals match (more reliable)
+            # and speed things up a little whilst we're at it
+            # (Have to do this in source code because monkeypatching doesn't
+            # work with multiprocessing)
+            self.updater.BASE_UPDATE_INTERVAL = 0.1
+            self.updater.BASE_SCAN_INTERVAL = 0.1
+
+        with updater_subproc(self.updater, self.filters):
             # pre-subscribe to the provided workflow if requested
             self.expand_on_load = {w_id or 'root'}
             if w_id:

--- a/cylc/flow/tui/updater.py
+++ b/cylc/flow/tui/updater.py
@@ -124,10 +124,10 @@ class Updater():
     """
 
     # the interval between workflow listing scans
-    BASE_SCAN_INTERVAL = 20
+    BASE_SCAN_INTERVAL: float = 20
 
     # the interval between workflow data updates
-    BASE_UPDATE_INTERVAL = 1
+    BASE_UPDATE_INTERVAL: float = 1
 
     # the command signal used to tell the updater to shut down
     SIGNAL_TERMINATE = 'terminate'

--- a/tests/integration/tui/conftest.py
+++ b/tests/integration/tui/conftest.py
@@ -253,17 +253,6 @@ def mod_rakiura(test_dir, request, monkeypatch):
 
 
 def _rakiura(test_dir, request, monkeypatch):
-    # make the workflow and scan update intervals match (more reliable)
-    # and speed things up a little whilst we're at it
-    monkeypatch.setattr(
-        'cylc.flow.tui.updater.Updater.BASE_UPDATE_INTERVAL',
-        0.1,
-    )
-    monkeypatch.setattr(
-        'cylc.flow.tui.updater.Updater.BASE_SCAN_INTERVAL',
-        0.1,
-    )
-
     # the user name and the prefix of workflow IDs are both variable
     # so we patch the render functions to make test output stable
     def get_display_id(id_):
@@ -302,6 +291,7 @@ def _rakiura(test_dir, request, monkeypatch):
             workflow_id,
             id_filter=workflow_filter,
             interactive=False,
+            _is_tests=True,
         ):
             yield RakiuraSession(
                 app,

--- a/tests/integration/tui/test_updater.py
+++ b/tests/integration/tui/test_updater.py
@@ -35,20 +35,12 @@ from cylc.flow.workflow_status import WorkflowStatus
 
 
 @pytest.fixture
-def updater(monkeypatch, test_dir):
+def updater(test_dir):
     """Return an updater ready for testing."""
-    # patch the update intervals so that everything runs for every update
-    monkeypatch.setattr(
-        'cylc.flow.tui.updater.Updater.BASE_UPDATE_INTERVAL',
-        0,
-    )
-    monkeypatch.setattr(
-        'cylc.flow.tui.updater.Updater.BASE_SCAN_INTERVAL',
-        0,
-    )
 
-    # create the updater
     updater = Updater()
+    # patch the update intervals so that everything runs for every update
+    updater.BASE_UPDATE_INTERVAL = updater.BASE_SCAN_INTERVAL = 0
 
     # swap multiprocessing.Queue for queue.Queue
     # (this means queued operations are instant making tests more stable)


### PR DESCRIPTION
Monkeypatching the `Updater` class attributes was not working, possibly because the updater runs in a different process? Might be https://github.com/pytest-dev/pytest/issues/12045

~40% speedup compared to [last run on master](https://github.com/cylc/cylc-flow/actions/runs/33883229053)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests, changelog, docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
