### PR TITLE
GH Actions: update versions on 8.6.x

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -34,7 +34,7 @@ jobs:
         uses: cylc/release-actions/stage-1/sanitize-inputs@v1
 
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.BASE_REF }}
           fetch-depth: 0  # need to fetch all commits to check contributors
@@ -43,7 +43,7 @@ jobs:
         uses: cylc/release-actions/check-shortlog@v1
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 

--- a/.github/workflows/2_auto_publish_release.yml
+++ b/.github/workflows/2_auto_publish_release.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         ref: ${{ env.MERGE_SHA }}
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
 

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -55,7 +55,7 @@ jobs:
       IMAGE: 'ghcr.io/cylc/cylc-bash-testing-2:master'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Run Docker container
         run: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'cylc-run (bash-${{ matrix.bash-version }})'
           path: cylc-run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,10 @@ jobs:
         python: ['3.12', '3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           cache-environment: true
           post-cleanup: 'all'

--- a/.github/workflows/shortlog.yml
+++ b/.github/workflows/shortlog.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # need to fetch all commits to check contributors
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test_conda-build.yml
+++ b/.github/workflows/test_conda-build.yml
@@ -33,7 +33,7 @@ jobs:
       ENV_FILE: conda-environment.yml
     steps:
       - name: checkout cylc-flow
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: modify conda env file
         run: |
@@ -44,7 +44,7 @@ jobs:
           cat "$ENV_FILE"
 
       - name: build conda env
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: ${{ env.ENV_FILE }}

--- a/.github/workflows/test_fast.yml
+++ b/.github/workflows/test_fast.yml
@@ -40,10 +40,10 @@ jobs:
       PYTEST_ADDOPTS: --cov --cov-append -n 5 --color=yes
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install System Dependencies
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           cache-environment: true
           post-cleanup: 'all'
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload failed tests artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cylc-run (${{ matrix.os }} py-${{ matrix.python-version }})
           path: ~/cylc-run/
@@ -100,7 +100,7 @@ jobs:
           coverage report
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage_${{ matrix.os }}_py-${{ matrix.python-version }}
           path: coverage.xml
@@ -116,10 +116,10 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install System Dependencies
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           cache-environment: true
           post-cleanup: 'all'
@@ -161,13 +161,13 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
 
       - name: Codecov upload
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: ${{ github.workflow }}
           flags: fast-tests

--- a/.github/workflows/test_functional.yml
+++ b/.github/workflows/test_functional.yml
@@ -106,10 +106,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Configure Python
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           cache-environment: true
           post-cleanup: 'all'
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload failed tests artifact
         if: failure() && steps.test.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cylc-run (${{ steps.uploadname.outputs.uploadname }})
           path: ~/cylc-run/
@@ -325,7 +325,7 @@ jobs:
           coverage report
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage_${{ steps.uploadname.outputs.uploadname }}
           path: coverage.xml
@@ -337,13 +337,13 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
 
       - name: Codecov upload
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           name: ${{ github.workflow }}
           flags: functional-tests

--- a/.github/workflows/test_tutorial_workflow.yml
+++ b/.github/workflows/test_tutorial_workflow.yml
@@ -39,12 +39,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: configure python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install docs/tutorial dependencies
         uses: cylc/cylc-doc/.github/actions/install-dependencies@master

--- a/.github/workflows/update_copyright.yml
+++ b/.github/workflows/update_copyright.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Configure git
       uses: cylc/release-actions/configure-git@v1


### PR DESCRIPTION
I noticed some errors with the upload artifact step that may be because we are using an old version on this branch


