### PR TITLE
parsec: fix plugin merging issue

### DIFF
--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -315,18 +315,17 @@ def process_plugins(fpath: 'str | Path', opts: 'Values'):
                 extra_vars[section].update(section_update)
 
         templating_detected = plugin_result.get(TEMPLATING_DETECTED, None)
-        if (
-            templating_detected is not None
-            and extra_vars[TEMPLATING_DETECTED] is not None
-            and extra_vars[TEMPLATING_DETECTED] != templating_detected
-        ):
-            # Don't allow subsequent plugins with different templating_detected
-            raise ParsecError(
-                "Can't merge templating languages "
-                f"{extra_vars[TEMPLATING_DETECTED]} and "
-                f"{templating_detected}"
-            )
-        else:
+        if templating_detected is not None:
+            if (
+                extra_vars[TEMPLATING_DETECTED] is not None
+                and extra_vars[TEMPLATING_DETECTED] != templating_detected
+            ):
+                # Don't allow subsequent plugins with different templating_detected
+                raise ParsecError(
+                    "Can't merge templating languages "
+                    f"{extra_vars[TEMPLATING_DETECTED]} and "
+                    f"{templating_detected}"
+                )
             extra_vars[TEMPLATING_DETECTED] = templating_detected
 
     return extra_vars

--- a/cylc/flow/parsec/fileparse.py
+++ b/cylc/flow/parsec/fileparse.py
@@ -320,7 +320,8 @@ def process_plugins(fpath: 'str | Path', opts: 'Values'):
                 extra_vars[TEMPLATING_DETECTED] is not None
                 and extra_vars[TEMPLATING_DETECTED] != templating_detected
             ):
-                # Don't allow subsequent plugins with different templating_detected
+                # Don't allow subsequent plugins with different
+                # templating_detected
                 raise ParsecError(
                     "Can't merge templating languages "
                     f"{extra_vars[TEMPLATING_DETECTED]} and "


### PR DESCRIPTION
* Fixes https://github.com/cylc/cylc-rose/issues/440

When multiple plugins are run, a `None` result should not override a non-None result.

It's not 100% clear if this should be an 8.6.x fix or not at this stage.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
