### PR TITLE
Changed max rss values to MiB to decrease number size

### DIFF
--- a/cylc/flow/scripts/profiler.py
+++ b/cylc/flow/scripts/profiler.py
@@ -100,7 +100,7 @@ def parse_memory_file(process: Process):
             with open(process.cgroup_memory_path, 'r') as f:
                 for line in f:
                     if "anon" in line:
-                        # convert bytes to megabytes
+                        # convert bytes to MiB
                         return int(''.join(filter(str.isdigit, line))) // (
                             1024 * 1024
                         )

--- a/cylc/flow/scripts/profiler.py
+++ b/cylc/flow/scripts/profiler.py
@@ -100,12 +100,18 @@ def parse_memory_file(process: Process):
             with open(process.cgroup_memory_path, 'r') as f:
                 for line in f:
                     if "anon" in line:
-                        return int(''.join(filter(str.isdigit, line)))
+                        # convert bytes to megabytes
+                        return int(''.join(filter(str.isdigit, line))) // (
+                            1024 * 1024
+                        )
         else:
             with open(process.cgroup_memory_path, 'r') as f:
                 for line in f:
                     if "total_rss" in line:
-                        return int(''.join(filter(str.isdigit, line)))
+                        # convert bytes to megabytes
+                        return int(''.join(filter(str.isdigit, line))) // (
+                            1024 * 1024
+                        )
     except Exception as err:
         raise CylcProfilerError(
             err, "Unable to find memory usage data") from err
@@ -120,7 +126,8 @@ def parse_memory_allocated(process: Process) -> int:
             with open(memory_max_file, 'r') as f:
                 line = f.readline()
                 if "max" not in line:
-                    return int(line)
+                    # convert bytes to megabytes
+                    return int(line) // (1024 * 1024)
                 cgroup_memory_path = cgroup_memory_path.parent
         return 0
     else:  # Memory limit not tracked for cgroups v1

--- a/tests/functional/jobscript/04-profiler.t
+++ b/tests/functional/jobscript/04-profiler.t
@@ -80,8 +80,8 @@ log_scan "${TEST_NAME_BASE}-task-failed" \
 # Verify the profiler data matches the mocked cgroup values:
 
 grep_workflow_log_ok "${TEST_NAME_BASE}-the_good-data" \
-    '1/the_good.*(received)_cylc_profiler.*"max_rss": 12345678.*"cpu_time": 56781.*"memory_allocated": 123456789'
+    '1/the_good.*(received)_cylc_profiler.*"max_rss": 11.*"cpu_time": 56781.*"memory_allocated": 117'
 grep_workflow_log_ok "${TEST_NAME_BASE}-the_bad-data" \
-    '1/the_bad.*(received)_cylc_profiler.*"max_rss": 12345678.*"cpu_time": 56781.*"memory_allocated": 123456789'
+    '1/the_bad.*(received)_cylc_profiler.*"max_rss": 11.*"cpu_time": 56781.*"memory_allocated": 117'
 
 purge

--- a/tests/unit/scripts/test_profiler.py
+++ b/tests/unit/scripts/test_profiler.py
@@ -102,9 +102,9 @@ def test_get_resource_usage():
 def test_parse_memory_file(tmpdir):
     """It should return the memory usage of the process."""
     mem_file_v1 = tmpdir.join("memory_file_v1.txt")
-    mem_file_v1.write('total_rss=1024')
+    mem_file_v1.write('total_rss=3145728')
     mem_file_v2 = tmpdir.join("memory_file_v2.txt")
-    mem_file_v2.write('anon=666')
+    mem_file_v2.write('anon=2097152')
     cpu_file = tmpdir.join("cpu_file.txt")
     cpu_file.write('5678')
     mem_allocated_file = tmpdir.join("memory_allocated.txt")
@@ -134,8 +134,8 @@ def test_parse_memory_file(tmpdir):
     assert "Unable to find memory usage data" in str(excinfo.value)
 
     # Test the parse_memory_file function
-    assert parse_memory_file(good_process_object_v1) == 1024
-    assert parse_memory_file(good_process_object_v2) == 666
+    assert parse_memory_file(good_process_object_v1) == 3
+    assert parse_memory_file(good_process_object_v2) == 2
 
 
 def test_parse_cpu_file(tmpdir):
@@ -217,7 +217,7 @@ def test_parse_memory_allocated(tmp_path_factory):
     """It should return the memory allocated to the process."""
     good_mem_dir = tmp_path_factory.mktemp("mem_dir")
     mem_allocated_file = good_mem_dir / "memory.max"
-    mem_allocated_file.write_text('99999')
+    mem_allocated_file.write_text('4194304')
 
     # We currently do not track memory allocated for cgroups v1
     good_process_object_v1 = Process(
@@ -242,7 +242,7 @@ def test_parse_memory_allocated(tmp_path_factory):
         max_rss=0)
 
     assert parse_memory_allocated(good_process_object_v1) == 0
-    assert parse_memory_allocated(good_process_object_v2) == 99999
+    assert parse_memory_allocated(good_process_object_v2) == 4
     with pytest.raises(CylcProfilerError) as excinfo:
         parse_memory_file(bad_process_object_v2_1)
     assert "Unable to find memory usage data" in str(excinfo.value)
@@ -287,8 +287,8 @@ def test_parse_memory_allocated(tmp_path_factory):
 
     # Add a memory.max file with a value to the top level directory
     # and check it is read
-    mem_file_1.write_text("99999")
-    assert parse_memory_allocated(bad_process_object_v2_2) == 99999
+    mem_file_1.write_text("5242880")
+    assert parse_memory_allocated(bad_process_object_v2_2) == 5
 
 
 def test_get_cgroup_name_file_not_found(mocker):


### PR DESCRIPTION
This PR is addressing a code review comment from https://github.com/cylc/cylc-uiserver/pull/675.
The memory data from the profiler can end up being large numbers. Large enough that a `BigInt` was used in the UI server.
We are not 100% positive that GraphQL handles big ints correctly. So we've changed memory values to be in Megabytes instead.
The accompanying changes in the UI server and UI are in PR's
https://github.com/cylc/cylc-uiserver/pull/675
https://github.com/cylc/cylc-ui/pull/2100

<!--

Thanks for your contribution! Please:
* List any related issues with a "closes" or "addresses" tag.
* Add a helpful title & description.
* Complete the checklist.

-->

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
