### PR TITLE
Allow changing logging verbosity of stopping workflow

### DIFF
--- a/cylc/flow/network/schema.py
+++ b/cylc/flow/network/schema.py
@@ -1931,7 +1931,7 @@ class SetVerbosity(Mutation):
             For example, if you choose `WARNING`, only warning, error and
             critical level messages will be logged.
 
-            Valid for: paused, running workflows.
+            Valid for: paused, running, stopping workflows.
         ''')
         resolver = mutator
 

--- a/cylc/flow/scheduler.py
+++ b/cylc/flow/scheduler.py
@@ -1470,6 +1470,33 @@ class Scheduler:
         if self.get_run_mode() != RunMode.SIMULATION:
             self.task_job_mgr.check_task_jobs(self.pool)
 
+    def can_stop(self) -> bool:
+        """Return True if workflow can stop."""
+        if self.stop_mode is None:
+            return False
+        if self.stop_mode == StopMode.REQUEST_NOW_NOW:
+            # Can stop irrespective of all other conditions
+            return True
+        if self.task_events_mgr._event_timers:
+            return False
+        if self.stop_mode in {
+            StopMode.REQUEST_NOW,
+            StopMode.AUTO,
+            StopMode.AUTO_ON_TASK_FAILURE,
+        }:
+            # Can stop as no pending event handlers
+            return True
+        # Else cannot stop if there are active tasks (unless they're
+        # ones we tried & failed to kill).
+        # NB preparing tasks get reset to waiting on restart.
+        return not any(
+            (
+                itask.state(*TASK_STATUSES_ACTIVE)
+                and not itask.state.kill_failed
+            )
+            for itask in self.pool.get_tasks()
+        )
+
     async def workflow_shutdown(self):
         """Determines if the workflow can be shutdown yet."""
         if self.pool.check_abort_on_task_fails():
@@ -1484,7 +1511,7 @@ class Scheduler:
             self._set_stop(StopMode.AUTO)
 
         # Is the workflow ready to shut down now?
-        if self.pool.can_stop(self.stop_mode):
+        if self.can_stop():
             await self.update_data_structure()
             self.proc_pool.close()
             if self.stop_mode != StopMode.REQUEST_NOW_NOW:
@@ -2008,10 +2035,10 @@ class Scheduler:
         self.workflow_db_mgr.put_workflow_stop_clock_time(self.stop_clock_time)
         self.update_data_store()
 
-    def stop_clock_done(self):
+    def stop_clock_done(self) -> bool:
         """Return True if wall clock stop time reached."""
         if self.stop_clock_time is None:
-            return
+            return False
         now = time()
         if now > self.stop_clock_time:
             LOG.info("Wall clock stop time reached: %s", time2str(
@@ -2023,7 +2050,7 @@ class Scheduler:
         LOG.debug("stop time=%d; current time=%d", self.stop_clock_time, now)
         return False
 
-    def check_auto_shutdown(self):
+    def check_auto_shutdown(self) -> bool:
         """Check if we should shut down now."""
         if (
             self.is_paused or

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -91,7 +91,6 @@ from cylc.flow.task_state import (
 )
 from cylc.flow.task_trigger import TaskTrigger
 from cylc.flow.util import deserialise_set
-from cylc.flow.workflow_status import StopMode
 from cylc.flow.scripts.set import XTRIGGER_PREREQ_PREFIX
 
 if TYPE_CHECKING:
@@ -227,7 +226,7 @@ class TaskPool:
         else:
             LOG.warning("Requested stop task name does not exist: %s" % name)
 
-    def stop_task_done(self):
+    def stop_task_done(self) -> bool:
         """Return True if stop task has succeeded."""
         if self.stop_task_id is not None and self.stop_task_finished:
             LOG.info("Stop task %s finished" % self.stop_task_id)
@@ -1189,30 +1188,6 @@ class TaskPool:
                 ):
                     self.data_store_mgr.delta_task_state(itask)
         return True
-
-    def can_stop(self, stop_mode):
-        """Return True if workflow can stop.
-
-        A task is considered active if:
-        * It is in the active state and not marked with a kill failure.
-        * It has pending event handlers.
-        """
-        if stop_mode is None:
-            return False
-        if stop_mode == StopMode.REQUEST_NOW_NOW:
-            return True
-        if self.task_events_mgr._event_timers:
-            return False
-
-        return not any(
-            (
-                stop_mode in [StopMode.REQUEST_CLEAN, StopMode.REQUEST_KILL]
-                and itask.state(*TASK_STATUSES_ACTIVE)
-                and not itask.state.kill_failed
-            )
-            # preparing tasks get reset to waiting on restart
-            for itask in self.get_tasks()
-        )
 
     def warn_stop_orphans(self) -> None:
         """Log (warning) orphaned tasks on workflow stop."""


### PR DESCRIPTION
Allow `cylc verbosity` (and equivalent GUI command) to work on a workflow that is in the stopping state.

Also includes a small code tidy.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No dependency changes 
- [x] Tests are not needed
- [x] Changelog entry not needed as minor
- [x] Docs not needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
